### PR TITLE
tests/end2end: fix --long-timeouts argument

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -60,7 +60,6 @@ def run_invoke_with_tox(
     context,
     environment_type: ToxEnvironment,
     command: str,
-    environment: Optional[dict] = None,
 ) -> invoke.runners.Result:
     assert isinstance(environment_type, ToxEnvironment)
     assert isinstance(command, str)
@@ -72,7 +71,6 @@ def run_invoke_with_tox(
                 -e {tox_py_version}-{environment_type.value} --
                 {command}
         """,
-        environment=environment,
     )
 
 
@@ -209,8 +207,9 @@ def test_end2end(
     environment = {}
     parallelize_argument = ""
 
-    if long_timeouts:
-        environment["STRICTDOC_LONGER_TIMEOUTS"] = "True"
+    long_timeouts_argument = (
+        "--strictdoc-long-timeouts" if long_timeouts else ""
+    )
 
     if parallelize:
         print(  # noqa: T201
@@ -232,6 +231,7 @@ def test_end2end(
             {parallelize_argument}
             {focus_argument}
             {exit_first_argument}
+            {long_timeouts_argument}
             tests/end2end
     """
 
@@ -249,7 +249,6 @@ def test_end2end(
         context,
         ToxEnvironment.CHECK,
         test_command,
-        environment=environment,
     )
 
 

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -12,43 +12,33 @@ sys.path.append(STRICTDOC_PATH)
 
 DOWNLOADED_FILES_PATH = os.path.join(STRICTDOC_PATH, "downloaded_files")
 
+test_environment: SDocTestEnvironment = SDocTestEnvironment.create_default()
 
-# Running Selenium tests on GitHub Actions CI is considerably slower.
-# Passing the flag via env because pytest makes it hard to introduce an extra
-# command-line argument when it is not used as a test fixture.
-if os.getenv("STRICTDOC_LONGER_TIMEOUTS") is not None:
-    WAIT_TIMEOUT = 30
-    POLL_TIMEOUT = 1
-    WARMUP_INTERVAL = 0
-    DOWNLOAD_FILE_TIMEOUT = 5
-    SERVER_TERM_TIMEOUT = 5
 
-    # Selenium timeout settings.
-    settings.MINI_TIMEOUT = 5
-    settings.SMALL_TIMEOUT = 10
-    settings.LARGE_TIMEOUT = 15
-    settings.EXTREME_TIMEOUT = 30
-else:
-    WAIT_TIMEOUT = 5
-    POLL_TIMEOUT = 0.1
-    WARMUP_INTERVAL = 0
-    DOWNLOAD_FILE_TIMEOUT = 2
-    SERVER_TERM_TIMEOUT = 1
+def pytest_addoption(parser):
+    parser.addoption(
+        "--strictdoc-long-timeouts", action="store_true", default=False
+    )
 
-    # Selenium timeout settings.
-    settings.MINI_TIMEOUT = 2
-    settings.SMALL_TIMEOUT = 7
-    settings.LARGE_TIMEOUT = 10
-    settings.EXTREME_TIMEOUT = 30
 
-test_environment = SDocTestEnvironment(
-    is_parallel_execution="STRICTDOC_PARALLELIZE" in os.environ,
-    wait_timeout_seconds=WAIT_TIMEOUT,
-    poll_timeout_seconds=POLL_TIMEOUT,
-    warm_up_interval_seconds=WARMUP_INTERVAL,
-    download_file_timeout_seconds=DOWNLOAD_FILE_TIMEOUT,
-    server_term_timeout_seconds=SERVER_TERM_TIMEOUT,
-)
+def pytest_configure(config):
+    long_timeouts = config.getoption("--strictdoc-long-timeouts")
+
+    if long_timeouts:
+        # Selenium timeout settings.
+        settings.MINI_TIMEOUT = 5
+        settings.SMALL_TIMEOUT = 10
+        settings.LARGE_TIMEOUT = 15
+        settings.EXTREME_TIMEOUT = 30
+
+        test_environment.switch_to_long_timeouts()
+    else:
+        # Selenium timeout settings.
+        settings.MINI_TIMEOUT = 2
+        settings.SMALL_TIMEOUT = 7
+        settings.LARGE_TIMEOUT = 10
+        settings.EXTREME_TIMEOUT = 30
+
 
 TESTS_TOTAL = 0
 

--- a/tests/end2end/project_index/UC56_export_tree_to_reqif/UC56_T01_export_tree_to_reqif/test_UC56_T01_export_tree_to_reqif.py
+++ b/tests/end2end/project_index/UC56_export_tree_to_reqif/UC56_T01_export_tree_to_reqif/test_UC56_T01_export_tree_to_reqif.py
@@ -4,7 +4,7 @@ from sys import platform
 
 from seleniumbase import BaseCase
 
-from tests.end2end.conftest import DOWNLOAD_FILE_TIMEOUT, DOWNLOADED_FILES_PATH
+from tests.end2end.conftest import DOWNLOADED_FILES_PATH, test_environment
 from tests.end2end.end2end_test_setup import End2EndTestSetup
 from tests.end2end.helpers.screens.document_tree.screen_document_tree import (
     Screen_DocumentTree,
@@ -36,7 +36,7 @@ class Test_UC56_T01_ExportTreeToReqIF(BaseCase):
             if platform == "linux" or platform == "linux2":
                 return
 
-            self.sleep(DOWNLOAD_FILE_TIMEOUT)
+            self.sleep(test_environment.download_file_timeout_seconds)
 
             assert os.path.exists(path_to_expected_downloaded_file)
 

--- a/tests/end2end/screens/document/UC20_export_to_reqif/UC20_T1_green_case/test_UC20_T1_green_case.py
+++ b/tests/end2end/screens/document/UC20_export_to_reqif/UC20_T1_green_case/test_UC20_T1_green_case.py
@@ -4,7 +4,7 @@ from sys import platform
 
 from seleniumbase import BaseCase
 
-from tests.end2end.conftest import DOWNLOAD_FILE_TIMEOUT, DOWNLOADED_FILES_PATH
+from tests.end2end.conftest import DOWNLOADED_FILES_PATH, test_environment
 from tests.end2end.helpers.screens.document_tree.screen_document_tree import (
     Screen_DocumentTree,
 )
@@ -45,5 +45,5 @@ class Test_UC20_T1_GreenCase(BaseCase):
             # FIXME: does not work on Linux CI
             if platform == "linux" or platform == "linux2":
                 return
-            self.sleep(DOWNLOAD_FILE_TIMEOUT)
+            self.sleep(test_environment.download_file_timeout_seconds)
             assert os.path.exists(path_to_expected_downloaded_file)

--- a/tests/end2end/sdoc_test_environment.py
+++ b/tests/end2end/sdoc_test_environment.py
@@ -1,17 +1,24 @@
+WAIT_TIMEOUT = 5
+POLL_TIMEOUT = 0.1
+WARMUP_INTERVAL = 0
+DOWNLOAD_FILE_TIMEOUT = 2
+SERVER_TERM_TIMEOUT = 1
+
+
 class SDocTestEnvironment:
     def __init__(
         self,
         *,
         is_parallel_execution: bool,
         wait_timeout_seconds: int,
-        poll_timeout_seconds: int,
+        poll_timeout_seconds: float,
         warm_up_interval_seconds: int,
         download_file_timeout_seconds: int,
         server_term_timeout_seconds: int,
     ):
         self.is_parallel_execution = is_parallel_execution
         self.wait_timeout_seconds: int = wait_timeout_seconds
-        self.poll_timeout_seconds: int = poll_timeout_seconds
+        self.poll_timeout_seconds: float = poll_timeout_seconds
         self.warm_up_interval_seconds: int = warm_up_interval_seconds
 
         # When Selenium clicks on a link that downloads a file, it takes some
@@ -19,3 +26,28 @@ class SDocTestEnvironment:
         self.download_file_timeout_seconds: int = download_file_timeout_seconds
 
         self.server_term_timeout: int = server_term_timeout_seconds
+
+    @staticmethod
+    def create_default():
+        return SDocTestEnvironment(
+            is_parallel_execution=False,
+            wait_timeout_seconds=WAIT_TIMEOUT,
+            poll_timeout_seconds=POLL_TIMEOUT,
+            warm_up_interval_seconds=WARMUP_INTERVAL,
+            download_file_timeout_seconds=DOWNLOAD_FILE_TIMEOUT,
+            server_term_timeout_seconds=SERVER_TERM_TIMEOUT,
+        )
+
+    def switch_to_long_timeouts(self):
+        """
+        Running Selenium tests on GitHub Actions CI is considerably slower.
+        Passing the flag via env because pytest makes it hard to introduce an
+        extra command-line argument when it is not used as a test fixture.
+        """
+        self.wait_timeout_seconds = 30
+        # FIXME: This line is likely obsolete.
+        self.poll_timeout_seconds = 1
+        # FIXME: This line is likely obsolete.
+        self.warm_up_interval_seconds = 0
+        self.download_file_timeout_seconds = 5
+        self.server_term_timeout = 5


### PR DESCRIPTION
As it turns out, Tox does not support passing env variables via command line but only via its .tox.ini options file. After we had migrated to Tox, the end2end tests started ignoring the --long-timeouts argument when run on GitHub Actions machines. This patch fixes the --long-timeouts argument by using the custom arguments feature of PyTest.

Closes #1104