### PR TITLE
Extend UID regex and use it in SDocNode

### DIFF
--- a/strictdoc/backend/sdoc/grammar/grammar.py
+++ b/strictdoc/backend/sdoc/grammar/grammar.py
@@ -1,8 +1,9 @@
-REGEX_UID = r"([A-Za-z0-9]+[A-Za-z0-9_\-]*)"
+REGEX_UID = r"([\w]+[\w\-. ]*)"
 
 NEGATIVE_MULTILINE_STRING_START = "(?!>>>\n)"
 NEGATIVE_MULTILINE_STRING_END = "(?!^<<<)"
 NEGATIVE_RELATIONS = "(?!^RELATIONS)"
+NEGATIVE_UID = "(?!^UID)"
 NEGATIVE_FREETEXT_END = "(?!^\\[\\/FREETEXT\\]\n)"
 NEGATIVE_INLINE_LINK_START = rf"(?!\[LINK: {REGEX_UID})"
 NEGATIVE_ANCHOR_START = rf"(?!^\[ANCHOR: {REGEX_UID})"
@@ -44,7 +45,7 @@ MultiLineString[noskipws]:
 ;
 
 FieldName[noskipws]:
-  /{NEGATIVE_RELATIONS}[A-Z]+[A-Z_]*/
+  /{NEGATIVE_UID}{NEGATIVE_RELATIONS}[A-Z]+[A-Z_]*/
 ;
 """
 
@@ -188,6 +189,8 @@ SDocCompositeNodeTagName[noskipws]:
 
 SDocNodeField[noskipws]:
   (
+    field_name = 'UID' ': ' parts=/{REGEX_UID}/ '\n'
+    |
     field_name = FieldName ':'
     (
         (' ' parts+=SingleLineTextPart '\n')

--- a/strictdoc/backend/sdoc/grammar/grammar.py
+++ b/strictdoc/backend/sdoc/grammar/grammar.py
@@ -189,7 +189,7 @@ SDocCompositeNodeTagName[noskipws]:
 
 SDocNodeField[noskipws]:
   (
-    field_name = 'UID' ': ' parts=/{REGEX_UID}/ '\n'
+    field_name = 'UID' ': ' parts+=/{REGEX_UID}/ '\n'
     |
     field_name = FieldName ':'
     (

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
@@ -193,6 +193,33 @@ TITLE: Test Section
     assert input_sdoc == output
 
 
+def test_022_requirement_uid_and_link():
+    input_sdoc = """
+[DOCUMENT]
+TITLE: Test Doc
+
+[REQUIREMENT]
+UID: With spaces and _ and - and . and non latin 特点
+STATEMENT: >>>
+This is a statement.
+
+[TEXT]
+STATEMENT: >>>
+[LINK: With spaces and _ and - and . and non latin 特点]
+<<<
+""".lstrip()
+
+    reader = SDReader()
+
+    document = reader.read(input_sdoc)
+    assert isinstance(document, SDocDocument)
+
+    writer = SDWriter()
+    output = writer.write(document)
+
+    assert input_sdoc == output
+
+
 def test_030_multiline_statement():
     input_sdoc = """
 [DOCUMENT]
@@ -912,7 +939,7 @@ UID:
         _ = reader.read(input_sdoc)
 
     assert exc_info.type is TextXSyntaxError
-    assert "Expected ' '" == exc_info.value.args[0].decode("utf-8")
+    assert "Expected ': '" == exc_info.value.args[0].decode("utf-8")
 
 
 def test_edge_case_03_uid_present_but_empty_with_space_character():
@@ -931,9 +958,8 @@ UID:
         _ = reader.read(input_sdoc)
 
     assert exc_info.type is TextXSyntaxError
-    assert (
-        "Expected '^\\[ANCHOR: ' or '[LINK: ' or '(?!>>>\\n)\\S.*' or '>>>\\n'"
-        in exc_info.value.args[0].decode("utf-8")
+    assert "Expected '([\\w]+[\\w\\-. ]*)'" in exc_info.value.args[0].decode(
+        "utf-8"
     )
 
 
@@ -953,9 +979,8 @@ UID:
         _ = reader.read(input_sdoc)
 
     assert exc_info.type is TextXSyntaxError
-    assert (
-        "Expected '^\\[ANCHOR: ' or '[LINK: ' or '(?!>>>\\n)\\S.*' or '>>>\\n'"
-        in exc_info.value.args[0].decode("utf-8")
+    assert "Expected '([\\w]+[\\w\\-. ]*)'" in exc_info.value.args[0].decode(
+        "utf-8"
     )
 
 
@@ -978,9 +1003,8 @@ COMMENT: >>>
     assert (
         "Expected '^\\[ANCHOR: ' or '[LINK: ' or "
         "'(?ms)(?!^<<<)(?!^\\[\\/FREETEXT\\]\\n)(?!\\[LINK: "
-        "([A-Za-z0-9]+[A-Za-z0-9_\\-]*))(?!^\\[ANCHOR: "
-        "([A-Za-z0-9]+[A-Za-z0-9_\\-]*)).'"
-        in exc_info.value.args[0].decode("utf-8")
+        "([\\w]+[\\w\\-. ]*))(?!^\\[ANCHOR: "
+        "([\\w]+[\\w\\-. ]*)).'" in exc_info.value.args[0].decode("utf-8")
     )
 
 


### PR DESCRIPTION
This fixes two things:
- The UID regex is now used in SDocNode to make UID allowed character validation the same as for UIDs from DOCUMENT, SECTION, LINK, ANCHOR.
- The UID regex is extended so that it allows also non latin letters and digits. Dots and whitespaces become valid too, but not as 1st character.

There are multiple approaches how one could fix the issues. This one is the least invasive and most backwards compatible.
- It continues to accept UIDs at arbitrary field positions in custom grammars for backwards compatibility.
- It continues to model a UID as python class SDocNodeField with argument parts of type list. So no code has to be changed at all (besides TextX grammar).

This sdoc works now:
```
[DOCUMENT]
TITLE: Link to UID with whitespace, dot, umlauts, non-latin characters

[REQUIREMENT]
UID: Ölrückstoßabdämpfung - 任何 47.11
STATEMENT: Foo

[TEXT]
STATEMENT: >>>
See [LINK: Ölrückstoßabdämpfung - 任何 47.11]
<<<
```

Fixes #1897.