### PR TITLE
UI: Do not auto-generate UID for TEXT nodes for now

### DIFF
--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -372,9 +372,14 @@ class RequirementFormObject(ErrorObject):
         *,
         document: SDocDocument,
         context_document_mid: str,
-        next_uid: str,
+        next_uid: Optional[str],
         element_type: str,
     ) -> "RequirementFormObject":
+        """
+        For now, the next_uid cannot be non-None for TEXT nodes. This will likely
+        change in the future.
+        """
+
         assert document.grammar is not None
 
         new_requirement_mid: MID = MID.create()
@@ -406,7 +411,7 @@ class RequirementFormObject(ErrorObject):
                 )
             )
             form_fields.append(form_field)
-            if form_field.field_name == "UID":
+            if form_field.field_name == "UID" and next_uid is not None:
                 form_field.field_unescaped_value = next_uid
                 form_field.field_escaped_value = next_uid
 

--- a/strictdoc/export/html/templates/screens/document/document/frame_requirement_form.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/frame_requirement_form.jinja
@@ -44,7 +44,7 @@
       {% set text_field_row_context.field_editable = true %}
       {% set text_field_row_context.field_type = "singleline" %}
       {% set text_field_row_context.reference_mid = form_object.requirement_mid %}
-      {%- if field_.field_name == "UID" and field_.field_escaped_value == "" -%}
+      {%- if form_object.element_type != "TEXT" and field_.field_name == "UID" and field_.field_escaped_value == "" -%}
         <turbo-frame id="uid_with_reset-{{ text_field_row_context.reference_mid }}">
           {# this template is turbo-frame and has a button to reset to the default value: #}
           {% include "components/form/row/row_uid_with_reset/frame.jinja" %}

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -723,14 +723,16 @@ def create_main_router(
         else:
             document = reference_node.document
 
-        document_tree_stats: DocumentTreeStats = (
-            DocumentUIDAnalyzer.analyze_document_tree(
-                export_action.traceability_index
+        next_uid: Optional[str] = None
+        if element_type != "TEXT":
+            document_tree_stats: DocumentTreeStats = (
+                DocumentUIDAnalyzer.analyze_document_tree(
+                    export_action.traceability_index
+                )
             )
-        )
-        next_uid: str = document_tree_stats.get_next_requirement_uid(
-            reference_node.get_requirement_prefix()
-        )
+            next_uid = document_tree_stats.get_next_requirement_uid(
+                reference_node.get_requirement_prefix()
+            )
         form_object = RequirementFormObject.create_new(
             document=document,
             context_document_mid=context_document_mid,

--- a/tests/end2end/helpers/components/node/add_node_menu.py
+++ b/tests/end2end/helpers/components/node/add_node_menu.py
@@ -121,6 +121,16 @@ class AddNode_Menu:  # pylint: disable=invalid-name
         )
         return Form_EditRequirement(self.test_case)
 
+    def do_node_add_text_first(self) -> Form_EditRequirement:
+        self.test_case.click(
+            selector=(
+                '//*[@data-testid="node-root"]'
+                '//*[@data-testid="node-add-text-first-action"]'
+            ),
+            by=By.XPATH,
+        )
+        return Form_EditRequirement(self.test_case)
+
     def do_node_add_element_first(
         self, element_tag: str
     ) -> Form_EditRequirement:

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/create_text_node_in_top_level_document/expected_output/document.sdoc
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/create_text_node_in_top_level_document/expected_output/document.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[TEXT]
+STATEMENT: >>>
+Some text here.
+<<<

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/create_text_node_in_top_level_document/input/document.sdoc
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/create_text_node_in_top_level_document/input/document.sdoc
@@ -1,0 +1,2 @@
+[DOCUMENT]
+TITLE: Document 1

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/create_text_node_in_top_level_document/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/create_text_node_in_top_level_document/test_case.py
@@ -1,0 +1,42 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.document.form_edit_requirement import (
+    Form_EditRequirement,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+
+            # Requirement 1
+            root_node = screen_document.get_root_node()
+            root_node_menu = root_node.do_open_node_menu()
+            form_edit_requirement: Form_EditRequirement = (
+                root_node_menu.do_node_add_text_first()
+            )
+            form_edit_requirement.do_fill_in_field_statement("Some text here.")
+            form_edit_requirement.do_form_submit()
+
+            screen_document.assert_text("Some text here.")
+
+        assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
It is not clear yet which prefixes should be used for text nodes. Previously, the text nodes didn't have UIDs at all, so it is fine to not introduce the auto-generation for these nodes just yet.