### PR TITLE
Code climate: improve css fix html rendering for ordered list

### DIFF
--- a/strictdoc/export/html/_static/_element.css
+++ b/strictdoc/export/html/_static/_element.css
@@ -111,3 +111,23 @@
   text-align: right;
   font-size: 0.75em;
 }
+
+ol.arabic {
+    list-style: decimal;
+}
+
+ol.loweralpha {
+    list-style: lower-alpha;
+}
+
+ol.upperalpha {
+    list-style: upper-alpha;
+}
+
+ol.lowerroman {
+    list-style: lower-roman;
+}
+
+ol.upperroman {
+    list-style: upper-roman;
+}


### PR DESCRIPTION
Improve `_element.css` by adding classes for correct html rendering of ordered non-numeral lists.
Fixes #653.