### PR TITLE
LINKs: Fix link to anchor in other sdoc

### DIFF
--- a/strictdoc/backend/sdoc/models/anchor.py
+++ b/strictdoc/backend/sdoc/models/anchor.py
@@ -30,11 +30,11 @@ class Anchor:
     def document(self):
         if self.parent.parent.__class__.__name__ == "SDocDocument":
             return self.parent.parent
-        return self.parent.parent.document
+        return self.parent_node().document
 
     @property
     def parent_or_including_document(self):
-        return self.parent.parent_or_including_document
+        return self.parent_node().parent_or_including_document
 
     def parent_node(self) -> Any:
         # Anchor -> FreeText -> Section|Document

--- a/tests/integration/commands/export/html/markup/03_referencing_anchor_with_LINK_external/input.sdoc
+++ b/tests/integration/commands/export/html/markup/03_referencing_anchor_with_LINK_external/input.sdoc
@@ -12,4 +12,13 @@ See the [LINK: AD2] for more details.
 See the [LINK: Interface_Control_Document] for more details.
 [/FREETEXT]
 
+[TEXT]
+STATEMENT: >>>
+See the [LINK: AD4] for more details.
+
+See the [LINK: AD5] for more details.
+
+See the [LINK: Supplemental Guide] for more details.
+<<<
+
 [/SECTION]

--- a/tests/integration/commands/export/html/markup/03_referencing_anchor_with_LINK_external/input2.sdoc
+++ b/tests/integration/commands/export/html/markup/03_referencing_anchor_with_LINK_external/input2.sdoc
@@ -23,4 +23,21 @@ Anchors end.
 
 [/FREETEXT]
 
+[TEXT]
+STATEMENT: >>>
+[ANCHOR: AD4]
+
+1) AD4. Threat Model.
+
+[ANCHOR: AD5, Software Tests]
+
+2) AD5. Software Tests.
+
+[ANCHOR: Supplemental Guide]
+
+3) AD6. Supplemental Guide.
+
+Anchors end.
+<<<
+
 [/SECTION]

--- a/tests/integration/commands/export/html/markup/03_referencing_anchor_with_LINK_external/test.itest
+++ b/tests/integration/commands/export/html/markup/03_referencing_anchor_with_LINK_external/test.itest
@@ -5,6 +5,9 @@ RUN: %cat %S/Output/html/03_referencing_anchor_with_LINK_external/input.html | f
 CHECK-HTML-DOC: <p>See the <a href="../03_referencing_anchor_with_LINK_external/input2.html#AD1">{{.*}}AD1</a> for more details.</p>
 CHECK-HTML-DOC: <p>See the <a href="../03_referencing_anchor_with_LINK_external/input2.html#AD2">{{.*}}Software requirements specification</a> for more details.</p>
 CHECK-HTML-DOC: <p>See the <a href="../03_referencing_anchor_with_LINK_external/input2.html#Interface_Control_Document">{{.*}}Interface_Control_Document</a> for more details.</p>
+CHECK-HTML-DOC: <p>See the <a href="../03_referencing_anchor_with_LINK_external/input2.html#AD4">{{.*}}AD4</a> for more details.</p>
+CHECK-HTML-DOC: <p>See the <a href="../03_referencing_anchor_with_LINK_external/input2.html#AD5">{{.*}}Software Tests</a> for more details.</p>
+CHECK-HTML-DOC: <p>See the <a href="../03_referencing_anchor_with_LINK_external/input2.html#Supplemental-Guide">{{.*}}Supplemental Guide</a> for more details.</p>
 
 RUN: %cat %S/Output/html/03_referencing_anchor_with_LINK_external/input2.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC2
 CHECK-HTML-DOC2:<sdoc-anchor id="AD1"{{.*}}
@@ -13,3 +16,9 @@ CHECK-HTML-DOC2:<sdoc-anchor id="AD2"{{.*}}
 CHECK-HTML-DOC2:<li>AD2. Software requirements specification.</li>
 CHECK-HTML-DOC2:<sdoc-anchor id="Interface_Control_Document"{{.*}}
 CHECK-HTML-DOC2:<li>AD3. Interface Control Document.</li>
+CHECK-HTML-DOC2:<sdoc-anchor id="AD4"{{.*}}
+CHECK-HTML-DOC2:<li>AD4. Threat Model.</li>
+CHECK-HTML-DOC2:<sdoc-anchor id="AD5"{{.*}}
+CHECK-HTML-DOC2:<li>AD5. Software Tests.</li>
+CHECK-HTML-DOC2:<sdoc-anchor id="Supplemental Guide"{{.*}}
+CHECK-HTML-DOC2:<li>AD6. Supplemental Guide.</li>


### PR DESCRIPTION
This kind of linking worked for `[FREETEXT]` (was covered by tests), but not for `[TEXT]` (was not covered by tests).

Root cause was that `Anchor.parent` is an `SDocNodeField` which has no parent_or_including_document. That property is defined on the `SDocNodeField.parent` `SDocNode`. So we need `Anchor.parent.parent`.

Fixes #1905.