### PR TITLE
backend/sdoc/grammar: Add optional DocumentConfig CLASSIFICATION field

### DIFF
--- a/strictdoc/backend/excel/import_/excel_to_sdoc_converter.py
+++ b/strictdoc/backend/excel/import_/excel_to_sdoc_converter.py
@@ -125,15 +125,7 @@ class ExcelToSDocConverter:
 
     @staticmethod
     def create_document(title: Optional[str], extra_header_pairs) -> Document:
-        document_config = DocumentConfig(
-            parent=None,
-            version=None,
-            uid=None,
-            markup=None,
-            auto_levels=None,
-            requirement_style=None,
-            requirement_in_toc=None,
-        )
+        document_config = DocumentConfig.default_config(None)
         document_title = title if title else "<No title>"
         document = Document(document_title, document_config, None, [], [])
 

--- a/strictdoc/backend/reqif/import_/reqif_to_sdoc_factory.py
+++ b/strictdoc/backend/reqif/import_/reqif_to_sdoc_factory.py
@@ -24,15 +24,7 @@ from strictdoc.helpers.string import unescape
 class ReqIFToSDocFactory:
     @staticmethod
     def create_document(title: Optional[str]) -> Document:
-        document_config = DocumentConfig(
-            parent=None,
-            version=None,
-            uid=None,
-            markup=None,
-            auto_levels=None,
-            requirement_style=None,
-            requirement_in_toc=None,
-        )
+        document_config = DocumentConfig.default_config(None)
         document_title = title if title else "<No title>"
         document = Document(document_title, document_config, None, [], [])
         document.grammar = DocumentGrammar.create_default(document)

--- a/strictdoc/backend/sdoc/grammar/grammar.py
+++ b/strictdoc/backend/sdoc/grammar/grammar.py
@@ -64,6 +64,7 @@ BooleanChoice[noskipws]:
 DocumentConfig[noskipws]:
   ('UID: ' uid = /.*$/ '\n')?
   ('VERSION: ' version = /.*$/ '\n')?
+  ('CLASSIFICATION: ' classification = /.*$/ '\n')?
 
   ('OPTIONS:' '\n'
     ('  MARKUP: ' (markup = MarkupChoice) '\n')?

--- a/strictdoc/backend/sdoc/models/document_config.py
+++ b/strictdoc/backend/sdoc/models/document_config.py
@@ -8,6 +8,7 @@ class DocumentConfig:  # pylint: disable=too-many-instance-attributes
             parent=document,
             version=None,
             uid=None,
+            classification=None,
             markup=None,
             auto_levels=None,
             requirement_style=None,
@@ -20,6 +21,7 @@ class DocumentConfig:  # pylint: disable=too-many-instance-attributes
         parent,
         version: Optional[str],
         uid: Optional[str],
+        classification: Optional[str],
         markup: Optional[str],
         auto_levels: Optional[str],
         requirement_style: Optional[str],
@@ -28,6 +30,7 @@ class DocumentConfig:  # pylint: disable=too-many-instance-attributes
         self.parent = parent
         self.version: Optional[str] = version
         self.uid: Optional[str] = uid
+        self.classification: Optional[str] = classification
         self.markup = markup
         self.auto_levels: bool = auto_levels is None or auto_levels == "On"
         self.requirement_style: Optional[str] = requirement_style
@@ -50,4 +53,17 @@ class DocumentConfig:  # pylint: disable=too-many-instance-attributes
         # This issue might deserve a bug report to TextX.
         return (self.uid is not None and len(self.uid) > 0) or (
             self.version is not None and len(self.version) > 0
+        )
+
+    def __str__(self):
+        return (
+            f"{self.__class__.__name__}("
+            f"version: {self.version}, "
+            f"uid: {self.uid}, "
+            f"classification: {self.classification}, "
+            f"markup: {self.markup}, "
+            f"auto_levels: {self.auto_levels}, "
+            f"requirement_style: {self.requirement_style}, "
+            f"requirement_in_toc: {self.requirement_in_toc}, "
+            ")"
         )

--- a/strictdoc/backend/sdoc/writer.py
+++ b/strictdoc/backend/sdoc/writer.py
@@ -41,14 +41,19 @@ class SDWriter:
 
         document_config: DocumentConfig = document.config
         if document_config:
+            uid = document_config.uid
+            if uid:
+                output += f"UID: {uid}"
+                output += "\n"
+
             version = document_config.version
             if version:
                 output += f"VERSION: {version}"
                 output += "\n"
 
-            uid = document_config.uid
-            if uid:
-                output += f"UID: {uid}"
+            classification = document_config.classification
+            if classification:
+                output += f"CLASSIFICATION: {classification}"
                 output += "\n"
 
             markup = document_config.markup

--- a/strictdoc/export/html/templates/single_document/document.jinja.html
+++ b/strictdoc/export/html/templates/single_document/document.jinja.html
@@ -54,6 +54,16 @@
             </td>
           </tr>
           {%- endif -%}
+          {%- if document.config.classification -%}
+          <tr>
+            <th>
+              CLASSIFICATION:
+            </th>
+            <td>
+              {{document.config.classification}}
+            </td>
+          </tr>
+          {%- endif -%}
         </table>
       </div>
     {%- endif -%}

--- a/strictdoc/export/html/templates/single_document_table/document.jinja.html
+++ b/strictdoc/export/html/templates/single_document_table/document.jinja.html
@@ -62,6 +62,16 @@
             </td>
           </tr>
           {%- endif -%}
+          {%- if document.config.classification -%}
+          <tr>
+            <th>
+              CLASSIFICATION:
+            </th>
+            <td>
+              {{document.config.classification}}
+            </td>
+          </tr>
+          {%- endif -%}
         </table>
       </div>
       {%- endif -%}

--- a/tests/unit/helpers/test_document_builder.py
+++ b/tests/unit/helpers/test_document_builder.py
@@ -61,6 +61,7 @@ class DocumentBuilder:
             parent=None,
             version="0.0.1",
             uid="DOC-1",
+            classification=None,
             markup=None,
             auto_levels=None,
             requirement_style=None,

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
@@ -3,6 +3,7 @@ from strictdoc.backend.sdoc.models.requirement import (
     Requirement,
     CompositeRequirement,
 )
+from strictdoc.backend.sdoc.models.section import Section
 from strictdoc.backend.sdoc.reader import SDReader
 from strictdoc.backend.sdoc.writer import SDWriter
 
@@ -619,6 +620,87 @@ REFS:
 
     document: Document = reader.read(input)
     assert document.config.uid == "SDOC-01"
+
+    writer = SDWriter()
+    output = writer.write(document)
+
+    assert input == output
+
+
+def test_072_document_config_classification():
+    input = """
+[DOCUMENT]
+TITLE: Test Doc
+UID: SDOC-01
+VERSION: 0.0.1
+CLASSIFICATION: Restricted
+
+[REQUIREMENT]
+REFS:
+- TYPE: File
+  VALUE: /tmp/sample.cpp
+""".lstrip()
+
+    reader = SDReader()
+
+    document = reader.read(input)
+    assert isinstance(document, Document)
+
+    document: Document = reader.read(input)
+    assert document.config.classification == "Restricted"
+
+    writer = SDWriter()
+    output = writer.write(document)
+
+    assert input == output
+
+
+def test_090_document_config_all_fields():
+    input = """
+[DOCUMENT]
+TITLE: Test Doc
+UID: SDOC-01
+VERSION: 0.0.1
+CLASSIFICATION: Restricted
+OPTIONS:
+  MARKUP: Text
+  AUTO_LEVELS: Off
+  REQUIREMENT_STYLE: Table
+  REQUIREMENT_IN_TOC: True
+
+[SECTION]
+LEVEL: 123
+TITLE: "Section"
+
+[REQUIREMENT]
+LEVEL: 456
+STATEMENT: ABC
+
+[/SECTION]
+""".lstrip()
+
+    reader = SDReader()
+
+    document = reader.read(input)
+    assert isinstance(document, Document)
+
+    document: Document = reader.read(input)
+    assert document.title == "Test Doc"
+    assert document.config.version == "0.0.1"
+    assert document.config.uid == "SDOC-01"
+    assert document.config.classification == "Restricted"
+    assert document.config.markup == "Text"
+    assert document.config.auto_levels == False
+    assert document.config.requirement_style == "Table"
+    assert document.config.requirement_in_toc == "True"
+
+    section = document.section_contents[0]
+    assert isinstance(section, Section)
+    assert section.level == "123"
+
+    requirement = section.section_contents[0]
+    assert isinstance(requirement, Requirement)
+    assert requirement.level == "456"
 
     writer = SDWriter()
     output = writer.write(document)

--- a/tests/unit/strictdoc/backend/sdoc/validations/test_requirement.py
+++ b/tests/unit/strictdoc/backend/sdoc/validations/test_requirement.py
@@ -28,15 +28,7 @@ def test_03_negative():
 
 
 def test_04_meta_multilines_not_nones():
-    document_config = DocumentConfig(
-        parent=None,
-        version=None,
-        uid=None,
-        markup=None,
-        auto_levels=None,
-        requirement_style=None,
-        requirement_in_toc=None,
-    )
+    document_config = DocumentConfig.default_config(None)
     document = Document("Test Doc", document_config, None, [], [])
 
     test_field = "META_TEST_FIELD"


### PR DESCRIPTION
Our QA-Manager criticized that the generated requirement documents do not have a confidentiality level classification.
Add optional DocumentConfig CLASSIFICATION field specifying the Document's confidentiality level. 
Added some Unit tests. Found and fixed SDoc-Writer DocumentConfig VERSION<=>UID Sequence.