### PR TITLE
Feature: LINK to requirements and custom nodes (static export only for now)

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -1654,14 +1654,16 @@ UID: SDOC_UG_LINKS_AND_ANCHORS
 TITLE: Links
 
 [FREETEXT]
-StrictDoc supports creating inline links to document sections and anchors.
+StrictDoc supports creating inline links to document sections, anchors, requirements and custom grammar elements.
 [/FREETEXT]
 
 [SECTION]
-TITLE: Section links
+TITLE: Links
 
 [FREETEXT]
-When a section has an UID, it is possible to reference this section from any other section's text using a ``[LINK: <Section UID>]`` tag.
+Elements that have an UID can be referenced from section text using a ``[LINK: <UID>]`` tag.
+To reference a section that has an UID, use ``[LINK: <Section UID>]`` tag.
+Likewise, a requirement can be referenced with ``[LINK: <Requirement UID>]``.
 
 Example:
 

--- a/strictdoc/core/transforms/section.py
+++ b/strictdoc/core/transforms/section.py
@@ -80,7 +80,7 @@ class UpdateSectionCommand:
             else:
                 if section.reserved_uid != form_object.section_uid:
                     section_incoming_links: Optional[List[InlineLink]] = (
-                        traceability_index.get_section_incoming_links(section)
+                        traceability_index.get_incoming_links(section)
                     )
                     if (
                         section_incoming_links is not None

--- a/strictdoc/export/html/renderers/markup_renderer.py
+++ b/strictdoc/export/html/renderers/markup_renderer.py
@@ -141,15 +141,14 @@ class MarkupRenderer:
             if isinstance(part, str):
                 parts_output += part
             elif isinstance(part, InlineLink):
-                node: Union[SDocSection, Anchor] = assert_cast(
-                    self.traceability_index.get_node_by_uid(part.link),
-                    (SDocSection, Anchor),
+                linkable_node = (
+                    self.traceability_index.get_linkable_node_by_uid(part.link)
                 )
                 href = self.link_renderer.render_node_link(
-                    node, self.context_document, document_type
+                    linkable_node.node, self.context_document, document_type
                 )
                 parts_output += self.fragment_writer.write_anchor_link(
-                    node.title, href
+                    linkable_node.title, href
                 )
             elif isinstance(part, Anchor):
                 parts_output += self.template_anchor.render(

--- a/strictdoc/export/html/templates/components/anchor/index.jinja
+++ b/strictdoc/export/html/templates/components/anchor/index.jinja
@@ -7,7 +7,7 @@
 >
 {%- if sdoc_entity.is_section -%}
 {%- set section = sdoc_entity %}
-{%- set incoming_links = view_object.traceability_index.get_section_incoming_links(section) %}
+{%- set incoming_links = view_object.traceability_index.get_incoming_links(section) %}
 {%- if incoming_links is not none and incoming_links|length > 0 -%}
 <template>
   incoming link{% if incoming_links|length > 1 -%}s{%- endif %} from:

--- a/strictdoc/export/html/templates/rst/anchor.jinja
+++ b/strictdoc/export/html/templates/rst/anchor.jinja
@@ -1,7 +1,7 @@
 .. raw:: html
 
     <sdoc-anchor id="{{ anchor.value }}" data-uid="{{ anchor.value }}" data-anchor="{{ anchor.value }}" style="top:unset">
-    {%- set incoming_links = traceability_index.get_section_incoming_links(anchor) -%}
+    {%- set incoming_links = traceability_index.get_incoming_links(anchor) -%}
     {%- if incoming_links is not none and incoming_links|length > 0 -%}
     <template>
       incoming link{% if incoming_links|length > 1 -%}s{%- endif %} from:

--- a/strictdoc/export/rst/writer.py
+++ b/strictdoc/export/rst/writer.py
@@ -126,7 +126,7 @@ class RSTWriter:
             if isinstance(part, str):
                 output += part
             elif isinstance(part, InlineLink):
-                anchor_or_none = self.index.get_linkable_node_by_uid_weak(
+                node_or_none = self.index.get_linkable_node_by_uid_weak(
                     part.link
                 )
 
@@ -134,13 +134,8 @@ class RSTWriter:
                 # referenced, but you must give the link an explicit title,
                 # using this syntax: :ref:`Link title <label-name>`.
                 # https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html
-                if anchor_or_none is not None:
-                    anchor_text = (
-                        anchor_or_none.title
-                        if anchor_or_none.title is not None
-                        else anchor_or_none.value
-                    )
-                    output += f":ref:`{anchor_text} <{part.link}>`"
+                if node_or_none is not None:
+                    output += f":ref:`{node_or_none.title} <{part.link}>`"
                 else:
                     output += f":ref:`{part.link}`"
             elif isinstance(part, Anchor):

--- a/tests/end2end/screens/document/_cross_cutting/anchors/document/update_document_add_requirement_and_create_section_with_link/expected_output/document.sdoc
+++ b/tests/end2end/screens/document/_cross_cutting/anchors/document/update_document_add_requirement_and_create_section_with_link/expected_output/document.sdoc
@@ -1,0 +1,15 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[FREETEXT]
+Modified free text!
+
+[LINK: REQ-1]
+[/FREETEXT]
+
+[REQUIREMENT]
+UID: REQ-1
+TITLE: Requirement title #1
+STATEMENT: >>>
+Foo.
+<<<

--- a/tests/end2end/screens/document/_cross_cutting/anchors/document/update_document_add_requirement_and_create_section_with_link/input/document.sdoc
+++ b/tests/end2end/screens/document/_cross_cutting/anchors/document/update_document_add_requirement_and_create_section_with_link/input/document.sdoc
@@ -1,0 +1,6 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[FREETEXT]
+Hello world!
+[/FREETEXT]

--- a/tests/end2end/screens/document/_cross_cutting/anchors/document/update_document_add_requirement_and_create_section_with_link/test_update_document_add_requirement_and_create_section_with_link.py
+++ b/tests/end2end/screens/document/_cross_cutting/anchors/document/update_document_add_requirement_and_create_section_with_link/test_update_document_add_requirement_and_create_section_with_link.py
@@ -1,0 +1,58 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.document.form_edit_config import (
+    Form_EditConfig,
+)
+from tests.end2end.helpers.screens.document.form_edit_requirement import (
+    Form_EditRequirement,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+            screen_document = screen_project_index.do_click_on_first_document()
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+            screen_document.assert_text("Hello world!")
+
+            # Insert new requirement with UID REQ-1
+            root_node = screen_document.get_root_node()
+            root_node_menu = root_node.do_open_node_menu()
+            form_edit_requirement: Form_EditRequirement = (
+                root_node_menu.do_node_add_requirement_first()
+            )
+            form_edit_requirement.do_fill_in_field_title("Requirement title #1")
+            form_edit_requirement.do_fill_in_field_uid("REQ-1")
+            form_edit_requirement.do_fill_in_field_statement("Foo.")
+            form_edit_requirement.do_form_submit()
+            requirement_1 = screen_document.get_requirement()
+            requirement_1.assert_requirement_title("Requirement title #1", "1")
+
+            # Modify document abstract to refer to requirement REQ-1
+            root_node = screen_document.get_root_node()
+            form_config: Form_EditConfig = root_node.do_open_form_edit_config()
+            form_config.do_fill_in_document_abstract(
+                """
+Modified free text!
+
+[LINK: REQ-1]
+"""
+            )
+            form_config.do_form_submit()
+            root_node.assert_document_abstract_contains("Modified free text!")
+
+        assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/integration/commands/export/html/markup/04_referencing_a_section_with_LINK_node/input.sdoc
+++ b/tests/integration/commands/export/html/markup/04_referencing_a_section_with_LINK_node/input.sdoc
@@ -1,0 +1,14 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[SECTION]
+UID: CHAPTER_1
+TITLE: Chapter 1
+
+[FREETEXT]
+[LINK: CUSTOM-1]
+
+[LINK: CUSTOM-2]
+[/FREETEXT]
+
+[/SECTION]

--- a/tests/integration/commands/export/html/markup/04_referencing_a_section_with_LINK_node/nodes.sdoc
+++ b/tests/integration/commands/export/html/markup/04_referencing_a_section_with_LINK_node/nodes.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Doc with a requirement
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: CUSTOM
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: DESCRIPTION
+    TYPE: String
+    REQUIRED: True
+
+[CUSTOM]
+UID: CUSTOM-1
+TITLE: Foo Bar
+DESCRIPTION: If a title field is defined it shall have precedence as link name.
+
+[CUSTOM]
+UID: CUSTOM-2
+DESCRIPTION: UID shall be used as link name if title is not defined.

--- a/tests/integration/commands/export/html/markup/04_referencing_a_section_with_LINK_node/test.itest
+++ b/tests/integration/commands/export/html/markup/04_referencing_a_section_with_LINK_node/test.itest
@@ -1,0 +1,14 @@
+RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+CHECK: Published: Hello world doc
+
+RUN: %cat %S/Output/html/04_referencing_a_section_with_LINK_node/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
+CHECK-HTML-DOC: <a href="../04_referencing_a_section_with_LINK_node/nodes.html#1-CUSTOM-1">{{.*}}Foo Bar</a></p>
+CHECK-HTML-DOC: <a href="../04_referencing_a_section_with_LINK_node/nodes.html#-CUSTOM-2">{{.*}}CUSTOM-2</a></p>
+
+RUN: %cat %S/Output/html/04_referencing_a_section_with_LINK_node/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TABLE
+CHECK-HTML-TABLE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TABLE.html#1-CUSTOM-1">{{.*}}Foo Bar</a></p>
+CHECK-HTML-TABLE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TABLE.html#-CUSTOM-2">{{.*}}CUSTOM-2</a></p>
+
+RUN: %cat %S/Output/html/04_referencing_a_section_with_LINK_node/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TRACE
+CHECK-HTML-TRACE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TRACE.html#1-CUSTOM-1">{{.*}}Foo Bar</a></p>
+CHECK-HTML-TRACE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TRACE.html#-CUSTOM-2">{{.*}}CUSTOM-2</a></p>

--- a/tests/integration/commands/export/rst/41_link_to_node/expected/input.rst
+++ b/tests/integration/commands/export/rst/41_link_to_node/expected/input.rst
@@ -1,0 +1,33 @@
+.. _CHAPTER_1:
+
+Chapter 1
+=========
+
+See :ref:`REQ-1 <REQ-1>` for more details.
+
+See :ref:`Foo Bar <REQ-2>` for more details.
+
+.. _REQ-1:
+
+.. list-table::
+    :align: left
+    :header-rows: 0
+
+    * - **UID:**
+      - REQ-1
+
+The foo must bar.
+
+.. _REQ-2:
+
+Foo Bar
+-------
+
+.. list-table::
+    :align: left
+    :header-rows: 0
+
+    * - **UID:**
+      - REQ-2
+
+The foo must bar.

--- a/tests/integration/commands/export/rst/41_link_to_node/input.sdoc
+++ b/tests/integration/commands/export/rst/41_link_to_node/input.sdoc
@@ -1,0 +1,23 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[SECTION]
+UID: CHAPTER_1
+TITLE: Chapter 1
+
+[FREETEXT]
+See [LINK: REQ-1] for more details.
+
+See [LINK: REQ-2] for more details.
+[/FREETEXT]
+
+[REQUIREMENT]
+UID: REQ-1
+STATEMENT: The foo must bar.
+
+[REQUIREMENT]
+UID: REQ-2
+TITLE: Foo Bar
+STATEMENT: The foo must bar.
+
+[/SECTION]

--- a/tests/integration/commands/export/rst/41_link_to_node/test.itest
+++ b/tests/integration/commands/export/rst/41_link_to_node/test.itest
@@ -1,0 +1,5 @@
+RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+
+RUN: %check_exists --file "%S/Output/rst/input.rst"
+
+RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"


### PR DESCRIPTION
Currently, a `[LINK: ID]` tag is limited to target either sections or anchors. This change extends the feature so that we can link to `[REQUIREMENT]`s or any other element from a custom grammar. E.g. the following will work now:

```
[DOCUMENT]
TITLE: Document

[GRAMMAR]
ELEMENTS:
- TAG: CUSTOM
  FIELDS:
  - TITLE: UID
    TYPE: String
    REQUIRED: False
  - TITLE: DESCRIPTION
    TYPE: String
    REQUIRED: True

[FREETEXT]
[LINK: CUSTOM-1]
[/FREETEXT]

[CUSTOM]
UID: CUSTOM-1
DESCRIPTION: foo
```

The logic to create the link title in case of requirement or custom element is:
1. Use title field, if defined.
2. Else use UID.
3. Elements without UID are not relevant, as one needs an an UID string to write a LINK tag in the first place.

For cleaner design, we introduce a small wrapper class `LinkableNode` that centralizes rules for how to create the link title.