### PR TITLE
grammar, anchors: handle edge case of malformed RST

### DIFF
--- a/strictdoc/__init__.py
+++ b/strictdoc/__init__.py
@@ -1,6 +1,6 @@
 from strictdoc.core.environment import SDocRuntimeEnvironment
 
-__version__ = "0.0.43a3"
+__version__ = "0.0.43a4"
 
 
 environment = SDocRuntimeEnvironment(__file__)

--- a/strictdoc/backend/sdoc/error_handling.py
+++ b/strictdoc/backend/sdoc/error_handling.py
@@ -1,3 +1,5 @@
+from textx import TextXSyntaxError
+
 from strictdoc.backend.sdoc.models.document_grammar import (
     DocumentGrammar,
     GrammarElementField,
@@ -7,6 +9,10 @@ from strictdoc.backend.sdoc.models.requirement import (
     Requirement,
     RequirementField,
 )
+
+
+def get_textx_syntax_error_message(exception: TextXSyntaxError):
+    return f"SDoc markup error: {exception.context}."
 
 
 class StrictDocSemanticError(Exception):

--- a/strictdoc/backend/sdoc/writer.py
+++ b/strictdoc/backend/sdoc/writer.py
@@ -318,7 +318,8 @@ class SDWriter:
     def print_free_text_content(free_text):
         assert isinstance(free_text, FreeText)
         output = ""
-        for part in free_text.parts:
+
+        for part_idx, part in enumerate(free_text.parts):
             if isinstance(part, str):
                 output += part
             elif isinstance(part, InlineLink):
@@ -332,6 +333,9 @@ class SDWriter:
                     output += ", "
                     output += part.title
                 output += "]"
+                output += "\n"
+                if part_idx != (len(free_text.parts) - 1):
+                    output += "\n"
             else:
                 raise NotImplementedError(part)
         return output

--- a/strictdoc/export/rst/rst_to_html_fragment_writer.py
+++ b/strictdoc/export/rst/rst_to_html_fragment_writer.py
@@ -153,4 +153,5 @@ class RstToHtmlFragmentWriter:
 .. raw:: html
 
     <sdoc-anchor id="{anchor}" data-anchor="📋{anchor}" style="top:unset"></sdoc-anchor>
+
 """

--- a/tests/end2end/screens/document/cross_cutting/anchors/document/_validations_document/document_create_anchor_broken_rst/expected_output/document.sdoc
+++ b/tests/end2end/screens/document/cross_cutting/anchors/document/_validations_document/document_create_anchor_broken_rst/expected_output/document.sdoc
@@ -1,0 +1,6 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[FREETEXT]
+Document free text.
+[/FREETEXT]

--- a/tests/end2end/screens/document/cross_cutting/anchors/document/_validations_document/document_create_anchor_broken_rst/input/document.sdoc
+++ b/tests/end2end/screens/document/cross_cutting/anchors/document/_validations_document/document_create_anchor_broken_rst/input/document.sdoc
@@ -1,0 +1,6 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[FREETEXT]
+Document free text.
+[/FREETEXT]

--- a/tests/end2end/screens/document/cross_cutting/anchors/document/_validations_document/document_create_anchor_broken_rst/test_document_create_anchor_broken_rst.py
+++ b/tests/end2end/screens/document/cross_cutting/anchors/document/_validations_document/document_create_anchor_broken_rst/test_document_create_anchor_broken_rst.py
@@ -1,0 +1,47 @@
+from seleniumbase import BaseCase
+
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.document.form_edit_config import (
+    Form_EditConfig,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(BaseCase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+            screen_document.assert_text("Document free text.")
+
+            root_node = screen_document.get_root_node()
+            form_config: Form_EditConfig = root_node.do_open_form_edit_config()
+
+            form_config.do_fill_in_document_abstract(
+                """
+Modified statement.
+
+[ANCHOR: AD1]!!!GARBAGE!!!
+"""
+            )
+            form_config.do_form_submit_and_catch_error(
+                "SDoc markup error: CHOR: AD1]*!!!GARBAGE"
+            )
+
+        assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/cross_cutting/anchors/section/_validations_section/create_section_add_anchor_broken_rst/expected_output/document.sdoc
+++ b/tests/end2end/screens/document/cross_cutting/anchors/section/_validations_section/create_section_add_anchor_broken_rst/expected_output/document.sdoc
@@ -1,0 +1,6 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[FREETEXT]
+Hello world!
+[/FREETEXT]

--- a/tests/end2end/screens/document/cross_cutting/anchors/section/_validations_section/create_section_add_anchor_broken_rst/input/document.sdoc
+++ b/tests/end2end/screens/document/cross_cutting/anchors/section/_validations_section/create_section_add_anchor_broken_rst/input/document.sdoc
@@ -1,0 +1,6 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[FREETEXT]
+Hello world!
+[/FREETEXT]

--- a/tests/end2end/screens/document/cross_cutting/anchors/section/_validations_section/create_section_add_anchor_broken_rst/test_create_section_add_anchor_broken_rst.py
+++ b/tests/end2end/screens/document/cross_cutting/anchors/section/_validations_section/create_section_add_anchor_broken_rst/test_create_section_add_anchor_broken_rst.py
@@ -1,0 +1,53 @@
+from seleniumbase import BaseCase
+
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.document.form_edit_section import (
+    Form_EditSection,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(BaseCase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        # Run server.
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+
+            screen_document.assert_text("Hello world!")
+
+            root_node = screen_document.get_root_node()
+            root_node_menu = root_node.do_open_node_menu()
+            form_edit_section: Form_EditSection = (
+                root_node_menu.do_node_add_section_first()
+            )
+
+            form_edit_section.do_fill_in_title("First title")
+            form_edit_section.do_fill_in_text(
+                """\
+Modified statement.
+
+[ANCHOR: AD1]!!!GARBAGE!!!
+"""
+            )
+            form_edit_section.do_form_submit_and_catch_error(
+                "SDoc markup error: CHOR: AD1]*!!!GARBAGE"
+            )
+
+        assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/cross_cutting/anchors/section/_validations_section/update_section_add_anchor_broken_rst/expected_output/document.sdoc
+++ b/tests/end2end/screens/document/cross_cutting/anchors/section/_validations_section/update_section_add_anchor_broken_rst/expected_output/document.sdoc
@@ -1,0 +1,15 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[FREETEXT]
+Hello world!
+[/FREETEXT]
+
+[SECTION]
+TITLE: First section
+
+[FREETEXT]
+This is a free text of this section.
+[/FREETEXT]
+
+[/SECTION]

--- a/tests/end2end/screens/document/cross_cutting/anchors/section/_validations_section/update_section_add_anchor_broken_rst/input/document.sdoc
+++ b/tests/end2end/screens/document/cross_cutting/anchors/section/_validations_section/update_section_add_anchor_broken_rst/input/document.sdoc
@@ -1,0 +1,15 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[FREETEXT]
+Hello world!
+[/FREETEXT]
+
+[SECTION]
+TITLE: First section
+
+[FREETEXT]
+This is a free text of this section.
+[/FREETEXT]
+
+[/SECTION]

--- a/tests/end2end/screens/document/cross_cutting/anchors/section/_validations_section/update_section_add_anchor_broken_rst/test_update_section_add_anchor_broken_rst.py
+++ b/tests/end2end/screens/document/cross_cutting/anchors/section/_validations_section/update_section_add_anchor_broken_rst/test_update_section_add_anchor_broken_rst.py
@@ -1,0 +1,50 @@
+from seleniumbase import BaseCase
+
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.document.form_edit_section import (
+    Form_EditSection,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(BaseCase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+
+            screen_document.assert_text("Hello world!")
+
+            section = screen_document.get_section()
+            form_edit_section: Form_EditSection = (
+                section.do_open_form_edit_section()
+            )
+            form_edit_section.do_fill_in_title("Modified title")
+            form_edit_section.do_fill_in_text(
+                """
+Modified statement.
+
+[ANCHOR: AD1]!!!GARBAGE!!!
+"""
+            )
+            form_edit_section.do_form_submit_and_catch_error(
+                "SDoc markup error: CHOR: AD1]*!!!GARBAGE"
+            )
+
+        assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/server.py
+++ b/tests/end2end/server.py
@@ -109,10 +109,6 @@ class SDocTestServer:  # pylint: disable=too-many-instance-attributes
         self.path_to_err_log = os.path.join(
             path_to_tmp_dir, f"strictdoc_server.{self.server_port}.err.log"
         )
-        if os.path.exists(self.path_to_out_log):
-            os.remove(self.path_to_out_log)
-        if os.path.exists(self.path_to_err_log):
-            os.remove(self.path_to_err_log)
 
         self.expectations = (
             expectations
@@ -161,10 +157,10 @@ class SDocTestServer:  # pylint: disable=too-many-instance-attributes
             )
 
         self.log_file_out = open(  # pylint: disable=consider-using-with
-            self.path_to_out_log, "ab"
+            self.path_to_out_log, "wb"
         )
         self.log_file_err = open(  # pylint: disable=consider-using-with
-            self.path_to_err_log, "ab"
+            self.path_to_err_log, "wb"
         )
         self.exit_stack.enter_context(self.log_file_out)
         self.exit_stack.enter_context(self.log_file_err)

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
@@ -285,6 +285,30 @@ String 4
     assert input == output
 
 
+def test_026_free_text_anchor_end_of_free_text():
+    input = """
+[DOCUMENT]
+TITLE: Test Doc
+
+[FREETEXT]
+String 1
+String 2 String 3
+
+[ANCHOR: REQ-001, Requirements document]
+[/FREETEXT]
+""".lstrip()
+
+    reader = SDReader()
+
+    document = reader.read(input)
+    assert isinstance(document, Document)
+
+    writer = SDWriter()
+    output = writer.write(document)
+
+    assert input == output
+
+
 def test_030_multiline_statement():
     input_sdoc = """
 [DOCUMENT]

--- a/tests/unit/strictdoc/backend/sdoc/test_free_text_reader.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_free_text_reader.py
@@ -1,8 +1,124 @@
+import pytest
+from textx import TextXSyntaxError
+
 from strictdoc.backend.sdoc.free_text_reader import SDFreeTextReader
+from strictdoc.backend.sdoc.models.anchor import Anchor
 from strictdoc.backend.sdoc.models.free_text import FreeText
 
 
-def test_001_hello_world():
+def test_001_anchor_without_space():
+    free_text_input = """
+Modified statement.
+
+[ANCHOR: AD1]!!!GARBAGE!!!
+""".lstrip()
+
+    reader = SDFreeTextReader()
+    with pytest.raises(TextXSyntaxError) as exc_info:
+        reader.read(free_text_input)
+    assert """\
+None:3:14: \
+Expected '\\Z|(\\n(\\n|\\Z|(?=\\[\\/FREETEXT\\])))' => 'CHOR: AD1]*!!!GARBAGE'\
+""" == str(
+        exc_info.value
+    )
+
+
+def test_002_anchor_without_newline_before():
+    """
+    The expectation here is that the anchor does not get recognized at all.
+    """
+
+    free_text_input = """
+Modified statement.
+
+!!!GARBAGE!!!
+[ANCHOR: AD1]
+""".lstrip()
+
+    reader = SDFreeTextReader()
+    free_text_container = reader.read(free_text_input)
+    assert (
+        free_text_container.parts[0]
+        == "Modified statement.\n\n!!!GARBAGE!!!\n[ANCHOR: AD1]\n"
+    )
+
+
+def test_003_anchor_with_only_one_newline():
+    free_text_input = """
+Modified statement.
+
+[ANCHOR: AD1]
+!!!GARBAGE!!!
+""".lstrip()
+
+    reader = SDFreeTextReader()
+    with pytest.raises(TextXSyntaxError) as exc_info:
+        reader.read(free_text_input)
+    assert (
+        str(exc_info.value)
+        == """\
+None:3:14: \
+Expected '\\Z|(\\n(\\n|\\Z|(?=\\[\\/FREETEXT\\])))' => 'CHOR: AD1]* !!!GARBAG'\
+"""
+    )
+
+
+def test_010_normal_anchor_end_of_line():
+    free_text_input = """
+Section free text.
+
+[ANCHOR: AD1]\
+""".lstrip()
+
+    reader = SDFreeTextReader()
+    free_text_container = reader.read(free_text_input)
+    assert free_text_container.parts[0] == "Section free text.\n\n"
+    assert isinstance(free_text_container.parts[1], Anchor)
+
+
+def test_011_normal_anchor_with_two_newlines():
+    free_text_input = """
+Modified statement.
+
+[ANCHOR: AD1]
+
+!!!TEXT!!!
+""".lstrip()
+
+    reader = SDFreeTextReader()
+    free_text_container = reader.read(free_text_input)
+    assert free_text_container.parts[0] == "Modified statement.\n\n"
+    assert isinstance(free_text_container.parts[1], Anchor)
+    assert free_text_container.parts[2] == "!!!TEXT!!!\n"
+
+
+def test_012_normal_anchor_end_of_line():
+    free_text_input = """
+Section free text.
+
+[ANCHOR: AD1]
+""".lstrip()
+
+    reader = SDFreeTextReader()
+    reader.read(free_text_input)
+    free_text_container = reader.read(free_text_input)
+    assert free_text_container.parts[0] == "Section free text.\n\n"
+    assert isinstance(free_text_container.parts[1], Anchor)
+
+
+def test_013_normal_anchor_no_other_text():
+    free_text_input = """
+[ANCHOR: AD1]
+""".lstrip()
+
+    reader = SDFreeTextReader()
+    reader.read(free_text_input)
+    free_text_container = reader.read(free_text_input)
+    assert isinstance(free_text_container.parts[0], Anchor)
+
+
+def test_020_link():
     free_text_input = """
 Hello world [LINK: FOO] Part
 """.lstrip()

--- a/tests/unit/strictdoc/export/rst/directives/test_raw_html_role.py
+++ b/tests/unit/strictdoc/export/rst/directives/test_raw_html_role.py
@@ -1,0 +1,27 @@
+import os
+
+from strictdoc.export.rst.rst_to_html_fragment_writer import (
+    RstToHtmlFragmentWriter,
+)
+
+FIXTURES_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "fixtures")
+)
+
+
+def test_01():
+    rst_input = """\
+:rawhtml:`<a href="foo.bar">LINK</a>`\
+"""
+
+    html_output = RstToHtmlFragmentWriter(context_document=None).write(
+        rst_input
+    )
+    assert (
+        html_output
+        == """\
+<div class="document">
+<p><a href="foo.bar">LINK</a></p>
+</div>
+"""
+    )


### PR DESCRIPTION
This change actually makes ANCHOR to be two lines separated with anything that can follow it in FREETEXT.

Also:
tests/end2end/server.py: stop removing log files with every run