### PR TITLE
Fix e2e test by using new chrome headless mode

### DIFF
--- a/.github/workflows/end2end-tests.yml
+++ b/.github/workflows/end2end-tests.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Run end-to-end tasks
       run: |
-        invoke test-end2end --long-timeouts --shard=${{ matrix.shard }} --exit-first
+        invoke test-end2end --long-timeouts --shard=${{ matrix.shard }} --exit-first --headless
 
   tests_end2end_linux:
     name: E2E - Linux
@@ -69,7 +69,7 @@ jobs:
 
     - name: Run end-to-end tasks
       run: |
-        invoke test-end2end --long-timeouts --exit-first
+        invoke test-end2end --long-timeouts --exit-first --headless
 
   build:
     name: E2E - Windows
@@ -108,4 +108,4 @@ jobs:
 
     - name: Run end-to-end tasks
       run: |
-        invoke test-end2end --long-timeouts --exit-first --shard=${{ matrix.shard }}
+        invoke test-end2end --long-timeouts --exit-first --shard=${{ matrix.shard }} --headless

--- a/tasks.py
+++ b/tasks.py
@@ -232,7 +232,7 @@ def test_end2end(
 
     focus_argument = f"-k {focus}" if focus is not None else ""
     exit_first_argument = "--exitfirst" if exit_first else ""
-    headless_argument = "--headless" if headless else ""
+    headless_argument = "--headless2" if headless else ""
 
     test_command = f"""
         pytest

--- a/tests/end2end/__init__.py
+++ b/tests/end2end/__init__.py
@@ -1,1 +1,1 @@
-# Dummy comment to trigger CI.
+# Dummy comment to trigger CI


### PR DESCRIPTION
Since version 112 chrome has a new [headless mode]( https://developer.chrome.com/docs/chromium/new-headless). By trial we found the old mode started to cause low and unchangeable window size on MacOS, which made some elements not clickable by Selenium. It's unclear what version bump exactly caused this behavior.

In new mode all elements are clickable. This change starts all e2e tests in new headless mode.

Chrome developers say regarding the new mode

> We intend to remove the old Headless from the Chrome binary and stop
> supporting this mode in Puppeteer in 2024.

seleniumbase `--headless` [means old mode](https://github.com/seleniumbase/SeleniumBase/blob/283c3db0228e30def2ca4f710d2d312a2bdae419/seleniumbase/core/browser_launcher.py#L3278) `chrome --headless=chrome`

seleniumbase `--headless2` [means new mode](https://github.com/seleniumbase/SeleniumBase/blob/283c3db0228e30def2ca4f710d2d312a2bdae419/seleniumbase/core/browser_launcher.py#L3276) `chrome --headless=new`

PS 1: I'd like to share the related debug story. One can use [lhotari/action-upterm](https://github.com/lhotari/action-upterm) to ssh into a running github workflow and capture browser screenshots as explained in commit a1c7750. One could probably go even a step further and start `chrome ---remote-debugging-port=0` and somehow tunnel it to a local `chrome://inspect` - but did not try that.

PS 2: @stanislaw suggested to fix tests by scrolling to elements before clicking them. This would be a sound approach, but I could not get seleniumbase `scroll_to()` working with StrictDoc modal form dialogs.