### PR TITLE
Code climate: Do not rely on SD working dirname in ConfTest

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,9 +1,7 @@
 import os
 import sys
 
-strictdoc_root_path = os.path.abspath(
-    os.path.join(__file__, "../../../../strictdoc")
-)
+strictdoc_root_path = os.path.abspath(os.path.join(__file__, "../../.."))
 assert os.path.exists(strictdoc_root_path), "does not exist: {}".format(
     strictdoc_root_path
 )

--- a/tests/unit_server/conftest.py
+++ b/tests/unit_server/conftest.py
@@ -1,9 +1,7 @@
 import os
 import sys
 
-STRICTDOC_ROOT_PATH = os.path.abspath(
-    os.path.join(__file__, "../../../../strictdoc")
-)
+STRICTDOC_ROOT_PATH = os.path.abspath(os.path.join(__file__, "../../.."))
 assert os.path.exists(STRICTDOC_ROOT_PATH), "does not exist: {}".format(
     STRICTDOC_ROOT_PATH
 )


### PR DESCRIPTION
Renaming StrictDoc's base Dirnname breaks pytest and itests.
Trying if conftest.py with only `../../..` works on all platforms.