### PR TITLE
Resolves #2065: Silence multiprocessing KeyboardInterrupt traceback

### DIFF
--- a/strictdoc/helpers/parallelizer.py
+++ b/strictdoc/helpers/parallelizer.py
@@ -116,11 +116,17 @@ class MultiprocessingParallelizer(Parallelizer):
         output_queue: "multiprocessing.Queue[Tuple[int, Any]]",
     ) -> None:
         while True:
-            content_idx, content, processing_func = input_queue.get(block=True)
-            result = processing_func(content)
-            sys.stdout.flush()
-            sys.stderr.flush()
-            output_queue.put((content_idx, result))
+            try:
+                content_idx, content, processing_func = input_queue.get(
+                    block=True
+                )
+                result = processing_func(content)
+                sys.stdout.flush()
+                sys.stderr.flush()
+                output_queue.put((content_idx, result))
+            except KeyboardInterrupt:
+                sys.stdout.flush()
+                sys.stderr.flush()
 
 
 class NullParallelizer(Parallelizer):


### PR DESCRIPTION
Previously when sending SIGINT to the server process, we would get tons of traceback output. This resolves #2065.

New output (compare to the linked issue):

```
INFO:     Started server process [3037336]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
ROOT: [3037270] KeyboardInterrupt - teardown started
ROOT: interrupt tox environment: py312-development
ROOT: requested interrupt of 3037286 from 3037270, activate in 0.00
ROOT: send signal SIGINT(2) to 3037286 from 3037270 with timeout 0.30
INFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [3037336]
INFO:     Stopping reloader process [3037286]
ROOT: interrupt finished with success
  py312-development: OK (4.96=setup[0.02]+cmd[0.06,4.88] seconds)
  congratulations :) (5.00 seconds)
```