### PR TITLE
backend/sdoc: instantiate doc/grammar meta models at start time

### DIFF
--- a/strictdoc/backend/sdoc/error_handling.py
+++ b/strictdoc/backend/sdoc/error_handling.py
@@ -365,7 +365,7 @@ class StrictDocSemanticError(Exception):
             filename=filename,
         )
 
-    def to_print_message(self):
+    def to_print_message(self) -> str:
         message = ""
         message += f"error: could not parse file: {self.file_path}.\n"
         message += f"Semantic error: {self.title}\n"

--- a/strictdoc/backend/sdoc/grammar/grammar_builder.py
+++ b/strictdoc/backend/sdoc/grammar/grammar_builder.py
@@ -1,4 +1,3 @@
-# mypy: disable-error-code="no-untyped-call,no-untyped-def"
 from strictdoc.backend.sdoc.grammar.grammar import (
     DOCUMENT_GRAMMAR,
     FREE_TEXT_PARSER_GRAMMAR,
@@ -16,12 +15,11 @@ from strictdoc.backend.sdoc.grammar.type_system import (
 
 class SDocGrammarBuilder:
     @staticmethod
-    def _prep_grammar(grammar):
-        grammar = (grammar).replace("'\\n'", "'\n'")
-        return grammar
+    def _prep_grammar(grammar: str) -> str:
+        return grammar.replace("'\\n'", "'\n'")
 
     @staticmethod
-    def create_grammar():
+    def create_grammar() -> str:
         grammar = SDocGrammarBuilder._prep_grammar(
             DOCUMENT_GRAMMAR
             + GRAMMAR_GRAMMAR
@@ -33,20 +31,20 @@ class SDocGrammarBuilder:
         return grammar
 
     @staticmethod
-    def create_free_text_grammar():
+    def create_free_text_grammar() -> str:
         return SDocGrammarBuilder._prep_grammar(
             FREE_TEXT_PARSER_GRAMMAR + TEXT_TYPES_GRAMMAR
         )
 
     @staticmethod
-    def create_grammar_grammar():
+    def create_grammar_grammar() -> str:
         grammar = SDocGrammarBuilder._prep_grammar(
             GRAMMAR_WRAPPER + GRAMMAR_GRAMMAR + STRICTDOC_BASIC_TYPE_SYSTEM
         )
         return grammar
 
     @staticmethod
-    def create_raw_grammar():
+    def create_raw_grammar() -> str:
         grammar = (
             DOCUMENT_GRAMMAR
             + GRAMMAR_GRAMMAR
@@ -55,5 +53,4 @@ class SDocGrammarBuilder:
             + TEXT_TYPES_GRAMMAR
             + STRICTDOC_BASIC_TYPE_SYSTEM
         )
-
         return grammar

--- a/strictdoc/backend/sdoc/reader.py
+++ b/strictdoc/backend/sdoc/reader.py
@@ -17,22 +17,24 @@ from strictdoc.helpers.textx import drop_textx_meta
 
 
 class SDReader:
+    meta_model = metamodel_from_str(
+        SDocGrammarBuilder.create_grammar(),
+        classes=DOCUMENT_MODELS,
+        use_regexp_group=True,
+    )
+
     def __init__(self, path_to_output_root: str = "NOT_RELEVANT"):
         self.path_to_output_root = path_to_output_root
 
     @staticmethod
     def _read(input_string, file_path=None):
-        meta_model = metamodel_from_str(
-            SDocGrammarBuilder.create_grammar(),
-            classes=DOCUMENT_MODELS,
-            use_regexp_group=True,
-        )
-
         parse_context = ParseContext(path_to_sdoc_file=file_path)
         processor = SDocParsingProcessor(parse_context=parse_context)
-        meta_model.register_obj_processors(processor.get_default_processors())
+        SDReader.meta_model.register_obj_processors(
+            processor.get_default_processors()
+        )
 
-        document: SDocDocument = meta_model.model_from_str(
+        document: SDocDocument = SDReader.meta_model.model_from_str(
             input_string, file_name=file_path
         )
         parse_context.document_reference.set_document(document)


### PR DESCRIPTION
This avoids instantiating the meta model each time an SDoc or an SGra file is read.