### PR TITLE
tests/integration: move away from a grep-based test

### DIFF
--- a/tests/integration/commands/export/html/file_traceability/05_multiple_files_per_requirement/test.itest
+++ b/tests/integration/commands/export/html/file_traceability/05_multiple_files_per_requirement/test.itest
@@ -9,7 +9,7 @@ CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001">
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: <a{{.*}}href="../05_multiple_files_per_requirement/input.html#1-REQ-001"{{.*}}>
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | grep "Requirement Title" | filecheck %s --dump-input=fail --check-prefix CHECK-NO-DUPLICATES
-RUN: %cat %S/Output/html/_source_files/file2.py.html | grep "Requirement Title" | filecheck %s --dump-input=fail --check-prefix CHECK-NO-DUPLICATES
+RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-NO-DUPLICATES
+RUN: %cat %S/Output/html/_source_files/file2.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-NO-DUPLICATES
 CHECK-NO-DUPLICATES: Requirement Title
-CHECK-NO-DUPLICATES-EMPTY:
+CHECK-NO-DUPLICATES-NOT: Requirement Title


### PR DESCRIPTION
Because it is not portable