### PR TITLE
server: validation: do not allow creating documents without .sdoc extension

### DIFF
--- a/strictdoc/helpers/string.py
+++ b/strictdoc/helpers/string.py
@@ -48,3 +48,8 @@ def sanitize_html_form_field(field: str, multiline: bool) -> str:
                 " ", sanitized_field
             )
     return ""
+
+
+def is_safe_alphanumeric_string(string: str) -> bool:
+    pattern = re.compile(r"^[\w.]+([/\\][\w.]+?)*$")
+    return pattern.match(string) is not None

--- a/tests/end2end/document_tree/UC51_creating_document/UC51_G1_validation/UC51_G1_T03_document_path_with_no_sdoc_extension/test_UC51_G1_T03_document_path_with_no_sdoc_extension.py
+++ b/tests/end2end/document_tree/UC51_creating_document/UC51_G1_validation/UC51_G1_T03_document_path_with_no_sdoc_extension/test_UC51_G1_T03_document_path_with_no_sdoc_extension.py
@@ -1,0 +1,34 @@
+import os
+
+from seleniumbase import BaseCase
+
+from tests.end2end.server import SDocTestServer
+
+path_to_this_test_file_folder = os.path.dirname(os.path.abspath(__file__))
+
+
+class Test_TC51_G1_T03_NoSDocExtension(BaseCase):
+    def test_01(self):
+        path_to_sandbox = os.path.join(
+            path_to_this_test_file_folder, ".sandbox"
+        )
+
+        test_server = SDocTestServer.create(path_to_sandbox)
+        test_server.run()
+
+        self.open(test_server.get_host_and_port())
+
+        self.assert_text("PROJECT INDEX")
+
+        self.assert_text("The document tree has no documents yet.")
+
+        self.click_link("Add document")
+
+        self.type("#document_title", "Document 1")  # Empty document
+        self.type("#document_path", "docs/document")
+
+        self.click_xpath("//button[@type='submit' and text()='Save']")
+        self.assert_text(
+            "Document path must end with a file name. "
+            "The file name must have the .sdoc extension."
+        )

--- a/tests/end2end/document_tree/UC51_creating_document/UC51_G1_validation/UC51_G1_T04_document_path_bad_chars/test_UC51_G1_T04_document_path_bad_chars.py
+++ b/tests/end2end/document_tree/UC51_creating_document/UC51_G1_validation/UC51_G1_T04_document_path_bad_chars/test_UC51_G1_T04_document_path_bad_chars.py
@@ -1,0 +1,34 @@
+import os
+
+from seleniumbase import BaseCase
+
+from tests.end2end.server import SDocTestServer
+
+path_to_this_test_file_folder = os.path.dirname(os.path.abspath(__file__))
+
+
+class Test_TC51_G1_T04_BadCharacters(BaseCase):
+    def test_01(self):
+        path_to_sandbox = os.path.join(
+            path_to_this_test_file_folder, ".sandbox"
+        )
+
+        test_server = SDocTestServer.create(path_to_sandbox)
+        test_server.run()
+
+        self.open(test_server.get_host_and_port())
+
+        self.assert_text("PROJECT INDEX")
+
+        self.assert_text("The document tree has no documents yet.")
+
+        self.click_link("Add document")
+
+        self.type("#document_title", "Document 1")  # Empty document
+        self.type("#document_path", "docs/doc!#ument.sdoc")
+
+        self.click_xpath("//button[@type='submit' and text()='Save']")
+        self.assert_text(
+            "Document path must be relative and only contain slashes, "
+            "alphanumeric characters, and underscore symbols."
+        )

--- a/tests/unit/strictdoc/helpers/test_string.py
+++ b/tests/unit/strictdoc/helpers/test_string.py
@@ -1,4 +1,8 @@
-from strictdoc.helpers.string import multireplace, sanitize_html_form_field
+from strictdoc.helpers.string import (
+    multireplace,
+    sanitize_html_form_field,
+    is_safe_alphanumeric_string,
+)
 
 
 def test_multireplace_01():
@@ -61,3 +65,17 @@ def test_sanitize_04_single_line_removes_all_newlines():
     """  # noqa: W291
     sanitized_field = sanitize_html_form_field(field, multiline=False)
     assert sanitized_field == "Hello world! Hello world! Hello world!"
+
+
+def test_is_safe_alphanumeric_string():
+    assert is_safe_alphanumeric_string("") is False
+    assert is_safe_alphanumeric_string("/") is False
+    assert is_safe_alphanumeric_string("/document.sdoc") is False
+    assert is_safe_alphanumeric_string("doc#%ument.sdoc") is False
+
+    assert is_safe_alphanumeric_string("document") is True
+    assert is_safe_alphanumeric_string("document.sdoc") is True
+    assert is_safe_alphanumeric_string("document.ext.sdoc") is True
+    assert is_safe_alphanumeric_string("docs/document.ext.sdoc") is True
+    assert is_safe_alphanumeric_string("docs/docs2/document.sdoc") is True
+    assert is_safe_alphanumeric_string("docs/document1.sdoc") is True


### PR DESCRIPTION
This is a good enough solution for now. Later we can consider adding the .sdoc extension automatically.

Closes #775