### PR TITLE
traceability: support linking Tex files to requirements 

### DIFF
--- a/strictdoc/core/finders/source_files_finder.py
+++ b/strictdoc/core/finders/source_files_finder.py
@@ -57,6 +57,9 @@ class SourceFile:  # pylint: disable=too-many-instance-attributes
     def is_cpp_file(self):
         return self.extension == ".cpp"
 
+    def is_tex_file(self):
+        return self.extension == ".tex"
+
 
 class SourceFilesFinder:
     @staticmethod
@@ -81,7 +84,7 @@ class SourceFilesFinder:
         doctree_root_mount_path = os.path.basename(doctree_root_abs_path)
 
         file_tree = FileFinder.find_files_with_extensions(
-            doctree_root_abs_path, config, {".py", ".c", ".cpp"}
+            doctree_root_abs_path, config, {".py", ".c", ".cpp", ".tex"}
         )
 
         root_level = doctree_root_abs_path.count(os.sep)

--- a/strictdoc/export/html/generators/source_file_view_generator.py
+++ b/strictdoc/export/html/generators/source_file_view_generator.py
@@ -3,6 +3,7 @@ from pygments import highlight
 from pygments.formatters.html import HtmlFormatter
 from pygments.lexers.c_cpp import CppLexer, CLexer
 from pygments.lexers.python import PythonLexer
+from pygments.lexers.markup import TexLexer
 
 from strictdoc.core.finders.source_files_finder import SourceFile
 from strictdoc.core.traceability_index import TraceabilityIndex
@@ -44,6 +45,8 @@ class SourceFileViewHTMLGenerator:
             lexer = CLexer()
         elif source_file.is_cpp_file():
             lexer = CppLexer()
+        elif source_file.is_tex_file():
+            lexer = TexLexer()
         else:
             assert NotImplementedError
 

--- a/tests/integration/commands/export/html/file_traceability/10_support_files_with_tex_extension/example.sdoc
+++ b/tests/integration/commands/export/html/file_traceability/10_support_files_with_tex_extension/example.sdoc
@@ -1,0 +1,18 @@
+[DOCUMENT]
+TITLE: Example: Traceability between requirements and source files
+
+[REQUIREMENT]
+UID: REQ-001
+REFS:
+- TYPE: File
+  VALUE: file.tex
+TITLE: Whole file reference
+STATEMENT: This requirement references the whole file.
+
+[REQUIREMENT]
+UID: REQ-002
+REFS:
+- TYPE: File
+  VALUE: file.tex
+TITLE: Source range reference
+STATEMENT: This requirement references a range in the file.

--- a/tests/integration/commands/export/html/file_traceability/10_support_files_with_tex_extension/file.tex
+++ b/tests/integration/commands/export/html/file_traceability/10_support_files_with_tex_extension/file.tex
@@ -1,0 +1,48 @@
+\documentclass[12pt]{article}
+\usepackage{lingmacros}
+\usepackage{tree-dvips}
+\begin{document}
+
+\section*{Notes for My Paper}
+
+Don't forget to include examples of topicalization.
+They look like this:
+
+{\small
+\enumsentence{Topicalization from sentential subject:\\ 
+\shortex{7}{a John$_i$ [a & kltukl & [el & 
+  {\bf l-}oltoir & er & ngii$_i$ & a Mary]]}
+{ & {\bf R-}clear & {\sc comp} & 
+  {\bf IR}.{\sc 3s}-love   & P & him & }
+{John, (it's) clear that Mary loves (him).}}
+}
+
+\subsection*{How to handle topicalization}
+
+I'll just assume a tree structure like (\ex{1}).
+
+{\small
+\enumsentence{Structure of A$'$ Projections:\\ [2ex]
+\begin{tabular}[t]{cccc}
+    & \node{i}{CP}\\ [2ex]
+    \node{ii}{Spec} &   &\node{iii}{C$'$}\\ [2ex]
+        &\node{iv}{C} & & \node{v}{SAgrP}
+\end{tabular}
+\nodeconnect{i}{ii}
+\nodeconnect{i}{iii}
+\nodeconnect{iii}{iv}
+\nodeconnect{iii}{v}
+}
+}
+
+% [REQ-002]
+\subsection*{Mood}
+
+Mood changes when there is a topic, as well as when
+there is WH-movement.  \emph{Irrealis} is the mood when
+there is a non-subject topic or WH-phrase in Comp.
+\emph{Realis} is the mood when there is a subject topic
+or WH-phrase.
+% [/REQ-002]
+
+\end{document}

--- a/tests/integration/commands/export/html/file_traceability/10_support_files_with_tex_extension/test.itest
+++ b/tests/integration/commands/export/html/file_traceability/10_support_files_with_tex_extension/test.itest
@@ -1,0 +1,10 @@
+RUN: %strictdoc export %S --experimental-enable-file-traceability --output-dir Output | filecheck %s --dump-input=fail
+CHECK: Published: Example: Traceability between requirements and source files
+
+RUN: %check_exists --file "%S/Output/html/_source_files/10_support_files_with_tex_extension/file.tex.html"
+
+RUN: cat %S/Output/html/10_support_files_with_tex_extension/example.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+CHECK-HTML: <a{{.*}}href="../_source_files/10_support_files_with_tex_extension/file.tex.html#REQ-001">
+
+RUN: cat %S/Output/html/_source_files/10_support_files_with_tex_extension/file.tex.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+CHECK-SOURCE-FILE: <a{{.*}}href="../../10_support_files_with_tex_extension/example.html#1-REQ-001"{{.*}}>


### PR DESCRIPTION
requirement references can now be added to latex files as comments. e.g. "% [REQ-001]"
