### PR TITLE
WIP: Feature: Support LINK in STATEMENT and other fields

### DIFF
--- a/strictdoc/export/html/templates/components/requirement/comments/index.jinja
+++ b/strictdoc/export/html/templates/components/requirement/comments/index.jinja
@@ -1,12 +1,12 @@
 {# comments #}
 
 {%- if requirement.comments and view_object.current_view.includes_field(requirement.requirement_type, "COMMENT") %}
-  {%- for comment in requirement.comments %}
+  {%- for comment in requirement.get_comment_fields() %}
     <sdoc-requirement-field-label>{{ requirement.get_field_human_title("COMMENT") }}:</sdoc-requirement-field-label>
     <sdoc-requirement-field
       data-field-label="comment"
     >
-      {%- with field_content = view_object.markup_renderer.render_comment(comment) -%}
+      {%- with field_content = view_object.markup_renderer.render_comment(view_object.document_type, comment) -%}
         {%- include "components/field/index.jinja" -%}
       {%- endwith -%}
     </sdoc-requirement-field>

--- a/strictdoc/export/html/templates/components/requirement/multiline/index.jinja
+++ b/strictdoc/export/html/templates/components/requirement/multiline/index.jinja
@@ -1,12 +1,12 @@
 {# multiline fields #}
 {# goes through all UNRESERVED fields #}
 {%- if requirement.has_meta %}
-  {% for meta_field in requirement.enumerate_meta_fields(skip_single_lines=True) if view_object.current_view.includes_field(requirement.requirement_type, meta_field[0]) %}
+  {% for meta_field in requirement.enumerate_meta_field_nodes(skip_single_lines=True) if view_object.current_view.includes_field(requirement.requirement_type, meta_field[0]) %}
     <sdoc-requirement-field-label>{{ meta_field[0] }}:</sdoc-requirement-field-label>
     <sdoc-requirement-field
       data-field-label="{{ meta_field[0] }}"
     >
-      {%- with field_content = view_object.markup_renderer.render_meta_value(meta_field[1]) %}
+      {%- with field_content = view_object.markup_renderer.render_meta_value(view_object.document_type, meta_field[1]) %}
         {%- include "components/field/index.jinja" -%}
       {%- endwith -%}
     </sdoc-requirement-field>

--- a/strictdoc/export/html/templates/components/requirement/statement/index.jinja
+++ b/strictdoc/export/html/templates/components/requirement/statement/index.jinja
@@ -10,7 +10,7 @@
     <sdoc-requirement-field
       data-field-label="statement"
     >
-      {%- with field_content = view_object.markup_renderer.render_requirement_statement(requirement) %}
+      {%- with field_content = view_object.markup_renderer.render_requirement_statement(view_object.document_type, requirement) %}
         {%- include "components/field/index.jinja" -%}
       {%- endwith -%}
     </sdoc-requirement-field>

--- a/strictdoc/export/html/templates/screens/document/table/main.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/main.jinja
@@ -119,7 +119,7 @@
                 </td>
                 <td class="content-view-td content-view-td-content">
                   {%- if requirement.reserved_statement -%}
-                    <sdoc-autogen>{{ view_object.markup_renderer.render_requirement_statement(requirement) }}</sdoc-autogen>
+                    <sdoc-autogen>{{ view_object.markup_renderer.render_requirement_statement(view_object.document_type, requirement) }}</sdoc-autogen>
                   {%- endif -%}
                 </td>
                 <td class="content-view-td content-view-td-content">
@@ -129,8 +129,8 @@
                 </td>
                 <td class="content-view-td content-view-td-content">
                   {%- if requirement.comments -%}
-                    {%- for comment in requirement.comments -%}
-                    <sdoc-autogen>{{ view_object.markup_renderer.render_comment(comment) }}</sdoc-autogen>
+                    {%- for comment in requirement.get_comment_fields() -%}
+                    <sdoc-autogen>{{ view_object.markup_renderer.render_comment(view_object.document_type, comment) }}</sdoc-autogen>
                     {%- endfor -%}
                   {%- endif -%}
                 </td>


### PR DESCRIPTION
Thanks to #1833 we can enhance the LINK feature to link from any requirement field to any other anchor, requirement or section. This example will work now:
```
[DOCUMENT]
TITLE: Document

[REQUIREMENT]
UID: REQ-1
TITLE: Foo
STATEMENT: >>>
Foo. See also [LINK: REQ-2].
<<<

[REQUIREMENT]
UID: REQ-2
TITLE: Bar
STATEMENT: Bar.
COMMENT: >>>
Foo. See also [LINK: REQ-1].
<<<
```

TODO
- [ ] Tests
- [ ] Prevent inconsistencies during UI workflows - see #1839