### PR TITLE
backend/sdoc/grammar: Add GRAMMAR for REFS-TypeValue variant

### DIFF
--- a/strictdoc/backend/reqif/export/sdoc_to_reqif_converter.py
+++ b/strictdoc/backend/reqif/export/sdoc_to_reqif_converter.py
@@ -45,6 +45,7 @@ from strictdoc.backend.sdoc.models.type_system import (
     GrammarElementFieldMultipleChoice,
     RequirementFieldName,
     ReferenceType,
+    GrammarElementFieldReference,
 )
 from strictdoc.backend.sdoc.writer import SDWriter
 from strictdoc.core.document_iterator import DocumentCachingIterator
@@ -158,6 +159,24 @@ class SDocToReqIFObjectConverter:
                         data_types.append(data_type)
                         data_types_lookup[
                             StrictDocReqIFTypes.MULTI_CHOICE.value
+                        ] = data_type.identifier
+                    elif isinstance(field, GrammarElementFieldReference):
+                        # TODO: implement correct reqIF Encoding for
+                        #  GrammarElementFieldReference. Treat as
+                        #  GrammarElementFieldString for now.
+                        if (
+                            StrictDocReqIFTypes.SINGLE_LINE_STRING.value
+                            in data_types_lookup
+                        ):
+                            continue
+                        data_type = ReqIFDataTypeDefinitionString.create(
+                            identifier=(
+                                StrictDocReqIFTypes.SINGLE_LINE_STRING.value
+                            ),
+                        )
+                        data_types.append(data_type)
+                        data_types_lookup[
+                            StrictDocReqIFTypes.SINGLE_LINE_STRING.value
                         ] = data_type.identifier
                     else:
                         raise NotImplementedError(field) from None
@@ -479,6 +498,22 @@ class SDocToReqIFObjectConverter:
                         long_name=field.title,
                         multi_valued=True,
                     )
+                elif isinstance(field, GrammarElementFieldReference):
+                    # TODO: implement correct reqIF Encoding for
+                    #  GrammarElementFieldReference. Treat as
+                    #  GrammarElementFieldString for now.
+                    field_title = field.title
+                    if field_title in SDocRequirementReservedField.SET:
+                        field_title = SDOC_TO_REQIF_FIELD_MAP[field_title]
+                    attribute = SpecAttributeDefinition.create(
+                        attribute_type=SpecObjectAttributeType.STRING,
+                        identifier=field_title,
+                        datatype_definition=(
+                            StrictDocReqIFTypes.SINGLE_LINE_STRING.value
+                        ),
+                        long_name=field_title,
+                    )
+
                 else:
                     raise NotImplementedError(field) from None
                 attribute_definitions.append(attribute)

--- a/strictdoc/backend/sdoc/error_handling.py
+++ b/strictdoc/backend/sdoc/error_handling.py
@@ -2,6 +2,7 @@ from strictdoc.backend.sdoc.models.document_grammar import (
     DocumentGrammar,
     GrammarElementField,
 )
+from strictdoc.backend.sdoc.models.reference import Reference
 from strictdoc.backend.sdoc.models.requirement import (
     Requirement,
     RequirementField,
@@ -229,6 +230,36 @@ class StrictDocSemanticError(Exception):
                 f"{requirement_field.field_value}"
             ),
             hint="Tag field requires ', '-separated values.",
+            example=None,
+            line=line,
+            col=col,
+            filename=filename,
+        )
+
+    @staticmethod
+    def invalid_reference_type_item(  # pylint: disable=too-many-arguments
+        requirement: Requirement,
+        document_grammar: DocumentGrammar,
+        requirement_field: RequirementField,
+        reference_item: Reference,
+        line=None,
+        col=None,
+        filename=None,
+    ):
+        return StrictDocSemanticError(
+            title=(
+                f"Requirement field of type Reference has an unsupported"
+                f" Reference Type item: "
+                f"{reference_item}"
+            ),
+            hint=(
+                f"Problematic field: {requirement_field.field_name}. "
+                f"Compare with the document grammar: "
+                f"["
+                f"{document_grammar.dump_fields(requirement.requirement_type)}"
+                f"] "
+                f"for type: {requirement.requirement_type}"
+            ),
             example=None,
             line=line,
             col=col,

--- a/strictdoc/backend/sdoc/grammar/grammar.py
+++ b/strictdoc/backend/sdoc/grammar/grammar.py
@@ -56,7 +56,8 @@ GrammarElementField[noskipws]:
   GrammarElementFieldString |
   GrammarElementFieldSingleChoice |
   GrammarElementFieldMultipleChoice |
-  GrammarElementFieldTag
+  GrammarElementFieldTag |
+  GrammarElementFieldReference
 ;
 
 GrammarElementFieldString[noskipws]:
@@ -83,6 +84,21 @@ GrammarElementFieldTag[noskipws]:
   '  - TITLE: ' title=FieldName '\n'
   '    TYPE: Tag' '\n'
   '    REQUIRED: ' (required = BooleanChoice) '\n'
+;
+
+GrammarElementFieldReference[noskipws]:
+  '  - TITLE: ' title=FieldName '\n'
+  '    TYPE: Reference'
+    '(' ((types = ReferenceType) (types *= ReferenceTypeXs)) ')' '\n'
+  '    REQUIRED: ' (required = BooleanChoice) '\n'
+;
+
+ReferenceType[noskipws]:
+  ('ParentReqReference' | 'FileReference')
+;
+
+ReferenceTypeXs[noskipws]:
+  /, /- ReferenceType
 ;
 
 BooleanChoice[noskipws]:

--- a/strictdoc/backend/sdoc/models/constants.py
+++ b/strictdoc/backend/sdoc/models/constants.py
@@ -24,6 +24,7 @@ from strictdoc.backend.sdoc.models.type_system import (
     GrammarElementFieldSingleChoice,
     GrammarElementFieldMultipleChoice,
     GrammarElementFieldTag,
+    GrammarElementFieldReference,
 )
 
 SECTION_MODELS = [
@@ -49,6 +50,7 @@ DOCUMENT_MODELS = [
     GrammarElementFieldSingleChoice,
     GrammarElementFieldMultipleChoice,
     GrammarElementFieldTag,
+    GrammarElementFieldReference,
 ]
 DOCUMENT_MODELS.extend(SECTION_MODELS)
 

--- a/strictdoc/backend/sdoc/models/document_grammar.py
+++ b/strictdoc/backend/sdoc/models/document_grammar.py
@@ -5,6 +5,8 @@ from strictdoc.backend.sdoc.models.type_system import (
     GrammarElementFieldString,
     RequirementFieldName,
     RESERVED_NON_META_FIELDS,
+    GrammarElementFieldReference,
+    GrammarReferenceType,
 )
 
 
@@ -84,8 +86,14 @@ class DocumentGrammar:
             GrammarElementFieldString(
                 parent=None, title=RequirementFieldName.TAGS, required="False"
             ),
-            GrammarElementFieldString(
-                parent=None, title=RequirementFieldName.REFS, required="False"
+            GrammarElementFieldReference(
+                parent=None,
+                title=RequirementFieldName.REFS,
+                types=[
+                    GrammarReferenceType.PARENT_REQ_REFERENCE,
+                    GrammarReferenceType.FILE_REFERENCE,
+                ],
+                required="False",
             ),
             GrammarElementFieldString(
                 parent=None,

--- a/strictdoc/backend/sdoc/models/reference.py
+++ b/strictdoc/backend/sdoc/models/reference.py
@@ -22,7 +22,12 @@ class FileReference(Reference):
         self.path_normalized = os.path.normpath(path_forward_slashes)
 
     def __str__(self):
-        raise NotImplementedError
+        return (
+            f"FileReference(ref_type = {self.ref_type},"
+            f" path = {self.path},"
+            f" path_forward_slashes = {self.path_forward_slashes},"
+            f" path_normalized = {self.path_normalized})"
+        )
 
 
 class ParentReqReference(Reference):

--- a/strictdoc/backend/sdoc/models/type_system.py
+++ b/strictdoc/backend/sdoc/models/type_system.py
@@ -28,17 +28,28 @@ class RequirementFieldType:
     SINGLE_CHOICE = "SingleChoice"
     MULTIPLE_CHOICE = "MultipleChoice"
     TAG = "Tag"
-    TYPE_VALUE = "TypeValue"
+    REFERENCE = "Reference"
+
+
+class GrammarReferenceType:
+    PARENT_REQ_REFERENCE = "ParentReqReference"
+    FILE_REFERENCE = "FileReference"
 
 
 class ReferenceType:
     PARENT = "Parent"
     FILE = "File"
 
+    GRAMMAR_REFERENCE_TYPE_MAP = {
+        PARENT: GrammarReferenceType.PARENT_REQ_REFERENCE,
+        FILE: GrammarReferenceType.FILE_REFERENCE,
+    }
+
 
 class GrammarElementField:
     def __init__(self):
         self.title: str = ""
+        self.gef_type: str = ""
         self.required: bool = False
 
 
@@ -47,6 +58,7 @@ class GrammarElementFieldString(GrammarElementField):
         super().__init__()
         self.parent = parent
         self.title: str = title
+        self.gef_type = RequirementFieldType.STRING
         self.required: bool = required == "True"
 
     def __str__(self):
@@ -54,6 +66,7 @@ class GrammarElementFieldString(GrammarElementField):
             "GrammarElementFieldString("
             f"parent: {self.parent}, "
             f"title: {self.title}, "
+            f"gef_type: {self.gef_type}, "
             f"required: {self.required}"
             ")"
         )
@@ -64,8 +77,19 @@ class GrammarElementFieldSingleChoice(GrammarElementField):
         super().__init__()
         self.parent = parent
         self.title: str = title
+        self.gef_type = RequirementFieldType.SINGLE_CHOICE
         self.options: List[str] = options
         self.required: bool = required == "True"
+
+    def __str__(self):
+        return (
+            "GrammarElementFieldSingleChoice("
+            f"parent: {self.parent}, "
+            f"title: {self.title}, "
+            f"gef_type: {self.gef_type}({', '.join(self.options)}), "
+            f"required: {self.required}"
+            ")"
+        )
 
 
 class GrammarElementFieldMultipleChoice(GrammarElementField):
@@ -73,8 +97,19 @@ class GrammarElementFieldMultipleChoice(GrammarElementField):
         super().__init__()
         self.parent = parent
         self.title: str = title
+        self.gef_type = RequirementFieldType.MULTIPLE_CHOICE
         self.options: List[str] = options
         self.required: bool = required == "True"
+
+    def __str__(self):
+        return (
+            "GrammarElementFieldMultipleChoice("
+            f"parent: {self.parent}, "
+            f"title: {self.title}, "
+            f"gef_type: {self.gef_type}({', '.join(self.options)}), "
+            f"required: {self.required}"
+            ")"
+        )
 
 
 class GrammarElementFieldTag(GrammarElementField):
@@ -82,4 +117,35 @@ class GrammarElementFieldTag(GrammarElementField):
         super().__init__()
         self.parent = parent
         self.title: str = title
+        self.gef_type = RequirementFieldType.TAG
         self.required: bool = required == "True"
+
+    def __str__(self):
+        return (
+            "GrammarElementFieldTag("
+            f"parent: {self.parent}, "
+            f"title: {self.title}, "
+            f"gef_type: {self.gef_type}, "
+            f"required: {self.required}"
+            ")"
+        )
+
+
+class GrammarElementFieldReference(GrammarElementField):
+    def __init__(self, parent, title: str, types: List[str], required: str):
+        super().__init__()
+        self.parent = parent
+        self.gef_type = RequirementFieldType.REFERENCE
+        self.title: str = title
+        self.types: List[str] = types
+        self.required: bool = required == "True"
+
+    def __str__(self):
+        return (
+            "GrammarElementFieldReference("
+            f"parent: {self.parent}, "
+            f"title: {self.title}, "
+            f"gef_type: {self.gef_type}({', '.join(self.types)}), "
+            f"required: {self.required}"
+            ")"
+        )

--- a/strictdoc/backend/sdoc/validations/requirement.py
+++ b/strictdoc/backend/sdoc/validations/requirement.py
@@ -17,7 +17,9 @@ from strictdoc.backend.sdoc.models.type_system import (
     GrammarElementFieldSingleChoice,
     GrammarElementFieldMultipleChoice,
     GrammarElementFieldTag,
+    GrammarElementFieldReference,
     RequirementFieldName,
+    ReferenceType,
 )
 
 
@@ -159,4 +161,24 @@ def validate_requirement_field(
                 requirement_field=requirement_field,
                 **get_location(requirement),
             )
+
+    elif isinstance(grammar_field, GrammarElementFieldReference):
+        requirement_field_value_references = (
+            requirement_field.field_value_references
+        )
+        for reference in requirement_field_value_references:
+            if (
+                reference.ref_type in ReferenceType.GRAMMAR_REFERENCE_TYPE_MAP
+                and ReferenceType.GRAMMAR_REFERENCE_TYPE_MAP[reference.ref_type]
+                in grammar_field.types
+            ):
+                continue
+            raise StrictDocSemanticError.invalid_reference_type_item(
+                requirement=requirement,
+                document_grammar=document_grammar,
+                requirement_field=requirement_field,
+                reference_item=reference,
+                **get_location(requirement),
+            )
+
     return True

--- a/strictdoc/backend/sdoc/writer.py
+++ b/strictdoc/backend/sdoc/writer.py
@@ -13,6 +13,7 @@ from strictdoc.backend.sdoc.models.type_system import (
     GrammarElementFieldSingleChoice,
     GrammarElementFieldMultipleChoice,
     GrammarElementFieldTag,
+    GrammarElementFieldReference,
     RequirementFieldType,
 )
 from strictdoc.core.document_iterator import DocumentCachingIterator
@@ -258,6 +259,11 @@ class SDWriter:
             output += ")"
         elif isinstance(grammar_field, GrammarElementFieldTag):
             output += RequirementFieldType.TAG
+        elif isinstance(grammar_field, GrammarElementFieldReference):
+            output += RequirementFieldType.REFERENCE
+            output += "("
+            output += ", ".join(grammar_field.types)
+            output += ")"
         else:
             raise NotImplementedError from None
 

--- a/tests/integration/backend/excel/import/01_import_basic_e2e/expected/expected.sdoc
+++ b/tests/integration/backend/excel/import/01_import_basic_e2e/expected/expected.sdoc
@@ -18,7 +18,7 @@ ELEMENTS:
     TYPE: String
     REQUIRED: False
   - TITLE: REFS
-    TYPE: String
+    TYPE: Reference(ParentReqReference, FileReference)
     REQUIRED: False
   - TITLE: TITLE
     TYPE: String

--- a/tests/integration/per_document_grammar/validation/06_gef_reference_type_not_allowed/input.sdoc
+++ b/tests/integration/per_document_grammar/validation/06_gef_reference_type_not_allowed/input.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test Doc
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: LOW_LEVEL_REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: True
+  - TITLE: REFS
+    TYPE: Reference(ParentReqReference)
+    REQUIRED: False
+
+[LOW_LEVEL_REQUIREMENT]
+UID: ID-001
+
+[LOW_LEVEL_REQUIREMENT]
+UID: ID-002
+REFS:
+- TYPE: Parent
+  VALUE: ID-001
+- TYPE: File
+  VALUE: /tmp/sample1.cpp

--- a/tests/integration/per_document_grammar/validation/06_gef_reference_type_not_allowed/test.itest
+++ b/tests/integration/per_document_grammar/validation/06_gef_reference_type_not_allowed/test.itest
@@ -1,0 +1,7 @@
+RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+
+CHECK:error: could not parse file: {{.*}}input.sdoc.
+CHECK: Semantic error: Requirement field of type Reference has an unsupported Reference Type item: FileReference(ref_type = File, path = /tmp/sample1.cpp, path_forward_slashes = /tmp/sample1.cpp, path_normalized = {{[\/\\]tmp[\/\\]sample1.cpp}})
+CHECK:Location: {{.*}}input.sdoc:18:1
+CHECK:Hint: Problematic field: REFS. Compare with the document grammar: [UID, REFS] for type: LOW_LEVEL_REQUIREMENT
+CHECK:error: Parallelizer: One of the child processes has exited prematurely.

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_grammars.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_grammars.py
@@ -33,7 +33,7 @@ ELEMENTS:
     TYPE: String
     REQUIRED: False
   - TITLE: REFS
-    TYPE: String
+    TYPE: Reference(ParentReqReference, FileReference)
     REQUIRED: False
   - TITLE: TITLE
     TYPE: String


### PR DESCRIPTION
Adding ParentReqReference and FileReference TypeValue-Grammar for GRAMMAR-REFS instead of String.
Note: Adding new ExternalReference and updating the Documentation will be done in a separate step.