### PR TITLE
export/pdf: fix TOC layout when starting from level 3

### DIFF
--- a/docs/sphinx/source/conf.py
+++ b/docs/sphinx/source/conf.py
@@ -91,7 +91,7 @@ latex_elements = {
         \usepackage{makecell}
 
         \setcounter{secnumdepth}{10}
-        \setcounter{tocdepth}{10}
+        \setcounter{tocdepth}{6}
         
         \newdateformat{MonthYearFormat}{%
             \monthname[\THEMONTH], \THEYEAR}
@@ -138,6 +138,48 @@ latex_elements = {
                 \renewcommand{\footrulewidth}{1.0pt}
             }
         \makeatother
+
+        \usepackage{eqparbox}
+        \usepackage{titletoc}
+
+        \titlecontents{chapter}
+                      [0em]
+                      {\vspace{.25\baselineskip}}
+                      {\eqparbox{ch}{\thecontentslabel}\hspace{0.2cm}}
+                      {}
+                      {\titlerule*[10pt]{$\cdot$}\contentspage}
+        
+        \titlecontents{section}
+                      [0.5cm]
+                      {\vspace{.25\baselineskip}}
+                      {\eqparbox{S}{\thecontentslabel}\hspace{0.2cm}}
+                      {}
+                      {\titlerule*[10pt]{$\cdot$}\contentspage}
+        
+        \titlecontents{subsection}
+                      [1cm]
+                      {\vspace{.25\baselineskip}}
+                      {\eqparbox{Ss}{\thecontentslabel}\hspace{0.2cm}}
+                      {}
+                      {\titlerule*[10pt]{$\cdot$}\contentspage}
+
+        \titlecontents{subsubsection}
+                      [1.5cm]{\vspace{.25\baselineskip}}
+                      {\eqparbox{Sss}{\thecontentslabel}\hspace{0.2cm}}
+                      {}
+                      {\titlerule*[10pt]{$\cdot$}\contentspage}
+        
+        \titlecontents{paragraph}
+                      [2cm]{\vspace{.25\baselineskip}}
+                      {\eqparbox{Sss}{\thecontentslabel}\hspace{0.2cm}}
+                      {}
+                      {\titlerule*[10pt]{$\cdot$}\contentspage}
+
+        \titlecontents{subparagraph}
+                      [2cm]{\vspace{.25\baselineskip}}
+                      {\eqparbox{Sss}{\thecontentslabel}\hspace{0.2cm}}
+                      {}
+                      {\titlerule*[10pt]{$\cdot$}\contentspage}
 
         \newcommand{\tablecell}[1] {{{#1}}}
     ''',

--- a/strictdoc/backend/dsl/reader.py
+++ b/strictdoc/backend/dsl/reader.py
@@ -47,6 +47,8 @@ def composite_requirement_obj_processor(composite_requirement):
 
         composite_requirement.parent.ng_sections.append(composite_requirement)
     elif isinstance(composite_requirement.parent, CompositeRequirement):
+        if not composite_requirement.parent.ng_level:
+            resolve_parents(composite_requirement)
         assert composite_requirement.parent.ng_level
         composite_requirement.ng_level = composite_requirement.parent.ng_level + 1
     elif isinstance(composite_requirement.parent, Document):
@@ -112,4 +114,5 @@ class SDReader:
             exit(1)
         except Exception as exc:
             print("error: could not parse file: {}.\n{}: {}".format(file_path, exc.__class__.__name__,  exc))
+            traceback.print_exc()
             exit(1)

--- a/strictdoc/export/rst/writer.py
+++ b/strictdoc/export/rst/writer.py
@@ -42,6 +42,7 @@ class RSTWriter:
             4: '^',
             5: '"',
             6: '#',
+            7: "'",
         }
         header_char = chars[level]
         output = ''


### PR DESCRIPTION
Starting from level 3, the default TOC printed by Sphinx doesn't ensure
space between chapter names and chapter titles.

The solution is to switch to managing this on the Tex level.