### PR TITLE
CI: --exit-first on macOS and Linux tests

### DIFF
--- a/.github/workflows/end2end-tests.yml
+++ b/.github/workflows/end2end-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Run end-to-end tasks
       run: |
-        invoke test-end2end --long-timeouts --shard=${{ matrix.shard }}
+        invoke test-end2end --long-timeouts --shard=${{ matrix.shard }} --exit-first
 
   tests_end2end_linux:
     name: E2E - Linux
@@ -69,7 +69,7 @@ jobs:
 
     - name: Run end-to-end tasks
       run: |
-        invoke test-end2end --long-timeouts
+        invoke test-end2end --long-timeouts --exit-first
 
   build:
     name: E2E - Windows

--- a/tests/end2end/__init__.py
+++ b/tests/end2end/__init__.py
@@ -1,0 +1,1 @@
+# Dummy comment to trigger CI.


### PR DESCRIPTION
It is often the case with Selenium and our setup with timeouts that all subsequent tests fail anyway if one test fails. Doing this to reduce the waiting time.