### PR TITLE
Add 'TAG' as a supported fieldtype for requirement nodes

### DIFF
--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -92,6 +92,7 @@ class RequirementFormField:
             RequirementFieldType.STRING,
             RequirementFieldType.SINGLE_CHOICE,
             RequirementFieldType.MULTIPLE_CHOICE,
+            RequirementFieldType.TAG,
         ):
             return RequirementFormField(
                 field_mid=MID.create(),


### PR DESCRIPTION
From the manual, tag is supported for Requirement nodes:
https://strictdoc.readthedocs.io/en/stable/strictdoc_01_user_guide.html#id6

Problem:
grammar defines "TAG" field for a Requirement element:
  - TITLE: TAGS
    TYPE: Tag
    REQUIRED: False
    
Using the web, I get a NotImplementedError exception when trying to create a new requirement:
NotImplementedError: GrammarElementFieldTag(title = "TAGS", human_title = NoneType(...),

Resolved by adding the TAG field to RequirementFieldType

