### PR TITLE
tasks: remove assert on the path to chromedriver

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -329,19 +329,20 @@ def test_integration(
     # parallelizable, or at least not in the way StrictDoc uses it.
     # If HTML2PDF option is provided, do not parallelize and only run the
     # HTML2PDF-specific tests.
+    chromedriver_param = ""
     if not html2pdf:
         parallelize_opts = "" if not no_parallelization else "--threads 1"
         html2pdf_param = ""
-        chromedriver_param = ""
         test_folder = f"{cwd}/tests/integration"
     else:
         parallelize_opts = "--threads 1"
         html2pdf_param = "--param TEST_HTML2PDF=1"
         chromedriver_path = os.environ.get("CHROMEWEBDRIVER")
-        assert (
-            chromedriver_path is not None
-        ), "TEST_HTML2PDF expects path to chromedriver in environment variable CHROMEWEBDRIVER"
-        chromedriver_param = f"--param CHROMEDRIVER={os.path.join(chromedriver_path, 'chromedriver')}"
+        if chromedriver_path is not None:
+            # NOTE: isfile() check does not work on GitHub Actions / Linux,
+            #       the exists() check works.
+            assert os.path.exists(chromedriver_path), chromedriver_path
+            chromedriver_param = f"--param CHROMEDRIVER={os.path.join(chromedriver_path, 'chromedriver')}"
         test_folder = f"{cwd}/tests/integration/features/html2pdf"
 
     strictdoc_cache_dir = os.path.join(tempfile.gettempdir(), "strictdoc_cache")

--- a/tests/integration/lit.cfg
+++ b/tests/integration/lit.cfg
@@ -45,5 +45,4 @@ if "TEST_HTML2PDF" in lit_config.params:
     config.available_features.add('TEST_HTML2PDF')
     if "CHROMEDRIVER" in lit_config.params:
         chromedriver = lit_config.params['CHROMEDRIVER']
-        assert os.path.exists(chromedriver), chromedriver
         config.substitutions.append(('%chromedriver', chromedriver))

--- a/tests/integration/lit.cfg
+++ b/tests/integration/lit.cfg
@@ -41,8 +41,9 @@ if not lit_config.isWindows:
     config.available_features.add('PLATFORM_IS_NOT_WINDOWS')
 
 if "TEST_HTML2PDF" in lit_config.params:
-    chromedriver = lit_config.params['CHROMEDRIVER']
-    assert(chromedriver)
-    config.available_features.add('TEST_HTML2PDF')
-    config.substitutions.append(('%chromedriver', chromedriver))
     config.name = "StrictDoc HTML2PDF integration tests"
+    config.available_features.add('TEST_HTML2PDF')
+    if "CHROMEDRIVER" in lit_config.params:
+        chromedriver = lit_config.params['CHROMEDRIVER']
+        assert os.path.exists(chromedriver), chromedriver
+        config.substitutions.append(('%chromedriver', chromedriver))


### PR DESCRIPTION
This assert prevented me from running the --html2pdf itests locally because my environment doesn't have CHROMEDRIVER.