### PR TITLE
export/html:  Fix the scroll top margin of the form

### DIFF
--- a/strictdoc/export/html/_static/form.css
+++ b/strictdoc/export/html/_static/form.css
@@ -565,3 +565,8 @@ sdoc-tab[data-errors]::after {
   position: relative;
   right: calc(var(--base-rhythm)*(-1));
 }
+
+form[data-controller~="scroll_into_view"] {
+    scroll-snap-margin-top: var(--base-margin);
+    scroll-margin-top:      var(--base-margin);
+}


### PR DESCRIPTION
Fix the scroll top margin of the form that has scroll_into_view controller