### PR TITLE
backend, sdoc, rst: remove trailing newlines by multistring fields

### DIFF
--- a/strictdoc/backend/sdoc/models/requirement.py
+++ b/strictdoc/backend/sdoc/models/requirement.py
@@ -31,7 +31,13 @@ class RequirementField:
         self.parent = parent
         self.field_name = field_name
         self.field_value: Optional[str] = field_value
-        self.field_value_multiline: Optional[str] = field_value_multiline
+
+        self.field_value_multiline: Optional[str] = (
+            field_value_multiline.rstrip()
+            if field_value_multiline is not None
+            else None
+        )
+
         self.field_value_references: Optional[
             List[Reference]
         ] = field_value_references
@@ -164,17 +170,8 @@ class Requirement(Node):  # pylint: disable=too-many-instance-attributes
         self.comments = comments
         self.requirements = requirements
 
-        # For multiline fields:
-        # Due to the details of how matching single vs multistring lines is
-        # implemented, the rstrip() is done to simplify SDoc code generation.
-        self.statement_multiline: Optional[str] = (
-            statement_multiline.rstrip()
-            if statement_multiline is not None
-            else None
-        )
-        self.rationale_multiline = (
-            rationale_multiline.rstrip() if rationale_multiline else None
-        )
+        self.statement_multiline: Optional[str] = statement_multiline
+        self.rationale_multiline: Optional[str] = rationale_multiline
 
         # TODO: Is it worth to move this to dedicated Presenter* classes to
         # keep this class textx-only?
@@ -247,13 +244,6 @@ class Requirement(Node):  # pylint: disable=too-many-instance-attributes
         if self.rationale_multiline:
             return self.rationale_multiline
         return None
-
-    def append_to_multiline_statement(self, new_statement):
-        statement_field = self.ordered_fields_lookup[
-            RequirementFieldName.STATEMENT
-        ][0]
-        statement_field.field_value_multiline += new_statement.rstrip()
-        self.statement_multiline = statement_field.field_value_multiline
 
     def enumerate_fields(self):
         requirement_fields = self.ordered_fields_lookup.values()
@@ -349,11 +339,7 @@ class RequirementComment:
         self.parent = parent
         self.comment_single: Optional[str] = comment_single
 
-        # Due to the details of how matching single vs multistring lines is
-        # implemented, the rstrip() is done to simplify SDoc code generation.
-        self.comment_multiline: Optional[str] = (
-            comment_multiline.rstrip() if comment_multiline else None
-        )
+        self.comment_multiline: Optional[str] = comment_multiline
 
     def __str__(self):
         return (

--- a/strictdoc/backend/sdoc/writer.py
+++ b/strictdoc/backend/sdoc/writer.py
@@ -183,7 +183,7 @@ class SDWriter:
                     output += f"{field_name}: >>>"
                     output += "\n"
                     if len(field.field_value_multiline) > 0:
-                        output += field.field_value_multiline.rstrip()
+                        output += field.field_value_multiline
                         output += "\n"
                     output += "<<<"
                     output += "\n"

--- a/strictdoc/export/rst/templates/requirement.jinja.rst
+++ b/strictdoc/export/rst/templates/requirement.jinja.rst
@@ -33,10 +33,10 @@
 {% endfor %}
 
 {%- if requirement.has_meta %}
-  {%- for meta_field in requirement.enumerate_meta_fields(skip_single_lines=True) %}
+{%- for meta_field in requirement.enumerate_meta_fields(skip_single_lines=True) %}
 **{{meta_field[0]}}:**
 {{ meta_field[1] }}
-  {%- endfor %}
+{% endfor %}
 {%- endif %}
 
 {%- set requirement_references = requirement.get_requirement_references() %}

--- a/tests/integration/commands/export/rst/08_custom_field/expected/input.rst
+++ b/tests/integration/commands/export/rst/08_custom_field/expected/input.rst
@@ -11,7 +11,6 @@
     * - **CRITICALITY:**
       - High
 
-
 the foo must bar
 
 **Rationale:** If the foo did not bar then it might instead baz, which must be avoided at all costs.

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
@@ -1043,6 +1043,38 @@ TAG_FIELD: A, C
     assert sdoc_input == output
 
 
+def test_154_grammar_multiline_custom_field():
+    sdoc_input = """
+[DOCUMENT]
+TITLE: Test Doc
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: MY_FIELD
+    TYPE: String
+    REQUIRED: True
+
+[REQUIREMENT]
+MY_FIELD: >>>
+Some text here...
+Some text here...
+Some text here...
+<<<
+""".lstrip()
+
+    reader = SDReader()
+
+    document = reader.read(sdoc_input)
+    assert isinstance(document, Document)
+
+    writer = SDWriter()
+    output = writer.write(document)
+
+    assert sdoc_input == output
+
+
 def test_160_grammar_refs():
     sdoc_input = """
 [DOCUMENT]


### PR DESCRIPTION
Additionally fixes: #779