### PR TITLE
UI: Diff screen: do not build source file traceability when doing history

### DIFF
--- a/strictdoc/core/traceability_index_builder.py
+++ b/strictdoc/core/traceability_index_builder.py
@@ -58,6 +58,7 @@ class TraceabilityIndexBuilder:
         *,
         project_config: ProjectConfig,
         parallelizer,
+        skip_source_files=False,
     ) -> TraceabilityIndex:
         # TODO: It would be great to hide this code behind --development flag.
         # There is no need for this to be activated in the Pip-released builds.
@@ -153,7 +154,7 @@ class TraceabilityIndexBuilder:
                     finished.add(document_)
 
         # File traceability
-        if project_config.is_feature_activated(
+        if not skip_source_files and project_config.is_feature_activated(
             ProjectFeature.REQUIREMENT_TO_SOURCE_TRACEABILITY
         ):
             source_tree: SourceTree = SourceFilesFinder.find_source_files(

--- a/strictdoc/git/change_generator.py
+++ b/strictdoc/git/change_generator.py
@@ -46,6 +46,8 @@ class ChangeGenerator:
             TraceabilityIndexBuilder.create(
                 project_config=lhs_project_config,
                 parallelizer=parallelizer,
+                # We don't want to deal with source files for Diff.
+                skip_source_files=True,
             )
         )
 
@@ -53,6 +55,8 @@ class ChangeGenerator:
             TraceabilityIndexBuilder.create(
                 project_config=rhs_project_config,
                 parallelizer=parallelizer,
+                # We don't want to deal with source files for Diff.
+                skip_source_files=True,
             )
         )
 


### PR DESCRIPTION

Diff'ing links between requirements and source files is a little more complicated than diff'ing just requirements. Disabling the file traceability because we are not using on the Diff screen anyway.