### PR TITLE
minor: replace all FREE_TEXT with FREETEXT

### DIFF
--- a/docs/sphinx/source/strictdoc.rst
+++ b/docs/sphinx/source/strictdoc.rst
@@ -184,13 +184,13 @@ The following grammatical constructs are currently supported:
 
 - ``DOCUMENT``
 
-  - ``FREE_TEXT``
+  - ``FREETEXT``
 
 - ``REQUIREMENT`` and ``COMPOSITE_REQUIREMENT``
 
 - ``SECTION``
 
-  - ``FREE_TEXT``
+  - ``FREETEXT``
 
 Each construct is described in more detail below.
 

--- a/docs/strictdoc-html/strictdoc-html/docs/strictdoc-TABLE.html
+++ b/docs/strictdoc-html/strictdoc-html/docs/strictdoc-TABLE.html
@@ -876,12 +876,12 @@ into <tt class="docutils literal">[SECTION]</tt> blocks.</p>
 <p>The following grammatical constructs are currently supported:</p>
 <ul class="simple">
 <li><tt class="docutils literal">DOCUMENT</tt><ul>
-<li><tt class="docutils literal">FREE_TEXT</tt></li>
+<li><tt class="docutils literal">FREETEXT</tt></li>
 </ul>
 </li>
 <li><tt class="docutils literal">REQUIREMENT</tt> and <tt class="docutils literal">COMPOSITE_REQUIREMENT</tt></li>
 <li><tt class="docutils literal">SECTION</tt><ul>
-<li><tt class="docutils literal">FREE_TEXT</tt></li>
+<li><tt class="docutils literal">FREETEXT</tt></li>
 </ul>
 </li>
 </ul>

--- a/docs/strictdoc-html/strictdoc-html/docs/strictdoc-TRACE.html
+++ b/docs/strictdoc-html/strictdoc-html/docs/strictdoc-TRACE.html
@@ -927,12 +927,12 @@ into <tt class="docutils literal">[SECTION]</tt> blocks.</p>
 <p>The following grammatical constructs are currently supported:</p>
 <ul class="simple">
 <li><tt class="docutils literal">DOCUMENT</tt><ul>
-<li><tt class="docutils literal">FREE_TEXT</tt></li>
+<li><tt class="docutils literal">FREETEXT</tt></li>
 </ul>
 </li>
 <li><tt class="docutils literal">REQUIREMENT</tt> and <tt class="docutils literal">COMPOSITE_REQUIREMENT</tt></li>
 <li><tt class="docutils literal">SECTION</tt><ul>
-<li><tt class="docutils literal">FREE_TEXT</tt></li>
+<li><tt class="docutils literal">FREETEXT</tt></li>
 </ul>
 </li>
 </ul>

--- a/docs/strictdoc-html/strictdoc-html/docs/strictdoc.html
+++ b/docs/strictdoc-html/strictdoc-html/docs/strictdoc.html
@@ -863,12 +863,12 @@ into <tt class="docutils literal">[SECTION]</tt> blocks.</p>
 <p>The following grammatical constructs are currently supported:</p>
 <ul class="simple">
 <li><tt class="docutils literal">DOCUMENT</tt><ul>
-<li><tt class="docutils literal">FREE_TEXT</tt></li>
+<li><tt class="docutils literal">FREETEXT</tt></li>
 </ul>
 </li>
 <li><tt class="docutils literal">REQUIREMENT</tt> and <tt class="docutils literal">COMPOSITE_REQUIREMENT</tt></li>
 <li><tt class="docutils literal">SECTION</tt><ul>
-<li><tt class="docutils literal">FREE_TEXT</tt></li>
+<li><tt class="docutils literal">FREETEXT</tt></li>
 </ul>
 </li>
 </ul>

--- a/docs/strictdoc.sdoc
+++ b/docs/strictdoc.sdoc
@@ -230,13 +230,13 @@ The following grammatical constructs are currently supported:
 
 - ``DOCUMENT``
 
-  - ``FREE_TEXT``
+  - ``FREETEXT``
 
 - ``REQUIREMENT`` and ``COMPOSITE_REQUIREMENT``
 
 - ``SECTION``
 
-  - ``FREE_TEXT``
+  - ``FREETEXT``
 
 Each construct is described in more detail below.
 [/FREETEXT]


### PR DESCRIPTION
It looks like `FREETEXT` is the token expected by strictdoc parser but `FREE_TEXT` showed up a couple paces in the documentation

PS thank you to the group here for creating strictdoc. we have been experimenting with using it at https://github.com/nmfta-repo/vcr-experiment and it is a very nice system so far.