### PR TITLE
export/html: Connect to websocket relative to current domain

### DIFF
--- a/strictdoc/export/html/templates/websocket.jinja.html
+++ b/strictdoc/export/html/templates/websocket.jinja.html
@@ -5,7 +5,8 @@
 
 <script>
   var clientId = Date.now();
-  var ws = new WebSocket(`ws://{{config.server_host}}:{{config.server_port}}/ws/${clientId}`);
+  var ws_protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  var ws = new WebSocket(`${ws_protocol}//${window.location.host}/ws/${clientId}`);
   ws.onmessage = function(event) {
     // Nothing just yet.
   };


### PR DESCRIPTION
If `strictdoc server` is being forwarded/tunnelled, it will not necessarily appear to be coming from the client that is configured in the strictdoc conf file. Since the client is already aware of the host/port/protocol that is being used to access the backend, it is possible to construct a suitable websocket URL.