### PR TITLE
Code climate: get_included_document -> get_including_document

### DIFF
--- a/strictdoc/backend/sdoc/models/anchor.py
+++ b/strictdoc/backend/sdoc/models/anchor.py
@@ -36,8 +36,8 @@ class Anchor:
     def parent_or_including_document(self):
         return self.parent_node().parent_or_including_document
 
-    def get_included_document(self):
-        return self.parent_node().get_included_document()
+    def get_including_document(self):
+        return self.parent_node().get_including_document()
 
     def parent_node(self) -> Any:
         # Anchor -> FreeText -> Section|Document

--- a/strictdoc/backend/sdoc/models/document.py
+++ b/strictdoc/backend/sdoc/models/document.py
@@ -103,7 +103,7 @@ class SDocDocument:
     def document_is_included(self) -> bool:
         return self.ng_including_document_reference.get_document() is not None
 
-    def get_included_document(self) -> Optional["SDocDocument"]:
+    def get_including_document(self) -> Optional["SDocDocument"]:
         # FIXME: Fix no-any-return when the circular references between
         #        SDocDocument and DocumentReference are fixed.
         return self.ng_including_document_reference.get_document()  # type: ignore[no-any-return]

--- a/strictdoc/backend/sdoc/models/node.py
+++ b/strictdoc/backend/sdoc/models/node.py
@@ -294,7 +294,7 @@ class SDocNode(SDocObject):
     def get_document(self) -> Optional[SDocDocument]:
         return self.ng_document_reference.get_document()
 
-    def get_included_document(self) -> Optional[SDocDocument]:
+    def get_including_document(self) -> Optional[SDocDocument]:
         return self.ng_including_document_reference.get_document()
 
     def get_display_node_type(self) -> str:

--- a/strictdoc/backend/sdoc/models/section.py
+++ b/strictdoc/backend/sdoc/models/section.py
@@ -92,7 +92,7 @@ class SDocSection(SDocObject):  # pylint: disable=too-many-instance-attributes
     def get_document(self):
         return self.ng_document_reference.get_document()
 
-    def get_included_document(self):
+    def get_including_document(self):
         return self.ng_including_document_reference.get_document()
 
     @property

--- a/strictdoc/core/transforms/section.py
+++ b/strictdoc/core/transforms/section.py
@@ -162,7 +162,7 @@ class CreateSectionCommand:
                     document = reference_node
                 else:
                     document = assert_cast(
-                        reference_node.get_included_document(), SDocDocument
+                        reference_node.get_including_document(), SDocDocument
                     )
         else:
             document = reference_node.document

--- a/strictdoc/export/html/renderers/link_renderer.py
+++ b/strictdoc/export/html/renderers/link_renderer.py
@@ -103,7 +103,7 @@ class LinkRenderer:
         assert isinstance(node, (SDocNode, SDocSection, Anchor)), node
         assert isinstance(document_type, DocumentType), document_type
         local_link = self.render_local_anchor(node)
-        including_document = node.get_included_document()
+        including_document = node.get_including_document()
         if (
             including_document is not None
             and including_document.is_bundle_document

--- a/strictdoc/export/html/templates/screens/project_index/project_tree_file.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/project_tree_file.jinja
@@ -26,7 +26,7 @@
     </div>
     {%- if is_included -%}
       <div class="project_tree-file-name">
-        <b>included by</b> {{ document.get_included_document().meta.input_doc_rel_path.relative_path_posix }}
+        <b>included by</b> {{ document.get_including_document().meta.input_doc_rel_path.relative_path_posix }}
       </div>
     {%- endif -%}
   </div>


### PR DESCRIPTION
The method name became outdated when the original implementation was removed.