### PR TITLE
marker_parser: Add support for curly braces

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -2299,7 +2299,7 @@ TITLE: Linking source code to requirements
 [TEXT]
 MID: c787c538cc0a422fb2898b525ec1006d
 STATEMENT: >>>
-To connect a source file to a requirement, a dedicated ``@relation`` marker must be added to the source file. Several marker types are supported, depending on the programming language. For example, the ``scope=class`` option is available for Python files but not for C files, as C does not support classes.
+To connect a source file to a requirement, a dedicated ``@relation`` marker must be added to the source file. Several marker types are supported, depending on the programming language. For example, the ``scope=class`` option is available for Python files but not for C files, as C does not support classes. The marker supports both () and {} for arguments.
 
 .. note::
 

--- a/strictdoc/backend/sdoc_source_code/marker_parser.py
+++ b/strictdoc/backend/sdoc_source_code/marker_parser.py
@@ -12,7 +12,9 @@ from strictdoc.backend.sdoc_source_code.models.requirement_marker import Req
 
 REGEX_REQ = r"[A-Za-z][A-Za-z0-9\\-]+"
 # @relation(REQ-1, scope=function) or @relation{REQ-1, scope=function}
-REGEX_MARKER = rf"@relation(\(|{{)({REGEX_REQ}(?:, {REGEX_REQ})*)\, scope=(file|class|function|line|range_start|range_end)(\)|}})"
+REGEX_MARKER = re.compile(
+    rf"@relation[({{]({REGEX_REQ}(?:, {REGEX_REQ})*), scope=(file|class|function|line|range_start|range_end)[)}}]"
+)
 
 
 class MarkerParser:
@@ -29,13 +31,13 @@ class MarkerParser:
         for input_line_idx_, input_line_ in enumerate(
             input_string.splitlines()
         ):
-            match = re.search(REGEX_MARKER, input_line_)
+            match = REGEX_MARKER.search(input_line_)
             if match is None:
                 continue
 
             assert match.lastindex is not None
-            marker_type = match.group(3)
-            req_list = match.group(2)
+            marker_type = match.group(match.lastindex)
+            req_list = match.group(1)
 
             first_requirement_index = match.start(1)
 

--- a/strictdoc/backend/sdoc_source_code/marker_parser.py
+++ b/strictdoc/backend/sdoc_source_code/marker_parser.py
@@ -11,8 +11,8 @@ from strictdoc.backend.sdoc_source_code.models.range_marker import (
 from strictdoc.backend.sdoc_source_code.models.requirement_marker import Req
 
 REGEX_REQ = r"[A-Za-z][A-Za-z0-9\\-]+"
-# @relation(REQ-1, scope=function)
-REGEX_MARKER = rf"@relation\(({REGEX_REQ}(?:, {REGEX_REQ})*)\, scope=(file|class|function|line|range_start|range_end)\)"
+# @relation(REQ-1, scope=function) or @relation{REQ-1, scope=function}
+REGEX_MARKER = rf"@relation(\(|{{)({REGEX_REQ}(?:, {REGEX_REQ})*)\, scope=(file|class|function|line|range_start|range_end)(\)|}})"
 
 
 class MarkerParser:
@@ -34,8 +34,8 @@ class MarkerParser:
                 continue
 
             assert match.lastindex is not None
-            marker_type = match.group(match.lastindex)
-            req_list = match.group(1)
+            marker_type = match.group(3)
+            req_list = match.group(2)
 
             first_requirement_index = match.start(1)
 

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
@@ -102,3 +102,23 @@ def test_05_():
     assert function_range.ng_range_line_end == 6
     assert function_range.reqs_objs[0].ng_source_line == 4
     assert function_range.reqs_objs[0].ng_source_column == 14
+
+
+def test_06_():
+    input_string = """\
+/**
+ * Some text.
+ *
+ * @relation{REQ-1, scope=function}
+ */
+"""
+
+    function_ranges = MarkerParser.parse(input_string, 1, 5, 1, 1)
+    function_range = function_ranges[0]
+
+    assert isinstance(function_range, FunctionRangeMarker)
+    assert function_range.ng_source_line_begin == 1
+    assert function_range.ng_range_line_begin == 1
+    assert function_range.ng_range_line_end == 5
+    assert function_range.reqs_objs[0].ng_source_line == 4
+    assert function_range.reqs_objs[0].ng_source_column == 14


### PR DESCRIPTION
Mainly to enable use of doxygen alias to generate a link to strictdoc html export via a tagfile export from strictdoc.