### PR TITLE
Code climate: introduce helpers/auto_described to print objects

### DIFF
--- a/strictdoc/backend/sdoc/models/document.py
+++ b/strictdoc/backend/sdoc/models/document.py
@@ -4,8 +4,10 @@ from typing import Optional
 from strictdoc.backend.sdoc.models.document_config import DocumentConfig
 from strictdoc.backend.sdoc.models.document_grammar import DocumentGrammar
 from strictdoc.core.document_meta import DocumentMeta
+from strictdoc.helpers.auto_described import auto_described
 
 
+@auto_described
 class Document:  # pylint: disable=too-many-instance-attributes
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -27,17 +29,6 @@ class Document:  # pylint: disable=too-many-instance-attributes
         self.ng_needs_generation = False
         self.meta: Optional[DocumentMeta] = None
         self.node_id = uuid.uuid4().hex
-
-    def __str__(self):
-        return (
-            f"Document("
-            f"id: {id(self)}, "
-            f"title: {self.title}, "
-            f"section_contents: {self.section_contents})"
-        )
-
-    def __repr__(self):
-        return self.__str__()
 
     def assign_meta(self, meta):
         assert isinstance(meta, DocumentMeta)

--- a/strictdoc/backend/sdoc/models/document_config.py
+++ b/strictdoc/backend/sdoc/models/document_config.py
@@ -1,6 +1,9 @@
 from typing import Optional
 
+from strictdoc.helpers.auto_described import auto_described
 
+
+@auto_described
 class DocumentConfig:  # pylint: disable=too-many-instance-attributes
     @staticmethod
     def default_config(document):
@@ -53,17 +56,4 @@ class DocumentConfig:  # pylint: disable=too-many-instance-attributes
         # This issue might deserve a bug report to TextX.
         return (self.uid is not None and len(self.uid) > 0) or (
             self.version is not None and len(self.version) > 0
-        )
-
-    def __str__(self):
-        return (
-            f"{self.__class__.__name__}("
-            f"version: {self.version}, "
-            f"uid: {self.uid}, "
-            f"classification: {self.classification}, "
-            f"markup: {self.markup}, "
-            f"auto_levels: {self.auto_levels}, "
-            f"requirement_style: {self.requirement_style}, "
-            f"requirement_in_toc: {self.requirement_in_toc}, "
-            ")"
         )

--- a/strictdoc/backend/sdoc/models/fragment.py
+++ b/strictdoc/backend/sdoc/models/fragment.py
@@ -1,8 +1,10 @@
 from typing import List
 
 from strictdoc.backend.sdoc.models.node import Node
+from strictdoc.helpers.auto_described import auto_described
 
 
+@auto_described
 class Fragment:  # pylint: disable=too-many-instance-attributes
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -11,13 +13,3 @@ class Fragment:  # pylint: disable=too-many-instance-attributes
         self.section_contents = section_contents
         self.ng_level = None
         self.ng_has_requirements = False
-
-    def __str__(self):
-        return (
-            f"Fragment("
-            f"id: {id(self)}, "
-            f"section_contents: {self.section_contents})"
-        )
-
-    def __repr__(self):
-        return self.__str__()

--- a/strictdoc/backend/sdoc/models/fragment_from_file.py
+++ b/strictdoc/backend/sdoc/models/fragment_from_file.py
@@ -1,7 +1,9 @@
 from strictdoc.backend.sdoc.models.node import Node
 from strictdoc.backend.sdoc.models.section import SectionContext
+from strictdoc.helpers.auto_described import auto_described
 
 
+@auto_described
 class FragmentFromFile(Node):  # pylint: disable=too-many-instance-attributes
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -15,12 +17,6 @@ class FragmentFromFile(Node):  # pylint: disable=too-many-instance-attributes
         self.ng_has_requirements = False
         self.ng_document_reference = None
         self.context = SectionContext()
-
-    def __str__(self):
-        return f"FragmentFromFile(level: {self.ng_level}, file: {self.file})"
-
-    def __repr__(self):
-        return self.__str__()
 
     @property
     def document(self):

--- a/strictdoc/backend/sdoc/models/free_text.py
+++ b/strictdoc/backend/sdoc/models/free_text.py
@@ -1,20 +1,16 @@
 from typing import List
 
 from strictdoc.backend.sdoc.models.inline_link import InlineLink
+from strictdoc.helpers.auto_described import auto_described
 
 
+@auto_described
 class FreeText:
     def __init__(self, parent, parts: List):
         assert isinstance(parts, list)
         self.parent = parent
         self.parts = parts
         self.ng_level = None
-
-    def __str__(self):
-        return f"FreeText(parts={self.parts})"
-
-    def __repr__(self):
-        return self.__str__()
 
     @property
     def is_requirement(self):

--- a/strictdoc/backend/sdoc/models/reference.py
+++ b/strictdoc/backend/sdoc/models/reference.py
@@ -3,59 +3,33 @@ from strictdoc.backend.sdoc.models.type_system import (
     BibEntry,
     FileEntry,
 )
+from strictdoc.helpers.auto_described import auto_described
 
 
+@auto_described
 class Reference:
     def __init__(self, ref_type, parent):
         self.parent = parent
         self.ref_type = ref_type
 
-    def __repr__(self):
-        return self.__str__()
 
-    def __str__(self):
-        return (
-            f"Reference("
-            f"parent = {self.parent.field_name},"
-            f" ref_type = {self.ref_type})"
-        )
-
-
+@auto_described
 class FileReference(Reference):
     def __init__(self, parent, file_entry: FileEntry):
         super().__init__(ReferenceType.FILE, parent)
         self.file_entry = file_entry
 
-    def __str__(self):
-        return (
-            f"FileReference("
-            f"parent = {self.parent.field_name},"
-            f" file_entry = {self.file_entry})"
-        )
 
-
+@auto_described
 class ParentReqReference(Reference):
     def __init__(self, parent, ref_uid):
         super().__init__(ReferenceType.PARENT, parent)
         self.ref_uid = ref_uid
 
-    def __str__(self):
-        return (
-            f"ParentReqReference("
-            f"parent = {self.parent.field_name},"
-            f" ref_uid = {self.ref_uid})"
-        )
 
-
+@auto_described
 class BibReference(Reference):
     def __init__(self, parent, bib_entry: BibEntry):
         super().__init__(ReferenceType.BIB_REF, parent)
         self.bib_entry = bib_entry
         # TODO Add bib_entry into Parent-Root Document.Bibliography
-
-    def __str__(self):
-        return (
-            f"BibReference("
-            f"parent = {self.parent.field_name},"
-            f" bib_entry = {self.bib_entry})"
-        )

--- a/strictdoc/backend/sdoc/models/requirement.py
+++ b/strictdoc/backend/sdoc/models/requirement.py
@@ -9,15 +9,18 @@ from strictdoc.backend.sdoc.models.type_system import (
     RequirementFieldName,
     RESERVED_NON_META_FIELDS,
 )
+from strictdoc.helpers.auto_described import auto_described
 
 MULTILINE_WORD_THRESHOLD = 6
 
 
+@auto_described
 class RequirementContext:
     def __init__(self):
         self.title_number_string = None
 
 
+@auto_described
 class RequirementField:
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -53,19 +56,6 @@ class RequirementField:
         self.field_value_references: Optional[
             List[Reference]
         ] = field_value_references
-
-    def __str__(self):
-        return (
-            f"{self.__class__.__name__}("
-            f"field_name: {self.field_name}, "
-            f"field_value: {self.field_value}, "
-            f"field_value_multiline: {self.field_value_multiline}, "
-            f"field_value_references: {self.field_value_references}, "
-            ")"
-        )
-
-    def __repr__(self):
-        return self.__str__()
 
 
 class Requirement(Node):  # pylint: disable=too-many-instance-attributes
@@ -198,20 +188,6 @@ class Requirement(Node):  # pylint: disable=too-many-instance-attributes
 
         self.node_id = uuid.uuid4().hex
 
-    def __str__(self):
-        return (
-            f"{self.__class__.__name__}("
-            f"ng_level: {self.ng_level}, "
-            f"level: {self.level}, "
-            f"uid: {self.uid}, "
-            f"title_or_none: {self.title}, "
-            f"statement: {self.statement}"
-            ")"
-        )
-
-    def __repr__(self):
-        return self.__str__()
-
     @property
     def is_requirement(self):
         return True
@@ -322,6 +298,7 @@ class Requirement(Node):  # pylint: disable=too-many-instance-attributes
         )
 
 
+@auto_described
 class CompositeRequirement(Requirement):
     def __init__(self, parent, **fields):
         super().__init__(parent, **fields)
@@ -337,18 +314,14 @@ class CompositeRequirement(Requirement):
         return self.ng_document_reference.get_document()
 
 
+@auto_described
 class Body:
     def __init__(self, parent, content):
         self.parent = parent
         self.content = content.strip()
 
-    def __str__(self):
-        return f"Body({self.content})"
 
-    def __repr__(self):
-        return self.__str__()
-
-
+@auto_described
 class RequirementComment:
     def __init__(
         self,
@@ -367,17 +340,6 @@ class RequirementComment:
         # assert comment_single is not None or comment_multiline is not None
         # TODO: One solution to simplify this would be to disallow empty fields
         # in the grammar completely.
-
-    def __str__(self):
-        return (
-            f"Comment("
-            f"comment_single: {self.comment_single}, "
-            f"comment_multiline: {self.comment_multiline}"
-            f")"
-        )
-
-    def __repr__(self):
-        return self.__str__()
 
     def get_comment(self):
         comment = (

--- a/strictdoc/backend/sdoc/models/section.py
+++ b/strictdoc/backend/sdoc/models/section.py
@@ -4,13 +4,16 @@ from typing import Optional, List
 from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.models.free_text import FreeText
 from strictdoc.backend.sdoc.models.node import Node
+from strictdoc.helpers.auto_described import auto_described
 
 
+@auto_described
 class SectionContext:
     def __init__(self):
         self.title_number_string = None
 
 
+@auto_described
 class Section(Node):  # pylint: disable=too-many-instance-attributes
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -34,12 +37,6 @@ class Section(Node):  # pylint: disable=too-many-instance-attributes
         self.ng_document_reference: Optional[DocumentReference] = None
         self.context = SectionContext()
         self.node_id = uuid.uuid4().hex
-
-    def __str__(self):
-        return f"Section(level: {self.ng_level}, title: {self.title})"
-
-    def __repr__(self):
-        return self.__str__()
 
     @property
     def document(self):

--- a/strictdoc/backend/sdoc/models/type_system.py
+++ b/strictdoc/backend/sdoc/models/type_system.py
@@ -3,6 +3,8 @@ from typing import List, Optional
 
 from pybtex.database import Entry
 
+from strictdoc.helpers.auto_described import auto_described
+
 
 class RequirementFieldName:
     UID = "UID"
@@ -40,6 +42,7 @@ class GrammarReferenceType:
     BIB_REFERENCE = "BibReference"
 
 
+@auto_described
 class FileEntry:
     def __init__(self, parent, file_format: Optional[str], file_path: str):
         self.parent = parent
@@ -49,16 +52,6 @@ class FileEntry:
         path_forward_slashes = file_path.replace("\\", "/")
         self.path_forward_slashes = path_forward_slashes
         self.path_normalized = os.path.normpath(path_forward_slashes)
-
-    def __str__(self):
-        return (
-            f"FileEntry("
-            f"parent = {self.parent.__class__.__name__},"
-            f" file_format = {self.file_format},"
-            f" file_path = {self.file_path},"
-            f" path_forward_slashes = {self.path_forward_slashes},"
-            f" path_normalized = {self.path_normalized})"
-        )
 
 
 class FileEntryFormat:
@@ -72,6 +65,7 @@ class BibEntryFormat:
     CITATION = "Citation"
 
 
+@auto_described
 class BibEntry:
     def __init__(self, parent, bib_format: Optional[str], bib_value: str):
         self.parent = parent
@@ -123,17 +117,6 @@ class BibEntry:
             )
             # TODO Verify/Reference the cited BibEntry
 
-    def __str__(self):
-        return (
-            f"BibEntry("
-            f"parent = {self.parent.__class__.__name__},"
-            f"ref_format = {self.bib_format},"
-            f" bib_value = {self.bib_value})"
-            f" ref_cite = {self.ref_cite})"
-            f" ref_detail = {self.ref_detail})"
-            f" bibtex_entry = {self.bibtex_entry})"
-        )
-
 
 class ReferenceType:
     PARENT = "Parent"
@@ -147,6 +130,7 @@ class ReferenceType:
     }
 
 
+@auto_described
 class GrammarElementField:
     def __init__(self):
         self.title: str = ""
@@ -154,6 +138,7 @@ class GrammarElementField:
         self.required: bool = False
 
 
+@auto_described
 class GrammarElementFieldString(GrammarElementField):
     def __init__(self, parent, title: str, required: str):
         super().__init__()
@@ -162,17 +147,8 @@ class GrammarElementFieldString(GrammarElementField):
         self.gef_type = RequirementFieldType.STRING
         self.required: bool = required == "True"
 
-    def __str__(self):
-        return (
-            "GrammarElementFieldString("
-            f"parent: {self.parent}, "
-            f"title: {self.title}, "
-            f"gef_type: {self.gef_type}, "
-            f"required: {self.required}"
-            ")"
-        )
 
-
+@auto_described
 class GrammarElementFieldSingleChoice(GrammarElementField):
     def __init__(self, parent, title: str, options: List[str], required: str):
         super().__init__()
@@ -182,17 +158,8 @@ class GrammarElementFieldSingleChoice(GrammarElementField):
         self.options: List[str] = options
         self.required: bool = required == "True"
 
-    def __str__(self):
-        return (
-            "GrammarElementFieldSingleChoice("
-            f"parent: {self.parent}, "
-            f"title: {self.title}, "
-            f"gef_type: {self.gef_type}({', '.join(self.options)}), "
-            f"required: {self.required}"
-            ")"
-        )
 
-
+@auto_described
 class GrammarElementFieldMultipleChoice(GrammarElementField):
     def __init__(self, parent, title: str, options: List[str], required: str):
         super().__init__()
@@ -202,17 +169,8 @@ class GrammarElementFieldMultipleChoice(GrammarElementField):
         self.options: List[str] = options
         self.required: bool = required == "True"
 
-    def __str__(self):
-        return (
-            "GrammarElementFieldMultipleChoice("
-            f"parent: {self.parent}, "
-            f"title: {self.title}, "
-            f"gef_type: {self.gef_type}({', '.join(self.options)}), "
-            f"required: {self.required}"
-            ")"
-        )
 
-
+@auto_described
 class GrammarElementFieldTag(GrammarElementField):
     def __init__(self, parent, title: str, required: str):
         super().__init__()
@@ -221,17 +179,8 @@ class GrammarElementFieldTag(GrammarElementField):
         self.gef_type = RequirementFieldType.TAG
         self.required: bool = required == "True"
 
-    def __str__(self):
-        return (
-            "GrammarElementFieldTag("
-            f"parent: {self.parent}, "
-            f"title: {self.title}, "
-            f"gef_type: {self.gef_type}, "
-            f"required: {self.required}"
-            ")"
-        )
 
-
+@auto_described
 class GrammarElementFieldReference(GrammarElementField):
     def __init__(self, parent, title: str, types: List[str], required: str):
         super().__init__()
@@ -240,13 +189,3 @@ class GrammarElementFieldReference(GrammarElementField):
         self.title: str = title
         self.types: List[str] = types
         self.required: bool = required == "True"
-
-    def __str__(self):
-        return (
-            "GrammarElementFieldReference("
-            f"parent: {self.parent}, "
-            f"title: {self.title}, "
-            f"gef_type: {self.gef_type}({', '.join(self.types)}), "
-            f"required: {self.required}"
-            ")"
-        )

--- a/strictdoc/backend/source_file_syntax/models/range_pragma.py
+++ b/strictdoc/backend/source_file_syntax/models/range_pragma.py
@@ -1,3 +1,7 @@
+from strictdoc.helpers.auto_described import auto_described
+
+
+@auto_described
 class RangePragma:
     def __init__(self, parent, begin_or_end, reqs_objs):
         assert isinstance(reqs_objs, list)
@@ -18,20 +22,6 @@ class RangePragma:
         #   ng_range_line_end == ng_source_line_begin
         self.ng_range_line_begin = None
         self.ng_range_line_end = None
-
-    def __str__(self):
-        return (
-            f"RangePragma("
-            f"begin_or_end: {self.begin_or_end}, "
-            f"ng_source_line_begin: {self.ng_source_line_begin}, "
-            f"ng_range_line_begin: {self.ng_range_line_begin}, "
-            f"ng_range_line_end: {self.ng_range_line_end}, "
-            f"reqs: {self.reqs}"
-            f")"
-        )
-
-    def __repr__(self):
-        return self.__str__()
 
     def is_begin(self):
         return self.begin_or_end == "["

--- a/strictdoc/backend/source_file_syntax/models/source_file_info.py
+++ b/strictdoc/backend/source_file_syntax/models/source_file_info.py
@@ -1,8 +1,10 @@
 from typing import List
 
 from strictdoc.backend.source_file_syntax.models.range_pragma import RangePragma
+from strictdoc.helpers.auto_described import auto_described
 
 
+@auto_described
 class SourceFileTraceabilityInfo:
     def __init__(self, parts):
         self.parts = parts
@@ -13,16 +15,6 @@ class SourceFileTraceabilityInfo:
         self._ng_lines_covered = 0
         self._coverage = 0
         self.pragmas: List[RangePragma] = []
-
-    def __str__(self):
-        return (
-            "SourceFileTraceabilityInfo(\n"
-            f"\tlines_total: {self._ng_lines_total}\n"
-            f"\tlines_covered: {self._ng_lines_covered}\n"
-            f"\tcoverage: {self._coverage}\n"
-            f"\tpragmas: {self.pragmas}\n"
-            ")"
-        )
 
     def get_coverage(self):
         return self._coverage

--- a/strictdoc/core/finders/source_files_finder.py
+++ b/strictdoc/core/finders/source_files_finder.py
@@ -5,8 +5,10 @@ from typing import List
 from strictdoc.cli.cli_arg_parser import ExportCommandConfig
 from strictdoc.core.file_tree import FileFinder, File
 from strictdoc.core.source_tree import SourceTree
+from strictdoc.helpers.auto_described import auto_described
 
 
+@auto_described
 class SourceFile:  # pylint: disable=too-many-instance-attributes
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -31,18 +33,6 @@ class SourceFile:  # pylint: disable=too-many-instance-attributes
 
         self.traceability_info = None
         self.is_referenced = False
-
-    def __str__(self):
-        return (
-            "SourceFile("
-            f"level: {self.level}, "
-            f"full_path: {self.full_path}, "
-            "in_doctree_source_file_rel_path: "
-            f"{self.in_doctree_source_file_rel_path}, "
-            f"output_path_dir_full_path: {self.output_dir_full_path}, "
-            f"output_path_file_full_path: {self.output_file_full_path}"
-            ")"
-        )
 
     def is_python_file(self):
         return self.extension == ".py"

--- a/strictdoc/helpers/auto_described.py
+++ b/strictdoc/helpers/auto_described.py
@@ -1,0 +1,63 @@
+# This function could be a separate package but keeping it within the project
+# for simplicity.
+__version__ = "0.0.1"
+
+
+# Maybe there is a better way to generate __str__ and __repr__.
+# But for now, this solution works good enough:
+# https://stackoverflow.com/a/33800620/598057
+# https://stackoverflow.com/a/24617244/598057
+def auto_described(cls=None, str_and_repr=True):
+    def configure_class(clz):
+        def __str__(self):
+            return auto_str(self)
+
+        def __repr__(self):
+            return auto_str(self)
+
+        clz.__str__ = __str__
+        if str_and_repr:
+            clz.__repr__ = __repr__
+        return clz
+
+    if cls is not None:
+        return configure_class(cls)
+
+    def factory(clz):
+        return configure_class(clz)
+
+    return factory
+
+
+def auto_str(obj: object) -> str:
+    items = []
+
+    # This is a rather defensive implementation that prevents auto_str from
+    # breaking on the objects with recursive references:
+    # Example: A -> B -> A.
+    for prop, value in obj.__dict__.items():
+        if type(value) == list:  # pylint: disable=unidiomatic-typecheck
+            if len(value) == 0:
+                item = f"{prop} = []"
+            else:
+                item = f"{prop} = [{len(value)} elements]"
+        elif type(value) == dict:  # pylint: disable=unidiomatic-typecheck
+            if len(value) == 0:
+                item = f"{prop} = {{}}"
+            else:
+                item = f"{prop} = {{{len(value)} elements}}"
+        elif isinstance(value, (list, dict, set)):
+            item = f"{prop} = {value.__class__.__name__}({len(value)} elements)"
+        elif isinstance(value, str):
+            item = f'{prop} = "{value}"'
+        elif isinstance(value, bytes):
+            item = f"{prop} = {value!r}"
+        elif isinstance(value, (int, float, bool)):
+            item = f"{prop} = {value}"
+        elif isinstance(value, object):
+            item = f"{prop} = {value.__class__.__name__}(...)"
+        else:
+            item = f"{prop} = {value}"
+
+        items.append(item)
+    return f"{obj.__class__.__name__}({', '.join(items)})"

--- a/tests/integration/per_document_grammar/validation/06_gef_reference_type_not_allowed/test.itest
+++ b/tests/integration/per_document_grammar/validation/06_gef_reference_type_not_allowed/test.itest
@@ -1,7 +1,7 @@
 RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
 
 CHECK:error: could not parse file: {{.*}}input.sdoc.
-CHECK: Semantic error: Requirement field of type Reference has an unsupported Reference Type item: FileReference(parent = REFS, file_entry = FileEntry(parent = FileReference, file_format = None, file_path = /tmp/sample1.cpp, path_forward_slashes = /tmp/sample1.cpp, path_normalized = {{[\/\\]tmp[\/\\]sample1.cpp}}))
+CHECK: Semantic error: Requirement field of type Reference has an unsupported Reference Type item: FileReference({{.*}})
 CHECK:Location: {{.*}}input.sdoc:18:1
 CHECK:Hint: Problematic field: REFS. Compare with the document grammar: [UID, REFS] for type: LOW_LEVEL_REQUIREMENT
 CHECK:error: Parallelizer: One of the child processes has exited prematurely.

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
@@ -1307,10 +1307,10 @@ REFS:
         _ = reader.read(sdoc_input)
 
     assert exc_info.type is StrictDocSemanticError
-    assert (
-        exc_info.value.args[0]
-        == "Requirement field of type Reference has an unsupported Reference "
-        "Type item: ParentReqReference(parent = REFS, ref_uid = ID-001)"
+    assert re.fullmatch(
+        "Requirement field of type Reference has an unsupported Reference "
+        'Type item: ParentReqReference\\(.*ref_uid = "ID-001".*\\)',
+        exc_info.value.args[0],
     )
 
 
@@ -1460,10 +1460,7 @@ REFS:
 
     assert re.fullmatch(
         f"Requirement field of type Reference has an unsupported Reference"
-        f" Type item: FileReference\\(parent = REFS, file_entry ="
-        f" FileEntry\\(parent = FileReference, file_format = None, file_path"
-        f" = /tmp/sample1.cpp, path_forward_slashes ="
-        f" /tmp/sample1.cpp, path_normalized = .+tmp.+sample1.cpp\\)\\)",
+        f" Type item: FileReference\\(.*\\)",
         exc_info.value.args[0],
     )
 
@@ -1667,8 +1664,8 @@ REFS:
 
     assert exc_info.type is StrictDocSemanticError
 
-    assert (
-        exc_info.value.args[0]
-        == "Requirement field of type Reference has an unsupported Reference "
-        "Type item: ParentReqReference(parent = REFS, ref_uid = ID-001)"
+    assert re.fullmatch(
+        "Requirement field of type Reference has an unsupported Reference "
+        'Type item: ParentReqReference\\(.*ref_uid = "ID-001".*\\)',
+        exc_info.value.args[0],
     )


### PR DESCRIPTION
The @auto_described implementation saves the effort of writing the custom __str__() descriptions for every class. The generalized implementation should be good enough for now.