### PR TITLE
rst: Fix link followed by non-ws/punctuation

### DIFF
--- a/tests/integration/commands/export/html/rst_markup_to_html/40_link/input.sdoc
+++ b/tests/integration/commands/export/html/rst_markup_to_html/40_link/input.sdoc
@@ -1,0 +1,16 @@
+[DOCUMENT]
+TITLE: Links
+
+[TEXT]
+STATEMENT: >>>
+[ANCHOR: THING-1, Thing]
+Something.
+<<<
+
+[TEXT]
+STATEMENT: >>>
+[LINK: THING-1] may be followed by whitespace.
+[LINK: THING-1]	may be followed by tab.
+Maybe punctuation like comma follows [LINK: THING-1], or dot follows [LINK: THING-1].
+[LINK: THING-1]s may be followed by character.
+<<<

--- a/tests/integration/commands/export/html/rst_markup_to_html/40_link/test.itest
+++ b/tests/integration/commands/export/html/rst_markup_to_html/40_link/test.itest
@@ -1,0 +1,8 @@
+RUN: %strictdoc export %S --formats=html --output-dir Output | filecheck %s --dump-input=fail
+CHECK: Published: Links
+
+RUN: %cat %S/Output/html/40_link/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-FILE
+CHECK-HTML-FILE: <a href="#THING-1">🔗&nbsp;Thing</a> may be followed by whitespace.
+CHECK-HTML-FILE: <a href="#THING-1">🔗&nbsp;Thing</a>  may be followed by tab.
+CHECK-HTML-FILE: Maybe punctuation like comma follows <a href="#THING-1">🔗&nbsp;Thing</a>, or dot follows <a href="#THING-1">🔗&nbsp;Thing</a>.
+CHECK-HTML-FILE: <a href="#THING-1">🔗&nbsp;Thing</a>s may be followed by character.


### PR DESCRIPTION
When rendering rst fragments to HTML, InlineLinks are first converted to ``':rawhtml:`<a href="#TGT">link text</a>`'``, then are rendered to HTML by docutils `publish_parts`. That rawhtml construct is a special form of inline markup, for which rst defines recognition [rules](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#inline-markup-recognition-rules). Rule 7 says

> Inline markup end-strings must end a text block or be immediately followed by whitespace, one of the ASCII characters - . , : ; ! ? \ / ' " ) ] } > or a similar non-ASCII punctuation character. [20]

That's why LINK followed by character produces error or odd HTML. To get around, we can use rst's [escaping mechanism](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#escaping-mechanism).

> Escaped non-white characters are prevented from playing a role in any markup interpretation. The escaped character represents the character itself.

The code change detects if an inline links is followed by non-whitespace or non-punctuation character and adds in a backslash if so.

Punctuation characters in the non-latin range are not explicitly checked and thus also joined with "\". This is unnecessary from RST syntax point of view, but doesn't hurt as it just maps them to themselves.

Fixes #1907.