### PR TITLE
backend/sdoc_source_code: make the default parser recognize @relation

### DIFF
--- a/strictdoc/backend/sdoc_source_code/grammar.py
+++ b/strictdoc/backend/sdoc_source_code/grammar.py
@@ -18,21 +18,36 @@ RangeMarker[noskipws]:
   // It is a hard-won result: it is important that the "@sdoc" is within the
   // regex. Putting it next to the regex as "@sdoc" does not work.
   // TODO: It would be great to check this with the TextX developers.
+  (
   /^.*?@sdoc/
   (begin_or_end = "[/" | begin_or_end = "[")
   (reqs_objs += Req[', ']) ']' '\n'?
+  )
+  |
+  (
+  /^.*?@relation/
+  '('
+  (reqs_objs += Req[', ']) ', scope=' scope=/(range_start|range_end)/ ')' '\n'?
+  )
 ;
 
 LineMarker[noskipws]:
   // It is a hard-won result: it is important that the "@sdoc" is within the
   // regex. Putting it next to the regex as "@sdoc" does not work.
   // TODO: It would be great to check this with the TextX developers.
+  (
   /^.*?@sdoc/
   "(" (reqs_objs += Req[', ']) ')' '\n'?
+  )
+  |
+  (
+  /^.*?@relation/
+  "(" (reqs_objs += Req[', ']) ', scope=line)' '\n'?
+  )
 ;
 
 Req[noskipws]:
-  uid = /[A-Za-z][A-Za-z0-9\\-]+/
+  uid = /(?!scope=)[A-Za-z][A-Za-z0-9\\-]+/
 ;
 
 SingleLineString[noskipws]:

--- a/strictdoc/backend/sdoc_source_code/models/range_marker.py
+++ b/strictdoc/backend/sdoc_source_code/models/range_marker.py
@@ -7,10 +7,24 @@ from strictdoc.helpers.auto_described import auto_described
 
 @auto_described
 class RangeMarker:
-    def __init__(self, parent: Any, begin_or_end: str, reqs_objs: List[Req]):
+    def __init__(
+        self,
+        parent: Any,
+        begin_or_end: str,
+        reqs_objs: List[Req],
+        scope: str = "",
+    ):
         assert isinstance(reqs_objs, list)
         self.parent: Any = parent
-        self.begin_or_end: str = begin_or_end
+        assert len(begin_or_end) > 0 or scope is not None
+
+        self.begin_or_end: str
+        if len(begin_or_end) > 0:
+            self.begin_or_end = begin_or_end
+        else:
+            assert scope in ("range_start", "range_end")
+            self.begin_or_end = "[" if scope == "range_start" else "[/"
+
         self.reqs_objs: List[Req] = reqs_objs
         self.reqs: List[str] = list(map(lambda req: req.uid, reqs_objs))
 

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_dsl_source_file_syntax.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_dsl_source_file_syntax.py
@@ -18,21 +18,30 @@ CONTENT 3
 # @sdoc[/REQ-001]
 """.lstrip()
 
-    reader = SourceFileTraceabilityReader()
+    source_input_new_syntax = """
+    # @relation(REQ-001, scope=range_start)
+    CONTENT 1
+    CONTENT 2
+    CONTENT 3
+    # @relation(REQ-001, scope=range_end)
+    """.lstrip()
 
-    document = reader.read(source_input)
-    markers = document.markers
-    assert markers[0].reqs == ["REQ-001"]
-    assert markers[0].begin_or_end == "["
-    assert markers[0].ng_source_line_begin == 1
-    assert markers[0].ng_range_line_begin == 1
-    assert markers[0].ng_range_line_end == 5
+    for source_input_ in [source_input, source_input_new_syntax]:
+        reader = SourceFileTraceabilityReader()
 
-    assert markers[1].reqs == ["REQ-001"]
-    assert markers[1].begin_or_end == "[/"
-    assert markers[1].ng_source_line_begin == 5
-    assert markers[1].ng_range_line_begin == 1
-    assert markers[1].ng_range_line_end == 5
+        document = reader.read(source_input_)
+        markers = document.markers
+        assert markers[0].reqs == ["REQ-001"]
+        assert markers[0].begin_or_end == "["
+        assert markers[0].ng_source_line_begin == 1
+        assert markers[0].ng_range_line_begin == 1
+        assert markers[0].ng_range_line_end == 5
+
+        assert markers[1].reqs == ["REQ-001"]
+        assert markers[1].begin_or_end == "[/"
+        assert markers[1].ng_source_line_begin == 5
+        assert markers[1].ng_range_line_begin == 1
+        assert markers[1].ng_range_line_end == 5
 
 
 def test_002_two_range_markers():
@@ -325,22 +334,32 @@ CONTENT 2
 CONTENT 3
 """.lstrip()
 
-    reader = SourceFileTraceabilityReader()
+    source_input_new_syntax = """
+    # @relation(REQ-001, scope=line)
+    CONTENT 1
+    # @relation(REQ-002, scope=line)
+    CONTENT 2
+    # @relation(REQ-003, scope=line)
+    CONTENT 3
+    """.lstrip()
 
-    document = reader.read(source_input)
-    markers = document.markers
-    assert markers[0].reqs == ["REQ-001"]
-    assert markers[0].ng_source_line_begin == 1
-    assert markers[0].ng_range_line_begin == 1
-    assert markers[0].ng_range_line_end == 1
-    assert markers[1].reqs == ["REQ-002"]
-    assert markers[1].ng_source_line_begin == 3
-    assert markers[1].ng_range_line_begin == 3
-    assert markers[1].ng_range_line_end == 3
-    assert markers[2].reqs == ["REQ-003"]
-    assert markers[2].ng_source_line_begin == 5
-    assert markers[2].ng_range_line_begin == 5
-    assert markers[2].ng_range_line_end == 5
+    for source_input_ in [source_input, source_input_new_syntax]:
+        reader = SourceFileTraceabilityReader()
+
+        document = reader.read(source_input_)
+        markers = document.markers
+        assert markers[0].reqs == ["REQ-001"]
+        assert markers[0].ng_source_line_begin == 1
+        assert markers[0].ng_range_line_begin == 1
+        assert markers[0].ng_range_line_end == 1
+        assert markers[1].reqs == ["REQ-002"]
+        assert markers[1].ng_source_line_begin == 3
+        assert markers[1].ng_range_line_begin == 3
+        assert markers[1].ng_range_line_end == 3
+        assert markers[2].reqs == ["REQ-003"]
+        assert markers[2].ng_source_line_begin == 5
+        assert markers[2].ng_range_line_begin == 5
+        assert markers[2].ng_range_line_end == 5
 
 
 def test_validation_01_one_range_marker_begin_req_not_equal_to_end_req():


### PR DESCRIPTION
The change is backwards-compatible.