### PR TITLE
server: Do not re-open NamedTemporaryFile on Windows

### DIFF
--- a/strictdoc/server/app.py
+++ b/strictdoc/server/app.py
@@ -39,8 +39,19 @@ def create_app(
 
 
 def strictdoc_production_app():
+    # This is a work-around to allow opening a file created with
+    # NamedTemporaryFile on Windows.
+    # See https://stackoverflow.com/a/15235559
+    def temp_opener(name, flag, mode=0o777):
+        try:
+            flag |= os.O_TEMPORARY
+        except AttributeError:
+            pass  # Only Windows has this flag
+
+        return os.open(name, flag, mode)
+
     path_to_tmp_config = os.environ[SDocServerEnvVariable.PATH_TO_CONFIG]
-    with open(path_to_tmp_config, "rb") as tmp_config_file:
+    with open(path_to_tmp_config, "rb", opener=temp_opener) as tmp_config_file:
         tmp_config_bytes = tmp_config_file.read()
 
     two_configs = pickle_load(tmp_config_bytes)

--- a/strictdoc/server/server.py
+++ b/strictdoc/server/server.py
@@ -1,6 +1,6 @@
 import os
 import tempfile
-from typing import Optional
+from contextlib import ExitStack
 
 import uvicorn
 
@@ -28,68 +28,61 @@ def run_strictdoc_server(
 ):
     print_warning_message()
 
-    temp_dir: Optional[tempfile.TemporaryDirectory] = None
-    if server_config.output_path is None:
-        temp_dir = (
-            tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
-        )
-        server_config.output_path = temp_dir.name
-
-    # uvicorn.run does not support passing arguments to the main
-    # function (strictdoc_production_app). Passing the pickled config through
-    # the environmental variables interface.
-    tmp_config_file = (
-        tempfile.NamedTemporaryFile()  # pylint: disable=consider-using-with  # noqa: E501
-    )
-    with open(tmp_config_file.name, "wb") as tmp_config_file_:
-        config_dump = pickle_dump((server_config, project_config))
-        tmp_config_file_.write(config_dump)
-    os.environ[SDocServerEnvVariable.PATH_TO_CONFIG] = tmp_config_file.name
-
-    uvicorn.run(
-        "strictdoc.server.app:strictdoc_production_app",
-        app_dir=".",
-        factory=True,
-        host="127.0.0.1",
-        log_level="info",
-        port=server_config.port,
-        reload=server_config.reload,
-        reload_dirs=[
-            os.path.join(
-                server_config.environment.path_to_strictdoc, "strictdoc"
+    with ExitStack() as stack:
+        if server_config.output_path is None:
+            server_config.output_path = stack.enter_context(
+                tempfile.TemporaryDirectory()
             )
-        ],
-        reload_includes=[
-            "*.py",
-            "*.html",
-            "*.jinja",
-            "*.css",
-            "*.js",
-        ],
-        reload_excludes=[
-            # "tests",  # Doesn't work.
-            # "tests/",  # Doesn't work.
-            # "tests/*",  # Doesn't work.
-            # "tests/**",  # Makes the process hang, server doesn't start.
-            # It looks like the regex engine does not support ** globs.
-            "tests/*/*.*",
-            "tests/*/*/*.*",
-            "tests/*/*/*/*.*",
-            "tests/*/*/*/*/*.*",
-            "tests/*/*/*/*/*/*.*",
-            "tests/*/*/*/*/*/*/*.*",
-            "tests/*/*/*/*/*/*/*/*.*",
-            "tests/*/*/*/*/*/*/*/*/*.*",
-            "tests/*/*/*/*/*/*/*/*/*/*.*",
-            "tests/*/*/*/*/*/*/*/*/*/*/*.*",
-            "tests/*/*/*/*/*/*/*/*/*/*/*/*.*",
-            "tests/*/*/*/*/*/*/*/*/*/*/*/*/*.*",
-            "tests/*/*/*/*/*/*/*/*/*/*/*/*/*/*.*",
-            "tests/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*.*",
-        ],
-    )
-    tmp_config_file.close()
-    if os.path.exists(tmp_config_file.name):
-        os.unlink(tmp_config_file.name)
-    if temp_dir is not None:
-        temp_dir.cleanup()
+
+        # uvicorn.run does not support passing arguments to the main
+        # function (strictdoc_production_app). Passing the pickled config
+        # through the environmental variables interface.
+        tmp_config_file = stack.enter_context(tempfile.NamedTemporaryFile())
+        config_dump = pickle_dump((server_config, project_config))
+        tmp_config_file.write(config_dump)
+        tmp_config_file.flush()
+
+        os.environ[SDocServerEnvVariable.PATH_TO_CONFIG] = tmp_config_file.name
+
+        uvicorn.run(
+            "strictdoc.server.app:strictdoc_production_app",
+            app_dir=".",
+            factory=True,
+            host="127.0.0.1",
+            log_level="info",
+            port=server_config.port,
+            reload=server_config.reload,
+            reload_dirs=[
+                os.path.join(
+                    server_config.environment.path_to_strictdoc, "strictdoc"
+                )
+            ],
+            reload_includes=[
+                "*.py",
+                "*.html",
+                "*.jinja",
+                "*.css",
+                "*.js",
+            ],
+            reload_excludes=[
+                # "tests",  # Doesn't work.
+                # "tests/",  # Doesn't work.
+                # "tests/*",  # Doesn't work.
+                # "tests/**",  # Makes the process hang, server doesn't start.
+                # It looks like the regex engine does not support ** globs.
+                "tests/*/*.*",
+                "tests/*/*/*.*",
+                "tests/*/*/*/*.*",
+                "tests/*/*/*/*/*.*",
+                "tests/*/*/*/*/*/*.*",
+                "tests/*/*/*/*/*/*/*.*",
+                "tests/*/*/*/*/*/*/*/*.*",
+                "tests/*/*/*/*/*/*/*/*/*.*",
+                "tests/*/*/*/*/*/*/*/*/*/*.*",
+                "tests/*/*/*/*/*/*/*/*/*/*/*.*",
+                "tests/*/*/*/*/*/*/*/*/*/*/*/*.*",
+                "tests/*/*/*/*/*/*/*/*/*/*/*/*/*.*",
+                "tests/*/*/*/*/*/*/*/*/*/*/*/*/*/*.*",
+                "tests/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*.*",
+            ],
+        )


### PR DESCRIPTION
From the Python docs: "Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows)"

The file-like object returned by NamedTemporaryFile can be used to write to the temporary file. The writes must be flushed before another process attempts to read the file.

Also, using an ExitStack removes the need to manually manage the clean-up of the (optional) TemporaryDirectory and NamedTemporaryFile used by `run_strictdoc_server()`.

Closes #1061