### PR TITLE
export/html: make collapsible_list.js based on MutationObserver

### DIFF
--- a/strictdoc/export/html/_static/collapsible_list.js
+++ b/strictdoc/export/html/_static/collapsible_list.js
@@ -119,37 +119,11 @@ const STYLE = `
 }
 `;
 
-Stimulus.register("collapsible_list", class extends Controller {
-  static targets = ["name"];
-
-  initialize() {
-    this.render(this.element)
-  }
-
-  render(listElement) {
-    // Processes the list and makes it collapse, if that makes sense
-    // (if the expanded list was long and would cause scrolling).
-    // Returns the processed list.
-    const branchList = prepareList(listElement);
-
-    // Do it if that makes sense (if there are branches
-    // in the list that could in principle be collapsible):
-    if (branchList.length > 0) {
-      processList(branchList);
-      addStyleElement(this.element, STYLE);
-
-      // Uncomment to add buttons for bulk operations:
-      // addBulkHandler(listElement, createBulkHandler(branchList));
-    }
-  }
-
-});
-
 function addStyleElement(target, styleTextContent, attr = 'style') {
   const style = document.createElement('style');
   style.setAttribute(`${ROOT_SELECTOR}-${attr}`, '');
   style.textContent = styleTextContent;
-  target.prepend(style);
+  target.before(style);
 }
 
 function prepareList(target) {
@@ -230,3 +204,60 @@ function bulkToggle(list, oldState) {
   // Update list:
   list.forEach(el => el.dataset[BRANCH_SELECTOR] = nextState);
 }
+
+// ******
+
+function run() {
+  const toc = document.querySelector(`[${ROOT_SELECTOR}]`);
+
+  // Processes the list and makes it collapse, if that makes sense
+  // (if the expanded list was long and would cause scrolling).
+  // Returns the processed list.
+  const branchList = prepareList(toc);
+
+  // Do it if that makes sense (if there are branches
+  // in the list that could in principle be collapsible):
+  if (branchList.length > 0) {
+    processList(branchList);
+    addStyleElement(toc, STYLE);
+
+    // Uncomment to add buttons for bulk operations:
+    // addBulkHandler(listElement, createBulkHandler(branchList));
+  }
+}
+
+function isCollapsibleList(node) {
+  return node.nodeType === 1 && node.hasAttribute(ROOT_SELECTOR)
+}
+
+window.addEventListener("load",function(){
+
+  let mutatingFrame = document.querySelector('#frame-toc');
+  if (!mutatingFrame) {
+    console.error("#frame-toc not found");
+    return;
+  }
+
+  new MutationObserver(function (mutationsList, observer) {
+
+    for (let mutation of mutationsList) {
+      if (mutation.type === 'childList') {
+        let addedToc = Array.from(mutation.addedNodes).find(node => isCollapsibleList(node));
+        if (addedToc) {
+          run()
+        }
+      }
+    }
+
+  }).observe(
+    mutatingFrame,
+    {
+      childList: true,
+      // subtree: true
+    }
+  );
+
+  // * Call for the first time.
+  run()
+
+},false);

--- a/strictdoc/export/html/_static/element.css
+++ b/strictdoc/export/html/_static/element.css
@@ -1257,7 +1257,7 @@ a.tree_item:hover {
 }
 
 /* TOC parented */
-/* behavior depends on collapsible_list_controller.js */
+/* behavior depends on collapsible_list.js */
 .toc [data-collapsible_list__branch="closed"] ~ a[parented]::after {
   background-color: var(--color-highlight);
 }

--- a/strictdoc/export/html/templates/screens/document/_shared/toc.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/toc.jinja
@@ -2,7 +2,7 @@
       data-testid="toc-list"
       js-collapsible_list="list"
       class="toc"
-      data-controller="draggable_list collapsible_list"
+      data-controller="draggable_list"
       {%- if last_moved_node_id is defined %}
       data-last_moved_node_id="{{ last_moved_node_id.get_string_value() }}"
       {% endif -%}

--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -10,6 +10,7 @@
   <script type="text/javascript" src="{{ view_object.render_static_url('viewtype_menu.js') }}"></script>
   {%- endif -%}
   <script type="text/javascript" src="{{ view_object.render_static_url('resizable_bar.js') }}"></script>
+  <script type="text/javascript" src="{{ view_object.render_static_url('collapsible_list.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('toc_highlighting.js') }}"></script>
 
   {%- if view_object.is_running_on_server and not view_object.standalone -%}
@@ -20,7 +21,6 @@
     window.Controller = Controller;
   </script>
   <script type="module" src="{{ view_object.render_static_url('controllers/anchor_controller.js') }}"></script>
-  <script type="module" src="{{ view_object.render_static_url('controllers/collapsible_list_controller.js') }}"></script>
   <script type="module" src="{{ view_object.render_static_url('controllers/draggable_list_controller.js') }}"></script>
   <script type="module" src="{{ view_object.render_static_url('controllers/dropdown_menu_controller.js') }}"></script>
   <script type="module" src="{{ view_object.render_static_url('controllers/editable_field_controller.js') }}"></script>

--- a/strictdoc/export/html/templates/screens/document/table/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/index.jinja
@@ -8,16 +8,8 @@
 {% block head_scripts %}
   <script type="text/javascript" src="{{ view_object.render_static_url('viewtype_menu.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('resizable_bar.js') }}"></script>
+  <script type="text/javascript" src="{{ view_object.render_static_url('collapsible_list.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('toc_highlighting.js') }}"></script>
-
-  {%- if view_object.project_config.is_running_on_server and not view_object.standalone -%}
-  <script type="module">
-    import { Application, Controller } from "{{ view_object.render_static_url('stimulus.min.js') }}";
-    window.Stimulus = Application.start();
-    window.Controller = Controller;
-  </script>
-  <script type="module" src="{{ view_object.render_static_url('controllers/collapsible_list_controller.js') }}"></script>
-  {%- endif -%}
 
   {%- if view_object.project_config.is_activated_mathjax() -%}
   <script id="MathJax-script" async src="{{ view_object.render_static_url('mathjax/tex-mml-chtml.js') }}"></script>

--- a/strictdoc/export/html/templates/screens/document/traceability/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/traceability/index.jinja
@@ -8,6 +8,7 @@
 {% block head_scripts %}
   <script type="text/javascript" src="{{ view_object.render_static_url('viewtype_menu.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('resizable_bar.js') }}"></script>
+  <script type="text/javascript" src="{{ view_object.render_static_url('collapsible_list.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('toc_highlighting.js') }}"></script>
 
   {%- if view_object.project_config.is_running_on_server and not view_object.standalone -%}
@@ -17,14 +18,13 @@
     window.Stimulus = Application.start();
     window.Controller = Controller;
   </script>
-  <script type="module" src="{{ view_object.render_static_url('controllers/collapsible_list_controller.js') }}"></script>
   <script type="module" src="{{ view_object.render_static_url('controllers/modal_controller.js') }}"></script>
   {%- endif -%}
 
   {%- if view_object.project_config.is_activated_mathjax() -%}
   <script id="MathJax-script" async src="{{ view_object.render_static_url('mathjax/tex-mml-chtml.js') }}"></script>
   {%- endif -%}
-  
+
   {%- if view_object.project_config.is_activated_rapidoc() -%}
   <script type="text/javascript" src="{{ view_object.render_static_url('rapidoc/rapidoc-min.js') }}"></script>
   {%- endif -%}

--- a/strictdoc/export/html/templates/screens/document/traceability_deep/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/traceability_deep/index.jinja
@@ -8,6 +8,7 @@
 {% block head_scripts %}
   <script type="text/javascript" src="{{ view_object.render_static_url('viewtype_menu.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('resizable_bar.js') }}"></script>
+  <script type="text/javascript" src="{{ view_object.render_static_url('collapsible_list.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('toc_highlighting.js') }}"></script>
 
   {%- if view_object.project_config.is_running_on_server and not view_object.standalone -%}
@@ -17,7 +18,6 @@
     window.Stimulus = Application.start();
     window.Controller = Controller;
   </script>
-  <script type="module" src="{{ view_object.render_static_url('controllers/collapsible_list_controller.js') }}"></script>
   <script type="module" src="{{ view_object.render_static_url('controllers/modal_controller.js') }}"></script>
   {%- endif -%}
 


### PR DESCRIPTION
Use MutationObserver instead of Stimulus in collapsible_list.js to make it work in static HTML exports

Closes #1097