### PR TITLE
html2pdf: specify UTF-8 encoding when writing HTML file

### DIFF
--- a/strictdoc/__init__.py
+++ b/strictdoc/__init__.py
@@ -1,6 +1,6 @@
 from strictdoc.core.environment import SDocRuntimeEnvironment
 
-__version__ = "0.0.56a1"
+__version__ = "0.0.56a2"
 
 
 environment = SDocRuntimeEnvironment(__file__)

--- a/strictdoc/export/html2pdf/html2pdf_generator.py
+++ b/strictdoc/export/html2pdf/html2pdf_generator.py
@@ -74,7 +74,9 @@ class HTML2PDFGenerator:
                 document_.meta.document_filename_base + ".html",
             )
 
-            with open(path_to_output_html_doc, "w+") as output_html_doc_file_:
+            with open(
+                path_to_output_html_doc, "w", encoding="utf8"
+            ) as output_html_doc_file_:
                 output_html_doc_file_.write(document_content)
 
             path_to_output_pdf_dir = os.path.join(


### PR DESCRIPTION
Follow-up to: #1773.