### PR TITLE
Use raw directive for tex instead of double escaping

### DIFF
--- a/docs/strictdoc-1-user-manual.sdoc
+++ b/docs/strictdoc-1-user-manual.sdoc
@@ -1000,11 +1000,13 @@ Example of using Mathjax:
 .. code-block:: text
 
     [FREETEXT]
-    $$
-    \\mathbf{\\underline{k}}_{\\text{a}} =
-    \\mathbf{\\underline{i}}_{\\text{a}} \\times
-    \\mathbf{\\underline{j}}_{\\text{a}}
-    $$
+    .. raw:: latex html
+        $$
+        \mathbf{\underline{k}}_{\text{a}} =
+        \mathbf{\underline{i}}_{\text{a}} \times
+        \mathbf{\underline{j}}_{\text{a}}
+        $$
+
     [/FREETEXT]
 [/FREETEXT]
 

--- a/tests/integration/examples/06_mathjax/example.sdoc
+++ b/tests/integration/examples/06_mathjax/example.sdoc
@@ -11,12 +11,14 @@ The ``--enable-mathjax`` option must be provided as follows:
     strictdoc export . --enable-mathjax --output-dir Output
 
 MathJax in FREETEXT:
+.. raw:: latex html
 
-$$
-\\mathbf{\\underline{k}}_{\\text{a}} =
-\\mathbf{\\underline{i}}_{\\text{a}} \\times
-\\mathbf{\\underline{j}}_{\\text{a}}
-$$
+    $$
+    \mathbf{\underline{k}}_{\text{a}} =
+    \mathbf{\underline{i}}_{\text{a}} \times
+    \mathbf{\underline{j}}_{\text{a}}
+    $$
+
 [/FREETEXT]
 
 [REQUIREMENT]
@@ -25,9 +27,12 @@ TITLE: Requirement #1 title
 STATEMENT: >>>
 MathJax in requirement's STATEMENT:
 
-$$
-\\mathbf{\\underline{k}}_{\\text{a}} =
-\\mathbf{\\underline{i}}_{\\text{a}} \\times
-\\mathbf{\\underline{j}}_{\\text{a}}
-$$
+.. raw:: latex html
+
+    $$
+    \mathbf{\underline{k}}_{\text{a}} =
+    \mathbf{\underline{i}}_{\text{a}} \times
+    \mathbf{\underline{j}}_{\text{a}}
+    $$
+
 <<<


### PR DESCRIPTION
I am coming back to using strictdoc after a wee while away. I remembered that when I added MathJax support in #444, the examples I added required double escaping backslashes in the LaTex.

This was quite annoying, and when I started using strictdoc again this week I decided I'd like to improve it. While investigating this, I realised I should probably learn a bit more about reStructuredText, and discovered the [raw directive](https://docutils.sourceforge.io/docs/ref/rst/directives.html#raw-data-pass-through) which works really well for using latex.

I've updated the examples that use tex to reflect this.