### PR TITLE
Dockerfile: use a shell script to create a host UID/GID-based container user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ FROM ubuntu:24.04
 RUN apt-get update && apt-get install -y \
     curl \
     git \
+    gosu \
     python3 \
     python3-pip \
     python3-venv \
@@ -25,15 +26,6 @@ RUN wget -q -O google-chrome.deb https://dl.google.com/linux/direct/google-chrom
     && apt-get update \
     && apt-get install -y ./google-chrome.deb \
     && rm google-chrome.deb
-
-# Create a new non-root user and group.
-# NOTE: It is important that a non-root user is used because otherwise the
-# Chrome Driver fails with: "User data directory is already in use"
-# https://github.com/SeleniumHQ/selenium/issues/15327#issuecomment-2688613182
-RUN groupadd -r strictdoc_user && useradd -r -m -g strictdoc_user strictdoc_user
-
-# Grant the new user sudo privileges.
-RUN echo "strictdoc_user ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/strictdoc_user
 
 # Create a virtual environment in the user's home directory.
 RUN python3 -m venv /opt/venv
@@ -55,9 +47,14 @@ RUN if [ "$STRICTDOC_SOURCE" = "pypi" ]; then \
     fi; \
     chmod -R 777 /opt/venv;
 
-USER strictdoc_user
+# Remove the default 'ubuntu' user.
+RUN userdel -r ubuntu 2>/dev/null || true
+
+# Allow updating the UID/GID dynamically at runtime
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 # Set the working directory to the user's home directory.
 WORKDIR /data
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# This custom entrypoint script is needed for creating a container user with
+# a host's UID/GUI which enables sharing of the files between the container
+# and the host.
+
+set -e
+
+# Ensure we have the environment variables
+if [ -z "$HOST_UID" ] || [ -z "$HOST_GID" ]; then
+    echo "HOST_UID and HOST_GID must be set!"
+    exit 1
+fi
+
+echo "strictdoc/docker: running a Docker container entrypoint."
+echo "strictdoc/docker: ensuring strictdoc user with UID=$HOST_UID and GID=$HOST_GID exists"
+
+# Check if a user with this UID already exists (e.g., "ubuntu")
+EXISTING_USER=$(getent passwd "$HOST_UID" | cut -d: -f1)
+
+if [ -n "$EXISTING_USER" ]; then
+    echo "error: strictdoc/docker: detected a wrong user: '$EXISTING_USER'. Ensure that any default users are removed from the Dockerfile. This entrypoint script is supposed to create a new user 'strictdoc'."
+    exit 1
+else
+    # Ensure the group exists.
+    EXISTING_GROUP=$(getent group "$HOST_GID" | cut -d: -f1)
+    if [ -z "$EXISTING_GROUP" ]; then
+        echo "strictdoc/docker: creating new group strictdoc with GID=$HOST_GID"
+        groupadd -g "$HOST_GID" strictdoc
+    else
+        echo "strictdoc/docker: group with GID=$HOST_GID already exists: $EXISTING_GROUP, reusing it."
+    fi
+
+    # Create the user.
+    echo "strictdoc/docker: creating new user strictdoc with UID=$HOST_UID"
+    useradd -m -u "$HOST_UID" -g "$HOST_GID" -s /bin/bash strictdoc
+
+    # Give the user root privileges. Useful for debugging.
+    echo "strictdoc ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/strictdoc
+fi
+
+echo "strictdoc/docker: show created user info:"
+id strictdoc
+
+# Run as the correct user. If no command is provided, run a shell.
+if [ $# -eq 0 ]; then
+    echo "strictdoc/docker: no command provided, opening an interactive shell."
+    exec gosu strictdoc /bin/bash
+else
+    # Otherwise, run the provided command.
+    exec gosu strictdoc "$@"
+fi


### PR DESCRIPTION
This done to implement the following constraints:

1) The Docker container runs a non-root user because otherwise
   Chrome/ChromeDriver are not happy as per this issue:
   https://github.com/SeleniumHQ/selenium/issues/15327

2) StrictDoc runs within a container and outputs artifacts that have the
   UID/GID of the host user.

The approaches that I could not make work:

1) Running with a default root user because of the permissions issue and
   Chrome raising an error about the environment.

2) Using `USER` inside the container and then running an image with `--user $(id
   -u):$(id -g)`. With this approach, the Chrome would not be happy
   because the container will be running from a user that does not have
   a proper home directory.

Maybe there are better solutions but the one with the entrypoint.sh seems to be good enough.