### PR TITLE
links: Consistent anchor id whitespace replacement

### DIFF
--- a/strictdoc/export/html/templates/rst/anchor.jinja
+++ b/strictdoc/export/html/templates/rst/anchor.jinja
@@ -5,7 +5,8 @@
 
 .. raw:: html
 
-    <sdoc-anchor id="{{ anchor.value }}" node-role="section" data-uid="{{ anchor.value }}" data-anchor="{{ anchor.value }}" style="top:unset">
+    {% set local_anchor = link_renderer.render_local_anchor(anchor) -%}
+    <sdoc-anchor id="{{ local_anchor }}" node-role="section" data-uid="{{ local_anchor }}" data-anchor="{{ local_anchor }}" style="top:unset">
     {%- set incoming_links = traceability_index.get_incoming_links(anchor) -%}
     {%- if incoming_links is not none and incoming_links|length > 0 -%}
     <template>

--- a/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_view/view_node_with_ANCHOR_when_uid_with_spaces/input/document.sdoc
+++ b/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_view/view_node_with_ANCHOR_when_uid_with_spaces/input/document.sdoc
@@ -1,0 +1,9 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[REQUIREMENT]
+UID: REQ-2
+TITLE: Req #2
+STATEMENT: >>>
+See [LINK: ANC 1].
+<<<

--- a/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_view/view_node_with_ANCHOR_when_uid_with_spaces/input/document2.sdoc
+++ b/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_view/view_node_with_ANCHOR_when_uid_with_spaces/input/document2.sdoc
@@ -1,0 +1,11 @@
+[DOCUMENT]
+TITLE: Document 2
+
+[REQUIREMENT]
+UID: REQ-1
+TITLE: Req #1
+STATEMENT: >>>
+Here we have an anchor:
+
+[ANCHOR: ANC 1, Anchor title]
+<<<

--- a/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_view/view_node_with_ANCHOR_when_uid_with_spaces/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_view/view_node_with_ANCHOR_when_uid_with_spaces/test_case.py
@@ -1,0 +1,40 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        """
+        This basic test ensures that an ANCHOR that has a UID with a space character
+        can be followed to by clicking a LINK that points to it.
+        The HTML anchors should have all space characters replaced with "-".
+        https://github.com/strictdoc-project/strictdoc/issues/1916
+        https://github.com/strictdoc-project/strictdoc/pull/1917
+        """
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+
+            self.click_xpath("//a[contains(., 'Anchor title')]")
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 2")
+
+            self.assert_url_contains("#ANC-1")

--- a/tests/integration/commands/export/html/markup/03_referencing_anchor_with_LINK_external/test.itest
+++ b/tests/integration/commands/export/html/markup/03_referencing_anchor_with_LINK_external/test.itest
@@ -20,5 +20,5 @@ CHECK-HTML-DOC2:<sdoc-anchor id="AD4"{{.*}}
 CHECK-HTML-DOC2:<li>AD4. Threat Model.</li>
 CHECK-HTML-DOC2:<sdoc-anchor id="AD5"{{.*}}
 CHECK-HTML-DOC2:<li>AD5. Software Tests.</li>
-CHECK-HTML-DOC2:<sdoc-anchor id="Supplemental Guide"{{.*}}
+CHECK-HTML-DOC2:<sdoc-anchor id="Supplemental-Guide"{{.*}}
 CHECK-HTML-DOC2:<li>AD6. Supplemental Guide.</li>


### PR DESCRIPTION
Whitespaces are valid in StrictDoc UIDs, but are not valid in HTML element ids. Therefore we have to sanitize them during HTML export. This was already done in most places, but not for anchor IDs in rst fragments. In consequence referencing links couldn't find their target.

This adds whitespace to dash replacement for rst-for-html anchors. It reuses LinkRenderer for consistent results.

Fixes #1916.