### PR TITLE
backend/sdoc and rst_to_html: take into account the output directory when hashing picked file names

### DIFF
--- a/.pylint.ini
+++ b/.pylint.ini
@@ -68,6 +68,7 @@ disable=missing-module-docstring,
         duplicate-code,
 
         fixme,
+        too-many-arguments,
         too-many-branches,
         too-many-lines,
         too-many-locals,

--- a/strictdoc/backend/sdoc/reader.py
+++ b/strictdoc/backend/sdoc/reader.py
@@ -22,6 +22,9 @@ from strictdoc.helpers.textx import drop_textx_meta
 
 
 class SDReader:
+    def __init__(self, path_to_output_root: str = "NOT_RELEVANT"):
+        self.path_to_output_root = path_to_output_root
+
     @staticmethod
     def _read(input_string, file_path=None):
         meta_model = metamodel_from_str(
@@ -67,12 +70,16 @@ class SDReader:
         )
 
         # File name contains an MD5 hash of its full path to ensure the
-        # uniqueness of the cached items.
-        full_path_to_file_md5 = hashlib.md5(
-            full_path_to_file.encode("utf-8")
+        # uniqueness of the cached items. Additionally, the unique file name
+        # contains a full path to the output root to prevent collisions
+        # between StrictDoc invocations running against the same set of SDoc
+        # files in parallel.
+        unique_identifier = self.path_to_output_root + full_path_to_file
+        unique_identifier_md5 = hashlib.md5(
+            unique_identifier.encode("utf-8")
         ).hexdigest()
         file_name = os.path.basename(full_path_to_file)
-        file_name += "_" + full_path_to_file_md5
+        file_name += "_" + unique_identifier_md5
 
         path_to_cached_file = os.path.join(
             path_to_tmp_dir,

--- a/strictdoc/core/actions/passthrough_action.py
+++ b/strictdoc/core/actions/passthrough_action.py
@@ -18,7 +18,9 @@ class PassthroughAction:
             print(err)  # noqa: T201
             sys.exit(1)
 
-        document = SDReader().read_from_file(config.input_file)
+        document = SDReader(config.output_file).read_from_file(
+            config.input_file
+        )
 
         writer = SDWriter()
         output = writer.write(document)

--- a/strictdoc/core/commands/section.py
+++ b/strictdoc/core/commands/section.py
@@ -18,6 +18,7 @@ from strictdoc.core.commands.validation_error import (
     MultipleValidationError,
     SingleValidationError,
 )
+from strictdoc.core.project_config import ProjectConfig
 from strictdoc.core.traceability_index import (
     RequirementConnections,
     TraceabilityIndex,
@@ -38,6 +39,7 @@ class UpdateSectionCommand:
         form_object: SectionFormObject,
         section: Section,
         traceability_index: TraceabilityIndex,
+        config: ProjectConfig,
     ):
         self.form_object: SectionFormObject = form_object
         self.section: Section = section
@@ -45,6 +47,7 @@ class UpdateSectionCommand:
         self.update_free_text_command = UpdateFreeTextCommand(
             node=section,
             traceability_index=traceability_index,
+            config=config,
             subject_field_name="section_statement",
             subject_field_content=form_object.section_statement_unescaped,
         )
@@ -159,11 +162,13 @@ class CreateSectionCommand:
         whereto: str,
         reference_mid: str,
         traceability_index: TraceabilityIndex,
+        config: ProjectConfig,
     ):
         self.form_object: SectionFormObject = form_object
         self.whereto: str = whereto
         self.reference_mid: str = reference_mid
         self.traceability_index: TraceabilityIndex = traceability_index
+        self.config: ProjectConfig = config
 
         self._created_section: Optional[Section] = None
 
@@ -220,7 +225,8 @@ class CreateSectionCommand:
                 parsed_html,
                 rst_error,
             ) = RstToHtmlFragmentWriter(
-                context_document=document
+                path_to_output_dir=self.config.export_output_dir,
+                context_document=document,
             ).write_with_validation(form_object.section_statement_unescaped)
             if parsed_html is None:
                 errors["section_statement"].append(rst_error)

--- a/strictdoc/core/commands/update_document_config.py
+++ b/strictdoc/core/commands/update_document_config.py
@@ -7,6 +7,7 @@ from strictdoc.core.commands.validation_error import (
     MultipleValidationError,
     SingleValidationError,
 )
+from strictdoc.core.project_config import ProjectConfig
 from strictdoc.core.traceability_index import (
     TraceabilityIndex,
 )
@@ -21,6 +22,7 @@ class UpdateDocumentConfigCommand:
         form_object: DocumentConfigFormObject,
         document: Document,
         traceability_index: TraceabilityIndex,
+        config: ProjectConfig,
     ):
         self.form_object: DocumentConfigFormObject = form_object
         self.document: Document = document
@@ -28,6 +30,7 @@ class UpdateDocumentConfigCommand:
         self.update_free_text_command = UpdateFreeTextCommand(
             node=document,
             traceability_index=traceability_index,
+            config=config,
             subject_field_name="FREETEXT",
             subject_field_content=form_object.document_freetext_unescaped,
         )

--- a/strictdoc/core/commands/update_free_text.py
+++ b/strictdoc/core/commands/update_free_text.py
@@ -12,6 +12,7 @@ from strictdoc.backend.sdoc.models.section import Section
 from strictdoc.core.commands.validation_error import (
     SingleValidationError,
 )
+from strictdoc.core.project_config import ProjectConfig
 from strictdoc.core.traceability_index import (
     GraphLinkType,
     TraceabilityIndex,
@@ -26,11 +27,13 @@ class UpdateFreeTextCommand:
         self,
         node: Union[Document, Section],
         traceability_index: TraceabilityIndex,
+        config: ProjectConfig,
         subject_field_name: str,
         subject_field_content: str,
     ):
         self.node: Union[Document, Section] = node
         self.traceability_index: TraceabilityIndex = traceability_index
+        self.config: ProjectConfig = config
         self.subject_field_name: str = subject_field_name
         self.subject_field_content: str = subject_field_content
 
@@ -49,7 +52,8 @@ class UpdateFreeTextCommand:
                 parsed_html,
                 rst_error,
             ) = RstToHtmlFragmentWriter(
-                context_document=context_document
+                path_to_output_dir=self.config.export_output_dir,
+                context_document=context_document,
             ).write_with_validation(subject_field_content)
 
             if parsed_html is None:

--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -23,6 +23,7 @@ from strictdoc.backend.sdoc.models.type_system import (
     GrammarElementField,
     RequirementFieldType,
 )
+from strictdoc.core.project_config import ProjectConfig
 from strictdoc.core.traceability_index import (
     RequirementConnections,
     TraceabilityIndex,
@@ -345,6 +346,7 @@ class RequirementFormObject(ErrorObject):
         *,
         traceability_index: TraceabilityIndex,
         context_document: Document,
+        config: ProjectConfig,
     ):
         assert isinstance(traceability_index, TraceabilityIndex)
         assert isinstance(context_document, Document)
@@ -361,6 +363,7 @@ class RequirementFormObject(ErrorObject):
                 parsed_html,
                 rst_error,
             ) = RstToHtmlFragmentWriter(
+                path_to_output_dir=config.export_output_dir,
                 context_document=context_document,
             ).write_with_validation(requirement_statement)
             if parsed_html is None:

--- a/strictdoc/export/html/generators/requirements_coverage.py
+++ b/strictdoc/export/html/generators/requirements_coverage.py
@@ -36,6 +36,7 @@ class RequirementsCoverageHTMLGenerator:
             traceability_index,
             link_renderer,
             html_templates,
+            project_config,
             None,
         )
         output += template.render(

--- a/strictdoc/export/html/generators/source_file_view_generator.py
+++ b/strictdoc/export/html/generators/source_file_view_generator.py
@@ -60,7 +60,12 @@ class SourceFileViewHTMLGenerator:
             static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
-            "RST", traceability_index, link_renderer, html_templates, None
+            "RST",
+            traceability_index,
+            link_renderer,
+            html_templates,
+            project_config,
+            None,
         )
         output += template.render(
             project_config=project_config,

--- a/strictdoc/export/html/html_generator.py
+++ b/strictdoc/export/html/html_generator.py
@@ -192,6 +192,7 @@ class HTMLGenerator:
             traceability_index,
             link_renderer,
             self.html_templates,
+            self.project_config,
             document,
         )
 

--- a/strictdoc/export/html/renderers/markup_renderer.py
+++ b/strictdoc/export/html/renderers/markup_renderer.py
@@ -7,6 +7,7 @@ from strictdoc.backend.sdoc.models.requirement import (
     Requirement,
 )
 from strictdoc.backend.sdoc.models.section import FreeText
+from strictdoc.core.project_config import ProjectConfig
 from strictdoc.core.traceability_index import TraceabilityIndex
 from strictdoc.export.html.document_type import DocumentType
 from strictdoc.export.html.html_templates import HTMLTemplates
@@ -28,6 +29,7 @@ class MarkupRenderer:
         traceability_index: TraceabilityIndex,
         link_renderer: LinkRenderer,
         html_templates: HTMLTemplates,
+        config: ProjectConfig,
         context_document: Optional[Document],
     ) -> "MarkupRenderer":
         assert isinstance(html_templates, HTMLTemplates)
@@ -38,7 +40,8 @@ class MarkupRenderer:
         ]
         if not markup or markup == "RST":
             html_fragment_writer = RstToHtmlFragmentWriter(
-                context_document=context_document
+                path_to_output_dir=config.export_output_dir,
+                context_document=context_document,
             )
         elif markup == "HTML":
             html_fragment_writer = HTMLFragmentWriter

--- a/strictdoc/export/rst/rst_to_html_fragment_writer.py
+++ b/strictdoc/export/rst/rst_to_html_fragment_writer.py
@@ -23,7 +23,18 @@ class RstToHtmlFragmentWriter:
 
     roles.register_local_role("rawhtml", raw_html_role)
 
-    def __init__(self, *, context_document: Optional[Document]):
+    def __init__(
+        self, *, path_to_output_dir: str, context_document: Optional[Document]
+    ):
+        path_to_output_dir_md5: str = hashlib.md5(
+            path_to_output_dir.encode("utf-8")
+        ).hexdigest()
+
+        path_to_tmp_dir = tempfile.gettempdir()
+        self.path_to_rst_cache_dir = os.path.join(
+            path_to_tmp_dir, "strictdoc_cache", "rst", path_to_output_dir_md5
+        )
+
         if context_document is not None:
             WildcardEnhancedImage.current_reference_path = (
                 context_document.meta.output_document_dir_full_path
@@ -53,13 +64,8 @@ class RstToHtmlFragmentWriter:
         if len(rst_fragment) < 0:
             return self._write_no_cache(rst_fragment)
 
-        path_to_tmp_dir = tempfile.gettempdir()
-
-        path_to_rst_cache_dir = os.path.join(
-            path_to_tmp_dir, "strictdoc_cache", "rst"
-        )
         path_to_rst_fragment_bucket_dir = os.path.join(
-            path_to_rst_cache_dir, str(len(rst_fragment))
+            self.path_to_rst_cache_dir, str(len(rst_fragment))
         )
         fragment_md5 = hashlib.md5(rst_fragment.encode("utf-8")).hexdigest()
         path_to_cached_fragment = os.path.join(

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -156,6 +156,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=requirement.document,
         )
         output = template.render(
@@ -217,6 +218,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=document,
         )
         output = template.render(
@@ -289,6 +291,7 @@ def create_main_router(
                 whereto=whereto,
                 reference_mid=reference_mid,
                 traceability_index=export_action.traceability_index,
+                config=project_config,
             )
             create_command.perform()
         except MultipleValidationError as validation_error:
@@ -307,6 +310,7 @@ def create_main_router(
                 traceability_index=export_action.traceability_index,
                 link_renderer=link_renderer,
                 html_templates=html_generator.html_templates,
+                config=project_config,
                 context_document=document,
             )
             output = template.render(
@@ -355,6 +359,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=document,
         )
         iterator = export_action.traceability_index.get_document_iterator(
@@ -407,6 +412,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=section.document,
         )
         output = template.render(
@@ -454,6 +460,7 @@ def create_main_router(
                 form_object=form_object,
                 section=section,
                 traceability_index=export_action.traceability_index,
+                config=project_config,
             )
             update_command.perform()
         except MultipleValidationError as validation_error:
@@ -472,6 +479,7 @@ def create_main_router(
                 traceability_index=export_action.traceability_index,
                 link_renderer=link_renderer,
                 html_templates=html_generator.html_templates,
+                config=project_config,
                 context_document=section.document,
             )
             output = template.render(
@@ -520,6 +528,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=section.document,
         )
         output = template.render(
@@ -584,6 +593,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=section.document,
         )
         output = template.render(
@@ -646,6 +656,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=document,
         )
         output = template.render(
@@ -712,6 +723,7 @@ def create_main_router(
         form_object.validate(
             traceability_index=export_action.traceability_index,
             context_document=document,
+            config=project_config,
         )
 
         if form_object.any_errors():
@@ -730,6 +742,7 @@ def create_main_router(
                 traceability_index=export_action.traceability_index,
                 link_renderer=link_renderer,
                 html_templates=html_generator.html_templates,
+                config=project_config,
                 context_document=document,
             )
 
@@ -804,6 +817,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=document,
         )
         iterator = export_action.traceability_index.get_document_iterator(
@@ -866,6 +880,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=document,
         )
         output = template.render(
@@ -910,6 +925,7 @@ def create_main_router(
         form_object.validate(
             traceability_index=export_action.traceability_index,
             context_document=document,
+            config=project_config,
         )
 
         if form_object.any_errors():
@@ -928,6 +944,7 @@ def create_main_router(
                 traceability_index=export_action.traceability_index,
                 link_renderer=link_renderer,
                 html_templates=html_generator.html_templates,
+                config=project_config,
                 context_document=document,
             )
             output = template.render(
@@ -1097,6 +1114,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=document,
         )
 
@@ -1182,6 +1200,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=document,
         )
         iterator = export_action.traceability_index.get_document_iterator(
@@ -1267,6 +1286,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=section.document,
         )
         iterator = export_action.traceability_index.get_document_iterator(
@@ -1353,6 +1373,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=requirement.document,
         )
         iterator = export_action.traceability_index.get_document_iterator(
@@ -1480,6 +1501,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=moved_node.document,
         )
         output = template.render(
@@ -1743,6 +1765,7 @@ def create_main_router(
                 form_object=form_object,
                 document=document,
                 traceability_index=export_action.traceability_index,
+                config=project_config,
             )
             update_command.perform()
         except MultipleValidationError as validation_error:
@@ -1789,6 +1812,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=document,
         )
         template = env().get_template(
@@ -1826,6 +1850,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=document,
         )
         template = env().get_template(
@@ -1962,6 +1987,7 @@ def create_main_router(
             traceability_index=export_action.traceability_index,
             link_renderer=link_renderer,
             html_templates=html_generator.html_templates,
+            config=project_config,
             context_document=document,
         )
         template = env().get_template(
@@ -1985,6 +2011,7 @@ def create_main_router(
                 traceability_index=export_action.traceability_index,
                 link_renderer=link_renderer,
                 html_templates=html_generator.html_templates,
+                config=project_config,
                 context_document=document,
             )
             template = env().get_template(

--- a/tests/unit/strictdoc/export/rst/directives/test_raw_html_role.py
+++ b/tests/unit/strictdoc/export/rst/directives/test_raw_html_role.py
@@ -14,9 +14,9 @@ def test_01():
 :rawhtml:`<a href="foo.bar">LINK</a>`\
 """
 
-    html_output = RstToHtmlFragmentWriter(context_document=None).write(
-        rst_input
-    )
+    html_output = RstToHtmlFragmentWriter(
+        path_to_output_dir="NOT_RELEVANT", context_document=None
+    ).write(rst_input)
     assert (
         html_output
         == """\

--- a/tests/unit/strictdoc/export/test_rst_to_html_fragment_writer.py
+++ b/tests/unit/strictdoc/export/test_rst_to_html_fragment_writer.py
@@ -26,9 +26,9 @@ def test_01():
      - Row 2, column 3
 """.lstrip()
 
-    html_output = RstToHtmlFragmentWriter(context_document=None).write(
-        rst_input
-    )
+    html_output = RstToHtmlFragmentWriter(
+        context_document=None, path_to_output_dir="NOT_RELEVANT"
+    ).write(rst_input)
     assert '<table border="1"' in html_output
 
 
@@ -50,7 +50,8 @@ def test_with_validation_01_tables():
 """.lstrip()
 
     html_output, _ = RstToHtmlFragmentWriter(
-        context_document=None
+        context_document=None,
+        path_to_output_dir="NOT_RELEVANT",
     ).write_with_validation(rst_input)
     assert '<table border="1"' in html_output
 
@@ -64,7 +65,8 @@ def test_with_validation_02_warning_message():
 """.lstrip()
 
     html_output, error = RstToHtmlFragmentWriter(
-        context_document=None
+        context_document=None,
+        path_to_output_dir="NOT_RELEVANT",
     ).write_with_validation(rst_input)
     assert html_output is None
     assert error == (
@@ -85,7 +87,8 @@ Hello. What nex?
 """.lstrip()
 
     html_output, error = RstToHtmlFragmentWriter(
-        context_document=None
+        context_document=None,
+        path_to_output_dir="NOT_RELEVANT",
     ).write_with_validation(rst_input)
     assert html_output is None
     assert error == (


### PR DESCRIPTION


This ensures that two invocations of StrictDoc running against the same SDoc files will not collide.

The assumption here is that no one will run StrictDoc two times against the same output directory.