### PR TITLE
Fixes #2062: Upgrade TextX 3.0 to 4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 
 # @sdoc[SDOC-SRS-89]
 dependencies = [
-    "textx >= 3.0.0, == 3.*",
+    "textx >= 4.0.0, == 4.*",
     "jinja2 >= 2.11.2",
     # Reading project config from strictdoc.toml file.
     "toml",


### PR DESCRIPTION
Fixes #2062. TextX used pkg_resources in the past, which is deprecated for Python >=3.12. They fixed it in commit 2e0ed15. Per TextX's release notes, this should be a safe upgrade for users of Python >= 3.8: https://github.com/textX/textX/releases/tag/4.0.0