### PR TITLE
docs: update Read the Docs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,7 +16,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.6
   install:
     - requirements: docs/sphinx/requirements.txt
 


### PR DESCRIPTION
The build process is failing with:

```
/usr/bin/python3.6: No module named virtualenv
```