### PR TITLE
export/html: TOC and document header improvements, :target highlighting

### DIFF
--- a/strictdoc/export/html/static/document_tree.css
+++ b/strictdoc/export/html/static/document_tree.css
@@ -13,6 +13,10 @@
   --half-sell-height: calc( var(--line-height)/2 + var(--cell-padding) );
 }
 
+.document-tree {
+  padding: calc(var(--toc-toggle-width) * 2);
+}
+
 .document-tree * {
   box-sizing: border-box;
   line-height: var(--line-height);

--- a/strictdoc/export/html/static/global.css
+++ b/strictdoc/export/html/static/global.css
@@ -12,6 +12,9 @@ div.document {
 /* general styles */
 
 :root {
+  --base-font-size: 16px;
+  --base-line-height: calc(var(--base-font-size) * 1.6);
+
   --color-text-main: #000;
   --color-text-lighter: #444;
   --color-text-light: #808080;
@@ -43,6 +46,29 @@ div.document {
 
 body {
   background-color: var(--color-bg-mac);
+}
+
+section {
+  /* for Fixed Headers + Section Anchors */
+  scroll-snap-margin-top: calc(var(--toc-toggle-width)*1.5);
+  scroll-margin-top:      calc(var(--toc-toggle-width)*1.5);
+}
+
+.view-article section:target .section-title,
+.view-table section:target .section-title,
+section:target [data-requirement-role="current"] .section-title {
+  background-color: rgb(255, 255, 125);
+}
+
+/* .content Layout */
+
+.content {
+  font-size: var(--base-font-size);
+  line-height: var(--base-line-height);
+}
+
+.content p {
+  margin: calc(var(--base-font-size) * 0.5) 0;
 }
 
 cite {
@@ -223,8 +249,6 @@ dl.requirement-meta {
 
 .view-article {
   max-width: 800px;
-  /* display: flex;
-  flex-direction: column; */
 }
 
 .view-article > section {
@@ -246,11 +270,10 @@ dl.requirement-meta {
 /* .view-table */
 
 .view-table {
-  width: 100%;
   min-width: 800px;
   box-sizing: border-box;
   background-color: #fff;
-  padding: 1rem;
+  padding: 1.5rem;
 }
 
 .view-table .free_text {
@@ -307,7 +330,6 @@ section.view-table_composite .requirement_section[data-role]::before,
   content: attr(data-role) " ";
   position: absolute;
   display: flex;
-  /* justify-content: center; */
   align-items: center;
   padding: 0 .75rem;
   background-color: var(--color-table-header-bg);
@@ -446,7 +468,6 @@ overflow: hidden;
 .recursive_cell {
   position: relative;
   height: 100%;
-  /* width: var(--secondary-requirement-card-width); */
   overflow: hidden;
 }
 

--- a/strictdoc/export/html/static/global.css
+++ b/strictdoc/export/html/static/global.css
@@ -42,6 +42,8 @@ div.document {
   --traceability-arrow: 1.25rem;
   --traceability-outer-row-gap: 1.25rem;
   --traceability-inner-row-gap: .5rem;
+
+  --highlight-color: rgb(255, 255, 125);
 }
 
 body {
@@ -57,7 +59,7 @@ section {
 .view-article section:target .section-title,
 .view-table section:target .section-title,
 section:target [data-requirement-role="current"] .section-title {
-  background-color: rgb(255, 255, 125);
+  background-color: var(--highlight-color);
 }
 
 /* .content Layout */
@@ -134,6 +136,7 @@ h4 { font-size: 1.2em; }
 h5 { font-size: 1em; }
 h6 { font-size: 1em; }
 
+.section-title,
 h1.section-title,
 h2.section-title,
 h3.section-title,
@@ -233,6 +236,7 @@ dl.requirement-meta {
 
 .section-title[data-level]::before {
   content: attr(data-level) " ";
+  font-weight: bold;
 }
 
 /* pre.code */

--- a/strictdoc/export/html/static/layout-main-with-toc.css
+++ b/strictdoc/export/html/static/layout-main-with-toc.css
@@ -172,22 +172,24 @@ header.toc_header {
 
 /* open / close */
 
-.layout-with-toc {
+.layout-with-toc[data-state="close"] {
   transition: var(--toc-layout-transition);
   margin-left: 0;
 }
 
+.layout-with-toc,
 .layout-with-toc[data-state="open"] {
   margin-left: var(--toc-width);
   transition: var(--toc-layout-transition);
 }
 
-.layout-with-toc .toc {
+.layout-with-toc[data-state="close"] .toc {
   left: calc(var(--toc-width) * (-1));
   right: 100%;
   transition: var(--toc-layout-transition);
 }
 
+.layout-with-toc .toc,
 .layout-with-toc[data-state="open"] .toc {
   left: 0;
   right: auto;

--- a/strictdoc/export/html/static/layout-main-with-toc.css
+++ b/strictdoc/export/html/static/layout-main-with-toc.css
@@ -159,15 +159,27 @@ header.toc_header {
   font-size: var(--toc-font-size);
 }
 
-.toc_list a:link,
+.toc_list a:link {
+  color: var(--toc-link-color);
+  text-decoration: none;
+}
+
 .toc_list a:visited {
   color: var(--toc-link-color);
   text-decoration: none;
 }
 
+.toc_list a:focus {
+  background: yellowgreen;
+}
+
 .toc_list a:hover {
   color: var(--toc-active-link-color);
   background-color: var(--toc-panel-bg-hover);
+}
+
+.toc_list a:active {
+  background: var(--highlight-color);
 }
 
 /* open / close */

--- a/strictdoc/export/html/static/layout-main-with-toc.css
+++ b/strictdoc/export/html/static/layout-main-with-toc.css
@@ -28,6 +28,9 @@
   --toc-width-index: 22;
 
   --content-padding-index: 3;
+
+  --toc-width: 330px;
+  --toc-toggle-width: 48px;
 }
 
 /* aside.toc */

--- a/strictdoc/export/html/static/layout-main-with-toc.css
+++ b/strictdoc/export/html/static/layout-main-with-toc.css
@@ -1,18 +1,3 @@
-.section-number {
-  font-size: 1em;
-  padding-right: 0.25em;
-}
-
-.link-back-to-index {
-  float: right;
-  font-size: 14px;
-  color: var(--color-text-lighter);
-}
-
-.link-back-to-index:hover {
-  color: var(--color-text-main);
-}
-
 /* layout-with-toc */
 
 :root {
@@ -33,12 +18,60 @@
   --toc-toggle-width: 48px;
 }
 
+.layout-with-toc main {
+  position: relative;
+}
+
+.layout-with-toc header.document-header {
+  position: fixed;
+  z-index: 1;
+  top: 0;
+  width: 100%;
+  height: var(--toc-toggle-width);
+
+  display: flex;
+  align-items: center;
+
+  padding: var(--toc-font-size);
+  padding-left: calc(var(--toc-toggle-width) + var(--toc-toggle-width));
+  padding-right: calc(var(--toc-toggle-width) + var(--toc-width));
+
+  background-color: var(--toc-panel-bg);
+  border-bottom: 2px solid var(--code-border-color);
+  box-shadow: 0 24px 24px var(--toc-panel-bg);
+
+  font-size: 1.6rem;
+  font-weight: bold;
+  margin: 0;
+  color: var(--color-accent-dark);
+}
+
+.layout-with-toc article {
+  margin: calc(var(--toc-toggle-width) * 2);
+  box-sizing: content-box;
+}
+
+/* *** */
+
+.section-number {
+  font-size: 1em;
+  padding-right: 0.25em;
+}
+
+.link-back-to-index {
+  float: right;
+  font-size: 14px;
+  color: var(--color-text-lighter);
+}
+
+.link-back-to-index:hover {
+  color: var(--color-text-main);
+}
+
+
 /* aside.toc */
 
 .toc {
-
-  --toc-width: calc(var(--toc-font-size) * var(--toc-width-index));
-
   position: fixed;
   z-index: 10;
   width: var(--toc-width);
@@ -46,18 +79,39 @@
   bottom: 0;
 }
 
-.toc_header {
+.toc_document-title {
+  position: fixed;
+  width: 100%;
+  height: var(--toc-toggle-width);
+  padding: var(--toc-font-size);
+  padding-left: calc(var(--toc-width) + var(--toc-font-size) * 3 + var(--toc-width));
+}
+
+header.toc_header {
+  position: absolute;
+  padding:           var(--toc-font-size);
+  padding-left: calc(var(--toc-font-size) * 1.75);
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--toc-toggle-width);
+  background-color: var(--toc-panel-bg);
+  border-bottom: 1px solid var(--code-border-color);
+}
+
+.toc_title {
   font-weight: bold;
-  padding-bottom: var(--toc-font-size);
 }
 
 .toc_container {
   position: absolute;
-  top: 0;
+  top: var(--toc-toggle-width);
   bottom: 0;
   left: 0;
   right: 0;
-  padding: calc(var(--toc-font-size) * 1.5);
+  padding-left:   calc(var(--toc-font-size) * 1.75);
+  padding-right:  calc(var(--toc-font-size) * 1);
+  padding-top:    calc(var(--toc-font-size) * 1);
   padding-bottom: calc(var(--toc-font-size) * 3);
   background-color: var(--toc-panel-bg);
   overflow: auto;
@@ -68,11 +122,16 @@
   left: 100%;
   top: 0;
   bottom: 0;
-  padding: calc(var(--toc-font-size) * 0.75);
+  width: var(--toc-toggle-width);
+  padding: var(--toc-font-size);
   text-align: center;
+
   background-color: var(--toc-panel-bg);
-  box-shadow: 0 0 var(--toc-font-size) rgba(0,0,0,0.2);
+  border-right: 4px solid var(--code-border-color);
+
   cursor: pointer;
+  display: flex;
+  flex-flow: column nowrap;
 }
 
 .toc_toggle:hover {
@@ -96,7 +155,7 @@
 }
 
 .toc_list li {
-  padding-top: calc(var(--toc-font-size) * 0.5);
+  padding-top: calc(var(--toc-font-size) * 0.75);
   font-size: var(--toc-font-size);
 }
 
@@ -111,36 +170,15 @@
   background-color: var(--toc-panel-bg-hover);
 }
 
-/* .content Layout */
-
-.content {
-  padding: calc(var(--toc-font-size) * 3);
-  position: relative;
-}
-
-/* main.content typo-styles */
-
-main.content {
-  --font-size: 16px;
-  --line-height: calc(var(--font-size) * 1.6);
-
-  font-size: var(--font-size);
-  line-height: var(--line-height);
-}
-
-main.content p {
-  margin: calc(var(--font-size) * 0.5) 0;
-}
-
 /* open / close */
 
 .layout-with-toc {
-  padding-left: calc(var(--toc-font-size) * var(--content-padding-index));
   transition: var(--toc-layout-transition);
+  margin-left: 0;
 }
 
 .layout-with-toc[data-state="open"] {
-  padding-left: calc(var(--toc-font-size) * (var(--toc-width-index) + var(--content-padding-index)));
+  margin-left: var(--toc-width);
   transition: var(--toc-layout-transition);
 }
 

--- a/strictdoc/export/html/static/toc.js
+++ b/strictdoc/export/html/static/toc.js
@@ -26,8 +26,8 @@ window.onload = function() {
   tocToggle = document.getElementById('toc_toggle');
   tocLayout = document.getElementById('toc_layout');
 
-  tocToggle.dataset.state = 'close';
-  tocLayout.dataset.state = 'close';
+  tocToggle.dataset.state = 'open';
+  tocLayout.dataset.state = 'open';
 
   tocToggle.addEventListener('click', () => {
     switchTOC(tocToggle.dataset.state);

--- a/strictdoc/export/html/templates/_shared/requirement.jinja.html
+++ b/strictdoc/export/html/templates/_shared/requirement.jinja.html
@@ -9,6 +9,10 @@ data-status='{{ requirement.status.lower() }}'
     <h{{ requirement.ng_level }} class="section-title" data-level="{{ requirement.export_title }}">
       {{ requirement.title }}
     </h{{ requirement.ng_level }}>
+  {% else %}
+    <p class="section-title" data-level="{{ requirement.export_title }}">
+      <i>[no title]</i>
+    </p>
   {%- endif %}
 
   {%- if requirement.has_meta -%}

--- a/strictdoc/export/html/templates/_shared/table_of_contents.jinja.html
+++ b/strictdoc/export/html/templates/_shared/table_of_contents.jinja.html
@@ -1,11 +1,14 @@
   <div id="toc_toggle" class="toc_toggle"></div>
 
-  <div class="toc_container">
+  <header class="toc_header">
     <a class="link-back-to-index" href="{{document.meta.get_root_path_prefix()}}/index.html">Back to Index</a>
+    {%- if document.ng_sections %}
+    <div class="toc_title">Table of Contents</div>
+    {%- endif %}
+  </header>
 
+  <div class="toc_container">
   {%- if document.ng_sections %}
-    <div class="toc_header">Table of Contents</div>
-
 
     <ul class="toc_list">
     {%- for section in document_iterator.table_of_contents() -%}

--- a/strictdoc/export/html/templates/document_tree/document_tree.jinja.html
+++ b/strictdoc/export/html/templates/document_tree/document_tree.jinja.html
@@ -12,10 +12,9 @@
 </head>
 
 <body>
-  <main class="content">
+  <main class="document-tree">
     <h1 class="document-title">Document Tree</h1>
 
-    <div class="document-tree">
       <div class="document-tree_table">
 
         <ul class="document-tree_ul_0">
@@ -105,6 +104,5 @@
         </ul>
 
       </div>
-    </div>
   </main>
 </body>

--- a/strictdoc/export/html/templates/single_document/document.jinja.html
+++ b/strictdoc/export/html/templates/single_document/document.jinja.html
@@ -22,7 +22,10 @@
     </aside>
 
     <main class="content">
-      <h1 class="document-title">{{document.name}}</h1>
+      <header class="document-header">
+        {{document.name}}
+      </header>
+
       <article class="view-article">
 
         {%- if document.free_texts -%}

--- a/strictdoc/export/html/templates/single_document_table/document.jinja.html
+++ b/strictdoc/export/html/templates/single_document_table/document.jinja.html
@@ -22,7 +22,9 @@
     </aside>
 
     <main class="content">
-      <h1 class="document-title">{{document.name}} <span class="document-view-type">Table</span></h1>
+      <header class="document-header">
+        {{document.name}} <span class="document-view-type">Table</span>
+      </header>
 
       {%- if traceability_index.has_tags(document) -%}
       <div id="tags-outline">

--- a/strictdoc/export/html/templates/single_document_traceability/document.jinja.html
+++ b/strictdoc/export/html/templates/single_document_traceability/document.jinja.html
@@ -20,7 +20,9 @@
     </aside>
 
     <main class="content">
-      <h1 class="document-title">{{document.name}} <span class="document-view-type">Traceability</span></h1>
+      <header class="document-header">
+        {{document.name}} <span class="document-view-type">Traceability</span>
+      </header>
 
       {%- if traceability_index.has_tags(document) -%}
       <div id="tags-outline">
@@ -32,7 +34,7 @@
       </div>
       {%- endif %}
 
-      <div class="view-traceability" id="sections-and-requirements">
+      <article class="view-traceability" id="sections-and-requirements">
       {%- for section_or_requirement in document_iterator.all_content() %}
 
         {%- if section_or_requirement.is_requirement %}
@@ -96,7 +98,7 @@
         {%- endif %}
 
       {%- endfor %}
-      </div>
+      </article>
 
     </main>
   </div>

--- a/strictdoc/export/html/templates/single_document_traceability_deep/document.jinja.html
+++ b/strictdoc/export/html/templates/single_document_traceability_deep/document.jinja.html
@@ -22,7 +22,9 @@
       {% include "_shared/table_of_contents.jinja.html" %}
     </aside>
     <main class="content">
-      <h1 class="document-title">{{document.name}} <span class="document-view-type">Deep Traceability</span></h1>
+      <header class="document-header">
+        {{document.name}} <span class="document-view-type">Deep Traceability</span>
+      </header>
 
       {%- if traceability_index.has_tags(document) -%}
       <div id="tags-outline">
@@ -34,7 +36,7 @@
       </div>
       {%- endif %}
 
-      <div class="view-traceability-deep">
+      <article class="view-traceability-deep">
       {%- for section_or_requirement in document_iterator.all_content() %}
         {%- if section_or_requirement.is_requirement %}
         <section class="view-traceability-deep_row" id="{{ link_renderer.render(section_or_requirement) }}">
@@ -61,7 +63,7 @@
         </section>
         {%- endif %}
       {%- endfor %}
-      </div>
+      </article>
 
     </main>
   </div>


### PR DESCRIPTION
- sticky document header 
Closes #136 
- make TOC open on page load
- scroll to :target with highlighting
- add `<i>[no title]</i>` for requirements that don't have a title