### PR TITLE
strictdoc.toml: introduce the html_assets_strictdoc_dir parameter

### DIFF
--- a/docs/strictdoc.toml
+++ b/docs/strictdoc.toml
@@ -1,0 +1,3 @@
+[project]
+title = "StrictDoc Documentation"
+html_assets_strictdoc_dir = "assets"

--- a/strictdoc/cli/cli_arg_parser.py
+++ b/strictdoc/cli/cli_arg_parser.py
@@ -8,6 +8,7 @@ from strictdoc.backend.reqif.sdoc_reqif_fields import ReqIFProfile
 from strictdoc.cli.argument_int_range import IntRange
 from strictdoc.core.environment import SDocRuntimeEnvironment
 from strictdoc.core.project_config import ProjectConfig
+from strictdoc.helpers.auto_described import auto_described
 
 EXPORT_FORMATS = ["html", "html-standalone", "rst", "excel", "reqif-sdoc"]
 EXCEL_PARSERS = ["basic"]
@@ -284,6 +285,7 @@ class PassthroughCommandConfig:
         self.output_file = output_file
 
 
+@auto_described
 class ServerCommandConfig:
     def __init__(
         self,
@@ -338,6 +340,11 @@ class ExportCommandConfig:  # pylint: disable=too-many-instance-attributes
         self.output_html_root: str = os.path.join(output_dir, "html")
 
         self.is_running_on_server = False
+
+        # This option comes from the project config when the
+        # config file is read.
+        self.dir_for_sdoc_assets: str = ""
+
         # FIXME: This does not belong here.
         self._server_port: Optional[int] = None
 
@@ -373,6 +380,7 @@ class ExportCommandConfig:  # pylint: disable=too-many-instance-attributes
     def integrate_project_config(self, project_config: ProjectConfig):
         if self.project_title is None:
             self.project_title = project_config.project_title
+        self.dir_for_sdoc_assets = project_config.dir_for_sdoc_assets
 
 
 class DumpGrammarCommandConfig:

--- a/strictdoc/cli/main.py
+++ b/strictdoc/cli/main.py
@@ -73,7 +73,7 @@ def _main(parallelizer):
         print(  # noqa: T201
             f"Parallelization: {parallelization_value}", flush=True
         )
-        export_action = ExportAction(config, parallelizer)
+        export_action = ExportAction(config=config, parallelizer=parallelizer)
         export_action.build_index()
         export_action.export()
 

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -2,16 +2,24 @@ import os
 
 import toml
 
+from strictdoc.helpers.auto_described import auto_described
 
+
+@auto_described
 class ProjectConfig:
     DEFAULT_PROJECT_TITLE = "Untitled Project"
+    DEFAULT_DIR_FOR_SDOC_ASSETS = "_static"
 
-    def __init__(self, project_title: str):
+    def __init__(self, project_title: str, dir_for_sdoc_assets: str):
         self.project_title: str = project_title
+        self.dir_for_sdoc_assets: str = dir_for_sdoc_assets
 
     @staticmethod
     def default_config():
-        return ProjectConfig(project_title=ProjectConfig.DEFAULT_PROJECT_TITLE)
+        return ProjectConfig(
+            project_title=ProjectConfig.DEFAULT_PROJECT_TITLE,
+            dir_for_sdoc_assets=ProjectConfig.DEFAULT_DIR_FOR_SDOC_ASSETS,
+        )
 
 
 class ProjectConfigLoader:
@@ -27,6 +35,7 @@ class ProjectConfigLoader:
             return ProjectConfig.default_config()
 
         project_title = ProjectConfig.DEFAULT_PROJECT_TITLE
+        dir_for_sdoc_assets = ProjectConfig.DEFAULT_DIR_FOR_SDOC_ASSETS
 
         try:
             config_content = toml.load(path_to_config)
@@ -45,4 +54,10 @@ class ProjectConfigLoader:
         if "project" in config_content:
             project_content = config_content["project"]
             project_title = project_content.get("title", project_title)
-        return ProjectConfig(project_title=project_title)
+            dir_for_sdoc_assets = project_content.get(
+                "html_assets_strictdoc_dir", dir_for_sdoc_assets
+            )
+        return ProjectConfig(
+            project_title=project_title,
+            dir_for_sdoc_assets=dir_for_sdoc_assets,
+        )

--- a/strictdoc/export/html/generators/document_tree.py
+++ b/strictdoc/export/html/generators/document_tree.py
@@ -1,4 +1,5 @@
 from strictdoc import __version__
+from strictdoc.cli.cli_arg_parser import ExportCommandConfig
 from strictdoc.core.document_tree_iterator import DocumentTreeIterator
 from strictdoc.core.traceability_index import TraceabilityIndex
 from strictdoc.export.html.html_templates import HTMLTemplates
@@ -10,7 +11,7 @@ class DocumentTreeHTMLGenerator:
 
     @staticmethod
     def export(
-        config,
+        config: ExportCommandConfig,
         traceability_index: TraceabilityIndex,
     ):
         document_tree_iterator = DocumentTreeIterator(
@@ -20,7 +21,9 @@ class DocumentTreeHTMLGenerator:
         template = DocumentTreeHTMLGenerator.env.get_template(
             "document_tree/document_tree.jinja.html"
         )
-        link_renderer = LinkRenderer(root_path="")
+        link_renderer = LinkRenderer(
+            root_path="", static_path=config.dir_for_sdoc_assets
+        )
 
         output = template.render(
             config=config,

--- a/strictdoc/export/html/generators/requirements_coverage.py
+++ b/strictdoc/export/html/generators/requirements_coverage.py
@@ -26,7 +26,9 @@ class RequirementsCoverageHTMLGenerator:
             "requirements_coverage/requirements_coverage.jinja.html"
         )
 
-        link_renderer = LinkRenderer(root_path="")
+        link_renderer = LinkRenderer(
+            root_path="", static_path=config.dir_for_sdoc_assets
+        )
         markup_renderer = MarkupRenderer.create(
             "RST",
             traceability_index,

--- a/strictdoc/export/html/generators/source_file_coverage.py
+++ b/strictdoc/export/html/generators/source_file_coverage.py
@@ -18,7 +18,9 @@ class SourceFileCoverageHTMLGenerator:
         template = SourceFileCoverageHTMLGenerator.env.get_template(
             "source_file_coverage/source_file_coverage.jinja.html"
         )
-        link_renderer = LinkRenderer(root_path="")
+        link_renderer = LinkRenderer(
+            root_path="", static_path=config.dir_for_sdoc_assets
+        )
         output += template.render(
             config=config,
             traceability_index=traceability_index,

--- a/strictdoc/export/html/generators/source_file_view_generator.py
+++ b/strictdoc/export/html/generators/source_file_view_generator.py
@@ -114,7 +114,10 @@ class SourceFileViewHTMLGenerator:
             )
         pygments_styles = html_formatter.get_style_defs(".highlight")
 
-        link_renderer = LinkRenderer(root_path=source_file.path_depth_prefix)
+        link_renderer = LinkRenderer(
+            root_path=source_file.path_depth_prefix,
+            static_path=config.dir_for_sdoc_assets,
+        )
         markup_renderer = MarkupRenderer.create(
             "RST", traceability_index, link_renderer, None
         )

--- a/strictdoc/export/html/html_generator.py
+++ b/strictdoc/export/html/html_generator.py
@@ -51,14 +51,14 @@ class HTMLGenerator:
 
         # Export StrictDoc's own assets.
         output_html_static_files = os.path.join(
-            config.output_html_root, "_static"
+            config.output_html_root, config.dir_for_sdoc_assets
         )
         sync_dir(config.get_static_files_path(), output_html_static_files)
 
         # Export MathJax
         if config.enable_mathjax:
             output_html_mathjax = os.path.join(
-                config.output_html_root, "_static", "mathjax"
+                config.output_html_root, config.dir_for_sdoc_assets, "mathjax"
             )
             Path(output_html_mathjax).mkdir(parents=True, exist_ok=True)
             mathjax_src = os.path.join(
@@ -176,7 +176,9 @@ class HTMLGenerator:
         Path(document_output_folder).mkdir(parents=True, exist_ok=True)
 
         root_path = document.meta.get_root_path_prefix()
-        link_renderer = LinkRenderer(root_path=root_path)
+        link_renderer = LinkRenderer(
+            root_path=root_path, static_path=config.dir_for_sdoc_assets
+        )
         markup_renderer = MarkupRenderer.create(
             document.config.markup,
             traceability_index,

--- a/strictdoc/export/html/renderers/link_renderer.py
+++ b/strictdoc/export/html/renderers/link_renderer.py
@@ -10,11 +10,16 @@ from strictdoc.export.html.document_type import DocumentType
 
 
 class LinkRenderer:
-    def __init__(self, *, root_path):
+    def __init__(self, *, root_path, static_path: str):
         assert isinstance(root_path, str)
+        assert isinstance(static_path, str), static_path
+        assert len(static_path) > 0, static_path
+
         self.root_path: str = root_path
         self.static_path: str = (
-            f"{root_path}/_static" if len(root_path) > 0 else "_static"
+            f"{root_path}/{static_path}"
+            if len(root_path) > 0
+            else f"{static_path}"
         )
         self.local_anchor_cache = {}
         self.req_link_cache = {}

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -116,6 +116,7 @@ def create_main_router(
         enable_mathjax=False,
         experimental_enable_file_traceability=False,
     )
+    export_config.integrate_project_config(project_config)
     export_config.configure_for_server(server_port=server_config.port)
     export_action = ExportAction(
         config=export_config, parallelizer=parallelizer
@@ -167,7 +168,8 @@ def create_main_router(
             "actions/document/create_section/stream_new_section.jinja.html"
         )
         link_renderer = LinkRenderer(
-            root_path=document.meta.get_root_path_prefix()
+            root_path=document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -250,7 +252,8 @@ def create_main_router(
                 "actions/document/create_section/stream_new_section.jinja.html"
             )
             link_renderer = LinkRenderer(
-                root_path=document.meta.get_root_path_prefix()
+                root_path=document.meta.get_root_path_prefix(),
+                static_path=project_config.dir_for_sdoc_assets,
             )
             markup_renderer = MarkupRenderer.create(
                 markup="RST",
@@ -348,7 +351,8 @@ def create_main_router(
             "actions/document/create_section/stream_created_section.jinja.html"
         )
         link_renderer = LinkRenderer(
-            root_path=document.meta.get_root_path_prefix()
+            root_path=document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -397,7 +401,8 @@ def create_main_router(
             "actions/document/edit_section/stream_edit_section.jinja.html"
         )
         link_renderer = LinkRenderer(
-            root_path=section.document.meta.get_root_path_prefix()
+            root_path=section.document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -461,7 +466,8 @@ def create_main_router(
                 "actions/document/edit_section/stream_edit_section.jinja.html"
             )
             link_renderer = LinkRenderer(
-                root_path=section.document.meta.get_root_path_prefix()
+                root_path=section.document.meta.get_root_path_prefix(),
+                static_path=project_config.dir_for_sdoc_assets,
             )
             markup_renderer = MarkupRenderer.create(
                 markup="RST",
@@ -524,7 +530,8 @@ def create_main_router(
             "actions/document/edit_section/stream_updated_section.jinja.html"
         )
         link_renderer = LinkRenderer(
-            root_path=section.document.meta.get_root_path_prefix()
+            root_path=section.document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -584,7 +591,8 @@ def create_main_router(
             "actions/document/edit_section/stream_updated_section.jinja.html"
         )
         link_renderer = LinkRenderer(
-            root_path=section.document.meta.get_root_path_prefix()
+            root_path=section.document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -642,7 +650,8 @@ def create_main_router(
             "stream_new_requirement.jinja.html"
         )
         link_renderer = LinkRenderer(
-            root_path=document.meta.get_root_path_prefix()
+            root_path=document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -723,7 +732,8 @@ def create_main_router(
                 "stream_new_requirement.jinja.html"
             )
             link_renderer = LinkRenderer(
-                root_path=document.meta.get_root_path_prefix()
+                root_path=document.meta.get_root_path_prefix(),
+                static_path=project_config.dir_for_sdoc_assets,
             )
             markup_renderer = MarkupRenderer.create(
                 markup="RST",
@@ -794,7 +804,8 @@ def create_main_router(
             "stream_created_requirement.jinja.html"
         )
         link_renderer = LinkRenderer(
-            root_path=document.meta.get_root_path_prefix()
+            root_path=document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -851,7 +862,8 @@ def create_main_router(
             "stream_edit_requirement.jinja.html"
         )
         link_renderer = LinkRenderer(
-            root_path=document.meta.get_root_path_prefix()
+            root_path=document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -908,7 +920,8 @@ def create_main_router(
                 "stream_edit_requirement.jinja.html"
             )
             link_renderer = LinkRenderer(
-                root_path=document.meta.get_root_path_prefix()
+                root_path=document.meta.get_root_path_prefix(),
+                static_path=project_config.dir_for_sdoc_assets,
             )
             markup_renderer = MarkupRenderer.create(
                 markup="RST",
@@ -1074,7 +1087,8 @@ def create_main_router(
             export_action.traceability_index.get_document_iterator(document)
         )
         link_renderer: LinkRenderer = LinkRenderer(
-            root_path=document.meta.get_root_path_prefix()
+            root_path=document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer: MarkupRenderer = MarkupRenderer.create(
             markup="RST",
@@ -1154,7 +1168,8 @@ def create_main_router(
             "stream_update_requirement.jinja.html"
         )
         link_renderer = LinkRenderer(
-            root_path=document.meta.get_root_path_prefix()
+            root_path=document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -1212,7 +1227,8 @@ def create_main_router(
             "actions/document/delete_section/stream_delete_section.jinja.html"
         )
         link_renderer = LinkRenderer(
-            root_path=section.document.meta.get_root_path_prefix()
+            root_path=section.document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -1279,7 +1295,8 @@ def create_main_router(
             "stream_delete_requirement.jinja.html"
         )
         link_renderer = LinkRenderer(
-            root_path=requirement.document.meta.get_root_path_prefix()
+            root_path=requirement.document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -1607,7 +1624,8 @@ def create_main_router(
         )
 
         link_renderer = LinkRenderer(
-            root_path=document.meta.get_root_path_prefix()
+            root_path=document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -1641,7 +1659,8 @@ def create_main_router(
             document_mid
         )
         link_renderer = LinkRenderer(
-            root_path=document.meta.get_root_path_prefix()
+            root_path=document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -1776,7 +1795,8 @@ def create_main_router(
         )
 
         link_renderer = LinkRenderer(
-            root_path=document.meta.get_root_path_prefix()
+            root_path=document.meta.get_root_path_prefix(),
+            static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
             markup="RST",
@@ -1798,7 +1818,8 @@ def create_main_router(
         )
         if massive_update:
             link_renderer = LinkRenderer(
-                root_path=document.meta.get_root_path_prefix()
+                root_path=document.meta.get_root_path_prefix(),
+                static_path=project_config.dir_for_sdoc_assets,
             )
             markup_renderer = MarkupRenderer.create(
                 markup="RST",

--- a/tests/integration/options/options_per_project/html_assets_strictdoc_dir/01_option_specified/input.sdoc
+++ b/tests/integration/options/options_per_project/html_assets_strictdoc_dir/01_option_specified/input.sdoc
@@ -1,0 +1,6 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[FREETEXT]
+**Hello world**
+[/FREETEXT]

--- a/tests/integration/options/options_per_project/html_assets_strictdoc_dir/01_option_specified/strictdoc.toml
+++ b/tests/integration/options/options_per_project/html_assets_strictdoc_dir/01_option_specified/strictdoc.toml
@@ -1,0 +1,2 @@
+[project]
+html_assets_strictdoc_dir = "assets"

--- a/tests/integration/options/options_per_project/html_assets_strictdoc_dir/01_option_specified/test.itest
+++ b/tests/integration/options/options_per_project/html_assets_strictdoc_dir/01_option_specified/test.itest
@@ -1,0 +1,12 @@
+RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --dir "%S/Output/html/assets"
+RUN: %check_exists --file "%S/Output/html/assets/base.css"
+RUN: %check_exists --file "%S/Output/html/assets/pan_with_space.js"
+
+RUN: %cat "%S/Output/html/index.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-TREE
+CHECK-HTML-TREE: <link rel="stylesheet" href="assets/base.css"/>
+
+RUN: %cat "%S/Output/html/01_option_specified/input.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-DOC
+CHECK-HTML-DOC: <link rel="stylesheet" href="../assets/base.css"/>

--- a/tests/integration/options/options_per_project/html_assets_strictdoc_dir/02_option_not_specified/input.sdoc
+++ b/tests/integration/options/options_per_project/html_assets_strictdoc_dir/02_option_not_specified/input.sdoc
@@ -1,0 +1,6 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[FREETEXT]
+**Hello world**
+[/FREETEXT]

--- a/tests/integration/options/options_per_project/html_assets_strictdoc_dir/02_option_not_specified/test.itest
+++ b/tests/integration/options/options_per_project/html_assets_strictdoc_dir/02_option_not_specified/test.itest
@@ -1,0 +1,12 @@
+RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --dir "%S/Output/html/_static"
+RUN: %check_exists --file "%S/Output/html/_static/base.css"
+RUN: %check_exists --file "%S/Output/html/_static/pan_with_space.js"
+
+RUN: %cat "%S/Output/html/index.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-TREE
+CHECK-HTML-TREE: <link rel="stylesheet" href="_static/base.css"/>
+
+RUN: %cat "%S/Output/html/02_option_not_specified/input.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-DOC
+CHECK-HTML-DOC: <link rel="stylesheet" href="../_static/base.css"/>


### PR DESCRIPTION
This helps to have StrictDoc's own assets in the assets/ folder which is the GitHub Pages convention for assets.

Related to #893