### PR TITLE
export/html: remove unused static_path variable from HTML templates

### DIFF
--- a/strictdoc/export/html/generators/requirements_coverage.py
+++ b/strictdoc/export/html/generators/requirements_coverage.py
@@ -39,7 +39,6 @@ class RequirementsCoverageHTMLGenerator:
             documents_iterator=document_tree_iterator.iterator(),
             link_renderer=link_renderer,
             renderer=markup_renderer,
-            static_path="_static",
             document_type=DocumentType.deeptrace(),
             strictdoc_version=__version__,
         )

--- a/strictdoc/export/html/generators/source_file_coverage.py
+++ b/strictdoc/export/html/generators/source_file_coverage.py
@@ -22,7 +22,6 @@ class SourceFileCoverageHTMLGenerator:
         output += template.render(
             config=config,
             traceability_index=traceability_index,
-            static_path="_static",
             link_renderer=link_renderer,
             strictdoc_version=__version__,
         )

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -1437,7 +1437,6 @@ def create_main_router(
             config=export_action.config,
             document_tree=export_action.traceability_index.document_tree,
             document_tree_iterator=document_tree_iterator,
-            static_path="_static",
             traceability_index=export_action.traceability_index,
         )
         return HTMLResponse(
@@ -1959,7 +1958,6 @@ def create_main_router(
             config=export_action.config,
             document_tree=export_action.traceability_index.document_tree,
             document_tree_iterator=document_tree_iterator,
-            static_path="_static",
             traceability_index=export_action.traceability_index,
         )
         return HTMLResponse(


### PR DESCRIPTION
A small clean-up towards https://github.com/strictdoc-project/strictdoc/issues/893.