### PR TITLE
project_config, UI: ensure that Search is only available in the web interface

### DIFF
--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -225,7 +225,10 @@ class ProjectConfig:  # pylint: disable=too-many-instance-attributes
         )
 
     def is_activated_search(self):
-        return ProjectFeature.SEARCH in self.project_features
+        return (
+            self.is_running_on_server
+            and ProjectFeature.SEARCH in self.project_features
+        )
 
     def is_activated_html2pdf(self) -> bool:
         return ProjectFeature.HTML2PDF in self.project_features

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -2284,6 +2284,11 @@ def create_main_router(
 
     @router.get("/search", response_class=Response)
     def get_search(q: Optional[str] = None):
+        if not project_config.is_activated_search():
+            return Response(
+                content="Search feature is not activated in the project config.",
+                status_code=412,
+            )
         search_results = []
         error = None
         node_query = None


### PR DESCRIPTION
This is the first feature that we can only have enabled in the web interface.