### PR TITLE
document_finder: switch to depth-first search

### DIFF
--- a/strictdoc/core/document_tree.py
+++ b/strictdoc/core/document_tree.py
@@ -35,14 +35,16 @@ class File(FileOrFolderEntry):
 
 
 class FileTree(FileOrFolderEntry):
-    def __init__(self, level=0):
+    def __init__(self, root_path, level):
+        assert os.path.isdir(root_path)
+
+        self.root_path = root_path
         self.level = level
-        self.root_path = None
         self.files = []
         self.subfolder_trees = []
 
     def __repr__(self):
-        return "FileTree: {} files: {}".format(self.root_path, self.files)
+        return "FileTree: (root_path: {}, files: {})".format(self.root_path, self.files)
 
     def is_folder(self):
         return True
@@ -56,16 +58,17 @@ class FileTree(FileOrFolderEntry):
     def get_folder_name(self):
         return os.path.basename(os.path.normpath(self.root_path))
 
-    def set(self, root_path, files, subfolders):
-        assert os.path.isdir(root_path)
-
-        self.root_path = root_path
+    def set(self, files):
         for file in files:
             full_file_path = os.path.join(self.root_path, file)
             self.files.append(File(self.level + 1, full_file_path))
 
-        for _ in subfolders:
-            self.subfolder_trees.append(FileTree(self.level + 1))
+    def add_subfolder_tree(self, subfolder_tree):
+        assert isinstance(subfolder_tree, FileTree)
+        self.subfolder_trees.append(subfolder_tree)
+
+    def sort_subfolder_trees(self):
+        self.subfolder_trees.sort(key=lambda subfolder: subfolder.root_path)
 
     def dump(self):
         print(self)

--- a/strictdoc/core/document_tree_iterator.py
+++ b/strictdoc/core/document_tree_iterator.py
@@ -1,0 +1,19 @@
+import collections
+
+from strictdoc.core.document_tree import FileTree, DocumentTree
+
+
+class DocumentTreeIterator:
+    def __init__(self, document_tree):
+        assert isinstance(document_tree, DocumentTree)
+        self.document_tree = document_tree
+
+    def iterator(self):
+        task_list = collections.deque(self.document_tree.file_tree)
+
+        while task_list:
+            file_tree_or_file = task_list.popleft()
+            yield file_tree_or_file
+            if isinstance(file_tree_or_file, FileTree):
+                task_list.extendleft(reversed(file_tree_or_file.files))
+                task_list.extendleft(reversed(file_tree_or_file.subfolder_trees))

--- a/strictdoc/export/html/export.py
+++ b/strictdoc/export/html/export.py
@@ -4,6 +4,7 @@ import os
 from jinja2 import Environment, PackageLoader
 
 from strictdoc.core.document_tree import FileTree
+from strictdoc.core.document_tree_iterator import DocumentTreeIterator
 from strictdoc.helpers.hyperlinks import string_to_anchor_id
 
 
@@ -31,20 +32,11 @@ class DocumentTreeHTMLExport:
 
     @staticmethod
     def export(document_tree):
-        task_list = collections.deque(document_tree.file_tree)
-        artefact_list = []
-
-        while task_list:
-            file_tree_or_file = task_list.popleft()
-            artefact_list.append(file_tree_or_file)
-            if isinstance(file_tree_or_file, FileTree):
-                task_list.extendleft(reversed(file_tree_or_file.files))
-                task_list.extendleft(reversed(file_tree_or_file.subfolder_trees))
-
+        document_tree_iterator = DocumentTreeIterator(document_tree)
 
         template = SingleDocumentHTMLExport.env.get_template('document_tree/document_tree.jinja.html')
         output = template.render(document_tree=document_tree,
-                                 artefact_list=artefact_list,
+                                 artefact_list=document_tree_iterator.iterator(),
                                  get_traceability_link=get_traceability_link,
                                  get_traceability_deep_link=get_traceability_deep_link)
 


### PR DESCRIPTION
With depth-first search, it is easier to skip adding folders that are known
to not contain any .sdoc files in contrast to the breadth-first where we
have to do through each and every folder to check if it might have any
*.sdoc in it.