### PR TITLE
views: Support custom views for passthrough

### DIFF
--- a/strictdoc/cli/cli_arg_parser.py
+++ b/strictdoc/cli/cli_arg_parser.py
@@ -74,12 +74,14 @@ class PassthroughCommandConfig:
         filter_requirements: Optional[str],
         filter_sections: Optional[str],
         free_text_to_text: bool,
+        view: Optional[str],
     ):
         self.input_file = input_file
         self.output_dir: Optional[str] = output_dir
         self.filter_requirements: Optional[str] = filter_requirements
         self.filter_sections: Optional[str] = filter_sections
         self.free_text_to_text: bool = free_text_to_text
+        self.view: Optional[str] = view
 
 
 @auto_described
@@ -266,6 +268,7 @@ class SDocArgsParser:
             filter_requirements=self.args.filter_requirements,
             filter_sections=self.args.filter_sections,
             free_text_to_text=self.args.free_text_to_text,
+            view=self.args.view,
         )
 
     def get_export_config(self) -> ExportCommandConfig:

--- a/strictdoc/cli/command_parser_builder.py
+++ b/strictdoc/cli/command_parser_builder.py
@@ -393,6 +393,11 @@ class CommandParserBuilder:
                 "TEXT nodes."
             ),
         )
+        command_parser_passthrough.add_argument(
+            "--view",
+            type=str,
+            help="Choose which view will be exported.",
+        )
 
     @staticmethod
     def add_dump_command(parent_command_parser):

--- a/strictdoc/commands/manage_autouid_command.py
+++ b/strictdoc/commands/manage_autouid_command.py
@@ -71,7 +71,7 @@ class ManageAutoUIDCommand:
                 next_number += 1
 
         for document in traceability_index.document_tree.document_list:
-            document_content = SDWriter().write(document)
+            document_content = SDWriter(project_config).write(document)
             document_meta = document.meta
             with open(
                 document_meta.input_doc_full_path, "w", encoding="utf8"

--- a/strictdoc/core/actions/import_action.py
+++ b/strictdoc/core/actions/import_action.py
@@ -40,7 +40,7 @@ class ImportAction:
                     create_safe_document_file_name(document_.reserved_title)
                     + ".sdoc",
                 )
-                document_content = SDWriter().write(document_)
+                document_content = SDWriter(project_config).write(document_)
                 with open(
                     path_to_output_document, "w", encoding="utf8"
                 ) as output_file:
@@ -55,7 +55,7 @@ class ImportAction:
                 os.path.splitext(os.path.basename(import_config.input_path))[0]
                 + ".sdoc",
             )
-            document_content = SDWriter().write(excel_document)
+            document_content = SDWriter(project_config).write(excel_document)
             with open(
                 path_to_output_document, "w", encoding="utf8"
             ) as output_file:

--- a/strictdoc/core/actions/passthrough_action.py
+++ b/strictdoc/core/actions/passthrough_action.py
@@ -29,7 +29,7 @@ class PassthroughAction:
             print(exc.to_print_message())  # noqa: T201
             sys.exit(1)
 
-        writer = SDWriter()
+        writer = SDWriter(project_config)
 
         output_dir = (
             project_config.passthrough_output_dir

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -222,6 +222,7 @@ class ProjectConfig:  # pylint: disable=too-many-instance-attributes
         self.passthrough_free_text_to_text = config.free_text_to_text
         self.filter_requirements = config.filter_requirements
         self.filter_sections = config.filter_sections
+        self.view = config.view
 
         # FIXME: Traceability Index is coupled with HTML output.
         self.export_output_html_root = "NOT_RELEVANT"

--- a/strictdoc/export/spdx/spdx_generator.py
+++ b/strictdoc/export/spdx/spdx_generator.py
@@ -438,7 +438,7 @@ class SPDXGenerator:
         if True:
             sdoc_document = SPDXToSDocConverter.convert(spdx_container)
 
-            sdoc_output = SDWriter().write(sdoc_document)
+            sdoc_output = SDWriter(project_config).write(sdoc_document)
 
             sdoc_output_path = os.path.join(
                 output_spdx_root, "output.spdx.sdoc"

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -428,7 +428,7 @@ def create_main_router(
         section: SDocSection = create_command.get_created_section()
 
         # Saving new content to .SDoc file.
-        SDWriter().write_to_file(section.document)
+        SDWriter(project_config).write_to_file(section.document)
 
         # Update the index because other documents might reference this
         # document's sections. These documents will be regenerated on demand,
@@ -584,7 +584,7 @@ def create_main_router(
             )
 
         # Saving new content to .SDoc file.
-        SDWriter().write_to_file(section.document)
+        SDWriter(project_config).write_to_file(section.document)
 
         # Update the index because other documents might reference this
         # document's sections. These documents will be regenerated on demand,
@@ -950,9 +950,9 @@ def create_main_router(
             )
 
         # Saving new content to .SDoc files.
-        SDWriter().write_to_file(document)
+        SDWriter(project_config).write_to_file(document)
         if document != context_document:
-            SDWriter().write_to_file(context_document)
+            SDWriter(project_config).write_to_file(context_document)
 
         # Exporting the updated document to HTML. Note that this happens after
         # the traceability index last update marker has been updated. This way
@@ -1187,7 +1187,7 @@ def create_main_router(
         )
 
         # Saving new content to .SDoc files.
-        SDWriter().write_to_file(document)
+        SDWriter(project_config).write_to_file(document)
 
         # Exporting the updated document to HTML. Note that this happens after
         # the traceability index last update marker has been updated. This way
@@ -1368,7 +1368,7 @@ def create_main_router(
         )
 
         # Saving new content to .SDoc file.
-        SDWriter().write_to_file(section.document)
+        SDWriter(project_config).write_to_file(section.document)
 
         # Rendering back the Turbo template.
         template = env().get_template(
@@ -1464,7 +1464,7 @@ def create_main_router(
             )
 
         # Saving new content to .SDoc file.
-        SDWriter().write_to_file(requirement.document)
+        SDWriter(project_config).write_to_file(requirement.document)
 
         context_document: SDocDocument = (
             export_action.traceability_index.get_node_by_mid(
@@ -1570,7 +1570,7 @@ def create_main_router(
             raise NotImplementedError
 
         # Saving new content to .SDoc file.
-        SDWriter().write_to_file(moved_node.document)
+        SDWriter(project_config).write_to_file(moved_node.document)
 
         # Update the index because other documents might reference this
         # document's sections. These documents will be regenerated on demand,
@@ -1751,7 +1751,7 @@ def create_main_router(
             output_document_dir_rel_path=SDocRelativePath("FIXME"),
         )
 
-        SDWriter().write_to_file(document)
+        SDWriter(project_config).write_to_file(document)
 
         export_action.build_index()
         export_action.export()
@@ -1973,7 +1973,7 @@ def create_main_router(
             )
 
         # Re-generate the document's SDOC.
-        SDWriter().write_to_file(document)
+        SDWriter(project_config).write_to_file(document)
 
         # Update the index because other documents might be referenced by this
         # document's free text. These documents will be regenerated on demand,
@@ -2057,7 +2057,7 @@ def create_main_router(
             )
 
         # Re-generate the document's SDOC.
-        SDWriter().write_to_file(document)
+        SDWriter(project_config).write_to_file(document)
 
         # Update the index because other documents might be referenced by this
         # document's free text. These documents will be regenerated on demand,
@@ -2239,7 +2239,7 @@ def create_main_router(
             )
 
         # Re-generate the document's SDOC.
-        SDWriter().write_to_file(document)
+        SDWriter(project_config).write_to_file(document)
 
         # Re-generate the document.
         html_generator.export_single_document(
@@ -2380,7 +2380,7 @@ def create_main_router(
             )
 
         # Re-generate the document's SDOC.
-        SDWriter().write_to_file(document)
+        SDWriter(project_config).write_to_file(document)
 
         # Re-generate the document.
         html_generator.export_single_document(
@@ -2568,7 +2568,7 @@ def create_main_router(
                 output_document_dir_rel_path=SDocRelativePath("FIXME"),
             )
 
-            SDWriter().write_to_file(document)
+            SDWriter(project_config).write_to_file(document)
 
         export_action.build_index()
         export_action.export()

--- a/tests/integration/commands/passthrough/--view/01_view_option_is_provided/input.sdoc
+++ b/tests/integration/commands/passthrough/--view/01_view_option_is_provided/input.sdoc
@@ -1,0 +1,48 @@
+[DOCUMENT]
+TITLE: Test Document
+OPTIONS:
+  DEFAULT_VIEW: PRINT_VIEW
+VIEWS:
+- ID: PRINT_VIEW
+  NAME: Print view
+  TAGS:
+  - OBJECT_TYPE: REQUIREMENT
+    VISIBLE_FIELDS:
+    - NAME: UID
+    - NAME: STATEMENT
+    - NAME: SECOND_EXTRA_FIELD
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+  - TITLE: RATIONALE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: FIRST_EXTRA_FIELD
+    TYPE: String
+    REQUIRED: False
+  - TITLE: SECOND_EXTRA_FIELD
+    TYPE: String
+    REQUIRED: False
+
+[REQUIREMENT]
+UID: REQ-1
+TITLE: Test Requirement.
+STATEMENT: Requirement statement.
+RATIONALE: Requirement rationale.
+COMMENT: Requirement comment.
+FIRST_EXTRA_FIELD: Requirement first extra field.
+SECOND_EXTRA_FIELD: Requirement second extra field.

--- a/tests/integration/commands/passthrough/--view/01_view_option_is_provided/test.itest
+++ b/tests/integration/commands/passthrough/--view/01_view_option_is_provided/test.itest
@@ -1,0 +1,9 @@
+RUN: %strictdoc passthrough %S --view PRINT_VIEW --output-dir Output/
+RUN: %cat %S/Output/input.sdoc | filecheck %s --check-prefix CHECK-SDOC
+
+CHECK-SDOC: REQ-1
+CHECK-SDOC: Requirement statement.
+CHECK-SDOC-NOT: Requirement rationale.
+CHECK-SDOC-NOT: Requirement comment.
+CHECK-SDOC-NOT: Requirement first extra field.
+CHECK-SDOC: Requirement second extra field.

--- a/tests/integration/commands/passthrough/--view/02_if_view_option_is_not_provided_then_default_view/input.sdoc
+++ b/tests/integration/commands/passthrough/--view/02_if_view_option_is_not_provided_then_default_view/input.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Test Document
+
+[REQUIREMENT]
+UID: REQ-1
+STATEMENT: Requirement statement.
+RATIONALE: Requirement rationale.

--- a/tests/integration/commands/passthrough/--view/02_if_view_option_is_not_provided_then_default_view/test.itest
+++ b/tests/integration/commands/passthrough/--view/02_if_view_option_is_not_provided_then_default_view/test.itest
@@ -1,0 +1,6 @@
+RUN: %strictdoc passthrough %S --output-dir Output/
+RUN: %cat %S/Output/input.sdoc | filecheck %s --check-prefix=CHECK-SDOC
+
+CHECK-SDOC: REQ-1
+CHECK-SDOC: Requirement statement.
+CHECK-SDOC: Requirement rationale.

--- a/tests/integration/scripting_examples/reqif/02_user_provided_example/script.py
+++ b/tests/integration/scripting_examples/reqif/02_user_provided_example/script.py
@@ -34,6 +34,8 @@ from strictdoc.backend.sdoc.models.type_system import (
     GrammarElementFieldString,
 )
 from strictdoc.backend.sdoc.writer import SDWriter
+from strictdoc.core.environment import SDocRuntimeEnvironment
+from strictdoc.core.project_config import ProjectConfig
 from strictdoc.helpers.string import ensure_newline, unescape
 
 
@@ -523,7 +525,8 @@ def main():
 
     document = documents[0]
 
-    document_content = SDWriter().write(document)
+    project_config = ProjectConfig.default_config(SDocRuntimeEnvironment(__file__))
+    document_content = SDWriter(project_config).write(document)
     output_folder = os.path.join(os.getcwd(), "Output")
     Path(output_folder).mkdir(parents=True, exist_ok=True)
     with open(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,8 +1,20 @@
 import os
 import sys
 
+import pytest
+
+from strictdoc.core.environment import SDocRuntimeEnvironment
+from strictdoc.core.project_config import ProjectConfig
+
 strictdoc_root_path = os.path.abspath(os.path.join(__file__, "../../.."))
 assert os.path.exists(
     strictdoc_root_path
 ), f"does not exist: {strictdoc_root_path}"
 sys.path.append(strictdoc_root_path)
+
+
+@pytest.fixture
+def default_project_config():
+    return ProjectConfig.default_config(
+        SDocRuntimeEnvironment(strictdoc_root_path)
+    )

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
@@ -17,7 +17,7 @@ from strictdoc.backend.sdoc.reader import SDReader
 from strictdoc.backend.sdoc.writer import SDWriter
 
 
-def test_001_minimal_doc():
+def test_001_minimal_doc(default_project_config):
     input_sdoc = """\
 [DOCUMENT]
 TITLE: Test Doc
@@ -34,13 +34,13 @@ TITLE: Test Doc
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_002_minimal_req():
+def test_002_minimal_req(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -54,13 +54,13 @@ TITLE: Hello
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_003_comments_01_several_comments():
+def test_003_comments_01_several_comments(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -77,13 +77,13 @@ COMMENT: Comment #3
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_004_several_tags():
+def test_004_several_tags(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -98,13 +98,13 @@ TITLE: Hello
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_010_multiple_sections():
+def test_010_multiple_sections(default_project_config):
     input_sdoc = """\
 [DOCUMENT]
 TITLE: Test Doc
@@ -139,12 +139,12 @@ This is a statement 3
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
     assert input_sdoc == output
 
 
-def test_020_requirement_mid():
+def test_020_requirement_mid(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -182,12 +182,12 @@ This is a statement 3
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
     assert input_sdoc == output
 
 
-def test_021_section_and_document_mid():
+def test_021_section_and_document_mid(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 MID: xyz09876
@@ -205,13 +205,13 @@ TITLE: Test Section
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_022_requirement_uid_and_link():
+def test_022_requirement_uid_and_link(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -232,13 +232,13 @@ STATEMENT: >>>
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_030_multiline_statement():
+def test_030_multiline_statement(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -270,13 +270,13 @@ This is a statement 3
         == "This is a statement 1\nThis is a statement 2\nThis is a statement 3\n"
     )
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_036_rationale_single_line():
+def test_036_rationale_single_line(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -296,7 +296,7 @@ RATIONALE: This is a Rationale
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
@@ -308,7 +308,7 @@ RATIONALE: This is a Rationale
     assert requirement_1.rationale == "This is a Rationale"
 
 
-def test_037_rationale_multi_line():
+def test_037_rationale_multi_line(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -332,7 +332,7 @@ This is a Rationale line 3
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
@@ -348,7 +348,7 @@ This is a Rationale line 3
     )
 
 
-def test_040_composite_requirement_1_level():
+def test_040_composite_requirement_1_level(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -382,7 +382,7 @@ This is a child body part 3
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
     assert input_sdoc == output
 
@@ -396,7 +396,7 @@ This is a child body part 3
     )
 
 
-def test_042_composite_requirement_2_level():
+def test_042_composite_requirement_2_level(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -434,7 +434,7 @@ body 1.1.1.1
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
@@ -481,7 +481,9 @@ body 1.1.1.1
 
 # This test is needed to make sure that the grammar details related
 # to the difference of parting single vs multiline strings are covered.
-def test_050_requirement_single_line_statement_one_symbol():
+def test_050_requirement_single_line_statement_one_symbol(
+    default_project_config,
+):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -499,13 +501,13 @@ STATEMENT: 1
     requirement = document.section_contents[0]
     assert requirement.reserved_statement == "1"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_060_file_ref():
+def test_060_file_ref(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -530,13 +532,13 @@ RELATIONS:
     assert reference.ref_type == ReferenceType.FILE
     assert reference.g_file_entry.g_file_path == "/tmp/sample.cpp"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_070_document_config_version():
+def test_070_document_config_version(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -553,13 +555,13 @@ VERSION: 0.0.1
     document: SDocDocument = reader.read(input_sdoc)
     assert document.config.version == "0.0.1"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_071_document_config_number():
+def test_071_document_config_number(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -576,13 +578,13 @@ UID: SDOC-01
     document: SDocDocument = reader.read(input_sdoc)
     assert document.config.uid == "SDOC-01"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_072_document_config_classification():
+def test_072_document_config_classification(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -601,13 +603,13 @@ CLASSIFICATION: Restricted
     document: SDocDocument = reader.read(input_sdoc)
     assert document.config.classification == "Restricted"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_073_document_config_requirement_prefix():
+def test_073_document_config_requirement_prefix(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -626,13 +628,13 @@ REQ_PREFIX: DOC-
     document: SDocDocument = reader.read(input_sdoc)
     assert document.config.requirement_prefix == "DOC-"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_090_document_config_all_fields():
+def test_090_document_config_all_fields(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -682,13 +684,13 @@ STATEMENT: ABC
     assert isinstance(requirement, SDocNode)
     assert requirement.custom_level == "456"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_100_basic_test():
+def test_100_basic_test(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -731,13 +733,13 @@ COMMENT: This requirement is very important
     assert requirement_1.reserved_tags[1] == "Tag 2"
     assert requirement_1.reserved_tags[2] == "Tag 3"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_081_document_config_markup_not_specified():
+def test_081_document_config_markup_not_specified(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -755,13 +757,13 @@ VERSION: 0.0.1
     assert document.config.version == "0.0.1"
     assert document.config.markup is None
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_081_document_config_markup_specified():
+def test_081_document_config_markup_specified(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -780,13 +782,15 @@ OPTIONS:
     document: SDocDocument = reader.read(input_sdoc)
     assert document.config.version == "0.0.1"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_082_document_config_auto_levels_specified_to_false():
+def test_082_document_config_auto_levels_specified_to_false(
+    default_project_config,
+):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -803,13 +807,13 @@ OPTIONS:
     document: SDocDocument = reader.read(input_sdoc)
     assert document.config.auto_levels is False
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_083_requirement_level():
+def test_083_requirement_level(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -842,13 +846,13 @@ STATEMENT: ABC
     assert isinstance(requirement, SDocNode)
     assert requirement.custom_level == "456"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_085_options_requirement_style():
+def test_085_options_requirement_style(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -865,13 +869,13 @@ OPTIONS:
     document: SDocDocument = reader.read(input_sdoc)
     assert document.config.requirement_style == "Table"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_087_options_requirement_in_toc():
+def test_087_options_requirement_in_toc(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -888,13 +892,13 @@ OPTIONS:
     document: SDocDocument = reader.read(input_sdoc)
     assert document.config.requirement_in_toc == "True"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_089_document_config_use_mid():
+def test_089_document_config_use_mid(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 MID: foobar
@@ -911,13 +915,13 @@ OPTIONS:
     document: SDocDocument = reader.read(input_sdoc)
     assert document.config.enable_mid is True
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_edge_case_01_minimal_requirement():
+def test_edge_case_01_minimal_requirement(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -935,7 +939,7 @@ TITLE: Test Doc
     assert requirement.reserved_title is None
     assert requirement.reserved_statement is None
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
@@ -1133,7 +1137,9 @@ TITLE:
     assert "Expected SingleLineString" in exc_info.value.args[0].decode("utf-8")
 
 
-def test_edge_case_23_leading_spaces_do_not_imply_empy_field():
+def test_edge_case_23_leading_spaces_do_not_imply_empy_field(
+    default_project_config,
+):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -1199,6 +1205,6 @@ MY_FIELD: >>>
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
     assert expected_sdoc == output

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_document_views.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_document_views.py
@@ -3,7 +3,7 @@ from strictdoc.backend.sdoc.reader import SDReader
 from strictdoc.backend.sdoc.writer import SDWriter
 
 
-def test_01_integrated_example():
+def test_01_integrated_example(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -39,7 +39,7 @@ VIEWS:
 
     document: SDocDocument = reader.read(input_sdoc)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_free_text.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_free_text.py
@@ -5,7 +5,7 @@ from strictdoc.backend.sdoc.reader import SDReader
 from strictdoc.backend.sdoc.writer import SDWriter
 
 
-def test_001_free_text():
+def test_001_free_text(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -20,13 +20,13 @@ Hello world
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_002_freetext_empty():
+def test_002_freetext_empty(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -40,13 +40,13 @@ TITLE: Test Doc
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_003_free_text_ending_free_text_not_recognized():
+def test_003_free_text_ending_free_text_not_recognized(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -61,13 +61,13 @@ AAA  [/FREETEXT]
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_004_section_free_text():
+def test_004_section_free_text(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -87,13 +87,13 @@ Hello world
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_020_free_text_inline_link():
+def test_020_free_text_inline_link(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -110,13 +110,13 @@ String 4
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_040_free_text_anchor_between_empty_lines():
+def test_040_free_text_anchor_between_empty_lines(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -141,13 +141,13 @@ String 4
     assert isinstance(content_field.parts[1], Anchor)
     assert content_field.parts[1].value == "REQ-001"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_041_free_text_anchor_start_of_free_text():
+def test_041_free_text_anchor_start_of_free_text(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -170,13 +170,13 @@ Test
     assert content_field.parts[0].value == "REQ-001"
 
     assert isinstance(content_field.parts[1], str)
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_042_two_anchors():
+def test_042_two_anchors(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Document 1
@@ -196,13 +196,13 @@ Modified text
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_042_free_text_anchor_end_of_free_text():
+def test_042_free_text_anchor_end_of_free_text(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -226,13 +226,13 @@ String 2 String 3
     assert isinstance(content_field.parts[1], Anchor)
     assert content_field.parts[1].value == "REQ-001"
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_043_free_text_anchor_between_lines():
+def test_043_free_text_anchor_between_lines(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -257,13 +257,13 @@ String 5
     assert isinstance(content_field.parts[1], Anchor)
     assert isinstance(content_field.parts[2], str)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_050_free_text_anchor_inline_not_recognized():
+def test_050_free_text_anchor_inline_not_recognized(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -284,13 +284,15 @@ String 4
     assert len(content_field.parts) == 1
     assert isinstance(content_field.parts[0], str)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_052_free_text_anchor_not_recognized_when_connected_to_text():
+def test_052_free_text_anchor_not_recognized_when_connected_to_text(
+    default_project_config,
+):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -311,13 +313,15 @@ String 2 String 3
     assert len(content_field.parts) == 2
     assert isinstance(content_field.parts[0], str)
     assert isinstance(content_field.parts[1], Anchor)
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_053_free_text_anchor_not_recognized_when_connected_to_text_newline_after():
+def test_053_free_text_anchor_not_recognized_when_connected_to_text_newline_after(
+    default_project_config,
+):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -341,7 +345,7 @@ TEST
     assert isinstance(content_field.parts[0], str)
     assert isinstance(content_field.parts[1], Anchor)
     assert isinstance(content_field.parts[2], str)
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_grammar.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_grammar.py
@@ -3,7 +3,7 @@ from strictdoc.backend.sdoc.reader import SDReader
 from strictdoc.backend.sdoc.writer import SDWriter
 
 
-def test_150_grammar_minimal_doc():
+def test_150_grammar_minimal_doc(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -44,13 +44,13 @@ ELEMENTS:
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert expected_sdoc == output
 
 
-def test_151_grammar_single_choice():
+def test_151_grammar_single_choice(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -104,13 +104,13 @@ SINGLE_CHOICE_FIELD: A
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert expected_sdoc == output
 
 
-def test_152_grammar_multiple_choice():
+def test_152_grammar_multiple_choice(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -164,13 +164,13 @@ MULTIPLE_CHOICE_FIELD: A, C
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert expected_sdoc == output
 
 
-def test_153_grammar_tag():
+def test_153_grammar_tag(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -224,13 +224,13 @@ TAG_FIELD: A, C
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert expected_sdoc == output
 
 
-def test_154_grammar_multiline_custom_field():
+def test_154_grammar_multiline_custom_field(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -292,13 +292,13 @@ Some text here...
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert expected_sdoc == output
 
 
-def test_170_grammar_relations():
+def test_170_grammar_relations(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -331,7 +331,7 @@ STATEMENT: This is a statement.
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_grammar_from_file.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_grammar_from_file.py
@@ -3,7 +3,7 @@ from strictdoc.backend.sdoc.reader import SDReader
 from strictdoc.backend.sdoc.writer import SDWriter
 
 
-def test_001_minimal_doc():
+def test_001_minimal_doc(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Fragment
@@ -22,7 +22,7 @@ TITLE: First section
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_relations.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_relations.py
@@ -3,7 +3,7 @@ from strictdoc.backend.sdoc.reader import SDReader
 from strictdoc.backend.sdoc.writer import SDWriter
 
 
-def test_001_parent_relation_without_role():
+def test_001_parent_relation_without_role(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -37,13 +37,13 @@ RELATIONS:
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output
 
 
-def test_002_parent_relation_with_refines_role():
+def test_002_parent_relation_with_refines_role(default_project_config):
     input_sdoc = """
 [DOCUMENT]
 TITLE: Test Doc
@@ -79,7 +79,7 @@ RELATIONS:
     document = reader.read(input_sdoc)
     assert isinstance(document, SDocDocument)
 
-    writer = SDWriter()
+    writer = SDWriter(default_project_config)
     output = writer.write(document)
 
     assert input_sdoc == output

--- a/tests/unit/strictdoc/cli/test_cli_arg_parser.py
+++ b/tests/unit/strictdoc/cli/test_cli_arg_parser.py
@@ -190,6 +190,7 @@ def test_passthrough_01_minimal():
         ("free_text_to_text", False),
         ("input_file", "input.sdoc"),
         ("output_dir", None),
+        ("view", None),
     ]
 
 
@@ -207,4 +208,5 @@ def test_passthrough_02_minimal():
         ("free_text_to_text", False),
         ("input_file", "input.sdoc"),
         ("output_dir", "SANDBOX/"),
+        ("view", None),
     ]

--- a/tools/confluence_html_table_import.py
+++ b/tools/confluence_html_table_import.py
@@ -15,6 +15,8 @@ sys.path.append(STRICTDOC_ROOT_PATH)
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.section import SDocSection
 from strictdoc.backend.sdoc.writer import SDWriter
+from strictdoc.core.environment import SDocRuntimeEnvironment
+from strictdoc.core.project_config import ProjectConfig
 
 
 class ConfluenceHTMLTableImport:
@@ -192,7 +194,8 @@ def main():
     sdoc = ConfluenceHTMLTableImport.import_from_file(path_to_input_html)
     print(sdoc)  # noqa: T201
 
-    sdoc_content = SDWriter().write(sdoc)
+    project_config = ProjectConfig.default_config(SDocRuntimeEnvironment(__file__))
+    sdoc_content = SDWriter(project_config).write(sdoc)
     with open("output.sdoc", "w") as output_file:
         output_file.write(sdoc_content)
 


### PR DESCRIPTION
This enhances #1509. It makes the custom views option available for the passthrough command. Command line syntax is the same as for export:
```
strictdoc passthrough --view MY_VIEW .
```

We can now do an sdoc -> sdoc transformation where only fields from a given custom view are retained in the output sdoc.