### PR TITLE
export/HTML: Fixing left panel (TOC) behavior

### DIFF
--- a/strictdoc/export/html/_static/_layout.css
+++ b/strictdoc/export/html/_static/_layout.css
@@ -222,7 +222,7 @@ body[data-state="open"] .layout {
   margin-left: 0;
 }
 
-body[data-state="close"] .layout {
+body[data-state="close"].withtoc .layout {
   margin-left: calc(var(--toc-width) * (-1));
 }
 

--- a/strictdoc/export/html/templates/base.jinja.html
+++ b/strictdoc/export/html/templates/base.jinja.html
@@ -25,7 +25,7 @@
   {% endblock head %}
 </head>
 
-<body class="{% block viewtype %}{% endblock %}">
+<body class="{% block viewtype %}{% endblock %} {% block withtoc %}{% endblock %}">
 <script>document.body.dataset.state = sessionStorage.getItem('tocState') || 'open';</script>
 
   <div class="layout" id="layout">

--- a/strictdoc/export/html/templates/single_document/document.jinja.html
+++ b/strictdoc/export/html/templates/single_document/document.jinja.html
@@ -11,6 +11,7 @@
 {% endblock head_scripts %}
 {% block title %}{{document.name}} - {{ template_type }}{% endblock title %}
 {% block viewtype %}document-view{% endblock %}
+{% block withtoc %}withtoc{% endblock %}
 
 {% block layout_nav %}
   {% include "_shared/doc_nav.jinja.html" %}

--- a/strictdoc/export/html/templates/single_document_table/document.jinja.html
+++ b/strictdoc/export/html/templates/single_document_table/document.jinja.html
@@ -11,6 +11,7 @@
 {% endblock head_scripts %}
 {% block title %}{{document.name}} - {{ template_type }}{% endblock %}
 {% block viewtype %}table-view{% endblock %}
+{% block withtoc %}withtoc{% endblock %}
 
 {% block layout_nav %}
   {% include "_shared/doc_nav.jinja.html" %}

--- a/strictdoc/export/html/templates/single_document_traceability/document.jinja.html
+++ b/strictdoc/export/html/templates/single_document_traceability/document.jinja.html
@@ -16,6 +16,7 @@
 {% endblock head_scripts %}
 {% block title %}{{document.name}} - {{ template_type }}{% endblock %}
 {% block viewtype %}traceability-view{% endblock %}
+{% block withtoc %}withtoc{% endblock %}
 
 {% block layout_nav %}
   {% include "_shared/doc_nav.jinja.html" %}

--- a/strictdoc/export/html/templates/single_document_traceability_deep/document.jinja.html
+++ b/strictdoc/export/html/templates/single_document_traceability_deep/document.jinja.html
@@ -19,6 +19,7 @@
 {% endblock head_scripts %}
 {% block title %}{{document.name}} - {{ template_type }}{% endblock %}
 {% block viewtype %}deep-traceability-view{% endblock %}
+{% block withtoc %}withtoc{% endblock %}
 
 {% block layout_nav %}
   {% include "_shared/doc_nav.jinja.html" %}


### PR DESCRIPTION
Fixing left panel (TOC) behavior (does not inherit "open-closed" status on pages without a corresponding control)