### PR TITLE
Mark more special HTML in templates as safe

### DIFF
--- a/strictdoc/export/html/templates/screens/document/_shared/toc.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/toc.jinja
@@ -33,7 +33,7 @@
               data-turbo="false"
             >
               <span class="section-number">
-                {{ section.context.title_number_string if section.context.title_number_string else "&nbsp;" * (section.ng_level * 2 - 1) }}
+                {{ section.context.title_number_string if section.context.title_number_string else "&nbsp;"|safe * (section.ng_level * 2 - 1) }}
               </span>{{- section.title -}}
               {# TODO #fragment #}
               {# {{ section.document_is_included() }} {{ section.parent_or_including_document.reserved_title }}/{{ section.get_document().reserved_title }} #}
@@ -47,7 +47,7 @@
           data-turbo="false"
         >
           <span class="section-number">
-            {{ section.context.title_number_string if section.context.title_number_string else "&nbsp;" * (section.ng_level * 2 - 1) }}
+            {{ section.context.title_number_string if section.context.title_number_string else "&nbsp;"|safe * (section.ng_level * 2 - 1) }}
           </span>
           {%- if section.reserved_title is not none -%}
             {{- section.reserved_title -}}

--- a/strictdoc/export/html/templates/screens/document/pdf/toc.jinja
+++ b/strictdoc/export/html/templates/screens/document/pdf/toc.jinja
@@ -10,7 +10,7 @@
       <div class="pdf-toc-row" data-nodeid="{{ item.reserved_mid }}">
 
           <span class="pdf-toc-cell">
-            {{ item.context.title_number_string if item.context.title_number_string else "&nbsp;" * (item.ng_level * 2 - 1) }}
+            {{ item.context.title_number_string if item.context.title_number_string else "&nbsp;"|safe * (item.ng_level * 2 - 1) }}
           </span>
           <span dotted class="pdf-toc-cell">
             <a href="#{{ view_object.render_local_anchor(item) }}" data-turbo="false">

--- a/strictdoc/export/html/templates/screens/git/node/requirement.jinja
+++ b/strictdoc/export/html/templates/screens/git/node/requirement.jinja
@@ -11,7 +11,7 @@
       {%- include "components/badge/index.jinja" -%}
     {%- endwith -%}
     <span>
-      {{ requirement.context.title_number_string if requirement.context.title_number_string else "&nbsp;" * (requirement.ng_level * 2 - 1) }}
+      {{ requirement.context.title_number_string if requirement.context.title_number_string else "&nbsp;"|safe * (requirement.ng_level * 2 - 1) }}
     </span>
     {%- if requirement.reserved_title is not none -%}
       <span>

--- a/strictdoc/export/html/templates/screens/git/node/section.jinja
+++ b/strictdoc/export/html/templates/screens/git/node/section.jinja
@@ -11,7 +11,7 @@
       {%- include "components/badge/index.jinja" -%}
     {%- endwith -%}
     <span>
-      {{ section.context.title_number_string if section.context.title_number_string else "&nbsp;" * (section.ng_level * 2 - 1) }}
+      {{ section.context.title_number_string if section.context.title_number_string else "&nbsp;"|safe * (section.ng_level * 2 - 1) }}
     </span>
     <span>{{ section.title }}</span>
     {%- if tab == "diff" -%}


### PR DESCRIPTION
There were some occurrences of `"&nbsp;" `in Python statements within Jinja2 templates. They must be marked as safe, otherwise they would be rendered to literal `&nbsp;` by auto escaping.

This happened in diff screen for any text node, and sections with `LEVEL: None`, as well as in TOCs for sections with `LEVEL: None`.

Relates to #1920.