### PR TITLE
resolve #1210: leading spaces allowed

### DIFF
--- a/strictdoc/backend/sdoc/grammar/type_system.py
+++ b/strictdoc/backend/sdoc/grammar/type_system.py
@@ -5,7 +5,7 @@ FieldName[noskipws]:
 
 // According to the Strict Grammar Rule #3, both SingleLineString and
 // MultiLineString can never be empty strings.
-// Both must start with a non-space character.
+// Both must eventualy start with a non-space character.
 SingleLineString:
   (!MultiLineStringStart /\S/) (!MultiLineStringStart /./)* /$/
 ;
@@ -20,7 +20,7 @@ MultiLineStringEnd[noskipws]:
 
 MultiLineString[noskipws]:
   MultiLineStringStart-
-  (!MultiLineStringEnd /\S/) (!MultiLineStringEnd /(?ms)./)+
+  (!MultiLineStringEnd /\W*\S/) (!MultiLineStringEnd /(?ms)./)+
   MultiLineStringEnd-
 ;
 

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
@@ -1727,9 +1727,7 @@ UID:
         _ = reader.read(sdoc_input)
 
     assert exc_info.type is TextXSyntaxError
-    assert "Expected Not or '\\S' or '>>>'" in exc_info.value.args[0].decode(
-        "utf-8"
-    )
+    assert "Expected Not or" in exc_info.value.args[0].decode("utf-8")
 
 
 def test_edge_case_04_uid_present_but_empty_with_two_space_characters():
@@ -1748,9 +1746,7 @@ UID:
         _ = reader.read(sdoc_input)
 
     assert exc_info.type is TextXSyntaxError
-    assert "Expected Not or '\\S' or '>>>'" in exc_info.value.args[0].decode(
-        "utf-8"
-    )
+    assert "Expected Not or" in exc_info.value.args[0].decode("utf-8")
 
 
 def test_edge_case_10_empty_multiline_field():
@@ -1789,7 +1785,7 @@ COMMENT: >>>
         _ = reader.read(sdoc_input)
 
     assert exc_info.type is TextXSyntaxError
-    assert "Expected Not or '\\S'" in exc_info.value.args[0].decode("utf-8")
+    assert "Expected Not or" in exc_info.value.args[0].decode("utf-8")
 
 
 def test_edge_case_20_empty_section_title():
@@ -1832,7 +1828,7 @@ TITLE:
         _ = reader.read(sdoc_input)
 
     assert exc_info.type is TextXSyntaxError
-    assert "Expected Not or '\\S'" == exc_info.value.args[0].decode("utf-8")
+    assert "Expected Not or" in exc_info.value.args[0].decode("utf-8")
 
 
 def test_edge_case_22_section_title_with_two_empty_spaces():
@@ -1853,4 +1849,36 @@ TITLE:
         _ = reader.read(sdoc_input)
 
     assert exc_info.type is TextXSyntaxError
-    assert "Expected Not or '\\S'" == exc_info.value.args[0].decode("utf-8")
+    assert "Expected Not or" in exc_info.value.args[0].decode("utf-8")
+
+
+def test_edge_case_23_leading_spaces_do_not_imply_empy_field():
+    sdoc_input = """
+[DOCUMENT]
+TITLE: Test Doc
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: MY_FIELD
+    TYPE: String
+    REQUIRED: True
+
+[REQUIREMENT]
+MY_FIELD: >>>
+    Some text here...
+    Some text here...
+    Some text here...
+<<<
+""".lstrip()
+
+    reader = SDReader()
+
+    document = reader.read(sdoc_input)
+    assert isinstance(document, Document)
+
+    writer = SDWriter()
+    output = writer.write(document)
+
+    assert sdoc_input == output


### PR DESCRIPTION
allow zero or more whitespace at the start of a multi-line string but still require that it be non-empty