### PR TITLE
backend/reqif: handle edge case with <xhtml:object> tag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "XlsxWriter >= 1.3.7, == 1.*",
     "xlrd >= 2.0.1, == 2.*",
 
-    "reqif >= 0.0.32, == 0.*",
+    "reqif >= 0.0.33, == 0.*",
 
     # Bibtex
     "pybtex >= 0.23.0, == 0.*",

--- a/tests/integration/backend/reqif/profiles/p11_polarion/03_xhtml_object_edge_case/sample.reqif
+++ b/tests/integration/backend/reqif/profiles/p11_polarion/03_xhtml_object_edge_case/sample.reqif
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<REQ-IF xmlns="http://www.omg.org/spec/ReqIF/20110401/reqif.xsd" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <THE-HEADER>
+    <REQ-IF-HEADER IDENTIFIER="_9212f09c-6c4c-4942-a38d-285d0a032431">
+      <CREATION-TIME>2023-02-01T08:22:28.005-08:00</CREATION-TIME>
+      <REQ-IF-TOOL-ID>Polarion ReqIF Roundtrip</REQ-IF-TOOL-ID>
+      <REQ-IF-VERSION>1.0</REQ-IF-VERSION>
+      <SOURCE-TOOL-ID>Polarion</SOURCE-TOOL-ID>
+      <TITLE>...Anonymized-7259913054...</TITLE>
+    </REQ-IF-HEADER>
+  </THE-HEADER>
+  <CORE-CONTENT>
+    <REQ-IF-CONTENT>
+      <DATATYPES>
+        <DATATYPE-DEFINITION-STRING IDENTIFIER="polarion_type_string" LAST-CHANGE="2013-01-01T00:00:00Z" LONG-NAME="String (single line plain text)" MAX-LENGTH="999999999"/>
+        <DATATYPE-DEFINITION-XHTML IDENTIFIER="polarion_type_rich_text" LAST-CHANGE="2013-01-01T00:00:00Z" LONG-NAME="Rich Text (multi-line)"/>
+        <DATATYPE-DEFINITION-DATE IDENTIFIER="polarion_type_date_time" LAST-CHANGE="2013-01-01T00:00:00Z" LONG-NAME="Date time"/>
+        <DATATYPE-DEFINITION-REAL ACCURACY="10" IDENTIFIER="polarion_type_float" LAST-CHANGE="2013-01-01T00:00:00Z" LONG-NAME="Float" MAX="3.4028235E38" MIN="1.4E-45"/>
+        <DATATYPE-DEFINITION-INTEGER IDENTIFIER="polarion_type_integer" LAST-CHANGE="2013-01-01T00:00:00Z" LONG-NAME="Integer" MAX="9223372036854775807" MIN="-9223372036854775808"/>
+      </DATATYPES>
+      <SPEC-TYPES>
+        <SPECIFICATION-TYPE IDENTIFIER="polarion_live_document" LAST-CHANGE="2013-01-01T00:00:00Z" LONG-NAME="Polarion Live Document"/>
+        <SPEC-OBJECT-TYPE IDENTIFIER="_c72b4453-3b94-4da4-8b01-1a92766fe276" LAST-CHANGE="2023-02-01T08:22:22.358-08:00" LONG-NAME="Heading">
+          <SPEC-ATTRIBUTES>
+            <ATTRIBUTE-DEFINITION-STRING IDENTIFIER="rmf-0ebf173d-49d4-49ec-b170-8deac3238f86" IS-EDITABLE="true" LAST-CHANGE="2023-02-01T08:22:22.358-08:00" LONG-NAME="ReqIF.ChapterName">
+              <TYPE>
+                <DATATYPE-DEFINITION-STRING-REF>polarion_type_string</DATATYPE-DEFINITION-STRING-REF>
+              </TYPE>
+            </ATTRIBUTE-DEFINITION-STRING>
+            <ATTRIBUTE-DEFINITION-STRING IDENTIFIER="rmf-f14d9142-c2a8-4e78-8a7f-e93f0ee0fbfc" IS-EDITABLE="true" LAST-CHANGE="2023-02-01T08:22:22.359-08:00" LONG-NAME="ReqIF.ForeignCreatedBy">
+              <TYPE>
+                <DATATYPE-DEFINITION-STRING-REF>polarion_type_string</DATATYPE-DEFINITION-STRING-REF>
+              </TYPE>
+            </ATTRIBUTE-DEFINITION-STRING>
+            <ATTRIBUTE-DEFINITION-DATE IDENTIFIER="rmf-1976b3b4-56a4-4933-a9e7-b44533b15655" IS-EDITABLE="true" LAST-CHANGE="2023-02-01T08:22:22.359-08:00" LONG-NAME="ReqIF.ForeignCreatedOn">
+              <TYPE>
+                <DATATYPE-DEFINITION-DATE-REF>polarion_type_date_time</DATATYPE-DEFINITION-DATE-REF>
+              </TYPE>
+            </ATTRIBUTE-DEFINITION-DATE>
+            <ATTRIBUTE-DEFINITION-STRING IDENTIFIER="rmf-8ad26cf3-dcae-4b0a-8434-d1945ba5178d" IS-EDITABLE="true" LAST-CHANGE="2023-02-01T08:22:22.359-08:00" LONG-NAME="ReqIF.ForeignID">
+              <TYPE>
+                <DATATYPE-DEFINITION-STRING-REF>polarion_type_string</DATATYPE-DEFINITION-STRING-REF>
+              </TYPE>
+            </ATTRIBUTE-DEFINITION-STRING>
+            <ATTRIBUTE-DEFINITION-XHTML IDENTIFIER="rmf-6e147798-f96b-423b-aa85-df2a0ba08e3a" IS-EDITABLE="true" LAST-CHANGE="2023-02-01T08:22:22.359-08:00" LONG-NAME="ReqIF.Text">
+              <TYPE>
+                <DATATYPE-DEFINITION-XHTML-REF>polarion_type_rich_text</DATATYPE-DEFINITION-XHTML-REF>
+              </TYPE>
+            </ATTRIBUTE-DEFINITION-XHTML>
+          </SPEC-ATTRIBUTES>
+        </SPEC-OBJECT-TYPE>
+        <SPEC-OBJECT-TYPE IDENTIFIER="_b26dff7a-531b-427e-8daf-9fa21e4f0dbe" LAST-CHANGE="2023-02-01T08:22:22.359-08:00" LONG-NAME="Software Requirement">
+          <SPEC-ATTRIBUTES>
+            <ATTRIBUTE-DEFINITION-STRING IDENTIFIER="rmf-1759a733-cd44-4740-a63f-88afc01d7b28" IS-EDITABLE="true" LAST-CHANGE="2023-02-01T08:22:22.359-08:00" LONG-NAME="ReqIF.ChapterName">
+              <TYPE>
+                <DATATYPE-DEFINITION-STRING-REF>polarion_type_string</DATATYPE-DEFINITION-STRING-REF>
+              </TYPE>
+            </ATTRIBUTE-DEFINITION-STRING>
+            <ATTRIBUTE-DEFINITION-STRING IDENTIFIER="rmf-5b05da73-825a-46cf-945b-81b619fc9480" IS-EDITABLE="true" LAST-CHANGE="2023-02-01T08:22:22.359-08:00" LONG-NAME="ReqIF.ForeignCreatedBy">
+              <TYPE>
+                <DATATYPE-DEFINITION-STRING-REF>polarion_type_string</DATATYPE-DEFINITION-STRING-REF>
+              </TYPE>
+            </ATTRIBUTE-DEFINITION-STRING>
+            <ATTRIBUTE-DEFINITION-DATE IDENTIFIER="rmf-7caf14b5-e997-47eb-a85d-6bd80a5aef3c" IS-EDITABLE="true" LAST-CHANGE="2023-02-01T08:22:22.359-08:00" LONG-NAME="ReqIF.ForeignCreatedOn">
+              <TYPE>
+                <DATATYPE-DEFINITION-DATE-REF>polarion_type_date_time</DATATYPE-DEFINITION-DATE-REF>
+              </TYPE>
+            </ATTRIBUTE-DEFINITION-DATE>
+            <ATTRIBUTE-DEFINITION-STRING IDENTIFIER="rmf-1b53584c-a9ad-47f4-b83a-0e7985fa3f7e" IS-EDITABLE="true" LAST-CHANGE="2023-02-01T08:22:22.361-08:00" LONG-NAME="ReqIF.ForeignID">
+              <TYPE>
+                <DATATYPE-DEFINITION-STRING-REF>polarion_type_string</DATATYPE-DEFINITION-STRING-REF>
+              </TYPE>
+            </ATTRIBUTE-DEFINITION-STRING>
+            <ATTRIBUTE-DEFINITION-XHTML IDENTIFIER="rmf-7d0ed062-e964-424c-8305-45067118d959" IS-EDITABLE="true" LAST-CHANGE="2023-02-01T08:22:22.361-08:00" LONG-NAME="ReqIF.Text">
+              <TYPE>
+                <DATATYPE-DEFINITION-XHTML-REF>polarion_type_rich_text</DATATYPE-DEFINITION-XHTML-REF>
+              </TYPE>
+            </ATTRIBUTE-DEFINITION-XHTML>
+          </SPEC-ATTRIBUTES>
+        </SPEC-OBJECT-TYPE>
+      </SPEC-TYPES>
+      <SPEC-OBJECTS>
+        <SPEC-OBJECT IDENTIFIER="rmf-3e0ae326-c60f-4206-b017-0dc7e418afef" LAST-CHANGE="2023-02-01T08:22:23.616-08:00">
+          <VALUES>
+            <ATTRIBUTE-VALUE-STRING THE-VALUE="...Anonymized-511784953...">
+              <DEFINITION>
+                <ATTRIBUTE-DEFINITION-STRING-REF>rmf-0ebf173d-49d4-49ec-b170-8deac3238f86</ATTRIBUTE-DEFINITION-STRING-REF>
+              </DEFINITION>
+            </ATTRIBUTE-VALUE-STRING>
+            <ATTRIBUTE-VALUE-STRING THE-VALUE="...Anonymized-2552513098...">
+              <DEFINITION>
+                <ATTRIBUTE-DEFINITION-STRING-REF>rmf-f14d9142-c2a8-4e78-8a7f-e93f0ee0fbfc</ATTRIBUTE-DEFINITION-STRING-REF>
+              </DEFINITION>
+            </ATTRIBUTE-VALUE-STRING>
+            <ATTRIBUTE-VALUE-STRING THE-VALUE="...Anonymized-3801107121...">
+              <DEFINITION>
+                <ATTRIBUTE-DEFINITION-STRING-REF>rmf-8ad26cf3-dcae-4b0a-8434-d1945ba5178d</ATTRIBUTE-DEFINITION-STRING-REF>
+              </DEFINITION>
+            </ATTRIBUTE-VALUE-STRING>
+            <ATTRIBUTE-VALUE-DATE THE-VALUE="2022-04-11T05:45:16.438-07:00">
+              <DEFINITION>
+                <ATTRIBUTE-DEFINITION-DATE-REF>rmf-1976b3b4-56a4-4933-a9e7-b44533b15655</ATTRIBUTE-DEFINITION-DATE-REF>
+              </DEFINITION>
+            </ATTRIBUTE-VALUE-DATE>
+          </VALUES>
+          <TYPE>
+            <SPEC-OBJECT-TYPE-REF>_c72b4453-3b94-4da4-8b01-1a92766fe276</SPEC-OBJECT-TYPE-REF>
+          </TYPE>
+        </SPEC-OBJECT>
+        <SPEC-OBJECT IDENTIFIER="rmf-2616fa87-f1f5-4c87-9725-4a084d718be6" LAST-CHANGE="2023-02-01T08:22:23.645-08:00">
+          <VALUES>
+            <ATTRIBUTE-VALUE-STRING THE-VALUE="...Anonymized-2728706743...">
+              <DEFINITION>
+                <ATTRIBUTE-DEFINITION-STRING-REF>rmf-0ebf173d-49d4-49ec-b170-8deac3238f86</ATTRIBUTE-DEFINITION-STRING-REF>
+              </DEFINITION>
+            </ATTRIBUTE-VALUE-STRING>
+            <ATTRIBUTE-VALUE-STRING THE-VALUE="...Anonymized-3286337206...">
+              <DEFINITION>
+                <ATTRIBUTE-DEFINITION-STRING-REF>rmf-f14d9142-c2a8-4e78-8a7f-e93f0ee0fbfc</ATTRIBUTE-DEFINITION-STRING-REF>
+              </DEFINITION>
+            </ATTRIBUTE-VALUE-STRING>
+            <ATTRIBUTE-VALUE-STRING THE-VALUE="...Anonymized-4343463957...">
+              <DEFINITION>
+                <ATTRIBUTE-DEFINITION-STRING-REF>rmf-8ad26cf3-dcae-4b0a-8434-d1945ba5178d</ATTRIBUTE-DEFINITION-STRING-REF>
+              </DEFINITION>
+            </ATTRIBUTE-VALUE-STRING>
+            <ATTRIBUTE-VALUE-DATE THE-VALUE="2022-09-21T08:52:41.148-07:00">
+              <DEFINITION>
+                <ATTRIBUTE-DEFINITION-DATE-REF>rmf-1976b3b4-56a4-4933-a9e7-b44533b15655</ATTRIBUTE-DEFINITION-DATE-REF>
+              </DEFINITION>
+            </ATTRIBUTE-VALUE-DATE>
+          </VALUES>
+          <TYPE>
+            <SPEC-OBJECT-TYPE-REF>_c72b4453-3b94-4da4-8b01-1a92766fe276</SPEC-OBJECT-TYPE-REF>
+          </TYPE>
+        </SPEC-OBJECT>
+        <SPEC-OBJECT IDENTIFIER="rmf-85c7695b-a2d1-45ec-bdf3-f17e4ded59ac" LAST-CHANGE="2023-02-01T08:22:23.663-08:00">
+          <VALUES>
+            <ATTRIBUTE-VALUE-STRING THE-VALUE="...Anonymized-1890729041...">
+              <DEFINITION>
+                <ATTRIBUTE-DEFINITION-STRING-REF>rmf-1b53584c-a9ad-47f4-b83a-0e7985fa3f7e</ATTRIBUTE-DEFINITION-STRING-REF>
+              </DEFINITION>
+            </ATTRIBUTE-VALUE-STRING>
+            <ATTRIBUTE-VALUE-XHTML>
+              <DEFINITION>
+                <ATTRIBUTE-DEFINITION-XHTML-REF>rmf-7d0ed062-e964-424c-8305-45067118d959</ATTRIBUTE-DEFINITION-XHTML-REF>
+              </DEFINITION>
+              <THE-VALUE>
+                <xhtml:div>
+                  Unclosed object tag follows here:
+                  <xhtml:object data="files/rmf-1b18ef37-ca1f-4e79-954d-747df083f861_DOCATTACHMENT_3-screenshot-20220926-051927.png" name="DOCATTACHMENT_3-screenshot-20220926-051927.png" type="image/png"/>
+                </xhtml:div>
+              </THE-VALUE>
+            </ATTRIBUTE-VALUE-XHTML>
+            <ATTRIBUTE-VALUE-DATE THE-VALUE="2022-09-21T08:57:45.429-07:00">
+              <DEFINITION>
+                <ATTRIBUTE-DEFINITION-DATE-REF>rmf-7caf14b5-e997-47eb-a85d-6bd80a5aef3c</ATTRIBUTE-DEFINITION-DATE-REF>
+              </DEFINITION>
+            </ATTRIBUTE-VALUE-DATE>
+            <ATTRIBUTE-VALUE-STRING THE-VALUE="...Anonymized-8651603154...">
+              <DEFINITION>
+                <ATTRIBUTE-DEFINITION-STRING-REF>rmf-1759a733-cd44-4740-a63f-88afc01d7b28</ATTRIBUTE-DEFINITION-STRING-REF>
+              </DEFINITION>
+            </ATTRIBUTE-VALUE-STRING>
+            <ATTRIBUTE-VALUE-STRING THE-VALUE="...Anonymized-3286337206...">
+              <DEFINITION>
+                <ATTRIBUTE-DEFINITION-STRING-REF>rmf-5b05da73-825a-46cf-945b-81b619fc9480</ATTRIBUTE-DEFINITION-STRING-REF>
+              </DEFINITION>
+            </ATTRIBUTE-VALUE-STRING>
+          </VALUES>
+          <TYPE>
+            <SPEC-OBJECT-TYPE-REF>_b26dff7a-531b-427e-8daf-9fa21e4f0dbe</SPEC-OBJECT-TYPE-REF>
+          </TYPE>
+        </SPEC-OBJECT>
+      </SPEC-OBJECTS>
+      <SPECIFICATIONS>
+        <SPECIFICATION IDENTIFIER="_db1d5146-5793-40a8-a23c-dab760934553" LAST-CHANGE="2023-02-01T08:22:22.353-08:00" LONG-NAME="...Anonymized-8684252467...">
+          <TYPE>
+            <SPECIFICATION-TYPE-REF>polarion_live_document</SPECIFICATION-TYPE-REF>
+          </TYPE>
+          <CHILDREN>
+            <SPEC-HIERARCHY IDENTIFIER="rmf-14f6ad27-8d22-4140-bfc0-04691bcb77f8" LAST-CHANGE="2023-02-01T08:22:23.613-08:00">
+              <OBJECT>
+                <SPEC-OBJECT-REF>rmf-3e0ae326-c60f-4206-b017-0dc7e418afef</SPEC-OBJECT-REF>
+              </OBJECT>
+              <CHILDREN>
+                <SPEC-HIERARCHY IDENTIFIER="rmf-d419e47f-dd14-4487-b3e3-8b2a052aa124" LAST-CHANGE="2023-02-01T08:22:23.645-08:00">
+                  <OBJECT>
+                    <SPEC-OBJECT-REF>rmf-2616fa87-f1f5-4c87-9725-4a084d718be6</SPEC-OBJECT-REF>
+                  </OBJECT>
+                  <CHILDREN>
+                    <SPEC-HIERARCHY IDENTIFIER="rmf-fecf6771-be15-4751-a3be-5d2225175f84" LAST-CHANGE="2023-02-01T08:22:23.646-08:00">
+                      <OBJECT>
+                        <SPEC-OBJECT-REF>rmf-85c7695b-a2d1-45ec-bdf3-f17e4ded59ac</SPEC-OBJECT-REF>
+                      </OBJECT>
+                    </SPEC-HIERARCHY>
+                  </CHILDREN>
+                </SPEC-HIERARCHY>
+              </CHILDREN>
+            </SPEC-HIERARCHY>
+          </CHILDREN>
+        </SPECIFICATION>
+      </SPECIFICATIONS>
+    </REQ-IF-CONTENT>
+  </CORE-CONTENT>
+</REQ-IF>

--- a/tests/integration/backend/reqif/profiles/p11_polarion/03_xhtml_object_edge_case/test.itest
+++ b/tests/integration/backend/reqif/profiles/p11_polarion/03_xhtml_object_edge_case/test.itest
@@ -1,0 +1,16 @@
+RUN: %mkdir %S/output
+RUN: %strictdoc import reqif p11_polarion %S/sample.reqif %S/output/output.sdoc
+
+RUN: %cat %S/output/output.sdoc | filecheck %s
+CHECK: [REQUIREMENT]
+CHECK: CREATED_BY: ...Anonymized-3286337206...
+CHECK: UID: ...Anonymized-1890729041...
+CHECK: STATEMENT: >>>
+<div>
+  Unclosed object tag follows here:
+  <object data="files/rmf-1b18ef37-ca1f-4e79-954d-747df083f861_DOCATTACHMENT_3-screenshot-20220926-051927.png" name="DOCATTACHMENT_3-screenshot-20220926-051927.png" type="image/png"></object>
+<div>
+CHECK: <<<
+
+RUN: %strictdoc export --formats=html %S/output/output.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/output/output.sdoc


### PR DESCRIPTION
<object> tag, when unclosed, breaks complete HTML markup of a document. lxml closes empty tags by default, so the upstream fix in the reqif library was to make an exception for the <object> tag and always print it with a closing tag.