### PR TITLE
Use Jinja2 autoescaping 

### DIFF
--- a/docs/strictdoc_25_design.sdoc
+++ b/docs/strictdoc_25_design.sdoc
@@ -136,3 +136,39 @@ One important implementation detail of Arpeggio that influences StrictDoc user e
 [/FREETEXT]
 
 [/SECTION]
+
+[SECTION]
+TITLE: HTML Escaping
+
+[TEXT]
+STATEMENT: >>>
+StrictDoc uses Jinja2 autoescaping_ for HTML output. `Template.render`_ calls
+will escape any Python object unless it's explicitly marked as safe.
+
+Good to know for a start:
+
+- If a Python object intentionally contains HTML it must be marked as safe
+  to bypass autoescaping. Templates can do this by piping to safe_, or Python code
+  can do it by wrapping an object into `markupsafe.Markup`_.
+- Passing text to the `Markup() <markupsafe.Markup_>`_ constructor marks that text
+  as safe, but *does not escape* it.
+- Text can be explicitly escaped with `markupsafe.escape`_. It's similar to
+  `html.escape`_, but the result is immediately marked safe.
+- `markupsafe.Markup`_ is responsible for some "magic". It's a :code:`str` subclass
+  with the same methods, but escaping arguments. For example,
+  :code:`"> " + Markup("<div>safe</div>")` will turn into :code:`"&gt; <div>safe</div>"`,
+  thanks to :code:`__radd__` in this specific case. To prevent escaping,
+  you would use :code:`Markup("> ") + Markup("<div>safe</div>")`. Basically the
+  same magic happens in templates when using safe_.
+- See also `Working with Automatic Escaping`_.
+
+.. _autoescaping: https://jinja.palletsprojects.com/en/latest/api/#autoescaping
+.. _Working with Automatic Escaping: https://jinja.palletsprojects.com/en/latest/templates/#working-with-automatic-escaping
+.. _markupsafe.Markup: https://markupsafe.palletsprojects.com/en/latest/escaping/#markupsafe.Markup
+.. _markupsafe.escape: https://markupsafe.palletsprojects.com/en/latest/escaping/#markupsafe.escape
+.. _safe: https://jinja.palletsprojects.com/en/latest/templates/#jinja-filters.safe
+.. _Template.render: https://jinja.palletsprojects.com/en/latest/api/#jinja2.Template.render
+.. _html.escape: https://docs.python.org/3/library/html.html#html.escape
+<<<
+
+[/SECTION]

--- a/strictdoc/backend/sdoc/models/free_text.py
+++ b/strictdoc/backend/sdoc/models/free_text.py
@@ -1,4 +1,3 @@
-import html
 from typing import Any, List, Optional
 
 from strictdoc.backend.sdoc.models.anchor import Anchor
@@ -54,9 +53,6 @@ class FreeText:
             else:
                 raise NotImplementedError(part)
         return text
-
-    def get_parts_as_text_escaped(self) -> str:
-        return html.escape(self.get_parts_as_text())
 
 
 class FreeTextContainer(FreeText):

--- a/strictdoc/backend/sdoc/models/node.py
+++ b/strictdoc/backend/sdoc/models/node.py
@@ -1,5 +1,4 @@
 # mypy: disable-error-code="union-attr"
-import html
 from collections import OrderedDict
 from typing import Any, Generator, List, Optional, Tuple, Union
 
@@ -91,9 +90,6 @@ class SDocNodeField:
             else:
                 raise NotImplementedError(part)
         return text
-
-    def get_text_value_escaped(self) -> str:
-        return html.escape(self.get_text_value())
 
 
 @auto_described
@@ -454,13 +450,6 @@ class SDocNode(SDocObject):
     ) -> Generator[Tuple[SDocNodeField, str, str], None, None]:
         for field in self.enumerate_fields():
             meta_field_value = field.get_text_value()
-            yield field, field.field_name, meta_field_value
-
-    def enumerate_all_fields_escaped(
-        self,
-    ) -> Generator[Tuple[SDocNodeField, str, str], None, None]:
-        for field in self.enumerate_fields():
-            meta_field_value = field.get_text_value_escaped()
             yield field, field.field_name, meta_field_value
 
     def enumerate_meta_fields(

--- a/strictdoc/core/transforms/create_requirement.py
+++ b/strictdoc/core/transforms/create_requirement.py
@@ -108,14 +108,14 @@ class CreateRequirementTransform:
                 ) = RstToHtmlFragmentWriter(
                     path_to_output_dir=self.project_config.export_output_dir,
                     context_document=document,
-                ).write_with_validation(field_.field_unescaped_value)
+                ).write_with_validation(field_.field_value)
                 if parsed_html is None:
                     errors[field_.field_name].append(rst_error)
                 else:
                     try:
                         free_text_container: Optional[FreeTextContainer] = (
-                            SDFreeTextReader.read(field_.field_unescaped_value)
-                            if len(field_.field_unescaped_value) > 0
+                            SDFreeTextReader.read(field_.field_value)
+                            if len(field_.field_value) > 0
                             else None
                         )
                         map_form_to_requirement_fields[field_] = (
@@ -208,7 +208,7 @@ class CreateRequirementTransform:
                     requirement.set_field_value(
                         field_name=form_field_name,
                         form_field_index=form_field_index,
-                        value=form_field.field_unescaped_value,
+                        value=form_field.field_value,
                     )
                     continue
 

--- a/strictdoc/core/transforms/update_requirement.py
+++ b/strictdoc/core/transforms/update_requirement.py
@@ -114,14 +114,14 @@ class CreateOrUpdateNodeCommand:
                 ) = RstToHtmlFragmentWriter(
                     path_to_output_dir=self.project_config.export_output_dir,
                     context_document=self.context_document,
-                ).write_with_validation(field_.field_unescaped_value)
+                ).write_with_validation(field_.field_value)
                 if parsed_html is None:
                     form_object.add_error(field_.field_name, rst_error)
                 else:
                     try:
                         free_text_container: Optional[FreeTextContainer] = (
-                            SDFreeTextReader.read(field_.field_unescaped_value)
-                            if len(field_.field_unescaped_value) > 0
+                            SDFreeTextReader.read(field_.field_value)
+                            if len(field_.field_value) > 0
                             else None
                         )
                         map_form_to_requirement_fields[field_] = (
@@ -455,7 +455,7 @@ class CreateOrUpdateNodeCommand:
                     node.set_field_value(
                         field_name=form_field_name,
                         form_field_index=form_field_index,
-                        value=form_field.field_unescaped_value,
+                        value=form_field.field_value,
                     )
                     continue
 

--- a/strictdoc/export/html/form_objects/form_object.py
+++ b/strictdoc/export/html/form_objects/form_object.py
@@ -2,25 +2,25 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
-from jinja2 import Environment, Template
+from strictdoc.export.html.html_templates import JinjaEnvironment
 
 
 @dataclass
 class RowWithReservedFieldFormObject:
     field: Any
     errors: Dict[str, List]
-    jinja_environment: Environment
+    jinja_environment: JinjaEnvironment
 
     def __post_init__(self):
         assert isinstance(
-            self.jinja_environment, Environment
+            self.jinja_environment, JinjaEnvironment
         ), self.jinja_environment
 
     def render(self):
-        template: Template = self.jinja_environment.get_template(
-            "components/grammar_form_element/row_with_reserved_field/index.jinja"
+        rendered_template = self.jinja_environment.render_template_as_markup(
+            "components/grammar_form_element/row_with_reserved_field/index.jinja",
+            form_object=self,
         )
-        rendered_template = template.render(form_object=self)
         return rendered_template
 
     def get_errors(self, field_name) -> List:
@@ -31,19 +31,19 @@ class RowWithReservedFieldFormObject:
 class RowWithCustomFieldFormObject:
     field: Any
     errors: Dict[str, List]
-    jinja_environment: Environment
+    jinja_environment: JinjaEnvironment
 
     def __post_init__(self):
         assert self.field is not None
         assert isinstance(
-            self.jinja_environment, Environment
+            self.jinja_environment, JinjaEnvironment
         ), self.jinja_environment
 
     def render(self):
-        template: Template = self.jinja_environment.get_template(
-            "components/grammar_form_element/row_with_custom_field/index.jinja"
+        rendered_template = self.jinja_environment.render_template_as_markup(
+            "components/grammar_form_element/row_with_custom_field/index.jinja",
+            form_object=self,
         )
-        rendered_template = template.render(form_object=self)
         return rendered_template
 
     def get_errors(self, field_name) -> List:
@@ -54,19 +54,19 @@ class RowWithCustomFieldFormObject:
 class RowWithRelationFormObject:
     relation: Any
     errors: Dict[str, List]
-    jinja_environment: Environment
+    jinja_environment: JinjaEnvironment
 
     def __post_init__(self):
         assert self.relation is not None
         assert isinstance(
-            self.jinja_environment, Environment
+            self.jinja_environment, JinjaEnvironment
         ), self.jinja_environment
 
     def render(self):
-        template: Template = self.jinja_environment.get_template(
-            "components/grammar_form_element/row_with_relation/index.jinja"
+        rendered_template = self.jinja_environment.render_template_as_markup(
+            "components/grammar_form_element/row_with_relation/index.jinja",
+            form_object=self,
         )
-        rendered_template = template.render(form_object=self)
         return rendered_template
 
     def get_errors(self, field_name) -> List:

--- a/strictdoc/export/html/form_objects/grammar_form_object.py
+++ b/strictdoc/export/html/form_objects/grammar_form_object.py
@@ -1,7 +1,6 @@
 # mypy: disable-error-code="arg-type,no-any-return,no-untyped-call,no-untyped-def,type-arg"
 from typing import Dict, List, Optional, Set
 
-from jinja2 import Environment, Template
 from starlette.datastructures import FormData
 
 from strictdoc.backend.sdoc.models.document import SDocDocument
@@ -13,6 +12,7 @@ from strictdoc.core.project_config import ProjectConfig
 from strictdoc.export.html.form_objects.rows.row_with_grammar_element_form_object import (
     RowWithGrammarElementFormObject,
 )
+from strictdoc.export.html.html_templates import JinjaEnvironment
 from strictdoc.helpers.auto_described import auto_described
 from strictdoc.helpers.cast import assert_cast
 from strictdoc.helpers.form_data import parse_form_data
@@ -68,7 +68,7 @@ class GrammarFormObject(ErrorObject):
         document_mid: str,
         fields: List[GrammarElementFormField],
         project_config: ProjectConfig,
-        jinja_environment: Environment,
+        jinja_environment: JinjaEnvironment,
         imported_grammar_file: Optional[str],
     ):
         assert isinstance(document_mid, str), document_mid
@@ -76,7 +76,7 @@ class GrammarFormObject(ErrorObject):
         self.document_mid = document_mid
         self.fields: List[GrammarElementFormField] = fields
         self.project_config: ProjectConfig = project_config
-        self.jinja_environment: Environment = jinja_environment
+        self.jinja_environment: JinjaEnvironment = jinja_environment
         self.imported_grammar_file: Optional[str] = imported_grammar_file
 
     @staticmethod
@@ -85,7 +85,7 @@ class GrammarFormObject(ErrorObject):
         document_mid: str,
         request_form_data: FormData,
         project_config: ProjectConfig,
-        jinja_environment: Environment,
+        jinja_environment: JinjaEnvironment,
     ) -> "GrammarFormObject":
         form_object_fields: List[GrammarElementFormField] = []
         request_form_data_as_list = [
@@ -125,7 +125,7 @@ class GrammarFormObject(ErrorObject):
         *,
         document: SDocDocument,
         project_config: ProjectConfig,
-        jinja_environment: Environment,
+        jinja_environment: JinjaEnvironment,
     ) -> "GrammarFormObject":
         assert isinstance(document, SDocDocument)
         assert isinstance(document.grammar, DocumentGrammar)
@@ -180,10 +180,9 @@ class GrammarFormObject(ErrorObject):
         return len(self.errors) == 0
 
     def render(self):
-        template: Template = self.jinja_environment.get_template(
-            "components/grammar_form/index.jinja"
+        rendered_template = self.jinja_environment.render_template_as_markup(
+            "components/grammar_form/index.jinja", form_object=self
         )
-        rendered_template = template.render(form_object=self)
         return render_turbo_stream(
             content=rendered_template, action="update", target="modal"
         )

--- a/strictdoc/export/html/form_objects/included_document_form_object.py
+++ b/strictdoc/export/html/form_objects/included_document_form_object.py
@@ -3,10 +3,10 @@ import re
 from collections import defaultdict
 from typing import Dict, List, Optional
 
-from jinja2 import Environment, Template
 from starlette.datastructures import FormData
 
 from strictdoc.backend.sdoc.models.document import SDocDocument
+from strictdoc.export.html.html_templates import JinjaEnvironment
 from strictdoc.helpers.auto_described import auto_described
 from strictdoc.helpers.cast import assert_cast
 from strictdoc.helpers.form_data import parse_form_data
@@ -23,7 +23,7 @@ class IncludedDocumentFormObject(ErrorObject):
         document_mid: str,
         context_document_mid: str,
         document_title: str,
-        jinja_environment: Environment,
+        jinja_environment: JinjaEnvironment,
     ):
         assert isinstance(document_mid, str), document_mid
         assert isinstance(context_document_mid, str), context_document_mid
@@ -32,11 +32,11 @@ class IncludedDocumentFormObject(ErrorObject):
         self.document_mid: Optional[str] = document_mid
         self.context_document_mid: Optional[str] = context_document_mid
         self.document_title: str = document_title
-        self.jinja_environment: Environment = jinja_environment
+        self.jinja_environment: JinjaEnvironment = jinja_environment
 
     @staticmethod
     def create_from_request(
-        *, request_form_data: FormData, jinja_environment: Environment
+        *, request_form_data: FormData, jinja_environment: JinjaEnvironment
     ) -> "IncludedDocumentFormObject":
         request_form_data_as_list = [
             (field_name, field_value)
@@ -76,7 +76,7 @@ class IncludedDocumentFormObject(ErrorObject):
         *,
         document: SDocDocument,
         context_document_mid: str,
-        jinja_environment: Environment,
+        jinja_environment: JinjaEnvironment,
     ) -> "IncludedDocumentFormObject":
         assert isinstance(document, SDocDocument)
 
@@ -88,10 +88,9 @@ class IncludedDocumentFormObject(ErrorObject):
         )
 
     def render_edit_form(self):
-        template: Template = self.jinja_environment.get_template(
-            "components/included_document_form/index.jinja"
+        rendered_template = self.jinja_environment.render_template_as_markup(
+            "components/included_document_form/index.jinja", form_object=self
         )
-        rendered_template = template.render(form_object=self)
         return render_turbo_stream(
             content=rendered_template,
             action="replace",

--- a/strictdoc/export/html/form_objects/rows/row_with_grammar_element_form_object.py
+++ b/strictdoc/export/html/form_objects/rows/row_with_grammar_element_form_object.py
@@ -2,33 +2,33 @@
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
-from jinja2 import Environment, Template
+from strictdoc.export.html.html_templates import JinjaEnvironment
 
 
 @dataclass
 class RowWithGrammarElementFormObject:
     field: Any
     errors: Dict[str, List]
-    jinja_environment: Environment
+    jinja_environment: JinjaEnvironment
 
     def __post_init__(self):
         assert self.field is not None
         assert isinstance(
-            self.jinja_environment, Environment
+            self.jinja_environment, JinjaEnvironment
         ), self.jinja_environment
 
     def render(self):
         if self.field.is_new:
-            template: Template = self.jinja_environment.get_template(
-                "components/grammar_form/row_with_new_grammar_element/index.jinja"
+            rendered_template = self.jinja_environment.render_template_as_markup(
+                "components/grammar_form/row_with_new_grammar_element/index.jinja",
+                form_object=self,
             )
-            rendered_template = template.render(form_object=self)
             return rendered_template
         else:
-            template: Template = self.jinja_environment.get_template(
-                "components/grammar_form/row_with_grammar_element/index.jinja"
+            rendered_template = self.jinja_environment.render_template_as_markup(
+                "components/grammar_form/row_with_grammar_element/index.jinja",
+                form_object=self,
             )
-            rendered_template = template.render(form_object=self)
             return rendered_template
 
     def get_errors(self, field_name) -> List:

--- a/strictdoc/export/html/form_objects/section_form_object.py
+++ b/strictdoc/export/html/form_objects/section_form_object.py
@@ -1,5 +1,4 @@
 # mypy: disable-error-code="arg-type,no-untyped-call,no-untyped-def,type-arg"
-import html
 from collections import defaultdict
 from typing import Dict
 
@@ -41,11 +40,11 @@ class SectionFormObject(ErrorObject):
 
     @property
     def section_uid(self):
-        return self.section_uid_field.field_unescaped_value
+        return self.section_uid_field.field_value
 
     @property
     def section_title(self):
-        return self.section_title_field.field_unescaped_value
+        return self.section_title_field.field_value
 
     @staticmethod
     def create_new(context_document_mid: str):
@@ -55,15 +54,13 @@ class SectionFormObject(ErrorObject):
                 field_mid=MID.create(),
                 field_name="UID",
                 field_type=RequirementFormFieldType.SINGLELINE,
-                field_unescaped_value="",
-                field_escaped_value="",
+                field_value="",
             ),
             section_title_field=RequirementFormField(
                 field_mid=MID.create(),
                 field_name="TITLE",
                 field_type=RequirementFormFieldType.SINGLELINE,
-                field_unescaped_value="",
-                field_escaped_value="",
+                field_value="",
             ),
             context_document_mid=context_document_mid,
         )
@@ -73,10 +70,7 @@ class SectionFormObject(ErrorObject):
         uid_field_value = (
             section.reserved_uid if section.reserved_uid is not None else ""
         )
-        uid_escaped_field_value = html.escape(uid_field_value)
-
         title_field_value = section.title if section.title is not None else ""
-        title_escaped_field_value = html.escape(title_field_value)
 
         return SectionFormObject(
             section_mid=section.reserved_mid,
@@ -84,15 +78,13 @@ class SectionFormObject(ErrorObject):
                 field_mid=MID.create(),
                 field_name="UID",
                 field_type=RequirementFormFieldType.SINGLELINE,
-                field_unescaped_value=uid_field_value,
-                field_escaped_value=uid_escaped_field_value,
+                field_value=uid_field_value,
             ),
             section_title_field=RequirementFormField(
                 field_mid=MID.create(),
                 field_name="TITLE",
                 field_type=RequirementFormFieldType.SINGLELINE,
-                field_unescaped_value=title_field_value,
-                field_escaped_value=title_escaped_field_value,
+                field_value=title_field_value,
             ),
             context_document_mid=context_document_mid,
         )
@@ -128,8 +120,7 @@ class SectionFormObject(ErrorObject):
             field_mid=MID.create(),
             field_name="UID",
             field_type=RequirementFormFieldType.SINGLELINE,
-            field_unescaped_value=sanitized_uid_field_value,
-            field_escaped_value=html.escape(sanitized_uid_field_value),
+            field_value=sanitized_uid_field_value,
         )
 
         title_field_value = requirement_fields["TITLE"][0]
@@ -140,8 +131,7 @@ class SectionFormObject(ErrorObject):
             field_mid=MID.create(),
             field_name="TITLE",
             field_type=RequirementFormFieldType.SINGLELINE,
-            field_unescaped_value=sanitized_title_field_value,
-            field_escaped_value=html.escape(sanitized_title_field_value),
+            field_value=sanitized_title_field_value,
         )
 
         form_object = SectionFormObject(

--- a/strictdoc/export/html/generators/source_file_coverage.py
+++ b/strictdoc/export/html/generators/source_file_coverage.py
@@ -1,10 +1,9 @@
 # mypy: disable-error-code="no-untyped-call,no-untyped-def"
-from jinja2 import Environment
 
 from strictdoc import __version__
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.core.traceability_index import TraceabilityIndex
-from strictdoc.export.html.html_templates import HTMLTemplates
+from strictdoc.export.html.html_templates import HTMLTemplates, JinjaEnvironment
 from strictdoc.export.html.renderers.link_renderer import LinkRenderer
 
 
@@ -24,11 +23,10 @@ class SourceCoverageViewObject:
         self.is_running_on_server: bool = project_config.is_running_on_server
         self.strictdoc_version = __version__
 
-    def render_screen(self, jinja_environment: Environment):
-        template = jinja_environment.get_template(
-            "screens/source_file_coverage/index.jinja"
+    def render_screen(self, jinja_environment: JinjaEnvironment):
+        return jinja_environment.render_template_as_markup(
+            "screens/source_file_coverage/index.jinja", view_object=self
         )
-        return template.render(view_object=self)
 
     def render_static_url(self, url: str):
         return self.link_renderer.render_static_url(url)

--- a/strictdoc/export/html/generators/source_file_view_generator.py
+++ b/strictdoc/export/html/generators/source_file_view_generator.py
@@ -1,7 +1,7 @@
 # mypy: disable-error-code="no-untyped-call,no-untyped-def,operator"
-import html
-from typing import List
+from typing import List, Tuple
 
+from markupsafe import Markup, escape
 from pygments import highlight
 from pygments.formatters.html import HtmlFormatter
 from pygments.lexers import get_lexer_for_filename
@@ -46,8 +46,8 @@ class SourceFileViewHTMLGenerator:
         with open(source_file.full_path, encoding="utf-8") as opened_file:
             source_file_lines = opened_file.readlines()
 
-        pygmented_source_file_lines: List[str] = []
-        pygments_styles: str = ""
+        pygmented_source_file_lines: List[Markup] = []
+        pygments_styles: Markup = Markup("")
 
         if len(source_file_lines) > 0:
             coverage_info: SourceFileTraceabilityInfo = (
@@ -89,7 +89,7 @@ class SourceFileViewHTMLGenerator:
         source_file: SourceFile,
         source_file_lines: List[str],
         coverage_info: SourceFileTraceabilityInfo,
-    ):
+    ) -> Tuple[List[Markup], Markup]:
         assert isinstance(source_file, SourceFile)
         assert isinstance(source_file_lines, list)
         assert isinstance(coverage_info, SourceFileTraceabilityInfo)
@@ -202,12 +202,9 @@ class SourceFileViewHTMLGenerator:
             assert closing_bracket_index is not None
             after_line = source_line[closing_bracket_index:].rstrip()
 
-            before_line = html.escape(before_line)
-            after_line = html.escape(after_line)
-
             pygmented_source_file_lines[pragma_line - 1] = (
-                before_line,
-                after_line,
+                escape(before_line),
+                escape(after_line),
                 pragma,
             )
         pygments_styles = (
@@ -215,4 +212,6 @@ class SourceFileViewHTMLGenerator:
             + html_formatter.get_style_defs(".highlight")
         )
 
-        return pygmented_source_file_lines, pygments_styles
+        return list(map(Markup, pygmented_source_file_lines)), Markup(
+            pygments_styles
+        )

--- a/strictdoc/export/html/generators/view_objects/diff_screen_results_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/diff_screen_results_view_object.py
@@ -3,10 +3,9 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
-from jinja2 import Environment
-
 from strictdoc import __version__
 from strictdoc.core.project_config import ProjectConfig
+from strictdoc.export.html.html_templates import JinjaEnvironment
 from strictdoc.export.html.renderers.link_renderer import LinkRenderer
 from strictdoc.git.change_generator import ChangeContainer
 
@@ -59,8 +58,10 @@ class DiffScreenResultsViewObject:
         self.strictdoc_version = __version__
         self.error_message: Optional[str] = None
 
-    def render_screen(self, jinja_environment: Environment):
-        template = jinja_environment.get_template("screens/git/index.jinja")
+    def render_screen(self, jinja_environment: JinjaEnvironment):
+        template = jinja_environment.environment.overlay(
+            autoescape=False
+        ).get_template("screens/git/index.jinja")
         return template.render(view_object=self)
 
     def render_url(self, url: str):

--- a/strictdoc/export/html/generators/view_objects/diff_screen_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/diff_screen_view_object.py
@@ -2,10 +2,9 @@
 from dataclasses import dataclass
 from datetime import datetime
 
-from jinja2 import Environment
-
 from strictdoc import __version__
 from strictdoc.core.project_config import ProjectConfig
+from strictdoc.export.html.html_templates import JinjaEnvironment
 from strictdoc.export.html.renderers.link_renderer import LinkRenderer
 
 
@@ -40,9 +39,10 @@ class DiffScreenViewObject:
         self.is_running_on_server: bool = project_config.is_running_on_server
         self.strictdoc_version = __version__
 
-    def render_screen(self, jinja_environment: Environment):
-        template = jinja_environment.get_template("screens/git/index.jinja")
-        return template.render(view_object=self)
+    def render_screen(self, jinja_environment: JinjaEnvironment):
+        return jinja_environment.render_template_as_markup(
+            "screens/git/index.jinja", view_object=self
+        )
 
     def render_url(self, url: str):
         return self.link_renderer.render_url(url)

--- a/strictdoc/export/html/generators/view_objects/nestor_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/nestor_view_object.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from jinja2 import Environment
-
 from strictdoc import __version__
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_view import DocumentView
@@ -10,7 +8,7 @@ from strictdoc.core.document_tree_iterator import DocumentTreeIterator
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.core.traceability_index import TraceabilityIndex
 from strictdoc.export.html.document_type import DocumentType
-from strictdoc.export.html.html_templates import HTMLTemplates
+from strictdoc.export.html.html_templates import HTMLTemplates, JinjaEnvironment
 from strictdoc.export.html.renderers.link_renderer import LinkRenderer
 from strictdoc.export.html.renderers.markup_renderer import MarkupRenderer
 
@@ -55,9 +53,10 @@ class NestorViewObject:
         self.link_document_type: DocumentType = DocumentType.document()
         self.document: Optional[SDocDocument] = None
 
-    def render_screen(self, jinja_environment: Environment) -> str:
-        template = jinja_environment.get_template("screens/nestor/index.jinja")
-        return template.render(view_object=self)
+    def render_screen(self, jinja_environment: JinjaEnvironment) -> str:
+        return jinja_environment.render_template_as_markup(
+            "screens/nestor/index.jinja", view_object=self
+        )
 
     def render_static_url(self, url: str) -> str:
         return self.link_renderer.render_static_url(url)

--- a/strictdoc/export/html/generators/view_objects/project_statistics_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/project_statistics_view_object.py
@@ -2,8 +2,6 @@
 from dataclasses import dataclass
 from datetime import datetime
 
-from jinja2 import Environment
-
 from strictdoc import __version__
 from strictdoc.core.document_tree_iterator import DocumentTreeIterator
 from strictdoc.core.project_config import ProjectConfig
@@ -11,6 +9,7 @@ from strictdoc.core.traceability_index import TraceabilityIndex
 from strictdoc.export.html.generators.view_objects.project_tree_stats import (
     DocumentTreeStats,
 )
+from strictdoc.export.html.html_templates import JinjaEnvironment
 from strictdoc.export.html.renderers.link_renderer import LinkRenderer
 
 
@@ -35,11 +34,10 @@ class ProjectStatisticsViewObject:
         self.is_running_on_server: bool = project_config.is_running_on_server
         self.strictdoc_version = __version__
 
-    def render_screen(self, jinja_environment: Environment):
-        template = jinja_environment.get_template(
-            "screens/project_statistics/index.jinja"
+    def render_screen(self, jinja_environment: JinjaEnvironment):
+        return jinja_environment.render_template_as_markup(
+            "screens/project_statistics/index.jinja", view_object=self
         )
-        return template.render(view_object=self)
 
     def render_static_url(self, url: str):
         return self.link_renderer.render_static_url(url)

--- a/strictdoc/export/html/generators/view_objects/project_tree_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/project_tree_view_object.py
@@ -1,12 +1,11 @@
 # mypy: disable-error-code="no-any-return,no-untyped-call,no-untyped-def"
 from dataclasses import dataclass
 
-from jinja2 import Environment
-
 from strictdoc import __version__
 from strictdoc.core.document_tree_iterator import DocumentTreeIterator
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.core.traceability_index import TraceabilityIndex
+from strictdoc.export.html.html_templates import JinjaEnvironment
 from strictdoc.export.html.renderers.link_renderer import LinkRenderer
 
 
@@ -36,11 +35,10 @@ class ProjectTreeViewObject:
             traceability_index.contains_included_documents
         )
 
-    def render_screen(self, jinja_environment: Environment):
-        template = jinja_environment.get_template(
-            "screens/project_index/index.jinja"
+    def render_screen(self, jinja_environment: JinjaEnvironment):
+        return jinja_environment.render_template_as_markup(
+            "screens/project_index/index.jinja", view_object=self
         )
-        return template.render(view_object=self)
 
     def render_static_url(self, url: str):
         return self.link_renderer.render_static_url(url)

--- a/strictdoc/export/html/generators/view_objects/search_screen_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/search_screen_view_object.py
@@ -3,16 +3,15 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
-from jinja2 import Environment
-
 from strictdoc import __version__
+from strictdoc.backend.sdoc.models.any_node import SDocAnyNode
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_view import DocumentView
 from strictdoc.core.document_tree_iterator import DocumentTreeIterator
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.core.traceability_index import TraceabilityIndex
 from strictdoc.export.html.document_type import DocumentType
-from strictdoc.export.html.html_templates import HTMLTemplates
+from strictdoc.export.html.html_templates import HTMLTemplates, JinjaEnvironment
 from strictdoc.export.html.renderers.link_renderer import LinkRenderer
 from strictdoc.export.html.renderers.markup_renderer import MarkupRenderer
 
@@ -25,8 +24,8 @@ class SearchScreenViewObject:
         traceability_index: TraceabilityIndex,
         project_config: ProjectConfig,
         templates: HTMLTemplates,
-        search_results,
-        search_value,
+        search_results: SDocAnyNode,
+        search_value: str,
         error,
     ):
         self.traceability_index: TraceabilityIndex = traceability_index
@@ -66,9 +65,10 @@ class SearchScreenViewObject:
             self.document_type, node
         )
 
-    def render_screen(self, jinja_environment: Environment):
-        template = jinja_environment.get_template("screens/search/index.jinja")
-        return template.render(view_object=self)
+    def render_screen(self, jinja_environment: JinjaEnvironment):
+        return jinja_environment.render_template_as_markup(
+            "screens/search/index.jinja", view_object=self
+        )
 
     def is_empty_tree(self) -> bool:
         return self.document_tree_iterator.is_empty_tree()

--- a/strictdoc/export/html/generators/view_objects/source_file_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/source_file_view_object.py
@@ -3,13 +3,14 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import List
 
-from jinja2 import Environment
+from markupsafe import Markup
 
 from strictdoc import __version__
 from strictdoc.core.document_tree_iterator import DocumentTreeIterator
 from strictdoc.core.finders.source_files_finder import SourceFile
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.core.traceability_index import TraceabilityIndex
+from strictdoc.export.html.html_templates import JinjaEnvironment
 from strictdoc.export.html.renderers.link_renderer import LinkRenderer
 from strictdoc.export.html.renderers.markup_renderer import MarkupRenderer
 
@@ -24,16 +25,16 @@ class SourceFileViewObject:
         link_renderer: LinkRenderer,
         markup_renderer: MarkupRenderer,
         source_file: SourceFile,
-        pygments_styles: str,
-        pygmented_source_file_lines: List[str],
+        pygments_styles: Markup,
+        pygmented_source_file_lines: List[Markup],
     ):
         self.traceability_index: TraceabilityIndex = traceability_index
         self.project_config: ProjectConfig = project_config
         self.link_renderer: LinkRenderer = link_renderer
         self.markup_renderer: MarkupRenderer = markup_renderer
         self.source_file: SourceFile = source_file
-        self.pygments_styles: str = pygments_styles
-        self.pygmented_source_file_lines: List[str] = (
+        self.pygments_styles: Markup = pygments_styles
+        self.pygmented_source_file_lines: List[Markup] = (
             pygmented_source_file_lines
         )
 
@@ -44,11 +45,10 @@ class SourceFileViewObject:
         self.is_running_on_server: bool = project_config.is_running_on_server
         self.strictdoc_version = __version__
 
-    def render_screen(self, jinja_environment: Environment):
-        template = jinja_environment.get_template(
-            "screens/source_file_view/index.jinja"
+    def render_screen(self, jinja_environment: JinjaEnvironment) -> Markup:
+        return jinja_environment.render_template_as_markup(
+            "screens/source_file_view/index.jinja", view_object=self
         )
-        return template.render(view_object=self)
 
     def is_empty_tree(self) -> bool:
         return self.document_tree_iterator.is_empty_tree()

--- a/strictdoc/export/html/generators/view_objects/traceability_matrix_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/traceability_matrix_view_object.py
@@ -1,15 +1,13 @@
 # mypy: disable-error-code="arg-type,no-any-return,no-untyped-call,no-untyped-def,union-attr,type-arg"
 from typing import Dict, List, Optional, Tuple
 
-from jinja2 import Environment
-
 from strictdoc import __version__
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_grammar import DocumentGrammar
 from strictdoc.core.document_tree_iterator import DocumentTreeIterator
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.core.traceability_index import TraceabilityIndex
-from strictdoc.export.html.html_templates import HTMLTemplates
+from strictdoc.export.html.html_templates import HTMLTemplates, JinjaEnvironment
 from strictdoc.export.html.renderers.link_renderer import LinkRenderer
 from strictdoc.export.html.renderers.markup_renderer import MarkupRenderer
 
@@ -42,11 +40,10 @@ class TraceabilityMatrixViewObject:
             self.traceability_index.document_tree.document_list,
         )
 
-    def render_screen(self, jinja_environment: Environment):
-        template = jinja_environment.get_template(
-            "screens/traceability_matrix/index.jinja"
+    def render_screen(self, jinja_environment: JinjaEnvironment):
+        return jinja_environment.render_template_as_markup(
+            "screens/traceability_matrix/index.jinja", view_object=self
         )
-        return template.render(view_object=self)
 
     def render_static_url(self, url: str):
         return self.link_renderer.render_static_url(url)

--- a/strictdoc/export/html/renderers/html_fragment_writer.py
+++ b/strictdoc/export/html/renderers/html_fragment_writer.py
@@ -1,7 +1,10 @@
+from markupsafe import Markup
+
+
 class HTMLFragmentWriter:
     @staticmethod
-    def write(text_fragment: str) -> str:
-        return text_fragment
+    def write(text_fragment: str) -> Markup:
+        return Markup(text_fragment)
 
     @staticmethod
     def write_anchor_link(title: str, href: str) -> str:

--- a/strictdoc/export/html/renderers/markup_renderer.py
+++ b/strictdoc/export/html/renderers/markup_renderer.py
@@ -1,5 +1,7 @@
 from typing import Dict, Optional, Tuple, Union
 
+from markupsafe import Markup
+
 from strictdoc.backend.sdoc.models.anchor import Anchor
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.inline_link import InlineLink
@@ -84,7 +86,7 @@ class MarkupRenderer:
         # FIXME: Now that the underlying RST fragment caching is in place,
         # This caching could be removed. It is unlikely that it adds any serious
         # performance improvement.
-        self.cache: Dict[Tuple[DocumentType, SDocNodeField], str] = {}
+        self.cache: Dict[Tuple[DocumentType, SDocNodeField], Markup] = {}
 
         self.template_anchor = html_templates.jinja_environment().get_template(
             "rst/anchor.jinja"
@@ -92,13 +94,13 @@ class MarkupRenderer:
 
     def render_node_statement(
         self, document_type: DocumentType, node: SDocNode
-    ) -> str:
+    ) -> Markup:
         assert isinstance(node, SDocNode)
         return self.render_node_field(document_type, node.get_content_field())
 
     def render_truncated_node_statement(
         self, document_type: DocumentType, node: SDocNode
-    ) -> str:
+    ) -> Markup:
         assert isinstance(node, SDocNode)
         # FIXME: Double-check and switch to truncating using CSS.
         # https://github.com/strictdoc-project/strictdoc/issues/1925
@@ -106,7 +108,7 @@ class MarkupRenderer:
 
     def render_node_rationale(
         self, document_type: DocumentType, node: SDocNode
-    ) -> str:
+    ) -> Markup:
         assert isinstance(node, SDocNode)
         return self.render_node_field(
             document_type,
@@ -115,7 +117,7 @@ class MarkupRenderer:
 
     def render_node_field(
         self, document_type: DocumentType, node_field: SDocNodeField
-    ) -> str:
+    ) -> Markup:
         assert isinstance(node_field, SDocNodeField), node_field
 
         if (document_type, node_field) in self.cache:
@@ -149,6 +151,7 @@ class MarkupRenderer:
             else:
                 raise NotImplementedError
             prev_part = part
+
         output = self.fragment_writer.write(parts_output)
         self.cache[(document_type, node_field)] = output
 

--- a/strictdoc/export/html/renderers/text_to_html_writer.py
+++ b/strictdoc/export/html/renderers/text_to_html_writer.py
@@ -1,10 +1,10 @@
-import html
+from markupsafe import Markup, escape
 
 
 class TextToHtmlWriter:
     @staticmethod
-    def write(text_fragment: str) -> str:
-        return html.escape(text_fragment, quote=True).replace("\n", "<br/>\n")
+    def write(text_fragment: str) -> Markup:
+        return escape(text_fragment).replace("\n", Markup("<br/>\n"))
 
     @staticmethod
     def write_anchor_link(title: str, href: str) -> str:

--- a/strictdoc/export/html/templates/components/form/row/row_uid_with_reset/example.jinja.html
+++ b/strictdoc/export/html/templates/components/form/row/row_uid_with_reset/example.jinja.html
@@ -7,7 +7,7 @@
       {% set text_field_row_context.field = field_ %}
       {% set text_field_row_context.field_type = "singleline" %}
       {% set text_field_row_context.reference_mid = form_object.requirement_mid %}
-      {%- if field_.field_name == "UID" and field_.field_escaped_value == "" -%}
+      {%- if field_.field_name == "UID" and field_.field_value == "" -%}
         <turbo-frame id="uid_with_reset-{{ text_field_row_context.reference_mid }}">
           {# this template is turbo-frame and has a button to reset to the default value: #}
           {% include "components/form/row/row_uid_with_reset/frame.jinja" %}

--- a/strictdoc/export/html/templates/components/form/row/row_uid_with_reset/frame.jinja
+++ b/strictdoc/export/html/templates/components/form/row/row_uid_with_reset/frame.jinja
@@ -41,7 +41,7 @@
     field_label = text_field_row_context.field.field_name,
     field_placeholder = "Enter "~placeholder_name~" here...",
     field_type = text_field_row_context.field_type,
-    field_value = text_field_row_context.field.field_escaped_value,
+    field_value = text_field_row_context.field.field_value,
     testid_postfix = text_field_row_context.field.field_name
   %}
     {%- include "components/form/field/contenteditable/index.jinja" %}

--- a/strictdoc/export/html/templates/components/form/row/row_with_comment.jinja
+++ b/strictdoc/export/html/templates/components/form/row/row_with_comment.jinja
@@ -36,7 +36,7 @@
     field_label = comment_field_row_context.field.field_name,
     field_placeholder = "Enter comment here...",
     field_type = "multiline",
-    field_value = comment_field_row_context.field.field_escaped_value,
+    field_value = comment_field_row_context.field.field_value,
     mid = comment_field_row_context.field.field_mid,
     testid_postfix = "COMMENT"
   %}

--- a/strictdoc/export/html/templates/components/form/row/row_with_text_field.jinja
+++ b/strictdoc/export/html/templates/components/form/row/row_with_text_field.jinja
@@ -39,7 +39,7 @@
     field_label = text_field_row_context.field.field_name,
     field_placeholder = "Enter "~placeholder_name~" here...",
     field_type = text_field_row_context.field_type,
-    field_value = text_field_row_context.field.field_escaped_value,
+    field_value = text_field_row_context.field.field_value,
     testid_postfix = text_field_row_context.field.field_name
   %}
   {%- include "components/form/field/contenteditable/index.jinja" %}

--- a/strictdoc/export/html/templates/components/node_field/section_h/index.jinja
+++ b/strictdoc/export/html/templates/components/node_field/section_h/index.jinja
@@ -14,7 +14,7 @@
 
     {%- if sdoc_entity.context.title_number_string -%}
       {#- add title 'number' part to the accumulator -#}
-      {%- set field_content_ = field_content_ + sdoc_entity.context.title_number_string + ".&nbsp;" -%}
+      {%- set field_content_ = field_content_ + sdoc_entity.context.title_number_string + ".&nbsp;"|safe -%}
     {%- endif -%}
 
     {%- set title = sdoc_entity.reserved_title if sdoc_entity.is_requirement else sdoc_entity.title -%}

--- a/strictdoc/export/html/templates/components/node_field/section_title/index.jinja
+++ b/strictdoc/export/html/templates/components/node_field/section_title/index.jinja
@@ -9,7 +9,7 @@
 
     {%- if sdoc_entity.context.title_number_string -%}
       {#- add title 'number' part to the accumulator -#}
-      {%- set field_content_ = field_content_ + sdoc_entity.context.title_number_string + ".&nbsp;" -%}
+      {%- set field_content_ = field_content_ + sdoc_entity.context.title_number_string + ".&nbsp;"|safe -%}
     {%- endif -%}
 
     {%- set title = sdoc_entity.reserved_title if sdoc_entity.is_requirement else sdoc_entity.title -%}

--- a/strictdoc/export/html/templates/components/node_field/title/index.jinja
+++ b/strictdoc/export/html/templates/components/node_field/title/index.jinja
@@ -8,7 +8,7 @@
     {%- if title_number is true -%}
       {%- if sdoc_entity.context.title_number_string %}
         {#- add title 'number' part to the accumulator -#}
-        {%- set field_content_ = field_content_ + sdoc_entity.context.title_number_string + ".&nbsp;" -%}
+        {%- set field_content_ = field_content_ + sdoc_entity.context.title_number_string + ".&nbsp;"|safe -%}
       {%- endif -%}
     {%- endif -%}
 

--- a/strictdoc/export/html/templates/screens/document/document/frame_requirement_form.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/frame_requirement_form.jinja
@@ -35,7 +35,7 @@
       {% set text_field_row_context.field_editable = true %}
       {% set text_field_row_context.field_type = "singleline" %}
       {% set text_field_row_context.reference_mid = form_object.requirement_mid %}
-      {%- if form_object.element_type != "TEXT" and field_.field_name == "UID" and field_.field_escaped_value == "" -%}
+      {%- if form_object.element_type != "TEXT" and field_.field_name == "UID" and field_.field_value == "" -%}
         <turbo-frame id="uid_with_reset-{{ text_field_row_context.reference_mid }}">
           {# this template is turbo-frame and has a button to reset to the default value: #}
           {% include "components/form/row/row_uid_with_reset/frame.jinja" %}
@@ -95,7 +95,7 @@
         {# If comments have not yet been added,
         show only the add field button below,
         and do not display the code of the field itself: #}
-        {%- if field_.field_escaped_value|length > 0 -%}
+        {%- if field_.field_value|length > 0 -%}
           {% set comment_field_row_context.field = field_ %}
           {% set comment_field_row_context.field_editable = true %}
           {% set comment_field_row_context.errors = form_object.get_errors(field_.field_name) %}

--- a/strictdoc/export/html/templates/screens/document/document/frame_section_form.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/frame_section_form.jinja
@@ -37,7 +37,7 @@
   {% set text_field_row_context.field_editable = true %}
   {% set text_field_row_context.field_type = "singleline" %}
   {% set text_field_row_context.reference_mid = form_object.section_mid %}
-  {%- if not is_new_section and form_object.section_uid_field.field_escaped_value == "" -%}
+  {%- if not is_new_section and form_object.section_uid_field.field_value == "" -%}
     <turbo-frame id="uid_with_reset-{{ form_object.section_mid }}">
       {# this template is turbo-frame and has a button to reset to the default value: #}
       {% include "components/form/row/row_uid_with_reset/frame.jinja" %}

--- a/strictdoc/export/html/templates/screens/git/fields/requirement_fields.jinja
+++ b/strictdoc/export/html/templates/screens/git/fields/requirement_fields.jinja
@@ -13,7 +13,7 @@
 {% endif %}
 
 <div class="diff_node_fields">
-  {%- for requirement_field_triple_ in requirement.enumerate_all_fields_escaped() -%}
+  {%- for requirement_field_triple_ in requirement.enumerate_all_fields() -%}
     {%- set is_multiline = requirement_field_triple_[0].is_multiline() -%}
 
     {% if requirement_change is not none -%}

--- a/strictdoc/export/html/templates/screens/source_file_view/index.jinja
+++ b/strictdoc/export/html/templates/screens/source_file_view/index.jinja
@@ -22,7 +22,7 @@
   {{ super() }}
 
   <style>
-    {{ view_object.pygments_styles | safe }}
+    {{ view_object.pygments_styles }}
   </style>
 {% endblock head %}
 

--- a/strictdoc/export/rst/rst_to_html_fragment_writer.py
+++ b/strictdoc/export/rst/rst_to_html_fragment_writer.py
@@ -11,6 +11,7 @@ from typing import Optional
 from docutils.core import publish_parts
 from docutils.parsers.rst import directives, roles
 from docutils.utils import SystemMessage
+from markupsafe import Markup
 
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.export.rst.directives.raw_html_role import raw_html_role
@@ -62,12 +63,12 @@ class RstToHtmlFragmentWriter:
             self.source_path: str = "<string>"
         self.context_document: Optional[SDocDocument] = context_document
 
-    def write(self, rst_fragment: str) -> str:
+    def write(self, rst_fragment: str) -> Markup:
         assert isinstance(rst_fragment, str), rst_fragment
 
         # FIXME: This is broken.
         if len(rst_fragment) < 0:
-            return self._write_no_cache(rst_fragment)
+            return Markup(self._write_no_cache(rst_fragment))
 
         path_to_rst_fragment_bucket_dir = os.path.join(
             self.path_to_rst_cache_dir, str(len(rst_fragment))
@@ -81,7 +82,7 @@ class RstToHtmlFragmentWriter:
                 with open(
                     path_to_cached_fragment, "rb"
                 ) as cached_fragment_file_:
-                    return cached_fragment_file_.read().decode("UTF-8")
+                    return Markup(cached_fragment_file_.read().decode("UTF-8"))
         else:
             Path(path_to_rst_fragment_bucket_dir).mkdir(
                 parents=True, exist_ok=True
@@ -93,7 +94,7 @@ class RstToHtmlFragmentWriter:
         with open(path_to_cached_fragment, "wb") as cached_fragment_file_:
             cached_fragment_file_.write(rendered_html_bytes)
 
-        return rendered_html
+        return Markup(rendered_html)
 
     def _write_no_cache(self, rst_fragment: str) -> str:
         assert isinstance(rst_fragment, str), rst_fragment
@@ -187,7 +188,7 @@ class RstToHtmlFragmentWriter:
         return html, None
 
     @staticmethod
-    def write_anchor_link(title, href):
+    def write_anchor_link(title, href) -> str:
         return f"""\
 :rawhtml:`<a href="{href}">🔗&nbsp;{title}</a>`\
 """

--- a/strictdoc/server/helpers/turbo.py
+++ b/strictdoc/server/helpers/turbo.py
@@ -1,3 +1,6 @@
+from markupsafe import Markup
+
+
 # mypy: disable-error-code="no-untyped-def"
 def render_turbo_stream(content: str, action: str, target: str):
     assert action in ("append", "replace", "update")
@@ -9,4 +12,4 @@ def render_turbo_stream(content: str, action: str, target: str):
   </template>
 </turbo-stream>
 """
-    return turbo_stream
+    return Markup(turbo_stream)

--- a/tests/end2end/project_index/import_document_from_reqif/UC55_G1_validations/UC55_G1_T01_not_a_reqif_format/test_UC55_G1_T01_not_a_reqif_file.py
+++ b/tests/end2end/project_index/import_document_from_reqif/UC55_G1_validations/UC55_G1_T01_not_a_reqif_format/test_UC55_G1_T01_not_a_reqif_file.py
@@ -33,5 +33,5 @@ class Test_UC55_G1_T01_NotAReqIFormat(E2ECase):
 
             form_import.do_form_submit_and_catch_error(
                 "Cannot parse ReqIF file: "
-                "Start tag expected, '<' not found, line 1, column 1 (, line 1)"
+                "Start tag expected, '<' not found, line 1, column 1 (<string>, line 1)"
             )

--- a/tests/integration/options/options_per_document/MARKUP/02_options_markup_is_text/test.itest
+++ b/tests/integration/options/options_per_document/MARKUP/02_options_markup_is_text/test.itest
@@ -3,4 +3,4 @@ CHECK: Published: Hello world doc
 
 RUN: %cat %S/Output/html/02_options_markup_is_text/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: **This text will not be converted to strong tag**
-CHECK-HTML: &lt;a href=&quot;url&quot;&gt;link&lt;/a&gt;
+CHECK-HTML: &lt;a href=&#34;url&#34;&gt;link&lt;/a&gt;

--- a/tests/unit/strictdoc/export/html/renderers/test_text_to_html_fragment_writer.py
+++ b/tests/unit/strictdoc/export/html/renderers/test_text_to_html_fragment_writer.py
@@ -7,7 +7,7 @@ def test_01_escapes_html_tags():
 """.strip()
 
     html_output = TextToHtmlWriter.write(text_input)
-    assert "&lt;a href=&quot;url&quot;&gt;link&lt;/a&gt;" == html_output
+    assert "&lt;a href=&#34;url&#34;&gt;link&lt;/a&gt;" == html_output
 
 
 def test_02_replaces_newlines_with_br():


### PR DESCRIPTION
This enables Jinja2 autoescaping everywhere, except for the diff screen which relies on pre generated HTML. The MR is not meant to be merged as-is.

It fixes the issues observed in #1920. Most integration tests pass. Tests fail for UI forms, presumably because they call `html.escape` manually and now are escaped twice.

Jinja2 [recommneds autoescaping](https://jinja.palletsprojects.com/en/3.1.x/api/#basics):

> In future versions of Jinja we might enable autoescaping by default for security reasons.
> As such you are encouraged to explicitly configure autoescaping now instead of relying on the default.

Templates access way more functions and variables than just `enumerate_all_fields()`. All need to be escaped. This does it automatically without risk of forgetting some places.

This MR changes some formerly explicit escaping:
- `enumerate_all_fields_escaped` was the `html.escape()` variant of `enumerate_all_fields`. It's only evaluated in Jinja2 templates, therefore completely covered by autoescaping now. This also eliminates the need for `get_text_value_escaped`, which was only used by `enumerate_all_fields_escaped`.
- `RequirementFormField.field_escaped_value` was the `html.escape()` variant of `field_unescaped_value`. `field_escaped_value` is only evaluated in Jinja2 templates, therefore completely covered by autoescaping now.
- `SearchScreenViewObject.search_value` was explictly `html.escape()`ed. `search_value` is only read by Jinja2 templates, therefore completely covered by autoescaping now.
- `SourceFileViewHTMLGenerator` changes some pygments output lines. pygements output is escaped, but we still have to escape our own changes. Changed `html.escape` to `markupsafe.escape` because that's what Jinja2 uses. It's better to use the same escaping function everywhere.
- `TextToHtmlWriter` escaped plain text from multiline statements. We still need to do that. Changed `html.escape` to `markupsafe.escape` for same reason as above.

Considerations about what to escape
- `render_*_link` make strings used as URL in href="`xyz`" . It's derived from filenames and UIDs. UIDs are restricted by a grammar regex. But Unix files can have weird names like `document"<injected>.sdoc`. So generated links should be URL encoded. HTML encoding is then not strictly necessary (wouldn't hurt either; could be considered as safety net). Suggestion: Do proper URL encoding in another PR; for now autoescaping prevents at least injection attacks.

TODO:
- [x] investigate failed ruff checks: Unrelated, new or changed ruff rule PLR1714
- [x] investigate failed integration tests (works locally): unrelated, we need either old filecheck 0.0.24 or fixed filecheck > 1.0.0
- [ ] investigate failed end2end tests
- [ ] try to replace some `| safe` with `Markup()` in code
- [ ] reconsider if autoescaping could be used for the diff screen
- [ ] Templates often render a variable that contains the output of calling a nested `Template.render()` programmatically. This output can be considered safe, yet we have to wrap it in `Markup`. Is there a way to automatically flag `Template.render()` as safe? Should already be that way: "Jinja functions (macros, super, self.BLOCKNAME) always return template data that is marked as safe."