### PR TITLE
requirements coverage: hide under the traceability flag for now

### DIFF
--- a/strictdoc/export/html/templates/_shared/nav.jinja.html
+++ b/strictdoc/export/html/templates/_shared/nav.jinja.html
@@ -11,6 +11,7 @@
   </a>
 
 {%- if traceability_index.has_requirements() -%}
+  {%- if config.experimental_enable_file_traceability -%}
   <a
     data-link="requirements_coverage"
     class="nav_button"
@@ -18,8 +19,6 @@
     title="Requirements coverage">
     {% include "_res/svg_ico16_requirement.jinja.html" %}
   </a>
-
-  {%- if config.experimental_enable_file_traceability -%}
   <a
     data-link="source_coverage"
     class="nav_button"


### PR DESCRIPTION
This feature is very incomplete. We will hide it under a corresponding feature toggle very soon but for now it is better to disable it from being shown by default.