### PR TITLE
export/html: fix turbo links that were broken by the recent refactoring

### DIFF
--- a/strictdoc/export/html/templates/screens/document/document/actions.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/actions.jinja
@@ -1,18 +1,24 @@
 {%- if config.is_running_on_server -%}
-<div class="actions_group">
-  <a
-    href="/actions/document/edit_grammar?document_mid={{document.node_id}}"
-    class="action_button"
-    data-turbo="true"
-    data-turbo-action="replace"
-    title="Edit document grammar"
-    data-testid="document-edit-grammar-action"
-  >{% include "_res/svg_ico16_gear.jinja.html" %} Edit grammar</a>
+{#
+  This turbo frame is important because it enables
+  the child turbo links below.
+#}
+<turbo-frame>
+  <div class="actions_group">
+    <a
+      href="/actions/document/edit_grammar?document_mid={{ document.node_id }}"
+      class="action_button"
+      data-turbo="true"
+      data-turbo-action="replace"
+      title="Edit document grammar"
+      data-testid="document-edit-grammar-action"
+    >{% include "_res/svg_ico16_gear.jinja.html" %} Edit grammar</a>
 
-  <a
-    class="action_button"
-    href="/reqif/export_document/{{document.node_id}}"
-    data-testid="document-export-reqif-action"
-  >Export to ReqIF</a>
-</div>
+    <a
+      class="action_button"
+      href="/reqif/export_document/{{ document.node_id }}"
+      data-testid="document-export-reqif-action"
+    >Export to ReqIF</a>
+  </div>
+</turbo-frame>
 {%- endif -%}

--- a/strictdoc/export/html/templates/screens/project_index/actions.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/actions.jinja
@@ -1,27 +1,33 @@
 {%- if config.is_running_on_server -%}
-<div class="actions_group">
-  <a
-    class="action_button"
-    href="/actions/project_index/new_document"
-    data-turbo="true"
-    title="Add new document"
-    data-testid="tree-add-document-action"
-  >{% include "_res/svg_ico16_add.jinja.html" %} Add document</a>
-  <a
-    class="action_button"
-    href="/actions/project_index/import_reqif_document_form"
-    data-turbo="true"
-    title="Import document tree from ReqIF"
-    data-testid="tree-import-reqif-action"
-  >Import from ReqIF</a>
+{#
+  This turbo frame is important because it enables
+  the child turbo links below.
+#}
+<turbo-frame>
+  <div class="actions_group">
+    <a
+      class="action_button"
+      href="/actions/project_index/new_document"
+      data-turbo="true"
+      title="Add new document"
+      data-testid="tree-add-document-action"
+    >{% include "_res/svg_ico16_add.jinja.html" %} Add document</a>
+    <a
+      class="action_button"
+      href="/actions/project_index/import_reqif_document_form"
+      data-turbo="true"
+      title="Import document tree from ReqIF"
+      data-testid="tree-import-reqif-action"
+    >Import from ReqIF</a>
 
-{%- if not document_tree_iterator.is_empty_tree() -%}
-  <a
-    class="action_button"
-    href="/reqif/export_tree"
-    title="Export document tree to ReqIF"
-    data-testid="tree-export-reqif-action"
-  >Export to ReqIF</a>
-{%- endif -%}
-</div>
+  {%- if not document_tree_iterator.is_empty_tree() -%}
+    <a
+      class="action_button"
+      href="/reqif/export_tree"
+      title="Export document tree to ReqIF"
+      data-testid="tree-export-reqif-action"
+    >Export to ReqIF</a>
+  {%- endif -%}
+  </div>
+</turbo-frame>
 {%- endif -%}


### PR DESCRIPTION
braking commit: 7db54d7c40bc5e0eefdc1a0768fc831185549af1