### PR TITLE
export/dot: disable requirement links

### DIFF
--- a/strictdoc/export/dot/document_dot_generator.py
+++ b/strictdoc/export/dot/document_dot_generator.py
@@ -127,7 +127,7 @@ class DocumentDotGenerator:
         assert os.path.isfile(output_path)
         dot = graphviz.Source.from_file(output_path)
         # view=True makes the output PDF be opened in a default viewer program.
-        dot.render(output_path, view=False)
+        dot.render(output_path, format="svg", view=False)
 
     def _print_folder_documents(
         self,

--- a/strictdoc/export/dot/templates/profile1/top_level.dot
+++ b/strictdoc/export/dot/templates/profile1/top_level.dot
@@ -28,7 +28,7 @@ digraph {
   // SO: How can I direct dot to use a shorter edge path?
   // https://stackoverflow.com/q/24107451/598057
   // #}
-  splines=ortho;
+  // splines=ortho;
 
   // Ensure some space between documents.
   graph [ranksep=2];
@@ -42,9 +42,9 @@ digraph {
 {% endfilter %}
 
   {% for accumulated_link in accumulated_links -%}
-    "value_{{accumulated_link[0]}}"->"value_{{accumulated_link[1]}}" [
-      style="dashed" color="{{random_color()}}", penwidth = 2, constraint=false
-    ];
+    // "value_{{accumulated_link[0]}}"->"value_{{accumulated_link[1]}}" [
+    //   style="dashed" color="{{random_color()}}", penwidth = 2, constraint=false
+    // ];
   {%- endfor %}
 
   {% for accumulated_section_sibling in accumulated_section_siblings -%}

--- a/strictdoc/export/dot/templates/profile2/top_level.dot
+++ b/strictdoc/export/dot/templates/profile2/top_level.dot
@@ -43,9 +43,9 @@ digraph {
 {% endfilter %}
 
   {% for accumulated_link in accumulated_links -%}
-    "value_{{accumulated_link[0]}}"->"value_{{accumulated_link[1]}}" [
-      style="dotted" color="#000000", penwidth = 2, constraint=false
-    ];
+    // "value_{{accumulated_link[0]}}"->"value_{{accumulated_link[1]}}" [
+    // style="dotted" color="#000000", penwidth = 2, constraint=false
+    // ];
   {%- endfor %}
 
   {% for single_document_flat_requirements in document_flat_requirements -%}

--- a/tests/integration/commands/export/dot/01_minimal_document/test.itest
+++ b/tests/integration/commands/export/dot/01_minimal_document/test.itest
@@ -5,8 +5,8 @@ CHECK: Step 'Parse SDoc project tree' took: {{.*}} sec.
 
 RUN: %check_exists --file "%S/Output/dot/output.profile1.dot"
 RUN: %check_exists --file "%S/Output/dot/output.profile2.dot"
-RUN: %check_exists --file "%S/Output/dot/output.profile2.dot.pdf"
-RUN: %check_exists --file "%S/Output/dot/output.profile2.dot.pdf"
+RUN: %check_exists --file "%S/Output/dot/output.profile2.dot.svg"
+RUN: %check_exists --file "%S/Output/dot/output.profile2.dot.svg"
 
 RUN: %cat %S/Output/dot/output.profile1.dot | filecheck %s --dump-input=fail --check-prefix CHECK-DOT-P1
 CHECK-DOT-P1: label = "Hello world doc";


### PR DESCRIPTION
- Adding requirement links on large graph makes the diagrams look overcomplicated. Removing all links for now.

- Also switch from PDF to SVG which makes the generation work faster.