### PR TITLE
export/html: collapsible_toc.js : Store the TOC state for each node

### DIFF
--- a/strictdoc/export/html/_static/collapsible_toc.js
+++ b/strictdoc/export/html/_static/collapsible_toc.js
@@ -1,0 +1,200 @@
+// To collapse and expand TOC branches
+
+const ROOT_ID = 'toc';
+const SS_ITEM = 'collapsibleTOC'; // sessionStorageItem
+const BRANCH_DATA_ATTR = `branch`; // li with a branch inside
+const HANDLER_DATA_ATTR = `handler`; // handler
+const NODE_ID_DATA_ATTR = `nodeid`; // from sdoc markup
+const _TRUE = 'collapsed';
+const _FALSE = 'expanded';
+
+const ROOT_SELECTOR = 'js-collapsible_list'; // is used in tests
+
+const SYMBOL_FALSE = '－';
+const SYMBOL_TRUE = '＋';
+const SYMBOL_SIZE = 16;
+
+const STYLE = `
+[data-${HANDLER_DATA_ATTR}] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  -webkit-box-align: center;
+  -webkit-box-pack: center;
+  background-clip: padding-box;
+  cursor: pointer;
+  user-select: none;
+  transition: .3s;
+  width: ${SYMBOL_SIZE}px;
+  height: ${SYMBOL_SIZE}px;
+  font-size: ${SYMBOL_SIZE * 0.875}px;
+  font-weight: bold;
+  line-height: 0;
+  border-radius: 50%;
+  color: rgba(0,0,0,0.5);
+  box-shadow: rgb(0 0 0 / 10%) 0px 1px 2px 0px;
+  position: absolute;
+  top: ${SYMBOL_SIZE * 0.5}px;
+  left: -${SYMBOL_SIZE * 0.75}px;
+}
+
+[data-${HANDLER_DATA_ATTR}]:hover {
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  box-shadow: rgb(0 0 0 / 15%) 0px 2px 8px 0px;
+  color: rgba(0,0,0,1);
+}
+
+[data-${HANDLER_DATA_ATTR}='${_TRUE}']::before {
+  content: '${SYMBOL_TRUE}';
+}
+
+[data-${HANDLER_DATA_ATTR}='${_FALSE}']::before {
+  content: '${SYMBOL_FALSE}';
+}
+
+[data-${BRANCH_DATA_ATTR}='${_TRUE}'] > ul {
+  display: none;
+}
+
+[data-${BRANCH_DATA_ATTR}='${_FALSE}'] > ul {
+  display: unset;
+}
+
+`;
+
+function sessionStorageGet() {
+  const item = sessionStorage.getItem(SS_ITEM);
+  const res = item ? JSON.parse(item) : {};
+  return res
+}
+
+function sessionStorageSet(obj) {
+  const string = JSON.stringify(obj);
+  sessionStorage.setItem(SS_ITEM, string)
+}
+
+function updateSessionStorage() {
+  const obj = {};
+  document.querySelector(`[${ROOT_SELECTOR}]`)
+    .querySelectorAll(`[data-${BRANCH_DATA_ATTR}]`)
+    .forEach(
+      branch => obj[branch.dataset[NODE_ID_DATA_ATTR]] = branch.dataset[BRANCH_DATA_ATTR]
+    );
+  sessionStorageSet(obj);
+}
+
+function addStyleElement(target, styleTextContent, attr = 'style') {
+  const style = document.createElement('style');
+  style.setAttribute(`collapsible-toc-${attr}`, '');
+  style.textContent = styleTextContent;
+  target.before(style);
+}
+
+function setBranchState(handler, state) {
+  handler.dataset[HANDLER_DATA_ATTR] = state;
+  handler.parentNode.dataset[BRANCH_DATA_ATTR] = state;
+}
+
+function createHandler(state) {
+  const div = document.createElement('div');
+  state && setBranchState(item, state);
+  return div
+}
+
+function processToc(toc) {
+  const storage = sessionStorageGet();
+
+  const branchList = toc.querySelectorAll('ul');
+
+  // Do it if that makes sense (if there are branches
+  // in the list that could in principle be collapsible):
+  if (branchList.length > 0) {
+    addStyleElement(toc, STYLE);
+
+    branchList.forEach(
+      ul => {
+        const handler = createHandler();
+
+        const parentNode = ul.parentNode;
+        const nodeID = parentNode.dataset[NODE_ID_DATA_ATTR];
+        const currentState = storage[nodeID] || _FALSE;
+
+        // parent.insertBefore(handler, ul);
+        // * I need the button to come before the link as well
+        parentNode.prepend(handler);
+        // Required:
+        parentNode.style = "position:relative";
+
+        // * run after the items have been added to the DOM
+        setBranchState(handler, currentState);
+
+        // * add event listeners
+        handler.addEventListener('click', () => {
+          toggle(handler);
+        });
+        handler.addEventListener('dblclick', () => {
+          bulkToggleChildBrunches(handler);
+        });
+      }
+    );
+
+    updateSessionStorage();
+  }
+}
+
+function toggle(handler) {
+  const newState = (handler.dataset[HANDLER_DATA_ATTR] === _FALSE) ? _TRUE : _FALSE;
+  setBranchState(handler, newState);
+  updateSessionStorage();
+}
+
+function bulkToggleChildBrunches(handler) {
+  const newState = (handler.dataset[HANDLER_DATA_ATTR] === _FALSE) ? _TRUE : _FALSE;
+  const list = handler.parentNode.querySelectorAll(`[data-${HANDLER_DATA_ATTR}]`);
+  list.forEach(handler => {
+    setBranchState(handler, newState);
+  });
+  updateSessionStorage();
+}
+
+// ******
+
+function run() {
+  processToc(document.querySelector(`[${ROOT_SELECTOR}]`));
+}
+
+function isCollapsibleList(node) {
+  return node.nodeType === 1 && node.id === ROOT_ID
+}
+
+window.addEventListener("load", function() {
+
+  let mutatingFrame = document.querySelector('#frame-toc');
+  if (!mutatingFrame) {
+    console.error("#frame-toc not found");
+    return;
+  }
+
+  new MutationObserver(function (mutationsList, observer) {
+
+    for (let mutation of mutationsList) {
+      if (mutation.type === 'childList') {
+        let addedToc = Array.from(mutation.addedNodes).find(node => isCollapsibleList(node));
+        if (addedToc) {
+          run()
+        }
+      }
+    }
+
+  }).observe(
+    mutatingFrame,
+    {
+      childList: true,
+      // subtree: true
+    }
+  );
+
+  // * Call for the first time.
+  run()
+
+},false);

--- a/strictdoc/export/html/templates/screens/document/_shared/toc.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/toc.jinja
@@ -2,6 +2,7 @@
       data-testid="toc-list"
       js-collapsible_list="list"
       class="toc"
+      id="toc"
       data-controller="draggable_list"
       {%- if last_moved_node_id is defined %}
       data-last_moved_node_id="{{ last_moved_node_id.get_string_value() }}"

--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -9,7 +9,7 @@
   <script type="text/javascript" src="{{ view_object.render_static_url('viewtype_menu.js') }}"></script>
   {%- endif -%}
   <script type="text/javascript" src="{{ view_object.render_static_url('resizable_bar.js') }}"></script>
-  <script type="text/javascript" src="{{ view_object.render_static_url('collapsible_list.js') }}"></script>
+  <script type="text/javascript" src="{{ view_object.render_static_url('collapsible_toc.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('toc_highlighting.js') }}"></script>
 
   {%- if view_object.is_running_on_server and not view_object.standalone -%}

--- a/strictdoc/export/html/templates/screens/document/table/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/index.jinja
@@ -8,7 +8,7 @@
 {% block head_scripts %}
   <script type="text/javascript" src="{{ view_object.render_static_url('viewtype_menu.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('resizable_bar.js') }}"></script>
-  <script type="text/javascript" src="{{ view_object.render_static_url('collapsible_list.js') }}"></script>
+  <script type="text/javascript" src="{{ view_object.render_static_url('collapsible_toc.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('toc_highlighting.js') }}"></script>
 
   {%- if view_object.project_config.is_activated_mathjax() -%}

--- a/strictdoc/export/html/templates/screens/document/traceability/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/traceability/index.jinja
@@ -8,7 +8,7 @@
 {% block head_scripts %}
   <script type="text/javascript" src="{{ view_object.render_static_url('viewtype_menu.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('resizable_bar.js') }}"></script>
-  <script type="text/javascript" src="{{ view_object.render_static_url('collapsible_list.js') }}"></script>
+  <script type="text/javascript" src="{{ view_object.render_static_url('collapsible_toc.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('toc_highlighting.js') }}"></script>
 
   {%- if view_object.project_config.is_running_on_server and not view_object.standalone -%}

--- a/strictdoc/export/html/templates/screens/document/traceability_deep/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/traceability_deep/index.jinja
@@ -8,7 +8,7 @@
 {% block head_scripts %}
   <script type="text/javascript" src="{{ view_object.render_static_url('viewtype_menu.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('resizable_bar.js') }}"></script>
-  <script type="text/javascript" src="{{ view_object.render_static_url('collapsible_list.js') }}"></script>
+  <script type="text/javascript" src="{{ view_object.render_static_url('collapsible_toc.js') }}"></script>
   <script type="text/javascript" src="{{ view_object.render_static_url('toc_highlighting.js') }}"></script>
 
   {%- if view_object.project_config.is_running_on_server and not view_object.standalone -%}

--- a/tests/end2end/helpers/components/collapsible_list.py
+++ b/tests/end2end/helpers/components/collapsible_list.py
@@ -23,7 +23,7 @@ class CollapsibleList:
 
     def assert_collapsible_handler(self) -> None:
         self.test_case.assert_element(
-            "//*[@data-collapsible_list__branch]",
+            "//*[@data-handler]",
             by=By.XPATH,
         )
 
@@ -31,13 +31,13 @@ class CollapsibleList:
 
     def assert_all_is_expanded(self) -> None:
         self.test_case.assert_element_not_visible(
-            '//*[@data-collapsible_list__branch="closed"]',
+            '//*[@data-handler="collapsed"]',
             by=By.XPATH,
         )
 
     def assert_all_is_collapsed(self) -> None:
         self.test_case.assert_element_not_visible(
-            '//*[@data-collapsible_list__branch="open"]',
+            '//*[@data-handler="expanded"]',
             by=By.XPATH,
         )
 
@@ -45,15 +45,13 @@ class CollapsibleList:
 
     def assert_is_expanded(self, string: str) -> None:
         self.test_case.assert_element(
-            f'//a[contains(., "{string}")]/..'
-            '/*[@data-collapsible_list__branch="open"]',
+            f'//a[contains(., "{string}")]/../*[@data-handler="expanded"]',
             by=By.XPATH,
         )
 
     def assert_is_collapsed(self, string: str) -> None:
         self.test_case.assert_element(
-            f'//a[contains(., "{string}")]/..'
-            '/*[@data-collapsible_list__branch="closed"]',
+            f'//a[contains(., "{string}")]/../*[@data-handler="collapsed"]',
             by=By.XPATH,
         )
 
@@ -75,20 +73,17 @@ class CollapsibleList:
 
     def do_toggle_collapsible(self, string: str) -> None:
         self.test_case.click_xpath(
-            f'//a[contains(., "{string}")]/..'
-            "/*[@data-collapsible_list__branch]",
+            f'//a[contains(., "{string}")]/../*[@data-handler]',
         )
 
     def do_bulk_collapse(self, string: str) -> None:
         self.test_case.double_click(
-            f'//a[contains(., "{string}")]/..'
-            '/*[@data-collapsible_list__branch="open"]',
+            f'//a[contains(., "{string}")]/../*[@data-handler="expanded"]',
             by=By.XPATH,
         )
 
     def do_bulk_expand(self, string: str) -> None:
         self.test_case.double_click(
-            f'//a[contains(., "{string}")]/..'
-            '/*[@data-collapsible_list__branch="closed"]',
+            f'//a[contains(., "{string}")]/../*[@data-handler="collapsed"]',
             by=By.XPATH,
         )

--- a/tests/end2end/navigation/collapsible_list/expected_output/document.sdoc
+++ b/tests/end2end/navigation/collapsible_list/expected_output/document.sdoc
@@ -19,6 +19,15 @@ TITLE: Nested section 1 title
 This is a free text of this nested section 1.
 [/FREETEXT]
 
+[SECTION]
+TITLE: Nested section 11 title
+
+[FREETEXT]
+This is a free text of this nested section 11.
+[/FREETEXT]
+
+[/SECTION]
+
 [/SECTION]
 
 [/SECTION]

--- a/tests/end2end/navigation/collapsible_list/input/document.sdoc
+++ b/tests/end2end/navigation/collapsible_list/input/document.sdoc
@@ -19,6 +19,15 @@ TITLE: Nested section 1 title
 This is a free text of this nested section 1.
 [/FREETEXT]
 
+[SECTION]
+TITLE: Nested section 11 title
+
+[FREETEXT]
+This is a free text of this nested section 11.
+[/FREETEXT]
+
+[/SECTION]
+
 [/SECTION]
 
 [/SECTION]

--- a/tests/end2end/navigation/collapsible_list/test_UC114_T01_UI_collapsible_list.py
+++ b/tests/end2end/navigation/collapsible_list/test_UC114_T01_UI_collapsible_list.py
@@ -68,11 +68,16 @@ class Test_UC114_T01_UI_collapsible_list(E2ECase):
             # test bulk operation
 
             collapsible_list.do_bulk_collapse("Section 1 title")
-            collapsible_list.assert_all_is_collapsed()
             collapsible_list.assert_visible_not("Nested section 1 title")
-            collapsible_list.assert_visible_not("Nested section 2 title")
+            collapsible_list.assert_visible_not("Nested section 11 title")
+            collapsible_list.do_toggle_collapsible("Section 1 title")
+            collapsible_list.assert_visible_not("Nested section 11 title")
 
+            collapsible_list.do_toggle_collapsible("Section 1 title")
+            collapsible_list.assert_visible_not("Nested section 1 title")
             collapsible_list.do_bulk_expand("Section 1 title")
+            collapsible_list.assert_visible("Nested section 11 title")
+
             collapsible_list.assert_all_is_expanded()
             collapsible_list.assert_visible("Nested section 1 title")
             collapsible_list.assert_visible("Nested section 2 title")
@@ -84,6 +89,7 @@ class Test_UC114_T01_UI_collapsible_list(E2ECase):
             collapsible_list.assert_all_is_expanded()
 
             collapsible_list.do_bulk_collapse("Section 1 title")
+            collapsible_list.do_bulk_collapse("Section 2 title")
             collapsible_list.assert_all_is_collapsed()
             self.refresh()
             collapsible_list.assert_all_is_collapsed()


### PR DESCRIPTION
Closes #1755

- Store the TOC state for each node
- double-click to close only child branches (instead of closing all branches of the tree)