### PR TITLE
export/html: simplify traceability page styles for now

### DIFF
--- a/strictdoc/export/html/static/single_document_traceability.css
+++ b/strictdoc/export/html/static/single_document_traceability.css
@@ -23,18 +23,19 @@ h1 {
   padding: 0px;
   margin: 0px 0px 0px 0px;
   border: 1px solid black;
+  border-bottom: 0;
 }
 
 .table-row:last-child {
-  border-bottom: 2px solid #000;
+  border-bottom: 1px solid #000;
 }
 
 .cell-section {
   display: inline-block;
-  width: 100%;
+  width: 33.33%;
   text-align: center;
-  background: #add8e6;
-  border: 2px solid #000;
+  //background: #add8e6;
+  ///border: 2px solid #000;
   margin: 0px 0px -1px 0px;
 }
 
@@ -42,7 +43,7 @@ h1 {
   width: 33.33%;
   border-left: 1px solid #ccc;
   box-sizing: border-box;
-  margin: 0px 0px -1px 0px;
+  margin: 0px 0px 0px 0px;
 }
 
 .cell-parent {

--- a/strictdoc/export/html/templates/single_document_traceability/document.jinja.html
+++ b/strictdoc/export/html/templates/single_document_traceability/document.jinja.html
@@ -64,9 +64,13 @@
         {%- endfor %}
       </div>
     {%- elif section_or_requirement.is_section %}
+      <div class="cell cell-parent">
+      </div>
       <div class="cell-section">
       {%- set section = section_or_requirement %}
       <h2 id="{{ string_to_anchor_id(section.title) }}">{{ section.title }}</h2>
+      </div>
+      <div class="cell cell-children">
       </div>
     {%- elif section_or_requirement.is_free_text %}
       <div class="cell cell-parent">


### PR DESCRIPTION
to provide a book-like reading of the middle comment when the new styles are
in place