### PR TITLE
Requirements-to-source tracing: find all source files without exceptions

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -6,6 +6,15 @@ This document maintains a record of all changes to StrictDoc since November 2023
 [/FREETEXT]
 
 [SECTION]
+TITLE: Unreleased work
+
+[FREETEXT]
+The source file identification mechanism of the requirement-to-source traceability feature has been expanded to locate all source files present in a given source input directory. Previously, it was limited to finding files with specific extensions such as .c, .py, .sdoc, .rst, among others. This restriction, originally implemented for historical reasons, has now been removed. Moreover, StrictDoc has now integrated the get_lexer_by_name() function to automatically identify a lexer based on a source file's extension. This enhancement enables StrictDoc to offer syntax highlighting tailored specifically to the format of each source file. Previously, StrictDoc's code directly hardcoded only a limited selection of Pygments' lexers. Thanks to @KlfJoat for helping us to prioritize and fix this issue sooner.
+[/FREETEXT]
+
+[/SECTION]
+
+[SECTION]
 TITLE: 0.0.48 (2024-01-24)
 
 [FREETEXT]

--- a/strictdoc/core/file_tree.py
+++ b/strictdoc/core/file_tree.py
@@ -148,15 +148,15 @@ class FileFinder:
         *,
         root_path: str,
         ignored_dirs: List[str],
-        extensions: List[str],
+        extensions: Optional[List[str]],
         include_paths: List[str],
         exclude_paths: List[str],
     ):
         assert os.path.isdir(root_path)
         assert os.path.isabs(root_path)
-        assert isinstance(extensions, list), extensions
 
-        extensions_tuple = tuple(extensions)
+        extensions_tuple = tuple(extensions) if extensions is not None else ()
+
         path_filter_includes = PathFilter(
             include_paths, positive_or_negative=True
         )
@@ -199,8 +199,11 @@ class FileFinder:
             )
 
             for file in files:
-                if not file.endswith(extensions_tuple):
+                if len(extensions_tuple) > 0 and not file.endswith(
+                    extensions_tuple
+                ):
                     continue
+
                 full_file_path = os.path.join(current_root_path, file)
                 rel_file_path = os.path.join(rel_path, file)
 

--- a/strictdoc/core/finders/source_files_finder.py
+++ b/strictdoc/core/finders/source_files_finder.py
@@ -23,6 +23,8 @@ class SourceFileType(Enum):
     RST = [".rst"]
     SDOC = [".sdoc"]
 
+    UNKNOWN = []
+
     @classmethod
     def create_from_path(cls, path_to_file: str) -> "SourceFileType":
         if path_to_file.endswith(".py"):
@@ -50,7 +52,7 @@ class SourceFileType(Enum):
         if path_to_file.endswith(".sdoc"):
             return cls.SDOC
 
-        raise NotImplementedError(path_to_file)
+        return cls.UNKNOWN
 
     @staticmethod
     def all() -> List[str]:  # noqa: A003
@@ -75,6 +77,7 @@ class SourceFile:  # pylint: disable=too-many-instance-attributes
 
         self.level = level
         self.full_path = full_path
+        self.file_name = os.path.basename(full_path)
         self.in_doctree_source_file_rel_path = in_doctree_source_file_rel_path
         self.in_doctree_source_file_rel_path_posix: str = (
             in_doctree_source_file_rel_path.replace("\\", "/")
@@ -138,10 +141,11 @@ class SourceFilesFinder:
         )
 
         assert isinstance(project_config.export_output_dir, str)
+
         file_tree = FileFinder.find_files_with_extensions(
             root_path=doctree_root_abs_path,
             ignored_dirs=[project_config.export_output_dir],
-            extensions=SourceFileType.all(),
+            extensions=None,
             include_paths=project_config.include_source_paths,
             exclude_paths=project_config.exclude_source_paths,
         )

--- a/tests/integration/commands/export/html/file_traceability/70_unregistered_file_extensions/file.unknown_extension
+++ b/tests/integration/commands/export/html/file_traceability/70_unregistered_file_extensions/file.unknown_extension
@@ -1,0 +1,5 @@
+Some content here
+@sdoc[REQ-001]
+Some content here
+@sdoc[/REQ-001]
+Some content here

--- a/tests/integration/commands/export/html/file_traceability/70_unregistered_file_extensions/input.sdoc
+++ b/tests/integration/commands/export/html/file_traceability/70_unregistered_file_extensions/input.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ-001
+REFS:
+- TYPE: File
+  VALUE: file.unknown_extension
+TITLE: Requirement Title
+STATEMENT: Requirement Statement

--- a/tests/integration/commands/export/html/file_traceability/70_unregistered_file_extensions/strictdoc.toml
+++ b/tests/integration/commands/export/html/file_traceability/70_unregistered_file_extensions/strictdoc.toml
@@ -1,0 +1,5 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+]

--- a/tests/integration/commands/export/html/file_traceability/70_unregistered_file_extensions/test.itest
+++ b/tests/integration/commands/export/html/file_traceability/70_unregistered_file_extensions/test.itest
@@ -1,0 +1,21 @@
+RUN: %strictdoc export . --output-dir Output | filecheck %s
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%S/Output/html/_source_files/file.unknown_extension.html"
+
+RUN: %cat %S/Output/html/70_unregistered_file_extensions/input.html | filecheck %s --check-prefix CHECK-HTML
+CHECK-HTML: <link rel="stylesheet" href="../_static/base.css"/>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.unknown_extension.html#REQ-001#2#4"
+
+RUN: %cat %S/Output/html/_source_files/file.unknown_extension.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+
+CHECK-SOURCE-FILE: <a{{.*}}href="../70_unregistered_file_extensions/input.html#1-REQ-001">
+
+CHECK-SOURCE-FILE: href="../_source_files/file.unknown_extension.html#REQ-001#2#4"
+CHECK-SOURCE-FILE: <b>[ 2-4 ]</b> file.unknown_extension
+
+RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+CHECK-SOURCE-COVERAGE: file.unknown_extension
+CHECK-SOURCE-COVERAGE: strictdoc.toml
+CHECK-SOURCE-COVERAGE: test.itest

--- a/tests/integration/commands/export/html/file_traceability/80_auto_finding_of_lexers/file.ml
+++ b/tests/integration/commands/export/html/file_traceability/80_auto_finding_of_lexers/file.ml
@@ -1,0 +1,5 @@
+open Core
+let () =
+  (* @sdoc[REQ-001] *)
+  printf "%s\n" "hello world"
+  (* @sdoc[/REQ-001] *)

--- a/tests/integration/commands/export/html/file_traceability/80_auto_finding_of_lexers/input.sdoc
+++ b/tests/integration/commands/export/html/file_traceability/80_auto_finding_of_lexers/input.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ-001
+REFS:
+- TYPE: File
+  VALUE: file.ml
+TITLE: Requirement Title
+STATEMENT: Requirement Statement

--- a/tests/integration/commands/export/html/file_traceability/80_auto_finding_of_lexers/strictdoc.toml
+++ b/tests/integration/commands/export/html/file_traceability/80_auto_finding_of_lexers/strictdoc.toml
@@ -1,0 +1,5 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+]

--- a/tests/integration/commands/export/html/file_traceability/80_auto_finding_of_lexers/test.itest
+++ b/tests/integration/commands/export/html/file_traceability/80_auto_finding_of_lexers/test.itest
@@ -1,0 +1,23 @@
+RUN: %strictdoc export . --output-dir Output | filecheck %s
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%S/Output/html/_source_files/file.ml.html"
+
+RUN: %cat %S/Output/html/80_auto_finding_of_lexers/input.html | filecheck %s --check-prefix CHECK-HTML
+CHECK-HTML: <link rel="stylesheet" href="../_static/base.css"/>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.ml.html#REQ-001#3#5"
+
+RUN: %cat %S/Output/html/_source_files/file.ml.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+
+NOTE: Ensure that the lexer is recognized correctly.
+CHECK-SOURCE-FILE: OCaml
+
+CHECK-SOURCE-FILE: <a{{.*}}href="../80_auto_finding_of_lexers/input.html#1-REQ-001">
+CHECK-SOURCE-FILE: href="../_source_files/file.ml.html#REQ-001#3#5"
+CHECK-SOURCE-FILE: <b>[ 3-5 ]</b> file.ml
+
+RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+CHECK-SOURCE-COVERAGE: file.ml
+CHECK-SOURCE-COVERAGE: strictdoc.toml
+CHECK-SOURCE-COVERAGE: test.itest


### PR DESCRIPTION
Also, use Pygments' ability to automatically detect a lexer for a given source file name.

Closes #1621