### PR TITLE
html: Rename "parent relations" to "parents" and "child relations" to "children"

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -874,6 +874,8 @@ A requirement relation can be specialized with a role. The role must be register
     - TYPE: Parent
       VALUE: REQ-1
       ROLE: Refines
+
+In this example REQ-1 is the parent of REQ-2 and REQ-2 refines REQ-1.
 [/FREETEXT]
 
 [/SECTION]

--- a/strictdoc/export/html/templates/components/requirement/links/index.jinja
+++ b/strictdoc/export/html/templates/components/requirement/links/index.jinja
@@ -1,5 +1,5 @@
   {%- if view_object.traceability_index.has_parent_requirements(requirement) %}
-    <sdoc-requirement-field-label>parent relations:</sdoc-requirement-field-label>
+    <sdoc-requirement-field-label>parents:</sdoc-requirement-field-label>
     <sdoc-requirement-field data-field-label="parent relations">
       <ul class="requirement__link">
         {%- for requirement, relation_role_ in view_object.traceability_index.get_parent_relations_with_roles(requirement) %}
@@ -20,7 +20,7 @@
   {%- endif %}
 
   {%- if view_object.traceability_index.has_children_requirements(requirement) %}
-    <sdoc-requirement-field-label>child relations:</sdoc-requirement-field-label>
+    <sdoc-requirement-field-label>children:</sdoc-requirement-field-label>
     <sdoc-requirement-field data-field-label="child relations">
       <ul class="requirement__link">
         {%- for requirement, relation_role_ in view_object.traceability_index.get_child_relations_with_roles(requirement) %}


### PR DESCRIPTION
This should improve comprehensibility and is consistent to what the rst generator already does.

Also add a sentence in the user documentation to explain by example who in the relation is the parent and who has the active role.