### PR TITLE
Windows path

### DIFF
--- a/strictdoc/core/document_meta.py
+++ b/strictdoc/core/document_meta.py
@@ -1,6 +1,7 @@
 from strictdoc.export.html.document_type import DocumentType
 import os
 
+
 class DocumentMeta:
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -17,8 +18,12 @@ class DocumentMeta:
         self.document_filename_base = os.path.normpath(document_filename_base)
         self.input_doc_full_path = os.path.normpath(input_doc_full_path)
         self.input_doc_rel_path = os.path.normpath(input_doc_dir_rel_path)
-        self.output_document_dir_full_path = os.path.normpath(output_document_dir_full_path)
-        self.output_document_dir_rel_path = os.path.normpath(output_document_dir_rel_path)
+        self.output_document_dir_full_path = os.path.normpath(
+            output_document_dir_full_path
+        )
+        self.output_document_dir_rel_path = os.path.normpath(
+            output_document_dir_rel_path
+        )
 
     # Paths
     def get_html_doc_path(self):

--- a/strictdoc/core/document_meta.py
+++ b/strictdoc/core/document_meta.py
@@ -1,5 +1,5 @@
 from strictdoc.export.html.document_type import DocumentType
-
+import os
 
 class DocumentMeta:
     def __init__(  # pylint: disable=too-many-arguments
@@ -13,12 +13,12 @@ class DocumentMeta:
         output_document_dir_rel_path,
     ):
         self.level = level
-        self.file_tree_mount_folder = file_tree_mount_folder
-        self.document_filename_base = document_filename_base
-        self.input_doc_full_path = input_doc_full_path
-        self.input_doc_rel_path = input_doc_dir_rel_path
-        self.output_document_dir_full_path = output_document_dir_full_path
-        self.output_document_dir_rel_path = output_document_dir_rel_path
+        self.file_tree_mount_folder = os.path.normpath(file_tree_mount_folder)
+        self.document_filename_base = os.path.normpath(document_filename_base)
+        self.input_doc_full_path = os.path.normpath(input_doc_full_path)
+        self.input_doc_rel_path = os.path.normpath(input_doc_dir_rel_path)
+        self.output_document_dir_full_path = os.path.normpath(output_document_dir_full_path)
+        self.output_document_dir_rel_path = os.path.normpath(output_document_dir_rel_path)
 
     # Paths
     def get_html_doc_path(self):

--- a/strictdoc/core/document_meta.py
+++ b/strictdoc/core/document_meta.py
@@ -1,5 +1,6 @@
-from strictdoc.export.html.document_type import DocumentType
 import os
+
+from strictdoc.export.html.document_type import DocumentType
 
 
 class DocumentMeta:

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -1,8 +1,9 @@
+import os
 from strictdoc.backend.sdoc.models.reference import Reference
 from strictdoc.backend.source_file_syntax.reader import (
     SourceFileTraceabilityInfo,
 )
-import os
+
 
 
 class FileTraceabilityIndex:

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -4,6 +4,7 @@ from strictdoc.backend.source_file_syntax.reader import (
 )
 import os
 
+
 class FileTraceabilityIndex:
     def __init__(self):
         self.map_paths_to_reqs = {}
@@ -18,7 +19,9 @@ class FileTraceabilityIndex:
         ref: Reference
         for ref in requirement.references:
             if ref.ref_type == "File":
-                requirements = self.map_paths_to_reqs.setdefault(os.path.normpath(ref.path), [])
+                requirements = self.map_paths_to_reqs.setdefault(
+                    os.path.normpath(ref.path), []
+                )
                 requirements.append(requirement)
 
                 paths = self.map_reqs_uids_to_paths.setdefault(

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -2,7 +2,7 @@ from strictdoc.backend.sdoc.models.reference import Reference
 from strictdoc.backend.source_file_syntax.reader import (
     SourceFileTraceabilityInfo,
 )
-
+import os
 
 class FileTraceabilityIndex:
     def __init__(self):
@@ -18,13 +18,13 @@ class FileTraceabilityIndex:
         ref: Reference
         for ref in requirement.references:
             if ref.ref_type == "File":
-                requirements = self.map_paths_to_reqs.setdefault(ref.path, [])
+                requirements = self.map_paths_to_reqs.setdefault(os.path.normpath(ref.path), [])
                 requirements.append(requirement)
 
                 paths = self.map_reqs_uids_to_paths.setdefault(
                     requirement.uid, []
                 )
-                paths.append(ref.path)
+                paths.append(os.path.normpath(ref.path))
 
     def get_requirement_file_links(self, requirement):
         if requirement.uid not in self.map_reqs_uids_to_paths:

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -5,7 +5,6 @@ from strictdoc.backend.source_file_syntax.reader import (
 )
 
 
-
 class FileTraceabilityIndex:
     def __init__(self):
         self.map_paths_to_reqs = {}

--- a/strictdoc/core/finders/source_files_finder.py
+++ b/strictdoc/core/finders/source_files_finder.py
@@ -80,7 +80,7 @@ class SourceFilesFinder:
             if os.path.isfile(doctree_root_abs_path)
             else doctree_root_abs_path
         )
-        #        doctree_root_abs_path =  os.path.normpath(os.path.join(doctree_root_abs_path, "../"))
+        # doctree_root_abs_path =  os.path.normpath(os.path.join(doctree_root_abs_path, "../"))
         doctree_root_abs_path = os.path.normpath(doctree_root_abs_path)
         doctree_root_mount_path = os.path.basename(doctree_root_abs_path)
 

--- a/strictdoc/core/finders/source_files_finder.py
+++ b/strictdoc/core/finders/source_files_finder.py
@@ -22,11 +22,11 @@ class SourceFile:  # pylint: disable=too-many-instance-attributes
         assert os.path.exists(full_path)
 
         self.level = level
-        self.full_path = full_path
-        self.doctree_root_mount_path = doctree_root_mount_path
-        self.in_doctree_source_file_rel_path = in_doctree_source_file_rel_path
-        self.output_dir_full_path = output_dir_full_path
-        self.output_file_full_path = output_file_full_path
+        self.full_path = os.path.normpath(full_path)
+        self.doctree_root_mount_path = os.path.normpath(doctree_root_mount_path)
+        self.in_doctree_source_file_rel_path = os.path.normpath(in_doctree_source_file_rel_path)
+        self.output_dir_full_path = os.path.normpath(output_dir_full_path)
+        self.output_file_full_path = os.path.normpath(output_file_full_path)
         self.path_depth_prefix = ("../" * (level + 2))[:-1]
 
         _, file_extension = os.path.splitext(in_doctree_source_file_rel_path)
@@ -78,6 +78,8 @@ class SourceFilesFinder:
             if os.path.isfile(doctree_root_abs_path)
             else doctree_root_abs_path
         )
+#        doctree_root_abs_path =  os.path.normpath(os.path.join(doctree_root_abs_path, "../"))
+        doctree_root_abs_path = os.path.normpath(doctree_root_abs_path)
         doctree_root_mount_path = os.path.basename(doctree_root_abs_path)
 
         file_tree = FileFinder.find_files_with_extensions(

--- a/strictdoc/core/finders/source_files_finder.py
+++ b/strictdoc/core/finders/source_files_finder.py
@@ -24,7 +24,9 @@ class SourceFile:  # pylint: disable=too-many-instance-attributes
         self.level = level
         self.full_path = os.path.normpath(full_path)
         self.doctree_root_mount_path = os.path.normpath(doctree_root_mount_path)
-        self.in_doctree_source_file_rel_path = os.path.normpath(in_doctree_source_file_rel_path)
+        self.in_doctree_source_file_rel_path = os.path.normpath(
+            in_doctree_source_file_rel_path
+        )
         self.output_dir_full_path = os.path.normpath(output_dir_full_path)
         self.output_file_full_path = os.path.normpath(output_file_full_path)
         self.path_depth_prefix = ("../" * (level + 2))[:-1]
@@ -78,7 +80,7 @@ class SourceFilesFinder:
             if os.path.isfile(doctree_root_abs_path)
             else doctree_root_abs_path
         )
-#        doctree_root_abs_path =  os.path.normpath(os.path.join(doctree_root_abs_path, "../"))
+        #        doctree_root_abs_path =  os.path.normpath(os.path.join(doctree_root_abs_path, "../"))
         doctree_root_abs_path = os.path.normpath(doctree_root_abs_path)
         doctree_root_mount_path = os.path.basename(doctree_root_abs_path)
 

--- a/strictdoc/export/html/renderers/link_renderer.py
+++ b/strictdoc/export/html/renderers/link_renderer.py
@@ -97,7 +97,7 @@ class LinkRenderer:
             f"/{source_file_link}.html"
         )
         source_file_link = os.path.normpath(source_file_link)
-       
+
         return source_file_link
 
     @staticmethod

--- a/strictdoc/export/html/renderers/link_renderer.py
+++ b/strictdoc/export/html/renderers/link_renderer.py
@@ -1,4 +1,5 @@
 import re
+import os
 from typing import Optional
 
 from strictdoc.backend.sdoc.models.document import Document
@@ -88,12 +89,15 @@ class LinkRenderer:
     ):
         document: Document = requirement.ng_document_reference.get_document()
         path_prefix = document.meta.get_root_path_prefix()
+
         source_file_link = (
             f"{path_prefix}"
             f"/_source_files"
             f"/{document.meta.file_tree_mount_folder}"
             f"/{source_file_link}.html"
         )
+        source_file_link = os.path.normpath(source_file_link)
+       
         return source_file_link
 
     @staticmethod
@@ -106,6 +110,7 @@ class LinkRenderer:
             f"/{document.meta.file_tree_mount_folder}"
             f"/{source_file_link}.html"
         )
+        source_file_link = os.path.normpath(source_file_link)
         return source_file_link
 
     @staticmethod
@@ -116,6 +121,7 @@ class LinkRenderer:
             f"/{source_file.doctree_root_mount_path}"
             f"/{source_file.in_doctree_source_file_rel_path}.html"
         )
+        source_file_link = os.path.normpath(source_file_link)
         return source_file_link
 
     @staticmethod
@@ -136,6 +142,7 @@ class LinkRenderer:
             f"/{document.meta.file_tree_mount_folder}"
             f"/{source_file_link}.html#"
         )
+        source_file_link = os.path.normpath(source_file_link)
         return source_file_link
 
     @staticmethod
@@ -159,6 +166,7 @@ class LinkRenderer:
             f"/{context_source_file.doctree_root_mount_path}"
             f"/{source_link}.html#{requirement.uid}"
         )
+        source_file_link = os.path.normpath(source_file_link)
         return source_file_link
 
     @staticmethod
@@ -186,6 +194,7 @@ class LinkRenderer:
             f"#{source_range.ng_range_line_begin}"
             f"#{source_range.ng_range_line_end}"
         )
+        source_file_link = os.path.normpath(source_file_link)
         return source_file_link
 
     def render_requirement_in_source_file_range_link(


### PR DESCRIPTION
Python should support Linux style path under Windows. 
As it turns out, this is only the case as long as the path string does not mix them, which occurs in the current implementation because path strings are dynamically built from different sources (user input, windows libs, files,...).