### PR TITLE
export/html: project_index: Show fragments by default, disable switcher, add info about including file

### DIFF
--- a/strictdoc/backend/sdoc/models/document.py
+++ b/strictdoc/backend/sdoc/models/document.py
@@ -62,6 +62,9 @@ class SDocDocument:  # pylint: disable=too-many-instance-attributes
     def document_is_included(self):
         return self.ng_including_document_reference.get_document() is not None
 
+    def get_included_document(self):
+        return self.ng_including_document_reference.get_document()
+
     @property
     def reserved_uid(self) -> Optional[str]:
         return self.config.uid

--- a/strictdoc/export/html/_static/project_tree.js
+++ b/strictdoc/export/html/_static/project_tree.js
@@ -187,7 +187,18 @@ class ProjectTree {
   }
 
   _getFragments() {
-    return [...this.mutatingFrame.querySelectorAll(FRAGMENT_SELECTOR)];
+    const fragments = [...this.mutatingFrame.querySelectorAll(FRAGMENT_SELECTOR)];
+    // this._prepareFragmentsFoldersAndNeighbors(fragments);
+    return fragments;
+  }
+
+  _prepareFragmentsFoldersAndNeighbors(fragments) {
+    // ul > li > .std-tree_row
+    // .std-tree_row === fragment
+    const folders = new Set();
+    this.fragments.forEach(element => {
+      element.style.display = display;
+    })
   }
 
   _updateFragmentsVisibility(bool) {

--- a/strictdoc/export/html/_static/project_tree.js
+++ b/strictdoc/export/html/_static/project_tree.js
@@ -245,12 +245,12 @@ class ProjectTree {
   _addControl() {
     const switcher = new Switch(
       {
-        labelText: 'Show included fragments',
+        labelText: '<b>Show fragments</b> included in other documents in the Project tree:',
         size: 0.5,
         stroke: 0.175,
         position: 'absolute',
-        topPosition: '20px',
-        rightPosition: '20px',
+        topPosition: '16px',
+        leftPosition: 0,
         // checked: false,
         checked: this.getCurrentFragmentVisibilityBool(),
         callback: (checked) => this.toggleFragmentsVisibility(checked),

--- a/strictdoc/export/html/_static/tree.css
+++ b/strictdoc/export/html/_static/tree.css
@@ -91,11 +91,6 @@
     justify-content: space-between;
   }
 
-  .std-tree_row[included-document] > * {
-    padding-left: calc(2 * var(--base-rhythm));
-    border-left: double #000;
-  }
-
   .std-tree_folder {
     font-weight: bold;
     display: flex;

--- a/strictdoc/export/html/templates/screens/project_index/index.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/index.jinja
@@ -15,9 +15,7 @@
        deactivate the "included documents" switch with a more
        fine-grained approach.
   #}
-  {% if view_object.contains_included_documents %}
-  <script type="module" src="{{ view_object.render_static_url('project_tree.js') }}"></script>
-  {% endif %}
+  {# <script type="module" src="{{ view_object.render_static_url('project_tree.js') }}"></script> #}
 {%- if view_object.project_config.is_running_on_server and not view_object.standalone -%}
   <script type="module">
     import hotwiredTurbo from "{{ view_object.render_static_url_with_prefix('turbo.min.js') }}";

--- a/strictdoc/export/html/templates/screens/project_index/project_tree.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/project_tree.jinja
@@ -36,7 +36,12 @@
               <div class="std-tree_file">
 
                 <i class="std-tree_ico">
-                  <svg class="ico__file" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="16px" height="16px"><path d="M14.17,5L19,9.83V19H5V5L14.17,5L14.17,5 M14.17,3H5C3.9,3,3,3.9,3,5v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V9.83 c0-0.53-0.21-1.04-0.59-1.41l-4.83-4.83C15.21,3.21,14.7,3,14.17,3L14.17,3z M7,15h10v2H7V15z M7,11h10v2H7V11z M7,7h7v2H7V7z"/></svg>
+                  {%- if is_included -%}
+                    {%- include "_res/svg_ico16_fragment_draft.jinja" -%}
+                  {%- else -%}
+                    {%- include "_res/svg_ico16_document.jinja.html" -%}
+                    {# <svg class="ico__file" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="black" width="16px" height="16px"><path d="M14.17,5L19,9.83V19H5V5L14.17,5L14.17,5 M14.17,3H5C3.9,3,3,3.9,3,5v14c0,1.1,0.9,2,2,2h14c1.1,0,2-0.9,2-2V9.83 c0-0.53-0.21-1.04-0.59-1.41l-4.83-4.83C15.21,3.21,14.7,3,14.17,3L14.17,3z M7,15h10v2H7V15z M7,11h10v2H7V11z M7,7h7v2H7V7z"/></svg> #}
+                  {%- endif -%}
                 </i>
 
                 <div class="std-tree_file-link">
@@ -52,6 +57,12 @@
                     <div class="std-tree_file__name">
                       {{ folder_or_file.get_file_name() }}
                     </div>
+
+                    {%- if is_included -%}
+                      <div class="std-tree_file__name">
+                        <b>included by</b> {{ document.get_included_document().meta.input_doc_rel_path }}
+                      </div>
+                    {%- endif -%}
                   </a>
                 </div>
               </div>


### PR DESCRIPTION
Closes #1709

- Show fragments by default, 
- disable switcher, 
- add info about including file
- update icons
- some improvement in JS (but for now, disable the script) 