### PR TITLE
tests/end2end: helpers: ensure more reliable scrolling when moving grammar fields

### DIFF
--- a/tests/end2end/e2e_case.py
+++ b/tests/end2end/e2e_case.py
@@ -1,6 +1,7 @@
 from time import sleep
 
 from selenium.common import WebDriverException
+from selenium.webdriver.common.by import By
 from seleniumbase import BaseCase
 
 
@@ -65,3 +66,14 @@ class E2ECase(BaseCase):
             "const text = await navigator.clipboard.readText(); return text;"
         )
         return pasted_text
+
+    def sdoc_do_scroll_to_element_by_xpath(self, xpath: str) -> None:
+        assert isinstance(xpath, str), xpath
+        element = self.wait_for_element_visible(
+            xpath,
+            by=By.XPATH,
+        )
+        self.execute_script(
+            "arguments[0].scrollIntoView({behavior: 'instant', block: 'center'});",
+            element,
+        )

--- a/tests/end2end/helpers/form/form.py
+++ b/tests/end2end/helpers/form/form.py
@@ -2,15 +2,15 @@
 
 from selenium.webdriver import Keys
 from selenium.webdriver.common.by import By
-from seleniumbase import BaseCase
 
 from strictdoc.helpers.mid import MID
+from tests.end2end.e2e_case import E2ECase
 
 
 class Form:  # pylint: disable=invalid-name
-    def __init__(self, test_case: BaseCase) -> None:
-        assert isinstance(test_case, BaseCase)
-        self.test_case: BaseCase = test_case
+    def __init__(self, test_case: E2ECase) -> None:
+        assert isinstance(test_case, E2ECase)
+        self.test_case: E2ECase = test_case
 
     # Base
 

--- a/tests/end2end/helpers/screens/document/form_edit_grammar.py
+++ b/tests/end2end/helpers/screens/document/form_edit_grammar.py
@@ -1,15 +1,15 @@
 # pylint: disable=invalid-name
 
 from selenium.webdriver.common.by import By
-from seleniumbase import BaseCase
 
 from strictdoc.helpers.mid import MID
+from tests.end2end.e2e_case import E2ECase
 from tests.end2end.helpers.form.form import Form
 
 
 class Form_EditGrammar(Form):  # pylint: disable=invalid-name
-    def __init__(self, test_case: BaseCase) -> None:
-        assert isinstance(test_case, BaseCase)
+    def __init__(self, test_case: E2ECase) -> None:
+        assert isinstance(test_case, E2ECase), test_case
         super().__init__(test_case)
 
     def assert_on_grammar(self) -> None:
@@ -106,6 +106,9 @@ class Form_EditGrammar(Form):  # pylint: disable=invalid-name
 
     def do_move_grammar_field_up(self, mid: MID) -> None:
         assert isinstance(mid, MID)
+        # Without this, the driver does not scroll by itself, even though the
+        # click_xpath calls into scroll=True.
+        self.do_scroll_to_grammar_field(mid)
         self.test_case.click_xpath(
             f"(//*[@mid='{mid}' "
             "and "
@@ -114,10 +117,19 @@ class Form_EditGrammar(Form):  # pylint: disable=invalid-name
 
     def do_move_grammar_field_down(self, mid: MID) -> None:
         assert isinstance(mid, MID)
+        # Without this, the driver does not scroll by itself, even though the
+        # click_xpath calls into scroll=True.
+        self.do_scroll_to_grammar_field(mid)
         self.test_case.click_xpath(
             f"(//*[@mid='{mid}' "
             "and "
             "@data-testid='form-move-down-field-action-custom-field'])"
+        )
+
+    def do_scroll_to_grammar_field(self, mid: MID) -> None:
+        assert isinstance(mid, MID)
+        self.test_case.sdoc_do_scroll_to_element_by_xpath(
+            f"(//*[@mid='{mid}' and @data-testid='form-move-up-field-action-custom-field'])",
         )
 
     def do_delete_grammar_field(self, mid: MID) -> None:


### PR DESCRIPTION

This reduces the likelihood of flaky tests showing up.