### PR TITLE
HTML export improvements

### DIFF
--- a/strictdoc/export/html/_static/_requirement.css
+++ b/strictdoc/export/html/_static/_requirement.css
@@ -278,6 +278,21 @@ dl.requirement_meta {
   background-color: var(--color-bg-main);
 }
 
+/* meta multiline list (next to comments/rationale) */
+
+.requirement_meta_multiline {
+  font-size: .9em;
+  font-style: italic;
+}
+
+.requirement_meta_multiline + .requirement_meta_multiline {
+  margin-top: var(--base-margin);
+}
+
+.requirement_meta_multiline_label {
+  font-weight: bold;
+}
+
 /* requirement: parent / child / file */
 
 ul.requirement_link {

--- a/strictdoc/export/html/renderers/markup_renderer.py
+++ b/strictdoc/export/html/renderers/markup_renderer.py
@@ -115,3 +115,13 @@ class MarkupRenderer:
         self.cache[(document_type, free_text)] = output
 
         return output
+
+    def render_meta_value(self, meta_field_value):
+        assert isinstance(meta_field_value, str)
+        if meta_field_value in self.cache:
+            return self.cache[meta_field_value]
+
+        output = self.fragment_writer.write(meta_field_value)
+        self.cache[meta_field_value] = output
+
+        return output

--- a/strictdoc/export/html/templates/_shared/requirement.jinja.html
+++ b/strictdoc/export/html/templates/_shared/requirement.jinja.html
@@ -21,6 +21,7 @@ data-status='{{ requirement.status.lower() }}'
 
     {% include "_shared/requirement_block/rationale.jinja.html" %}
     {% include "_shared/requirement_block/comment.jinja.html" %}
+    {% include "_shared/requirement_block/multi_line_metas.jinja.html" %}
 
   </section>
 

--- a/strictdoc/export/html/templates/_shared/requirement_block/h_title.jinja.html
+++ b/strictdoc/export/html/templates/_shared/requirement_block/h_title.jinja.html
@@ -1,5 +1,5 @@
 <h{{ requirement.ng_level }}
 class="section-title"
 data-level="{{ requirement.context.title_number_string }}"
->{{ requirement.title if requirement.title else '[no title]' }}
+>{{ requirement.title if requirement.title else (requirement.uid if requirement.uid else '[no title]') }}
 </h{{ requirement.ng_level }}>

--- a/strictdoc/export/html/templates/_shared/requirement_block/meta.jinja.html
+++ b/strictdoc/export/html/templates/_shared/requirement_block/meta.jinja.html
@@ -1,6 +1,6 @@
 {%- if requirement.has_meta -%}
   <dl class="requirement_meta">
-    {% for meta_field in requirement.enumerate_meta_fields() %}
+    {% for meta_field in requirement.enumerate_meta_fields(skip_multi_lines=True) %}
     <dt><i>{{meta_field[0]}}</i></dt>
     <dd>{{ meta_field[1] }}</dd>
     {% endfor %}

--- a/strictdoc/export/html/templates/_shared/requirement_block/multi_line_metas.jinja.html
+++ b/strictdoc/export/html/templates/_shared/requirement_block/multi_line_metas.jinja.html
@@ -1,0 +1,6 @@
+{%- if requirement.has_meta %}
+  {% for meta_field in requirement.enumerate_meta_fields(skip_single_lines=True) %}
+    <div class="requirement_meta_multiline_label">{{meta_field[0]}}:</div>
+    <div class="requirement_meta_multiline">{{ renderer.render_meta_value(meta_field[1]) }}</div>
+  {%- endfor %}
+{%- endif %}

--- a/strictdoc/export/html/templates/_shared/requirement_block/related.jinja.html
+++ b/strictdoc/export/html/templates/_shared/requirement_block/related.jinja.html
@@ -6,7 +6,7 @@
       {%- if requirement.uid %}
       <span class="requirement_parent-uid">{{ requirement.uid }}</span>
       {%- endif %}
-      {{ requirement.title }}
+      {{ requirement.title if requirement.title else "" }}
     </a>
   </li>
   {%- endfor %}
@@ -21,7 +21,7 @@
       {%- if requirement.uid %}
       <span class="requirement_child-uid">{{ requirement.uid }}</span>
       {%- endif %}
-      {{ requirement.title }}
+      {{ requirement.title if requirement.title else "" }}
     </a>
   </li>
   {%- endfor %}


### PR DESCRIPTION
1. don't use [no title] when there is a UID (but still no title)
2. don't link to 'UID None' when there is a UID (but still no title)
3. render really long meta fields next to rationale and comments

example before:
![image](https://user-images.githubusercontent.com/243321/166931935-37504cf7-2bfd-43e9-a036-48edf8349725.png)

example after:
![image](https://user-images.githubusercontent.com/243321/166931993-816ccf3b-bc81-42d3-943a-a45db383d120.png)
