### PR TITLE
doxygen: Change compound type and file suffix

### DIFF
--- a/strictdoc/export/doxygen/doxygen_generator.py
+++ b/strictdoc/export/doxygen/doxygen_generator.py
@@ -20,7 +20,7 @@ class DoxygenGenerator:
         path_to_output_dir: str,
     ) -> None:
         Path(path_to_output_dir).mkdir(parents=True, exist_ok=True)
-        output_path = os.path.join(path_to_output_dir, "strictdoc.xml")
+        output_path = os.path.join(path_to_output_dir, "strictdoc.tag")
 
         link_renderer = LinkRenderer(
             root_path="NOT_RELEVANT", static_path="NOT_RELEVANT"
@@ -28,7 +28,7 @@ class DoxygenGenerator:
 
         def template_node(node_uid: str, path_to_html: str) -> str:
             return f"""\
-  <compound kind="page">
+  <compound kind="file">
     <name>{node_uid}</name>
     <filename>html/{path_to_html}</filename>
   </compound>

--- a/tests/integration/features/doxygen/01_basic_export/strictdoc.tag
+++ b/tests/integration/features/doxygen/01_basic_export/strictdoc.tag
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
 <tagfile doxygen_version="1.9.8">
-  <compound kind="page">
+  <compound kind="file">
     <name>REQ-1</name>
     <filename>html/01_basic_export/input1.html#1-REQ-1</filename>
   </compound>
-  <compound kind="page">
+  <compound kind="file">
     <name>REQ-2</name>
     <filename>html/01_basic_export/folder/input2.html#1-REQ-2</filename>
   </compound>
-  <compound kind="page">
+  <compound kind="file">
     <name>REQ-3</name>
     <filename>html/01_basic_export/folder/subfolder/input3.html#1-REQ-3</filename>
   </compound>

--- a/tests/integration/features/doxygen/01_basic_export/test.itest
+++ b/tests/integration/features/doxygen/01_basic_export/test.itest
@@ -1,4 +1,4 @@
 RUN: %strictdoc export %S --formats doxygen --output-dir Output | filecheck %s --dump-input=fail
 CHECK: Step 'Export SDoc' took: {{.*}} sec.
 
-RUN: %diff %S/strictdoc.xml %S/Output/doxygen/strictdoc.xml
+RUN: %diff %S/strictdoc.tag %S/Output/doxygen/strictdoc.tag


### PR DESCRIPTION
Change compound type from page to file to prevent that all tags end up in the doxygen TOC. 
Change export file suffix from .xml to .tag.