### PR TITLE
Report search query error message on UI

### DIFF
--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -2657,8 +2657,8 @@ def create_main_router(
                 node_query = QueryObject(
                     query, export_action.traceability_index
                 )
-            except:
-                error = "error: Cannot parse query."
+            except Exception as e:
+                error = f"error: {e}"
 
         if node_query is not None:
             result = []

--- a/tests/end2end/helpers/screens/search/search.py
+++ b/tests/end2end/helpers/screens/search/search.py
@@ -1,3 +1,4 @@
+from selenium import webdriver
 from selenium.webdriver.common.by import By
 
 from tests.end2end.helpers.screens.screen import Screen
@@ -8,6 +9,11 @@ class Screen_SearchResults(Screen):  # pylint: disable=invalid-name
         self.test_case.click_xpath(
             '//a[@data-testid="node.is_requirement"]',
         )
+
+    def get_search_error_msg(self):
+        return self.test_case.find_element(
+            By.XPATH, "//div[@class='sdoc-form-error']"
+        ).text
 
     def assert_nr_results(self, nr_results: int):
         content = (
@@ -31,5 +37,16 @@ class Screen_Search(Screen):  # pylint: disable=invalid-name
     def do_click_on_search_sections(self) -> Screen_SearchResults:
         self.test_case.click_xpath(
             '//a[@data-testid="node.is_section"]',
+        )
+        return Screen_SearchResults(self.test_case)
+
+    def do_search(self, query) -> Screen_SearchResults:
+        textBox = self.test_case.driver.find_element(
+            By.XPATH, "//input[@id='q']"
+        )
+        textBox.clear()
+        textBox.send_keys(query)
+        self.test_case.click_xpath(
+            '//button[@data-testid="form-submit-action"]',
         )
         return Screen_SearchResults(self.test_case)

--- a/tests/end2end/screens/search/view_search_screen/test_case.py
+++ b/tests/end2end/screens/search/view_search_screen/test_case.py
@@ -14,12 +14,11 @@ path_to_this_test_file_folder = os.path.dirname(os.path.abspath(__file__))
 
 
 class Test(E2ECase):
-    def test(self):
+    def test_search_links(self):
         with SDocTestServer(
             input_path=path_to_this_test_file_folder
         ) as test_server:
             self.open(test_server.get_host_and_port())
-
             screen_project_index = Screen_ProjectIndex(self)
             screen_project_index.assert_on_screen()
             screen_project_index.assert_link_to_search_screen_present()
@@ -38,3 +37,40 @@ class Test(E2ECase):
 
             screen_search_results = screen_search.do_click_on_search_sections()
             screen_search_results.assert_text("Section title")
+
+    def test_empty_search(self):
+        with SDocTestServer(
+            input_path=path_to_this_test_file_folder
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+
+            screen_search: Screen_Search = (
+                screen_project_index.do_click_on_search_screen_link()
+            )
+            screen_search_results = screen_search.do_search(
+                """(node.is_requirement and node["STATEMENT"] == "NONE")"""
+            )
+
+            screen_search_results.assert_nr_results(0)
+
+    def test_invalid_search(self):
+        with SDocTestServer(
+            input_path=path_to_this_test_file_folder
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+
+            screen_search: Screen_Search = (
+                screen_project_index.do_click_on_search_screen_link()
+            )
+            screen_search_results = screen_search.do_search("""foo""")
+
+            self.assertRegex(
+                screen_search_results.get_search_error_msg(),
+                "error:.+Expected.+[*]foo",
+            )


### PR DESCRIPTION
Shows helpful error messages on the UI for failed search queries.

Before
![image](https://github.com/user-attachments/assets/53fc398e-5ea5-47a5-bd9c-4fb9345cd8bc)

After:
![image](https://github.com/user-attachments/assets/449c66ea-c95e-4cc5-b6c4-bb5034c98d88)
