### PR TITLE
export/html: define the copy_to_clipboard in expandable node components

### DIFF
--- a/strictdoc/export/html/templates/components/node/index.jinja
+++ b/strictdoc/export/html/templates/components/node/index.jinja
@@ -34,6 +34,13 @@
     {# anchor #}
     {% include "components/anchor/index.jinja" %}
 
+    {#
+      copy_to_clipboard must be defined befor sdoc_entity block,
+      and define them in node components that have editing options:
+      node & root
+    #}
+    {%- set copy_to_clipboard = True -%}
+
     {# sdoc_entity #}
     {% block sdoc_entity %}
     {% include "components/"~sdoc_entity.get_type_string()~"/index.jinja" %}

--- a/strictdoc/export/html/templates/components/node/root.jinja
+++ b/strictdoc/export/html/templates/components/node/root.jinja
@@ -20,6 +20,13 @@
     data-testid="node-root"
   >
 
+    {#
+      copy_to_clipboard must be defined befor sdoc_entity block,
+      and define them in node components that have editing options:
+      node & root
+    #}
+    {%- set copy_to_clipboard = True -%}
+
     {# sdoc_entity #}
     {% block sdoc_entity %}
     {% endblock sdoc_entity %}

--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -86,6 +86,5 @@
 {% endblock header_content %}
 
 {% block main_content %}
-  {% set copy_to_clipboard = True %}
   {% include "screens/document/document/main.jinja" %}
 {% endblock main_content %}


### PR DESCRIPTION
that have editing options, i.e: node(index) and root, so that it is not lost on ajax reloading.

Closes #1588