### PR TITLE
Fix a crash when following the user guide.

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -1968,15 +1968,15 @@ The requirement declaration contains a reference of the type ``File``:
 .. code-block:: text
 
     [REQUIREMENT]
-    UID: REQ-001
+    UID: REQ-002
     RELATIONS:
     - TYPE: File
       VALUE: file.py
-    TITLE: Whole file reference
+    TITLE: Range file reference
     STATEMENT: This requirement references the file.py file.
     COMMENT: >>>
     If the file.py contains a source range that is connected back to this
-    requirement (REQ-001), the link becomes a link to the source range.
+    requirement (REQ-002), the link becomes a link to the source range.
     <<<
 
 The source file:


### PR DESCRIPTION
Strictly following the user guide for this part yield to a crash because the requirement number 2 does not exist.