### PR TITLE
backend/sdoc: disallow empty multiline fields completely.

### DIFF
--- a/docs/sphinx/source/strictdoc_01_user_guide.rst
+++ b/docs/sphinx/source/strictdoc_01_user_guide.rst
@@ -326,6 +326,49 @@ written in form of requirements:
 be specified using ``[FREETEXT]`` nodes. By design, the ``[FREETEXT]`` nodes can
 be only attached to the ``[DOCUMENT]`` and ``[SECTION]`` nodes.
 
+Strict rule #3: No empty strings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+StrictDoc's grammar does not allow empty strings. This rule is applicable to
+both single-line and multiline strings and both section fields and requirement
+fields. A field is either missing or is a non-empty string.
+
+The following patterns are all invalid for single-line fields:
+
+.. code-block::
+
+    [SECTION]
+    TITLE:
+
+    [SECTION]
+    TITLE: (any number of space characters after colons)
+
+    [REQUIREMENT]
+    STATEMENT:
+
+    [REQUIREMENT]
+    STATEMENT: (any number of space characters after colons)
+
+The following patterns are all invalid for multiline fields:
+
+.. code-block::
+
+    [REQUIREMENT]
+    COMMENT: >>>
+    <<<
+
+    [REQUIREMENT]
+    COMMENT: >>>
+    (any number of space characters)
+    <<<
+
+If you need to provide a placeholder for a field that you know has to be filled
+out soon, add a "TBD" (to be done) or a "TBC" (to be confirmed) string.
+
+One of the upcoming features of StrictDoc is a calculation of document maturity
+based on a number of TBD/TBCs found in document. This is a common practice in
+the regulared industries.
+
 Grammar elements
 ----------------
 

--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -394,6 +394,53 @@ be only attached to the ``[DOCUMENT]`` and ``[SECTION]`` nodes.
 
 [/SECTION]
 
+[SECTION]
+TITLE: Strict rule #3: No empty strings
+
+[FREETEXT]
+StrictDoc's grammar does not allow empty strings. This rule is applicable to
+both single-line and multiline strings and both section fields and requirement
+fields. A field is either missing or is a non-empty string.
+
+The following patterns are all invalid for single-line fields:
+
+.. code-block::
+
+    [SECTION]
+    TITLE:
+
+    [SECTION]
+    TITLE: (any number of space characters after colons)
+
+    [REQUIREMENT]
+    STATEMENT:
+
+    [REQUIREMENT]
+    STATEMENT: (any number of space characters after colons)
+
+The following patterns are all invalid for multiline fields:
+
+.. code-block::
+
+    [REQUIREMENT]
+    COMMENT: >>>
+    <<<
+
+    [REQUIREMENT]
+    COMMENT: >>>
+    (any number of space characters)
+    <<<
+
+If you need to provide a placeholder for a field that you know has to be filled
+out soon, add a "TBD" (to be done) or a "TBC" (to be confirmed) string.
+
+One of the upcoming features of StrictDoc is a calculation of document maturity
+based on a number of TBD/TBCs found in document. This is a common practice in
+the regulared industries.
+[/FREETEXT]
+
+[/SECTION]
+
 [/SECTION]
 
 [SECTION]

--- a/strictdoc/backend/sdoc/grammar/grammar.py
+++ b/strictdoc/backend/sdoc/grammar/grammar.py
@@ -149,9 +149,9 @@ SECTION_GRAMMAR = r"""
 Section[noskipws]:
   '[SECTION]'
   '\n'
-  ('UID: ' uid = /.+$/ '\n')?
-  ('LEVEL: ' custom_level = /.*/ '\n')?
-  'TITLE: ' title = /.*$/ '\n'
+  ('UID: ' uid = SingleLineString '\n')?
+  ('LEVEL: ' custom_level = SingleLineString '\n')?
+  'TITLE: ' title = SingleLineString '\n'
   free_texts *= SpaceThenFreeText
   section_contents *= SectionOrRequirement
   '\n'

--- a/strictdoc/backend/sdoc/grammar/type_system.py
+++ b/strictdoc/backend/sdoc/grammar/type_system.py
@@ -3,8 +3,11 @@ FieldName[noskipws]:
   /[A-Z]+[A-Z_]*/
 ;
 
+// According to the Strict Grammar Rule #3, both SingleLineString and
+// MultiLineString can never be empty strings.
+// Both must start with a non-space character.
 SingleLineString:
-  (!MultiLineStringStart /\S/) (!MultiLineStringStart /./)*
+  (!MultiLineStringStart /\S/) (!MultiLineStringStart /./)* /$/
 ;
 
 MultiLineStringStart[noskipws]:
@@ -17,7 +20,7 @@ MultiLineStringEnd[noskipws]:
 
 MultiLineString[noskipws]:
   MultiLineStringStart-
-  ((!MultiLineStringEnd /(?ms)./)+ | '')
+  (!MultiLineStringEnd /\S/) (!MultiLineStringEnd /(?ms)./)+
   MultiLineStringEnd-
 ;
 

--- a/strictdoc/backend/sdoc/models/requirement.py
+++ b/strictdoc/backend/sdoc/models/requirement.py
@@ -42,7 +42,10 @@ class RequirementField:
         # FIXME: This should be strict_assert at some point.
         assert (
             (field_value is not None and len(field_value) > 0)
-            or field_value_multiline is not None
+            or (
+                field_value_multiline is not None
+                and len(field_value_multiline) > 0
+            )
             or (
                 field_value_references is not None
                 and len(field_value_references) > 0


### PR DESCRIPTION
Also, harden section fields in the same way.

Follow-up to: https://github.com/strictdoc-project/strictdoc/issues/823, https://github.com/strictdoc-project/strictdoc/issues/1083