### PR TITLE
Support roles for file relations and markers

### DIFF
--- a/strictdoc/backend/sdoc/error_handling.py
+++ b/strictdoc/backend/sdoc/error_handling.py
@@ -1,5 +1,5 @@
 # mypy: disable-error-code="attr-defined,no-untyped-call,no-untyped-def,union-attr"
-from typing import Optional
+from typing import Optional, Union
 
 from textx import TextXSyntaxError
 
@@ -19,6 +19,15 @@ from strictdoc.backend.sdoc.models.node import (
     SDocNodeField,
 )
 from strictdoc.backend.sdoc.models.reference import Reference
+from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
+    ForwardFunctionRangeMarker,
+    FunctionRangeMarker,
+)
+from strictdoc.backend.sdoc_source_code.models.range_marker import (
+    ForwardRangeMarker,
+    LineMarker,
+    RangeMarker,
+)
 
 
 def get_textx_syntax_error_message(exception: TextXSyntaxError):
@@ -255,6 +264,28 @@ class StrictDocSemanticError(Exception):
             line=node.ng_line_start,
             col=node.ng_col_start,
             filename=path_to_sdoc_file,
+        )
+
+    @staticmethod
+    def invalid_marker_role(
+        node: SDocNode,
+        marker: Union[
+            ForwardFunctionRangeMarker,
+            FunctionRangeMarker,
+            LineMarker,
+            RangeMarker,
+            ForwardRangeMarker,
+        ],
+        path_to_src_file: str,
+    ):
+        role_and_type = marker.role if marker.role is not None else "Any"
+        return StrictDocSemanticError(
+            title=(f"File marker role is not registered: {role_and_type}."),
+            hint=f"Problematic requirement: {node.reserved_uid}.",
+            example=None,
+            line=marker.ng_source_line_begin,
+            col=marker.ng_source_column_begin,
+            filename=path_to_src_file,
         )
 
     @staticmethod

--- a/strictdoc/backend/sdoc/grammar/grammar_grammar.py
+++ b/strictdoc/backend/sdoc/grammar/grammar_grammar.py
@@ -39,6 +39,7 @@ GrammarElementRelationChild[noskipws]:
 
 GrammarElementRelationFile[noskipws]:
   '  - TYPE: ' relation_type='File' '\n'
+  ('    ROLE: ' relation_role=/.+/ '\n')?
 ;
 
 GrammarElementField[noskipws]:

--- a/strictdoc/backend/sdoc/grammar/type_system.py
+++ b/strictdoc/backend/sdoc/grammar/type_system.py
@@ -40,6 +40,7 @@ ChildReqReference[noskipws]:
 FileReference[noskipws]:
   // FileReference is an early, experimental feature. Do not use yet.
   '- TYPE: File' '\n'
+  ('  ROLE: ' role = /.+$/ '\n')?
   g_file_entry = FileEntry
 ;
 

--- a/strictdoc/backend/sdoc/models/document_grammar.py
+++ b/strictdoc/backend/sdoc/models/document_grammar.py
@@ -35,6 +35,7 @@ def create_default_relations(
         GrammarElementRelationFile(
             parent=parent,
             relation_type="File",
+            relation_role=None,
         ),
     ]
 

--- a/strictdoc/backend/sdoc/models/reference.py
+++ b/strictdoc/backend/sdoc/models/reference.py
@@ -19,10 +19,14 @@ class Reference:
 
 @auto_described
 class FileReference(Reference):
-    def __init__(self, parent, g_file_entry: FileEntry):
+    def __init__(
+        self, parent, g_file_entry: FileEntry, role: Optional[str] = None
+    ):
         super().__init__(ReferenceType.FILE, parent)
         self.g_file_entry: FileEntry = g_file_entry
-        self.role: Optional[str] = None
+        self.role: Optional[str] = (
+            role if role is not None and len(role) > 0 else None
+        )
         self.mid = MID.create()
 
     def get_posix_path(self) -> str:

--- a/strictdoc/backend/sdoc/models/type_system.py
+++ b/strictdoc/backend/sdoc/models/type_system.py
@@ -239,11 +239,17 @@ class GrammarElementRelationChild:
 
 @auto_described
 class GrammarElementRelationFile:
-    def __init__(self, parent, relation_type: str):
+    def __init__(
+        self, parent, relation_type: str, relation_role: Optional[str]
+    ):
         assert relation_type == "File"
         self.parent = parent
         self.relation_type = relation_type
-        self.relation_role: Optional[str] = None
+        self.relation_role: Optional[str] = (
+            relation_role
+            if relation_role is not None and len(relation_role) > 0
+            else None
+        )
         self.mid: MID = MID.create()
 
 

--- a/strictdoc/backend/sdoc_source_code/grammar.py
+++ b/strictdoc/backend/sdoc_source_code/grammar.py
@@ -1,4 +1,6 @@
-SOURCE_FILE_GRAMMAR = """
+REGEX_ROLE = r"[^)]+"
+
+SOURCE_FILE_GRAMMAR = f"""
 SourceFileTraceabilityInfo[noskipws]:
   g_parts += Part
 ;
@@ -27,13 +29,13 @@ RangeMarker[noskipws]:
   (
   /^.*?@relation/
   '('
-  (reqs_objs += Req[', ']) ', scope=' scope=/(range_start|range_end)/ ')' '\n'?
+  (reqs_objs += Req[', ']) ', scope=' scope=/(range_start|range_end)/ (", role=" role=/{REGEX_ROLE}/)? ')' '\n'?
   )
 ;
 
 FunctionRangeMarker[noskipws]:
   /^.*?@relation/
-  "(" (reqs_objs += Req[', ']) ', scope=' scope="file" ')' '\n'?
+  "(" (reqs_objs += Req[', ']) ', scope=' scope="file" (", role=" role=/{REGEX_ROLE}/)? ')' '\n'?
 ;
 
 LineMarker[noskipws]:
@@ -47,7 +49,7 @@ LineMarker[noskipws]:
   |
   (
   /^.*?@relation/
-  "(" (reqs_objs += Req[', ']) ', scope=line)' '\n'?
+  "(" (reqs_objs += Req[', ']) ', scope=line' (", role=" role=/{REGEX_ROLE}/)? ")" '\n'?
   )
 ;
 

--- a/strictdoc/backend/sdoc_source_code/models/function_range_marker.py
+++ b/strictdoc/backend/sdoc_source_code/models/function_range_marker.py
@@ -14,12 +14,17 @@ class RangeMarkerType(Enum):
 
 @auto_described
 class FunctionRangeMarker:
-    def __init__(self, parent, reqs_objs: List[Req], scope: str):
+    def __init__(
+        self, parent, reqs_objs: List[Req], scope: str, role: Optional[str]
+    ):
         assert isinstance(reqs_objs, list)
         assert isinstance(scope, str), scope
         self.parent = parent
         self.reqs_objs: List[Req] = reqs_objs
         self.reqs: List[str] = list(map(lambda req: req.uid, reqs_objs))
+        self.role: Optional[str] = (
+            role if role is not None and len(role) > 0 else None
+        )
 
         self.scope: RangeMarkerType = RangeMarkerType(scope)
 
@@ -67,5 +72,11 @@ class FunctionRangeMarker:
 
 @auto_described
 class ForwardFunctionRangeMarker(FunctionRangeMarker):
-    def __init__(self, parent, reqs_objs: List[Req], scope: str):
-        super().__init__(parent, reqs_objs, scope)
+    def __init__(
+        self,
+        parent,
+        reqs_objs: List[Req],
+        scope: str,
+        role: Optional[str] = None,
+    ):
+        super().__init__(parent, reqs_objs, scope, role)

--- a/strictdoc/backend/sdoc_source_code/models/range_marker.py
+++ b/strictdoc/backend/sdoc_source_code/models/range_marker.py
@@ -13,6 +13,7 @@ class RangeMarker:
         begin_or_end: str,
         reqs_objs: List[Req],
         scope: str = "",
+        role: Optional[str] = None,
     ):
         assert isinstance(reqs_objs, list)
         self.parent: Any = parent
@@ -28,6 +29,9 @@ class RangeMarker:
 
         self.reqs_objs: List[Req] = reqs_objs
         self.reqs: List[str] = list(map(lambda req: req.uid, reqs_objs))
+        self.role: Optional[str] = (
+            role if role is not None and len(role) > 0 else None
+        )
 
         # Line number of the marker in the source code.
         self.ng_source_line_begin: Optional[int] = None
@@ -65,11 +69,16 @@ class RangeMarker:
 
 @auto_described
 class LineMarker:
-    def __init__(self, parent: Any, reqs_objs: List[Req]) -> None:
+    def __init__(
+        self, parent: Any, reqs_objs: List[Req], role: Optional[str] = None
+    ) -> None:
         assert isinstance(reqs_objs, list)
         self.parent = parent
         self.reqs_objs = reqs_objs
         self.reqs = list(map(lambda req: req.uid, reqs_objs))
+        self.role: Optional[str] = (
+            role if role is not None and len(role) > 0 else None
+        )
 
         # Line number of the marker in the source code.
         self.ng_source_line_begin: Optional[int] = None
@@ -98,11 +107,16 @@ class LineMarker:
 
 @auto_described
 class ForwardRangeMarker:
-    def __init__(self, start_or_end: bool, reqs_objs: List):
+    def __init__(
+        self, start_or_end: bool, reqs_objs: List, role: Optional[str] = None
+    ):
         assert len(reqs_objs) > 0
         self.start_or_end: bool = start_or_end
 
         self.reqs_objs = reqs_objs
+        self.role: Optional[str] = (
+            role if role is not None and len(role) > 0 else None
+        )
 
         # Line number of the marker in the source code.
         self.ng_source_line_begin: Optional[int] = None

--- a/strictdoc/export/html/form_objects/grammar_element_form_object.py
+++ b/strictdoc/export/html/form_objects/grammar_element_form_object.py
@@ -348,6 +348,7 @@ class GrammarElementFormObject(ErrorObject):
                     GrammarElementRelationFile(
                         parent=None,
                         relation_type=relation.relation_type,
+                        relation_role=relation.relation_role,
                     )
                 )
             else:

--- a/strictdoc/export/html/templates/components/node_field/files/index.jinja
+++ b/strictdoc/export/html/templates/components/node_field/files/index.jinja
@@ -5,7 +5,7 @@
       <sdoc-requirement-field-label>files:</sdoc-requirement-field-label>
       <sdoc-requirement-field data-field-label="files">
         <ul class="requirement__link">
-          {%- for link, opt_ranges in requirement_file_links %}
+          {%- for link, fwd_role, opt_ranges in requirement_file_links %}
             {%- if opt_ranges -%}
               {%- for range in opt_ranges %}
                 <li>
@@ -16,6 +16,11 @@
                       , {{ description }}
                     {%- endif -%}
                     {# TODO optional relation role #}
+                    {% if range.role is not none %}
+                        <span class="requirement__type-tag">({{ range.role }})</span>
+                    {% elif fwd_role is not none %}
+                        <span class="requirement__type-tag">({{ fwd_role }})</span>
+                    {% endif %}
                   </a>
                 </li>
               {%- endfor -%}
@@ -23,7 +28,9 @@
               <li>
                 <a data-turbo="false" class="requirement__link-file" href="{{ view_object.link_renderer.render_source_file_link(sdoc_entity, link) }}#{{ sdoc_entity.reserved_uid }}">
                   {{ link }}
-                  {# TODO optional relation role #}
+                  {% if fwd_role is not none %}
+                      <span class="requirement__type-tag">({{ fwd_role }})</span>
+                  {% endif %}
                 </a>
               </li>
             {%- endif -%}

--- a/strictdoc/export/html/templates/screens/document/table/main.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/main.jinja
@@ -87,7 +87,7 @@
                     {%- if requirement_file_links %}
                       Source files:
                       <ul class="requirement__link">
-                        {%- for link, opt_ranges in requirement_file_links %}
+                        {%- for link, fwd_role_, opt_ranges in requirement_file_links %}
                           {%- if opt_ranges -%}
                             {%- for range in opt_ranges %}
                               <li>

--- a/strictdoc/export/html/templates/screens/source_file_view/requirement.jinja
+++ b/strictdoc/export/html/templates/screens/source_file_view/requirement.jinja
@@ -21,7 +21,7 @@
  {%- set requirement_file_links = view_object.traceability_index.get_requirement_file_links(requirement) %}
  {%- if requirement_file_links %}
   <ul class="requirement-tree_downward">
-  {%- for link, opt_ranges in requirement_file_links %}
+  {%- for link, fwd_role_, opt_ranges in requirement_file_links %}
     {%- assert link.__class__.__name__ == "str", "Expected str" -%}
 
     {%- set this_file_or_other = view_object.source_file.in_doctree_source_file_rel_path_posix == link -%}

--- a/strictdoc/export/html/templates/screens/traceability_matrix/file.jinja
+++ b/strictdoc/export/html/templates/screens/traceability_matrix/file.jinja
@@ -6,7 +6,7 @@
 {%- set requirement_file_links = view_object.traceability_index.get_requirement_file_links(requirement) %}
 {%- if requirement_file_links %}
 
-  {%- for link, opt_ranges in requirement_file_links %}
+  {%- for link, fwd_role_, opt_ranges in requirement_file_links %}
     {%- if opt_ranges -%}
       {%- for range in opt_ranges %}
           <div class="traceability_matrix__file" with_relation="file">

--- a/strictdoc/export/spdx/spdx_generator.py
+++ b/strictdoc/export/spdx/spdx_generator.py
@@ -314,7 +314,7 @@ class SPDXGenerator:
                     node_links = traceability_index.get_requirement_file_links(
                         node
                     )
-                    for node_link_path_, _ in node_links:
+                    for node_link_path_, _role, _range_markers in node_links:
                         if node_link_path_ in lookup_file_name_to_spdx_file:
                             continue
 

--- a/strictdoc/export/spdx/spdx_to_sdoc_converter.py
+++ b/strictdoc/export/spdx/spdx_to_sdoc_converter.py
@@ -504,6 +504,7 @@ class SPDXToSDocConverter:
                 GrammarElementRelationFile(
                     parent=None,
                     relation_type="File",
+                    relation_role=None,
                 ),
             ],
         )
@@ -565,6 +566,7 @@ class SPDXToSDocConverter:
                     GrammarElementRelationFile(
                         parent=None,
                         relation_type="File",
+                        relation_role=None,
                     ),
                 ],
             )

--- a/strictdoc/helpers/ordered_set.py
+++ b/strictdoc/helpers/ordered_set.py
@@ -49,4 +49,12 @@ class OrderedSet(t.MutableSet[T]):
         return f"<OrderedSet {self}>"
 
     def sort(self, key=None) -> None:
-        self._d = dict(sorted(self._d.items(), key=key))
+        key_wrapper: t.Optional[t.Callable[[t.Any], t.Any]]
+        if key:
+
+            def key_wrapper(item):
+                return key(item[0])
+        else:
+            key_wrapper = None
+
+        self._d = dict(sorted(self._d.items(), key=key_wrapper))

--- a/tests/integration/features/file_traceability/file_roles/01_relations_with_role/file.c
+++ b/tests/integration/features/file_traceability/file_roles/01_relations_with_role/file.c
@@ -1,0 +1,21 @@
+// @relation(REQ-001, scope=function, role=Implementation)
+extern int extfoo();
+
+int extfoo() {
+    return 0;
+}
+
+static void foo();
+
+int main() {
+    foo();  // @relation(REQ-001, scope=line, role=Implementation)
+    return 0;
+}
+
+// @relation(REQ-001, scope=function, role=Implementation)
+static void foo() {}
+
+// @relation(REQ-001, scope=range_start, role=Implementation)
+static void bar1() {}
+static void bar2() {}
+// @relation(REQ-001, scope=range_end)

--- a/tests/integration/features/file_traceability/file_roles/01_relations_with_role/file.py
+++ b/tests/integration/features/file_traceability/file_roles/01_relations_with_role/file.py
@@ -1,0 +1,22 @@
+class Foo:
+    """@relation(REQ-001, scope=class, role=Implementation)"""
+    pass
+
+
+def foo():
+    """@relation(REQ-001, scope=function, role=Implementation)"""
+    pass
+
+
+# @relation(REQ-001, scope=range_start, role=Implementation)
+def bar1():
+    pass
+
+
+def bar2():
+    pass
+# @relation(REQ-001, scope=range_end)
+
+
+if __name__ == "__main__":
+    pass  # @relation(REQ-001, scope=line, role=Implementation)

--- a/tests/integration/features/file_traceability/file_roles/01_relations_with_role/file.txt
+++ b/tests/integration/features/file_traceability/file_roles/01_relations_with_role/file.txt
@@ -1,0 +1,6 @@
+A generic line @relation(REQ-001, scope=line, role=Implementation)
+
+@relation(REQ-001, scope=range_start, role=Implementation)
+A generic
+line range
+@relation(REQ-001, scope=range_end)

--- a/tests/integration/features/file_traceability/file_roles/01_relations_with_role/input.sdoc
+++ b/tests/integration/features/file_traceability/file_roles/01_relations_with_role/input.sdoc
@@ -1,0 +1,32 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: MID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: File
+    ROLE: Implementation
+  - TYPE: File
+    ROLE: Test
+  - TYPE: File
+
+[REQUIREMENT]
+UID: REQ-001
+TITLE: Requirement Title 1
+STATEMENT: >>>
+Requirement with reverse relations from files.
+<<<

--- a/tests/integration/features/file_traceability/file_roles/01_relations_with_role/strictdoc.toml
+++ b/tests/integration/features/file_traceability/file_roles/01_relations_with_role/strictdoc.toml
@@ -1,0 +1,6 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+  "SOURCE_FILE_LANGUAGE_PARSERS",
+]

--- a/tests/integration/features/file_traceability/file_roles/01_relations_with_role/test.itest
+++ b/tests/integration/features/file_traceability/file_roles/01_relations_with_role/test.itest
@@ -1,0 +1,54 @@
+REQUIRES: PYTHON_39_OR_HIGHER
+
+RUN: %strictdoc export . --output-dir Output | filecheck %s --dump-input=fail
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%S/Output/html/_source_files/file.c.html"
+RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%S/Output/html/_source_files/file.txt.html"
+
+RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#1#2">
+CHECK-HTML: file.c, <i>lines: 1-2</i>, function extfoo
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#4#6">
+CHECK-HTML: file.c, <i>lines: 4-6</i>, function extfoo
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#11#11">
+CHECK-HTML: file.c, <i>lines: 11-11</i>, line
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#15#16">
+CHECK-HTML: file.c, <i>lines: 15-16</i>, function foo
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#18#21">
+CHECK-HTML: file.c, <i>lines: 18-21</i>, range
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#1#3">
+CHECK-HTML: file.py, <i>lines: 1-3</i>, class Foo
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#6#8">
+CHECK-HTML: file.py, <i>lines: 6-8</i>, function foo
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#11#18">
+CHECK-HTML: file.py, <i>lines: 11-18</i>, range
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#22#22">
+CHECK-HTML: file.py, <i>lines: 22-22</i>, line
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.txt.html#REQ-001#1#1">
+CHECK-HTML: file.txt, <i>lines: 1-1</i>, line
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.txt.html#REQ-001#3#6">
+CHECK-HTML: file.txt, <i>lines: 3-6</i>, range
+CHECK-HTML: <span{{.*}}">(Implementation)</span>

--- a/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/file.c
+++ b/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/file.c
@@ -1,0 +1,11 @@
+static void foo();
+
+int main() {
+    foo();
+    return 0;
+}
+
+static void foo() {}
+
+static void bar1() {}
+static void bar2() {}

--- a/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/file.py
+++ b/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/file.py
@@ -1,0 +1,18 @@
+class Foo:
+    pass
+
+
+def foo():
+    pass
+
+
+def bar1():
+    pass
+
+
+def bar2():
+    pass
+
+
+if __name__ == "__main__":
+    pass

--- a/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/file.txt
+++ b/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/file.txt
@@ -1,0 +1,2 @@
+A generic
+line range

--- a/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/input.sdoc
+++ b/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/input.sdoc
@@ -1,0 +1,63 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: MID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: File
+    ROLE: Implementation
+
+[REQUIREMENT]
+UID: REQ-001
+TITLE: Requirement Title 1
+STATEMENT: >>>
+Requirement with forward relations from files.
+<<<
+RELATIONS:
+- TYPE: File
+  ROLE: Implementation
+  VALUE: file.c
+- TYPE: File
+  ROLE: Implementation
+  VALUE: file.c
+  FUNCTION: foo
+- TYPE: File
+  ROLE: Implementation
+  VALUE: file.c
+  LINE_RANGE: 10, 11
+- TYPE: File
+  ROLE: Implementation
+  VALUE: file.py
+- TYPE: File
+  ROLE: Implementation
+  VALUE: file.py
+  FUNCTION: foo
+- TYPE: File
+  ROLE: Implementation
+  VALUE: file.py
+  CLASS: Foo
+- TYPE: File
+  ROLE: Implementation
+  VALUE: file.py
+  LINE_RANGE: 9, 14
+- TYPE: File
+  ROLE: Implementation
+  VALUE: file.txt
+- TYPE: File
+  ROLE: Implementation
+  VALUE: file.txt
+  LINE_RANGE: 1, 2

--- a/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/strictdoc.toml
+++ b/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/strictdoc.toml
@@ -1,0 +1,6 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+  "SOURCE_FILE_LANGUAGE_PARSERS",
+]

--- a/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/test.itest
+++ b/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/test.itest
@@ -1,0 +1,38 @@
+REQUIRES: PYTHON_39_OR_HIGHER
+
+RUN: %strictdoc export . --output-dir Output | filecheck %s --dump-input=fail
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%S/Output/html/_source_files/file.c.html"
+RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%S/Output/html/_source_files/file.txt.html"
+
+RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#1#1">
+CHECK-HTML: file.c, <i>lines: 1-1</i>, function foo
+CHECK-HTML: <span{{.*}}>(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#8#8">
+CHECK-HTML: file.c, <i>lines: 8-8</i>, function foo
+CHECK-HTML: <span{{.*}}>(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#10#11">
+CHECK-HTML: file.c, <i>lines: 10-11</i>, range
+CHECK-HTML: <span{{.*}}>(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#1#2">
+CHECK-HTML: file.py, <i>lines: 1-2</i>, class Foo
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#5#6">
+CHECK-HTML: file.py, <i>lines: 5-6</i>, function foo
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#9#14">
+CHECK-HTML: file.py, <i>lines: 9-14</i>, range
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.txt.html#REQ-001#1#2">
+CHECK-HTML: file.txt, <i>lines: 1-2</i>, range
+CHECK-HTML: <span{{.*}}">(Implementation)</span>


### PR DESCRIPTION
Some incomplete snippets of what will be possible.

Forward file relations with roles...
```
[REQUIREMENT]
UID: REQ-001
...
RELATIONS:
- TYPE: File
  ROLE: Implementation
  VALUE: foo.py
  FUNCTION: foo
```

and "backward" file relations with roles
```py
@pytest.mark.req("@relation(REQ-002, scope=line, role=Test)")
def test_some_function_of_req002():
    some_test_assertion()
```

See integration tests for more examples.

This is WIP. I created the MR anyway to enable discussions. Known TODOs:
- [x] Forward class relation not working. See also #2113.
- [x] ~Better strategy for multiple markers per SourceMarkerTuple needed.~ Will be done with #2099.
- [ ] I don't like the special handling of simple forward file references in map_reqs_uids_to_paths_with_role; we should better create dynamic markers for it, as already done for forward function/class/range relations.
- [x] Section "Resolve definitions to declarations (only applicable for C and C++)" in validate_and_resolve creates a marker without role. Have to understand the use case first to adapt this part.
- [x] 2 failing integrations tests with Python 3.8, something about calling `__init__()` with wrong args
- [ ] Role is only rendered in document view, not yet in "special views".
- [X] Let tests test, not just render. Note: Only input.html, but not source code html is checked, because #2099 will likely change the output (see "req badges").
- [ ] Only trivial test cases are provided; special cases and error handling missing.
- [ ] User Guide.

To execute test cases:
```
invoke test-integration --focus 01_relations_with_role
invoke test-integration --focus 02_forward_relations_with_role
```