### PR TITLE
Prevent query failure when node is missing requested field

### DIFF
--- a/strictdoc/core/query_engine/query_object.py
+++ b/strictdoc/core/query_engine/query_object.py
@@ -208,11 +208,7 @@ class QueryObject:
             )
             grammar_field_titles = list(map(lambda f: f.title, element.fields))
             if field_name not in grammar_field_titles:
-                # These fields are used on the statistics screen but a user
-                # may have them disabled in the grammar.
-                if field_name in ("UID", "STATUS", "RATIONALE"):
-                    return None
-                raise AttributeError(f"No such requirement field: {field_name}")
+                return None
             field_value = requirement._get_cached_field(field_name, False)
             if field_value is not None:
                 return field_value


### PR DESCRIPTION
Returns failure instead of throwing exception when querying node fields that are not defined for all node types.

Problem Scenario:
Project contains documents with 'REQUIREMENT' nodes and custom element nodes
where the custom elements have a "RESULT" field not defined for "REQUIREMENTS"

The following query fails with "No such requirement field: RESULT", because requirement nodes do not have the "RESULT" field.
(not node.is_section and node["RESULT"] == "N/A" ) 
