### PR TITLE
UI: use UID as anchor when available

### DIFF
--- a/strictdoc/export/html/renderers/link_renderer.py
+++ b/strictdoc/export/html/renderers/link_renderer.py
@@ -49,11 +49,11 @@ class LinkRenderer:
         if isinstance(node, Anchor):
             return f"{self._string_to_link(node.value)}"
 
-        if node.reserved_uid and len(node.reserved_uid) > 0:
-            # uid is unique enough
-            local_anchor = f"{self._string_to_link(node.reserved_uid)}"
+        if node.reserved_uid is not None and len(node.reserved_uid) > 0:
+            # UID is unique enough.
+            local_anchor = self._string_to_link(node.reserved_uid)
         else:
-            # we need to provide some uniqueness
+            # If an element as no UID, provide some uniqueness.
             unique_prefix = node.context.title_number_string
             if isinstance(node, (SDocSection, SDocDocument)):
                 local_anchor = (

--- a/strictdoc/export/html/renderers/link_renderer.py
+++ b/strictdoc/export/html/renderers/link_renderer.py
@@ -49,26 +49,30 @@ class LinkRenderer:
         if isinstance(node, Anchor):
             return f"{self._string_to_link(node.value)}"
 
-        unique_prefix = node.context.title_number_string
-        if isinstance(node, (SDocSection, SDocDocument)):
-            local_anchor = f"{unique_prefix}-{self._string_to_link(node.title)}"
-        elif isinstance(node, SDocNode):
-            if node.reserved_uid and len(node.reserved_uid) > 0:
-                local_anchor = (
-                    f"{unique_prefix}-{self._string_to_link(node.reserved_uid)}"
-                )
-            elif (
-                node.reserved_title is not None and len(node.reserved_title) > 0
-            ):
-                local_anchor = (
-                    f"{unique_prefix}-"
-                    f"{self._string_to_link(node.reserved_title)}"
-                )
-            else:
-                # TODO: This is not reliable
-                local_anchor = str(id(node))
+        if node.reserved_uid and len(node.reserved_uid) > 0:
+            # uid is unique enough
+            local_anchor = f"{self._string_to_link(node.reserved_uid)}"
         else:
-            raise NotImplementedError
+            # we need to provide some uniqueness
+            unique_prefix = node.context.title_number_string
+            if isinstance(node, (SDocSection, SDocDocument)):
+                local_anchor = (
+                    f"{unique_prefix}-{self._string_to_link(node.title)}"
+                )
+            elif isinstance(node, SDocNode):
+                if (
+                    node.reserved_title is not None
+                    and len(node.reserved_title) > 0
+                ):
+                    local_anchor = (
+                        f"{unique_prefix}-"
+                        f"{self._string_to_link(node.reserved_title)}"
+                    )
+                else:
+                    # TODO: This is not reliable
+                    local_anchor = str(id(node))
+            else:
+                raise NotImplementedError
         self.local_anchor_cache[node] = local_anchor
         return local_anchor
 

--- a/tests/end2end/navigation/toc/toc_navigation/test_case.py
+++ b/tests/end2end/navigation/toc/toc_navigation/test_case.py
@@ -53,8 +53,8 @@ class Test(E2ECase):
             # *** where unique_prefix = node.context.title_number_string
 
             toc_section_without_uid_anchor = "1-Section-without-UID"
-            toc_section_with_uid_anchor = "2-Section-with-UID"
-            toc_requirement_with_title_anchor = "3-REQ_02"
+            toc_section_with_uid_anchor = "SECTION_01"
+            toc_requirement_with_title_anchor = "REQ_02"
 
             screen_toc.do_toc_go_to_anchor(toc_section_without_uid_anchor)
             screen_document.assert_target_by_anchor(

--- a/tests/end2end/screens/deep_traceability/view_document/view_document_go_from_requirement_card_to_requirement_in_document_view/test_case.py
+++ b/tests/end2end/screens/deep_traceability/view_document/view_document_go_from_requirement_card_to_requirement_in_document_view/test_case.py
@@ -43,6 +43,6 @@ class Test(E2ECase):
                 requirement.do_go_to_this_requirement_in_document_view()
             )
             screen_document_.assert_on_screen_document()
-            screen_document_.assert_target_by_anchor("1-REQ-001")
+            screen_document_.assert_target_by_anchor("REQ-001")
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/integration/features/doxygen/01_basic_export/strictdoc.tag
+++ b/tests/integration/features/doxygen/01_basic_export/strictdoc.tag
@@ -2,14 +2,14 @@
 <tagfile doxygen_version="1.9.8">
   <compound kind="file">
     <name>REQ-1</name>
-    <filename>html/01_basic_export/input1.html#1-REQ-1</filename>
+    <filename>html/01_basic_export/input1.html#REQ-1</filename>
   </compound>
   <compound kind="file">
     <name>REQ-2</name>
-    <filename>html/01_basic_export/folder/input2.html#1-REQ-2</filename>
+    <filename>html/01_basic_export/folder/input2.html#REQ-2</filename>
   </compound>
   <compound kind="file">
     <name>REQ-3</name>
-    <filename>html/01_basic_export/folder/subfolder/input3.html#1-REQ-3</filename>
+    <filename>html/01_basic_export/folder/subfolder/input3.html#REQ-3</filename>
   </compound>
 </tagfile>

--- a/tests/integration/features/file_traceability/01_basic_req_to_file_link_full_path/test.itest
+++ b/tests/integration/features/file_traceability/01_basic_req_to_file_link_full_path/test.itest
@@ -7,5 +7,5 @@ RUN: %cat %S/Output/html/01_basic_req_to_file_link_full_path/input.html | filech
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../01_basic_req_to_file_link_full_path/input.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../01_basic_req_to_file_link_full_path/input.html#REQ-001"{{.*}}>
 CHECK-SOURCE-FILE: <span class="c1"># noqa: T201</span></pre>

--- a/tests/integration/features/file_traceability/02_basic_req_to_file_link_cwd_dot/test.itest
+++ b/tests/integration/features/file_traceability/02_basic_req_to_file_link_cwd_dot/test.itest
@@ -8,4 +8,4 @@ CHECK-HTML: <link rel="stylesheet" href="../_static/base.css"/>
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../02_basic_req_to_file_link_cwd_dot/input.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../02_basic_req_to_file_link_cwd_dot/input.html#REQ-001"{{.*}}>

--- a/tests/integration/features/file_traceability/03_basic_req_to_file_link_range/test.itest
+++ b/tests/integration/features/file_traceability/03_basic_req_to_file_link_range/test.itest
@@ -9,7 +9,7 @@ CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#2#4">
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 
-CHECK-SOURCE-FILE: <a{{.*}}href="../03_basic_req_to_file_link_range/input.html#1-REQ-001">
+CHECK-SOURCE-FILE: <a{{.*}}href="../03_basic_req_to_file_link_range/input.html#REQ-001">
 
 CHECK-SOURCE-FILE: href="../_source_files/file.py.html#REQ-001#2#4"
 CHECK-SOURCE-FILE: <b>[ 2-4 ]</b>

--- a/tests/integration/features/file_traceability/04_input_is_single_file/test.itest
+++ b/tests/integration/features/file_traceability/04_input_is_single_file/test.itest
@@ -7,4 +7,4 @@ RUN: %cat %S/Output/html/04_input_is_single_file/input.html | filecheck %s --dum
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../04_input_is_single_file/input.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../04_input_is_single_file/input.html#REQ-001"{{.*}}>

--- a/tests/integration/features/file_traceability/05_multiple_files_per_requirement/test.itest
+++ b/tests/integration/features/file_traceability/05_multiple_files_per_requirement/test.itest
@@ -7,7 +7,7 @@ RUN: %cat %S/Output/html/05_multiple_files_per_requirement/input.html | filechec
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../05_multiple_files_per_requirement/input.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../05_multiple_files_per_requirement/input.html#REQ-001"{{.*}}>
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-NO-DUPLICATES
 RUN: %cat %S/Output/html/_source_files/file2.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-NO-DUPLICATES

--- a/tests/integration/features/file_traceability/07_utf8_symbols_in_source_files/test.itest
+++ b/tests/integration/features/file_traceability/07_utf8_symbols_in_source_files/test.itest
@@ -7,7 +7,7 @@ RUN: %cat %S/Output/html/07_utf8_symbols_in_source_files/input.html | filecheck 
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../07_utf8_symbols_in_source_files/input.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../07_utf8_symbols_in_source_files/input.html#REQ-001"{{.*}}>
 
 CHECK-SOURCE-FILE: # © A line with UTF-8 produces
 CHECK-SOURCE-FILE: # UnicodeDecodeError: &#39;ascii&#39; codec can&#39;t decode byte

--- a/tests/integration/features/file_traceability/11_paths_with_windows_backward_slashes/test.itest
+++ b/tests/integration/features/file_traceability/11_paths_with_windows_backward_slashes/test.itest
@@ -14,5 +14,5 @@ CHECK-HTML: <a{{.*}}href="../_source_files/subdir/file.py.html#REQ-001">
 CHECK-HTML: subdir/file.py
 
 RUN: %cat %S/Output/html/_source_files/subdir/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../../11_paths_with_windows_backward_slashes/input.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../../11_paths_with_windows_backward_slashes/input.html#REQ-001"{{.*}}>
 CHECK-SOURCE-FILE: subdir/file.py

--- a/tests/integration/features/file_traceability/12_basic_req_to_file_link_full_path/test.itest
+++ b/tests/integration/features/file_traceability/12_basic_req_to_file_link_full_path/test.itest
@@ -7,4 +7,4 @@ RUN: %cat %S/Output/html/12_basic_req_to_file_link_full_path/input.html | filech
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../12_basic_req_to_file_link_full_path/input.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../12_basic_req_to_file_link_full_path/input.html#REQ-001"{{.*}}>

--- a/tests/integration/features/file_traceability/13_file_link_to_a_file_with_empty_first_string/test.itest
+++ b/tests/integration/features/file_traceability/13_file_link_to_a_file_with_empty_first_string/test.itest
@@ -11,4 +11,4 @@ RUN: %cat %S/Output/html/13_file_link_to_a_file_with_empty_first_string/input.ht
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../13_file_link_to_a_file_with_empty_first_string/input.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../13_file_link_to_a_file_with_empty_first_string/input.html#REQ-001"{{.*}}>

--- a/tests/integration/features/file_traceability/19_no_newline_at_end_of_file/test.itest
+++ b/tests/integration/features/file_traceability/19_no_newline_at_end_of_file/test.itest
@@ -7,5 +7,5 @@ RUN: %cat %S/Output/html/19_no_newline_at_end_of_file/input.html | filecheck %s 
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../19_no_newline_at_end_of_file/input.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../19_no_newline_at_end_of_file/input.html#REQ-001"{{.*}}>
 CHECK-SOURCE-FILE: <pre class="highlight"><span class="mi">123123</span>  <span class="c1"># noqa: W292, B018</span></pre>

--- a/tests/integration/features/file_traceability/30_path_to_source_files_option/test.itest
+++ b/tests/integration/features/file_traceability/30_path_to_source_files_option/test.itest
@@ -7,5 +7,5 @@ RUN: %cat %S/Output/html/30_path_to_source_files_option/input.html | filecheck %
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../30_path_to_source_files_option/input.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../30_path_to_source_files_option/input.html#REQ-001"{{.*}}>
 CHECK-SOURCE-FILE: <span class="c1"># noqa: T201</span></pre>

--- a/tests/integration/features/file_traceability/31_relative_path_to_source_files_option/test.itest
+++ b/tests/integration/features/file_traceability/31_relative_path_to_source_files_option/test.itest
@@ -7,5 +7,5 @@ RUN: %cat %S/root/Output/html/root/input.html | filecheck %s --dump-input=fail -
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001">
 
 RUN: %cat %S/root/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../root/input.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../root/input.html#REQ-001"{{.*}}>
 CHECK-SOURCE-FILE: <span class="c1"># noqa: T201</span></pre>

--- a/tests/integration/features/file_traceability/60_file_range_with_line_range/test.itest
+++ b/tests/integration/features/file_traceability/60_file_range_with_line_range/test.itest
@@ -14,7 +14,7 @@ CHECK-HTML: <a{{.*}}href="../_source_files/file2.py.html#REQ-001#2#4">
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 
-CHECK-SOURCE-FILE: <a{{.*}}href="../60_file_range_with_line_range/input.html#1-REQ-001">
+CHECK-SOURCE-FILE: <a{{.*}}href="../60_file_range_with_line_range/input.html#REQ-001">
 
 CHECK-SOURCE-FILE: href="../_source_files/file.py.html#REQ-001#2#4"
 CHECK-SOURCE-FILE: <b>[ 2-4 ]</b> file.py

--- a/tests/integration/features/file_traceability/70_unregistered_file_extensions/test.itest
+++ b/tests/integration/features/file_traceability/70_unregistered_file_extensions/test.itest
@@ -10,7 +10,7 @@ CHECK-HTML: <a{{.*}}href="../_source_files/file.unknown_extension.html#REQ-001#2
 
 RUN: %cat %S/Output/html/_source_files/file.unknown_extension.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 
-CHECK-SOURCE-FILE: <a{{.*}}href="../70_unregistered_file_extensions/input.html#1-REQ-001">
+CHECK-SOURCE-FILE: <a{{.*}}href="../70_unregistered_file_extensions/input.html#REQ-001">
 
 CHECK-SOURCE-FILE: href="../_source_files/file.unknown_extension.html#REQ-001#2#4"
 CHECK-SOURCE-FILE: <b>[ 2-4 ]</b> file.unknown_extension

--- a/tests/integration/features/file_traceability/80_auto_finding_of_lexers/test.itest
+++ b/tests/integration/features/file_traceability/80_auto_finding_of_lexers/test.itest
@@ -13,7 +13,7 @@ RUN: %cat %S/Output/html/_source_files/file.ml.html | filecheck %s --check-prefi
 NOTE: Ensure that the lexer is recognized correctly.
 CHECK-SOURCE-FILE: OCaml
 
-CHECK-SOURCE-FILE: <a{{.*}}href="../80_auto_finding_of_lexers/input.html#1-REQ-001">
+CHECK-SOURCE-FILE: <a{{.*}}href="../80_auto_finding_of_lexers/input.html#REQ-001">
 CHECK-SOURCE-FILE: href="../_source_files/file.ml.html#REQ-001#3#5"
 CHECK-SOURCE-FILE: <b>[ 3-5 ]</b> file.ml
 

--- a/tests/integration/features/file_traceability/90_relation_keyword/test.itest
+++ b/tests/integration/features/file_traceability/90_relation_keyword/test.itest
@@ -9,7 +9,7 @@ CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#2#4">
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 
-CHECK-SOURCE-FILE: <a{{.*}}href="../90_relation_keyword/input.html#1-REQ-001">
+CHECK-SOURCE-FILE: <a{{.*}}href="../90_relation_keyword/input.html#REQ-001">
 
 CHECK-SOURCE-FILE: href="../_source_files/file.py.html#REQ-001#2#4"
 CHECK-SOURCE-FILE: <b>[ 2-4 ]</b>

--- a/tests/integration/features/file_traceability/_language_parsers/c/01_c_range/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/c/01_c_range/test.itest
@@ -8,7 +8,7 @@ RUN: %check_exists --file "%S/Output/html/_source_files/file.c.html"
 RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#2#4">
 RUN: %cat %S/Output/html/_source_files/file.c.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../{{.*}}/input.html#1-REQ-1"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../{{.*}}/input.html#REQ-1"{{.*}}>
 
 RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 60.0%

--- a/tests/integration/features/file_traceability/_language_parsers/cpp/01_cpp_class_function_declaration/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/cpp/01_cpp_class_function_declaration/test.itest
@@ -9,7 +9,7 @@ RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-inpu
 CHECK-HTML: <a{{.*}}href="../_source_files/file.hpp.html#REQ-1#4#5">
 
 RUN: %cat %S/Output/html/_source_files/file.hpp.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../{{.*}}/input.html#1-REQ-1"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../{{.*}}/input.html#REQ-1"{{.*}}>
 
 RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 33.3%

--- a/tests/integration/features/file_traceability/_language_parsers/cpp/02_cpp_class_function_declaration_and_definition/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/cpp/02_cpp_class_function_declaration_and_definition/test.itest
@@ -10,7 +10,7 @@ CHECK-HTML: <a{{.*}}href="../_source_files/file.cpp.html#REQ-1#1#3">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.hpp.html#REQ-1#4#5">
 
 RUN: %cat %S/Output/html/_source_files/file.hpp.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../{{.*}}/input.html#1-REQ-1"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../{{.*}}/input.html#REQ-1"{{.*}}>
 
 RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 33.3%

--- a/tests/integration/features/file_traceability/_language_parsers/cpp/03_cpp_overloaded_constructors/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/cpp/03_cpp_overloaded_constructors/test.itest
@@ -14,7 +14,7 @@ CHECK-HTML: <a{{.*}}href="../_source_files/file.hpp.html#REQ-1#6#7">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.hpp.html#REQ-1#8#9">
 
 RUN: %cat %S/Output/html/_source_files/file.hpp.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../{{.*}}/input.html#1-REQ-1"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../{{.*}}/input.html#REQ-1"{{.*}}>
 
 RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 69.2%

--- a/tests/integration/features/file_traceability/_language_parsers/python/01_python_range/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/python/01_python_range/test.itest
@@ -9,7 +9,7 @@ RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-inpu
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#2#4">
 
 RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../{{.*}}/input.html#1-REQ-1"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../{{.*}}/input.html#REQ-1"{{.*}}>
 CHECK-SOURCE-FILE: href="../_source_files/file.py.html#REQ-1#2#4"
 CHECK-SOURCE-FILE: title="lines 2-4 in file file.py"
 CHECK-SOURCE-FILE: <b>[ 2-4 ]</b> file.py, range

--- a/tests/integration/features/file_traceability/g1_file_types/10_tex/test.itest
+++ b/tests/integration/features/file_traceability/g1_file_types/10_tex/test.itest
@@ -7,4 +7,4 @@ RUN: %cat %S/Output/html/10_tex/example.html | filecheck %s --dump-input=fail --
 CHECK-HTML: <a{{.*}}href="../_source_files/file.tex.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.tex.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../10_tex/example.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../10_tex/example.html#REQ-001"{{.*}}>

--- a/tests/integration/features/file_traceability/g1_file_types/20_jinja/test.itest
+++ b/tests/integration/features/file_traceability/g1_file_types/20_jinja/test.itest
@@ -8,7 +8,7 @@ CHECK-HTML: <a{{.*}}href="../_source_files/file.jinja2.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.jinja2.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 # Links to REQ-001, REQ-002, REQ-003 are correct.
-CHECK-SOURCE-FILE:{{.*}}href="../20_jinja/example.html#2-REQ-002"{{.*}}
-CHECK-SOURCE-FILE:{{.*}}href="../20_jinja/example.html#3-REQ-003"{{.*}}
+CHECK-SOURCE-FILE:{{.*}}href="../20_jinja/example.html#REQ-002"{{.*}}
+CHECK-SOURCE-FILE:{{.*}}href="../20_jinja/example.html#REQ-003"{{.*}}
 
-CHECK-SOURCE-FILE:{{.*}}href="../20_jinja/example.html#1-REQ-001"{{.*}}
+CHECK-SOURCE-FILE:{{.*}}href="../20_jinja/example.html#REQ-001"{{.*}}

--- a/tests/integration/features/file_traceability/g1_file_types/30_cc/test.itest
+++ b/tests/integration/features/file_traceability/g1_file_types/30_cc/test.itest
@@ -7,4 +7,4 @@ RUN: %cat %S/Output/html/30_cc/example.html | filecheck %s --dump-input=fail --c
 CHECK-HTML: <a{{.*}}href="../_source_files/file.cc.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.cc.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../30_cc/example.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../30_cc/example.html#REQ-001"{{.*}}>

--- a/tests/integration/features/file_traceability/g1_file_types/40_rst/test.itest
+++ b/tests/integration/features/file_traceability/g1_file_types/40_rst/test.itest
@@ -7,4 +7,4 @@ RUN: %cat %S/Output/html/40_rst/example.html | filecheck %s --dump-input=fail --
 CHECK-HTML: <a{{.*}}href="../_source_files/file.rst.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.rst.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../40_rst/example.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../40_rst/example.html#REQ-001"{{.*}}>

--- a/tests/integration/features/file_traceability/g1_file_types/50_js/test.itest
+++ b/tests/integration/features/file_traceability/g1_file_types/50_js/test.itest
@@ -7,4 +7,4 @@ RUN: %cat %S/Output/html/50_js/example.html | filecheck %s --dump-input=fail --c
 CHECK-HTML: <a{{.*}}href="../_source_files/file.js.html#REQ-001">
 
 RUN: %cat %S/Output/html/_source_files/file.js.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: <a{{.*}}href="../50_js/example.html#1-REQ-001"{{.*}}>
+CHECK-SOURCE-FILE: <a{{.*}}href="../50_js/example.html#REQ-001"{{.*}}>

--- a/tests/integration/features/html/markup/01_referencing_a_section_with_LINK/test.itest
+++ b/tests/integration/features/html/markup/01_referencing_a_section_with_LINK/test.itest
@@ -2,10 +2,10 @@ RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
 RUN: %cat %S/Output/html/01_referencing_a_section_with_LINK/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
-CHECK-HTML-DOC: <a href="../01_referencing_a_section_with_LINK/section.html#1-Referenced-section">{{.*}}Referenced section</a></p>
+CHECK-HTML-DOC: <a href="../01_referencing_a_section_with_LINK/section.html#SECTION">{{.*}}Referenced section</a></p>
 
 RUN: %cat %S/Output/html/01_referencing_a_section_with_LINK/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TABLE
-CHECK-HTML-TABLE: <a href="../01_referencing_a_section_with_LINK/section-TABLE.html#1-Referenced-section">{{.*}}Referenced section</a></p>
+CHECK-HTML-TABLE: <a href="../01_referencing_a_section_with_LINK/section-TABLE.html#SECTION">{{.*}}Referenced section</a></p>
 
 RUN: %cat %S/Output/html/01_referencing_a_section_with_LINK/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TRACE
-CHECK-HTML-TRACE: <a href="../01_referencing_a_section_with_LINK/section-TRACE.html#1-Referenced-section">{{.*}}Referenced section</a></p>
+CHECK-HTML-TRACE: <a href="../01_referencing_a_section_with_LINK/section-TRACE.html#SECTION">{{.*}}Referenced section</a></p>

--- a/tests/integration/features/html/markup/04_referencing_a_section_with_LINK_node/test.itest
+++ b/tests/integration/features/html/markup/04_referencing_a_section_with_LINK_node/test.itest
@@ -2,13 +2,13 @@ RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
 RUN: %cat %S/Output/html/04_referencing_a_section_with_LINK_node/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
-CHECK-HTML-DOC: <a href="../04_referencing_a_section_with_LINK_node/nodes.html#1-CUSTOM-1">{{.*}}Foo Bar</a></p>
-CHECK-HTML-DOC: <a href="../04_referencing_a_section_with_LINK_node/nodes.html#-CUSTOM-2">{{.*}}CUSTOM-2</a></p>
+CHECK-HTML-DOC: <a href="../04_referencing_a_section_with_LINK_node/nodes.html#CUSTOM-1">{{.*}}Foo Bar</a></p>
+CHECK-HTML-DOC: <a href="../04_referencing_a_section_with_LINK_node/nodes.html#CUSTOM-2">{{.*}}CUSTOM-2</a></p>
 
 RUN: %cat %S/Output/html/04_referencing_a_section_with_LINK_node/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TABLE
-CHECK-HTML-TABLE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TABLE.html#1-CUSTOM-1">{{.*}}Foo Bar</a></p>
-CHECK-HTML-TABLE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TABLE.html#-CUSTOM-2">{{.*}}CUSTOM-2</a></p>
+CHECK-HTML-TABLE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TABLE.html#CUSTOM-1">{{.*}}Foo Bar</a></p>
+CHECK-HTML-TABLE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TABLE.html#CUSTOM-2">{{.*}}CUSTOM-2</a></p>
 
 RUN: %cat %S/Output/html/04_referencing_a_section_with_LINK_node/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TRACE
-CHECK-HTML-TRACE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TRACE.html#1-CUSTOM-1">{{.*}}Foo Bar</a></p>
-CHECK-HTML-TRACE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TRACE.html#-CUSTOM-2">{{.*}}CUSTOM-2</a></p>
+CHECK-HTML-TRACE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TRACE.html#CUSTOM-1">{{.*}}Foo Bar</a></p>
+CHECK-HTML-TRACE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TRACE.html#CUSTOM-2">{{.*}}CUSTOM-2</a></p>

--- a/tests/integration/features/html/markup/10_node_LINK_references_a_section/test.itest
+++ b/tests/integration/features/html/markup/10_node_LINK_references_a_section/test.itest
@@ -4,12 +4,12 @@ CHECK: Published: Hello world doc
 RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
 
 # [LINK: ...] is used 6 times in the doc.
-CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#1-Referenced-section">🔗&nbsp;Referenced section</a>
-CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#1-Referenced-section">🔗&nbsp;Referenced section</a>
-CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#1-Referenced-section">🔗&nbsp;Referenced section</a>
-CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#1-Referenced-section">🔗&nbsp;Referenced section</a>
-CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#1-Referenced-section">🔗&nbsp;Referenced section</a>
-CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#1-Referenced-section">🔗&nbsp;Referenced section</a>
+CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#SECTION">🔗&nbsp;Referenced section</a>
+CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#SECTION">🔗&nbsp;Referenced section</a>
+CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#SECTION">🔗&nbsp;Referenced section</a>
+CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#SECTION">🔗&nbsp;Referenced section</a>
+CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#SECTION">🔗&nbsp;Referenced section</a>
+CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#SECTION">🔗&nbsp;Referenced section</a>
 
 # The referenced section shall have 6 incoming links.
 RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/section.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC-REFERENCED-SECTION
@@ -23,7 +23,7 @@ CHECK-HTML-DOC-REFERENCED-SECTION: <a href="../10_node_LINK_references_a_section
 CHECK-HTML-DOC-REFERENCED-SECTION: <a href="../10_node_LINK_references_a_section/input.html#{{.*}}">
 
 RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TABLE
-CHECK-HTML-TABLE: <a href="../10_node_LINK_references_a_section/section-TABLE.html#1-Referenced-section">{{.*}}Referenced section</a></p>
+CHECK-HTML-TABLE: <a href="../10_node_LINK_references_a_section/section-TABLE.html#SECTION">{{.*}}Referenced section</a></p>
 
 RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TRACE
-CHECK-HTML-TRACE: <a href="../10_node_LINK_references_a_section/section-TRACE.html#1-Referenced-section">{{.*}}Referenced section</a></p>
+CHECK-HTML-TRACE: <a href="../10_node_LINK_references_a_section/section-TRACE.html#SECTION">{{.*}}Referenced section</a></p>

--- a/tests/integration/features/html2pdf/05_generate_bundle_document/test.itest
+++ b/tests/integration/features/html2pdf/05_generate_bundle_document/test.itest
@@ -13,7 +13,7 @@ RUN: %check_exists --file %S/Output/html2pdf/html/%THIS_TEST_FOLDER/nested/subne
 
 RUN: %cat %S/Output/html2pdf/html/bundle.html | filecheck %s --check-prefix CHECK-DOC-HTML
 # This ensures that the link is resolved correctly.
-CHECK-DOC-HTML:<a href="#1.1-Section-1">🔗&nbsp;Section #1</a>
+CHECK-DOC-HTML:<a href="#SEC-1">🔗&nbsp;Section #1</a>
 
 # Git meta information.
 CHECK-DOC-HTML: {{.* \(Git branch: .*\)}}

--- a/tests/integration/features/options/options_per_section/LEVEL/02_level_is_None_for_requirements/test.itest
+++ b/tests/integration/features/options/options_per_section/LEVEL/02_level_is_None_for_requirements/test.itest
@@ -5,10 +5,10 @@ RUN: %cat %S/Output/html/02_level_is_None_for_requirements/input.html | filechec
 
 CHECK-HTML:href="#1-First-section-numbered"
 CHECK-HTML:href="#-Second-section-unnumbered"
-CHECK-HTML:href="#-REQ-001"
-CHECK-HTML:href="#-REQ-002"
+CHECK-HTML:href="#REQ-001"
+CHECK-HTML:href="#REQ-002"
 CHECK-HTML:href="#2-Second-section-numbered"
-CHECK-HTML:href="#2.1-REQ-003"
+CHECK-HTML:href="#REQ-003"
 
 
 CHECK-HTML:<sdoc-anchor

--- a/tests/integration/self_testing/commands/export/03_strictdoc_smoke_test_source_files/test.itest
+++ b/tests/integration/self_testing/commands/export/03_strictdoc_smoke_test_source_files/test.itest
@@ -27,5 +27,5 @@ CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/traceability_inde
 CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/tree_cycle_detector.py.html#SDOC-SRS-30"
 
 RUN: %cat "%S/Output/html/_source_files/strictdoc/core/tree_cycle_detector.py.html" | filecheck %s --check-prefix CHECK-TREE-CYCLE-DETECTOR
-CHECK-TREE-CYCLE-DETECTOR: href="../../../strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html#{{.*}}-SDOC-SRS-30"
+CHECK-TREE-CYCLE-DETECTOR: href="../../../strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html#SDOC-SRS-30"
 CHECK-TREE-CYCLE-DETECTOR: href="../../../_source_files/strictdoc/core/traceability_index_builder.py.html#SDOC-SRS-30

--- a/tests/integration/self_testing/commands/export/04_strictdoc_smoke_test_source_files_from_another_directory/test.itest
+++ b/tests/integration/self_testing/commands/export/04_strictdoc_smoke_test_source_files_from_another_directory/test.itest
@@ -18,5 +18,5 @@ CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/traceability_inde
 CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/tree_cycle_detector.py.html#SDOC-SRS-30"
 
 RUN: %cat "%S/Output/html/_source_files/strictdoc/core/tree_cycle_detector.py.html" | filecheck %s --check-prefix CHECK-TREE-CYCLE-DETECTOR
-CHECK-TREE-CYCLE-DETECTOR: href="../../../strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html#{{.*}}-SDOC-SRS-30"
+CHECK-TREE-CYCLE-DETECTOR: href="../../../strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html#SDOC-SRS-30"
 CHECK-TREE-CYCLE-DETECTOR: href="../../../_source_files/strictdoc/core/traceability_index_builder.py.html#SDOC-SRS-30


### PR DESCRIPTION
 to decouple inbound links to requirements from section numbering, should address #2070 