### PR TITLE
rst: Render links and anchors in node fields

### DIFF
--- a/strictdoc/export/html/renderers/markup_renderer.py
+++ b/strictdoc/export/html/renderers/markup_renderer.py
@@ -19,8 +19,7 @@ from strictdoc.export.html.renderers.text_to_html_writer import TextToHtmlWriter
 from strictdoc.export.rst.rst_to_html_fragment_writer import (
     RstToHtmlFragmentWriter,
 )
-
-VALID_AFTER_INLINE_MARKUP = " \t-.,:;!?\\/'\")]}>"
+from strictdoc.helpers.rst import escape_str_after_inline_markup
 
 
 class MarkupRenderer:
@@ -115,11 +114,8 @@ class MarkupRenderer:
         parts_output = ""
         for part in node_field.parts:
             if isinstance(part, str):
-                if (
-                    isinstance(prev_part, InlineLink)
-                    and part[0] not in VALID_AFTER_INLINE_MARKUP
-                ):
-                    parts_output += f"\\{part}"
+                if isinstance(prev_part, InlineLink):
+                    parts_output += escape_str_after_inline_markup(part)
                 else:
                     parts_output += part
             elif isinstance(part, InlineLink):

--- a/strictdoc/export/rst/templates/requirement.jinja.rst
+++ b/strictdoc/export/rst/templates/requirement.jinja.rst
@@ -15,26 +15,26 @@
 
 {% for meta_field in requirement.enumerate_meta_fields(skip_multi_lines=True) -%}
 {%- if true %}    {% endif %}* - **{{meta_field[0]}}:**
-      - {{ meta_field[1].get_text_value() }}
+      - {{ _print_node_field(meta_field[1]) }}
 {% endfor %}
 {% endif %}
 
 {%- if requirement.reserved_statement is not none -%}
-{{ requirement.reserved_statement.rstrip() }}
+{{ _print_node_field(requirement.get_content_field()).rstrip() }}
 
 {% endif -%}
 
 {%- if requirement.rationale -%}
 **{{ requirement.get_field_human_title("RATIONALE") }}:**
 
-{{ requirement.rationale.rstrip() }}
+{{ _print_node_field(requirement.get_field_by_name("RATIONALE")).rstrip() }}
 
 {% endif -%}
 
 {%- for comment_field_ in requirement.get_comment_fields() -%}
 **{{ requirement.get_field_human_title("COMMENT") }}:**
 
-{{ comment_field_.get_text_value().rstrip() }}
+{{ _print_node_field(comment_field_).rstrip() }}
 
 {% endfor -%}
 
@@ -42,7 +42,7 @@
 {%- for meta_field in requirement.enumerate_meta_fields(skip_single_lines=True) -%}
 **{{meta_field[0]}}:**
 
-{{ meta_field[1].get_text_value().rstrip() }}
+{{ _print_node_field(meta_field[1]).rstrip() }}
 
 {% endfor -%}
 {%- endif %}

--- a/strictdoc/helpers/rst.py
+++ b/strictdoc/helpers/rst.py
@@ -4,7 +4,19 @@ import re
 # .. image:: _assets/picture.svg
 # .. csv-table:: (has no argument)
 RST_DIRECTIVE_PATTERN = re.compile(r"^\.\. [a-z-]+:: ?.*$", re.MULTILINE)
+VALID_AFTER_INLINE_MARKUP = " \t\n-.,:;!?\\/'\")]}>"
 
 
 def string_contains_rst_directive(input_string: str) -> bool:
     return RST_DIRECTIVE_PATTERN.match(input_string) is not None
+
+
+def escape_str_after_inline_markup(str_after_inline_markup: str) -> str:
+    # Ensure inline markup recognition rule #7
+    # https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#inline-markup-recognition-rules
+    if (
+        str_after_inline_markup
+        and str_after_inline_markup[0] not in VALID_AFTER_INLINE_MARKUP
+    ):
+        return f"\\{str_after_inline_markup}"
+    return str_after_inline_markup

--- a/tests/integration/commands/export/rst/41_link_to_node/expected/input.rst
+++ b/tests/integration/commands/export/rst/41_link_to_node/expected/input.rst
@@ -5,6 +5,15 @@ Chapter 1
 
 See :ref:`REQ-1 <REQ-1>` for more details.
 
+.. _THING:
+
+.. list-table::
+    :align: left
+    :header-rows: 0
+
+    * - **UID:**
+      - THING
+
 See :ref:`Foo Bar <REQ-2>` for more details.
 
 .. _REQ-1:
@@ -18,6 +27,10 @@ See :ref:`Foo Bar <REQ-2>` for more details.
 
 The foo must bar.
 
+**COMMENT:**
+
+As the :ref:`THING <THING>`\y explains.
+
 .. _REQ-2:
 
 Foo Bar
@@ -30,4 +43,4 @@ Foo Bar
     * - **UID:**
       - REQ-2
 
-The foo must bar.
+Go and read :ref:`Chapter 1 <CHAPTER_1>`.

--- a/tests/integration/commands/export/rst/41_link_to_node/input.sdoc
+++ b/tests/integration/commands/export/rst/41_link_to_node/input.sdoc
@@ -7,17 +7,26 @@ TITLE: Chapter 1
 
 [FREETEXT]
 See [LINK: REQ-1] for more details.
-
-See [LINK: REQ-2] for more details.
 [/FREETEXT]
+
+[TEXT]
+UID: THING
+STATEMENT: >>>
+See [LINK: REQ-2] for more details.
+<<<
 
 [REQUIREMENT]
 UID: REQ-1
 STATEMENT: The foo must bar.
+COMMENT: >>>
+As the [LINK: THING]y explains.
+<<<
 
 [REQUIREMENT]
 UID: REQ-2
 TITLE: Foo Bar
-STATEMENT: The foo must bar.
+STATEMENT: >>>
+Go and read [LINK: CHAPTER_1].
+<<<
 
 [/SECTION]

--- a/tests/integration/commands/export/rst/42_link_with_custom_grammar/expected/input.rst
+++ b/tests/integration/commands/export/rst/42_link_with_custom_grammar/expected/input.rst
@@ -1,0 +1,33 @@
+.. _NOTE-1:
+
+.. list-table::
+    :align: left
+    :header-rows: 0
+
+    * - **UID:**
+      - NOTE-1
+    * - **SUMMARY:**
+      - Goto [LINK: NOTE-2]
+
+Read :ref:`NOTE-2 <NOTE-2>`.
+
+**NOTE:**
+
+:ref:`NOTE-2 <NOTE-2>` is below.
+
+.. _NOTE-2:
+
+.. list-table::
+    :align: left
+    :header-rows: 0
+
+    * - **UID:**
+      - NOTE-2
+    * - **SUMMARY:**
+      - Goto [LINK: NOTE-1]
+
+Read :ref:`NOTE-1 <NOTE-1>`.
+
+**NOTE:**
+
+:ref:`NOTE-1 <NOTE-1>` is above.

--- a/tests/integration/commands/export/rst/42_link_with_custom_grammar/input.sdoc
+++ b/tests/integration/commands/export/rst/42_link_with_custom_grammar/input.sdoc
@@ -1,0 +1,39 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: CUSTOM
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: True
+  - TITLE: SUMMARY
+    TYPE: String
+    REQUIRED: False
+  - TITLE: DESCRIPTION
+    TYPE: String
+    REQUIRED: True
+  - TITLE: NOTE
+    TYPE: String
+    REQUIRED: False
+
+[CUSTOM]
+UID: NOTE-1
+SUMMARY: Goto [LINK: NOTE-2]
+DESCRIPTION: >>>
+Read [LINK: NOTE-2].
+<<<
+NOTE: >>>
+[LINK: NOTE-2] is below.
+<<<
+
+[CUSTOM]
+UID: NOTE-2
+SUMMARY: Goto [LINK: NOTE-1]
+DESCRIPTION: >>>
+Read [LINK: NOTE-1].
+<<<
+NOTE: >>>
+[LINK: NOTE-1] is above.
+<<<

--- a/tests/integration/commands/export/rst/42_link_with_custom_grammar/test.itest
+++ b/tests/integration/commands/export/rst/42_link_with_custom_grammar/test.itest
@@ -1,0 +1,5 @@
+RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+
+RUN: %check_exists --file "%S/Output/rst/input.rst"
+
+RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"


### PR DESCRIPTION
This worked only for freetext. Now it works for any node including [TEXT] and [REQUIREMENT].

The change includes some drive-by fixes:
- rst output now renders links immediately followed by character (same story as #1907).
- Escaping text following inline markup missed a check for newline, which is now added and effective for rst and HTML.

Fixes #1888.