### PR TITLE
pyproject.toml: update python-datauri

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     # Static HTML export with embedded assets.
     "beautifulsoup4 >= 4.12.0, == 4.*",
     "html5lib>=1.1",  # Used by beautifulsoup4 as an optional plugin.
-    "python-datauri >= 0.2.9, == 0.*",
+    "python-datauri >= 2.1.1, == 2.*",
 
     # Excel
     "XlsxWriter >= 1.3.7, == 1.*",


### PR DESCRIPTION
Hi there,

First off very excited to have found this project, thank you for sharing it!

While experimenting with StrictDoc for one of my projects I ran into an integration issue with the datauri library installing tests to the virtual environment. The library maintainer was kind enough to help me quickly resolve the issue in https://github.com/fcurella/python-datauri/pull/14.

This pull request is to update StrictDoc to use the latest version of `python-datauri` that incorporates that fix. I realize that this would be a jump forward by two major versions, but from examination of the diff the actual library content does not appear to be all that different: https://github.com/fcurella/python-datauri/compare/v0.2.9...v2.1.1. The scope of usage within StrictDoc also seems to be pretty small.

Please let me know if there is anything I can do to help further test this dependency update, thanks!