### PR TITLE
WIP: Represent forward file reference as marker

### DIFF
--- a/strictdoc/backend/sdoc_source_code/models/range_marker.py
+++ b/strictdoc/backend/sdoc_source_code/models/range_marker.py
@@ -48,7 +48,7 @@ class RangeMarker:
         self.ng_range_line_begin: Optional[int] = None
         self.ng_range_line_end: Optional[int] = None
 
-        self.ng_is_nodoc = "nosdoc" in self.reqs
+        self.ng_is_nodoc: bool = "nosdoc" in self.reqs
         self.ng_new_relation_keyword = scope is not None and len(scope) > 0
 
     def is_begin(self) -> bool:
@@ -74,8 +74,8 @@ class LineMarker:
     ) -> None:
         assert isinstance(reqs_objs, list)
         self.parent = parent
-        self.reqs_objs = reqs_objs
-        self.reqs = list(map(lambda req: req.uid, reqs_objs))
+        self.reqs_objs: List[Req] = reqs_objs
+        self.reqs: List[str] = list(map(lambda req: req.uid, reqs_objs))
         self.role: Optional[str] = (
             role if role is not None and len(role) > 0 else None
         )
@@ -87,7 +87,7 @@ class LineMarker:
         self.ng_range_line_begin: Optional[int] = None
         self.ng_range_line_end: Optional[int] = None
 
-        self.ng_is_nodoc = "nosdoc" in self.reqs
+        self.ng_is_nodoc: bool = "nosdoc" in self.reqs
 
     def is_begin(self) -> bool:
         return True
@@ -113,7 +113,7 @@ class ForwardRangeMarker:
         assert len(reqs_objs) > 0
         self.start_or_end: bool = start_or_end
 
-        self.reqs_objs = reqs_objs
+        self.reqs_objs: List[str] = reqs_objs
         self.role: Optional[str] = (
             role if role is not None and len(role) > 0 else None
         )
@@ -124,7 +124,7 @@ class ForwardRangeMarker:
         self.ng_range_line_begin: Optional[int] = None
         self.ng_range_line_end: Optional[int] = None
 
-        self.ng_is_nodoc = False
+        self.ng_is_nodoc: bool = False
 
     def is_begin(self) -> bool:
         return self.start_or_end
@@ -140,3 +140,12 @@ class ForwardRangeMarker:
 
     def get_description(self) -> Optional[str]:
         return "range"
+
+
+@auto_described
+class ForwardFileMarker(ForwardRangeMarker):
+    def __init__(self, reqs_objs: List, role: Optional[str] = None):
+        super().__init__(True, reqs_objs, role)
+
+    def get_description(self) -> Optional[str]:
+        return "file"

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -16,6 +16,7 @@ from strictdoc.backend.sdoc_source_code.models.range_marker import (
     ForwardRangeMarker,
     LineMarker,
     RangeMarker,
+    ForwardFileMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.requirement_marker import Req
 from strictdoc.backend.sdoc_source_code.reader import (
@@ -33,10 +34,8 @@ class FileTraceabilityIndex:
         # "file.py" -> List[SDocNode]
         self.map_paths_to_reqs: Dict[str, OrderedSet[SDocNode]] = {}
 
-        # "REQ-001" -> {("file.py", "Implementation"), ...}
-        self.map_reqs_uids_to_paths_with_role: Dict[
-            str, OrderedSet[Tuple[str, Optional[str]]]
-        ] = {}
+        # "REQ-001" -> {"file.py", ...}
+        self.map_reqs_uids_to_paths: Dict[str, OrderedSet[str]] = {}
 
         # "file.py" -> SourceFileTraceabilityInfo
         self.map_paths_to_source_file_traceability_info: Dict[
@@ -83,25 +82,20 @@ class FileTraceabilityIndex:
 
     def get_requirement_file_links(
         self, requirement: SDocNode
-    ) -> List[Tuple[str, Optional[str], Optional[List[RangeMarker]]]]:
-        if (
-            requirement.reserved_uid
-            not in self.map_reqs_uids_to_paths_with_role
-        ):
+    ) -> List[Tuple[str, List[RangeMarker]]]:
+        if requirement.reserved_uid not in self.map_reqs_uids_to_paths:
             return []
 
-        matching_links_with_opt_ranges: List[
-            Tuple[str, Optional[str], Optional[List[RangeMarker]]]
-        ] = []
-        requirement_source_paths: OrderedSet[Tuple[str, Optional[str]]] = (
-            self.map_reqs_uids_to_paths_with_role[requirement.reserved_uid]
-        )
+        matching_links_with_markers: List[Tuple[str, List[RangeMarker]]] = []
+        requirement_source_paths: OrderedSet[str] = self.map_reqs_uids_to_paths[
+            requirement.reserved_uid
+        ]
 
         # Now that one requirement can have multiple File-relations to the same file.
         # This can be multiple FUNCTION: or RANGE: forward-relations.
         # To avoid duplication of results, visit each unique file link path only once.
         visited_file_links: Set[str] = set()
-        for requirement_source_path_, forward_role in requirement_source_paths:
+        for requirement_source_path_ in requirement_source_paths:
             if requirement_source_path_ in visited_file_links:
                 continue
             visited_file_links.add(requirement_source_path_)
@@ -119,15 +113,15 @@ class FileTraceabilityIndex:
                 requirement.reserved_uid
             )
             if not markers:
-                matching_links_with_opt_ranges.append(
-                    (requirement_source_path_, forward_role, None)
+                matching_links_with_markers.append(
+                    (requirement_source_path_, [])
                 )
                 continue
-            matching_links_with_opt_ranges.append(
-                (requirement_source_path_, forward_role, markers)
+            matching_links_with_markers.append(
+                (requirement_source_path_, markers)
             )
 
-        return matching_links_with_opt_ranges
+        return matching_links_with_markers
 
     def indexed_source_files(self) -> Iterator[SourceFile]:
         for _, sfti in self.map_paths_to_source_file_traceability_info.items():
@@ -297,9 +291,10 @@ class FileTraceabilityIndex:
                     file_posix_path, OrderedSet()
                 ).add(forward_requirement_)
 
-                self.map_reqs_uids_to_paths_with_role.setdefault(
+                assert forward_requirement_.reserved_uid is not None
+                self.map_reqs_uids_to_paths.setdefault(
                     forward_requirement_.reserved_uid, OrderedSet()
-                ).add((file_posix_path, relation_.role))
+                ).add(file_posix_path)
 
                 if file_reference.g_file_entry.function is not None:
                     one_file_function_name_to_reqs_uids = (
@@ -324,18 +319,52 @@ class FileTraceabilityIndex:
                         (forward_requirement_.reserved_uid, relation_.role)
                     )
                 elif file_reference.g_file_entry.line_range is not None:
-                    assert forward_requirement_.reserved_uid is not None
-                    path_range_with_role = (
-                        file_posix_path,
-                        file_reference.g_file_entry.line_range,
+                    line_range = file_reference.g_file_entry.line_range
+                    uid = forward_requirement_.reserved_uid
+                    source_file_info = (
+                        self.map_paths_to_source_file_traceability_info[
+                            file_posix_path
+                        ]
+                    )
+                    start_marker, end_marker = (
+                        self.forward_range_markers_from_range(
+                            line_range, uid, relation_.role
+                        )
+                    )
+                    source_file_info.ng_map_reqs_to_markers.setdefault(
+                        uid, []
+                    ).append(start_marker)
+                    source_file_info.markers.append(start_marker)
+                    source_file_info.markers.append(end_marker)
+                    self.map_reqs_uids_to_line_range_file_refs.setdefault(
+                        uid, []
+                    ).append((file_posix_path, line_range, relation_.role))
+                else:
+                    uid = forward_requirement_.reserved_uid
+                    source_file_info = (
+                        self.map_paths_to_source_file_traceability_info[
+                            file_posix_path
+                        ]
+                    )
+                    marker = self.forward_file_marker_from_file_info(
+                        source_file_info,
+                        uid,
                         relation_.role,
                     )
-                    self.map_reqs_uids_to_line_range_file_refs.setdefault(
+                    file_range = (
+                        marker.ng_range_line_begin,
+                        marker.ng_range_line_end,
+                    )
+                    source_file_info.ng_map_reqs_to_markers.setdefault(
                         forward_requirement_.reserved_uid, []
-                    ).append(path_range_with_role)
+                    ).append(marker)
+                    source_file_info.markers.append(marker)
+                    self.map_reqs_uids_to_line_range_file_refs.setdefault(
+                        uid, []
+                    ).append((file_posix_path, file_range, relation_.role))
 
         #
-        # STEP:
+        # STEP: Add markers for forward relations to functions and classes
         #
         for trace_info_ in self.trace_infos:
             source_file = assert_cast(trace_info_.source_file, SourceFile)
@@ -388,14 +417,9 @@ class FileTraceabilityIndex:
                             )
                         validated_requirement_uids.add(requirement_uid_)
 
-                    self.map_reqs_uids_to_paths_with_role.setdefault(
+                    self.map_reqs_uids_to_paths.setdefault(
                         requirement_uid_, OrderedSet()
-                    ).add(
-                        (
-                            source_file.in_doctree_source_file_rel_path_posix,
-                            marker_.role,
-                        )
-                    )
+                    ).add(source_file.in_doctree_source_file_rel_path_posix)
 
                     node_id = traceability_index.get_node_by_uid(
                         requirement_uid_
@@ -410,8 +434,8 @@ class FileTraceabilityIndex:
         for (
             requirement_uid,
             file_links,
-        ) in self.map_reqs_uids_to_paths_with_role.items():
-            for file_link, _forward_role in file_links:
+        ) in self.map_reqs_uids_to_paths.items():
+            for file_link in file_links:
                 source_file_traceability_info: Optional[
                     SourceFileTraceabilityInfo
                 ] = self.map_paths_to_source_file_traceability_info.get(
@@ -422,34 +446,6 @@ class FileTraceabilityIndex:
                         f"Requirement {requirement_uid} references a file"
                         f" that does not exist: {file_link}."
                     )
-
-        for (
-            requirement_uid_,
-            file_range_pairs_,
-        ) in self.map_reqs_uids_to_line_range_file_refs.items():
-            for file_range_pair_ in file_range_pairs_:
-                path_to_file = file_range_pair_[0]
-                file_range = file_range_pair_[1]
-                role = file_range_pair_[2]
-
-                source_file_info = (
-                    self.map_paths_to_source_file_traceability_info[
-                        path_to_file
-                    ]
-                )
-
-                start_marker, end_marker = (
-                    self.forward_range_markers_from_range(
-                        file_range, requirement_uid_, role
-                    )
-                )
-
-                source_file_info.ng_map_reqs_to_markers.setdefault(
-                    requirement_uid_, []
-                ).append(start_marker)
-
-                source_file_info.markers.append(start_marker)
-                source_file_info.markers.append(end_marker)
 
         #
         # Resolve definitions to declarations (only applicable for C and C++).
@@ -506,9 +502,9 @@ class FileTraceabilityIndex:
                                 path_to_info = reversed_trace_info[
                                     definition_function_trace_info
                                 ]
-                                self.map_reqs_uids_to_paths_with_role.setdefault(
+                                self.map_reqs_uids_to_paths.setdefault(
                                     req_uid_, OrderedSet()
-                                ).add((path_to_info, marker_.role))
+                                ).add(path_to_info)
 
                                 node = traceability_index.get_node_by_uid(
                                     req_uid_
@@ -602,12 +598,8 @@ class FileTraceabilityIndex:
                         )
 
         # Sort by paths alphabetically.
-        for paths_with_role in self.map_reqs_uids_to_paths_with_role.values():
-
-            def compare_pathrole_by_path(path_with_role):
-                return path_with_role[0]
-
-            paths_with_role.sort(key=compare_pathrole_by_path)
+        for paths_with_role in self.map_reqs_uids_to_paths.values():
+            paths_with_role.sort()
 
         # Sort by node UID alphabetically.
         for path_requirements_ in self.map_paths_to_reqs.values():
@@ -726,3 +718,18 @@ class FileTraceabilityIndex:
         end_marker.ng_range_line_end = file_range[1]
 
         return start_marker, end_marker
+
+    @staticmethod
+    def forward_file_marker_from_file_info(
+        file_info: SourceFileTraceabilityInfo,
+        requirement_uid_: str,
+        role: Optional[str],
+    ) -> ForwardFileMarker:
+        marker = ForwardFileMarker(
+            reqs_objs=[Req(parent=None, uid=requirement_uid_)],
+            role=role,
+        )
+        marker.ng_range_line_begin = 1
+        marker.ng_source_line_begin = 1
+        marker.ng_range_line_end = file_info.ng_lines_total
+        return marker

--- a/strictdoc/export/html/generators/source_file_view_generator.py
+++ b/strictdoc/export/html/generators/source_file_view_generator.py
@@ -25,6 +25,7 @@ from strictdoc.backend.sdoc_source_code.models.range_marker import (
     ForwardRangeMarker,
     LineMarker,
     RangeMarker,
+    ForwardFileMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.source_file_info import (
     SourceFileTraceabilityInfo,
@@ -229,6 +230,9 @@ class SourceFileViewHTMLGenerator:
         )
 
         for marker in coverage_info.markers:
+            # if isinstance(marker, ForwardFileMarker):
+            #    continue
+
             marker_line = marker.ng_source_line_begin
             assert isinstance(marker_line, int)
             pygmented_source_file_line = assert_cast(

--- a/strictdoc/export/html/templates/components/node_field/files/index.jinja
+++ b/strictdoc/export/html/templates/components/node_field/files/index.jinja
@@ -5,35 +5,21 @@
       <sdoc-requirement-field-label>files:</sdoc-requirement-field-label>
       <sdoc-requirement-field data-field-label="files">
         <ul class="requirement__link">
-          {%- for link, fwd_role, opt_ranges in requirement_file_links %}
-            {%- if opt_ranges -%}
-              {%- for range in opt_ranges %}
-                <li>
-                  <a data-turbo="false" class="requirement__link-file" href="{{ view_object.link_renderer.render_source_file_link(sdoc_entity, link) }}#{{ sdoc_entity.reserved_uid }}#{{ range.ng_range_line_begin }}#{{ range.ng_range_line_end }}">
-                    {{ link }}, <i>lines: {{ range.ng_range_line_begin }}-{{ range.ng_range_line_end }}</i>
-                    {%- set description = range.get_description() -%}
-                    {%- if description -%}
-                      , {{ description }}
-                    {%- endif -%}
-                    {# TODO optional relation role #}
-                    {% if range.role is not none %}
-                        <span class="requirement__type-tag">({{ range.role }})</span>
-                    {% elif fwd_role is not none %}
-                        <span class="requirement__type-tag">({{ fwd_role }})</span>
-                    {% endif %}
-                  </a>
-                </li>
-              {%- endfor -%}
-            {%- else -%}
+          {%- for link, markers in requirement_file_links %}
+            {%- for marker in markers %}
               <li>
-                <a data-turbo="false" class="requirement__link-file" href="{{ view_object.link_renderer.render_source_file_link(sdoc_entity, link) }}#{{ sdoc_entity.reserved_uid }}">
-                  {{ link }}
-                  {% if fwd_role is not none %}
-                      <span class="requirement__type-tag">({{ fwd_role }})</span>
+                <a data-turbo="false" class="requirement__link-file" href="{{ view_object.link_renderer.render_source_file_link(sdoc_entity, link) }}#{{ sdoc_entity.reserved_uid }}#{{ marker.ng_range_line_begin }}#{{ marker.ng_range_line_end }}">
+                  {{ link }}, <i>lines: {{ marker.ng_range_line_begin }}-{{ marker.ng_range_line_end }}</i>
+                  {%- set description = marker.get_description() -%}
+                  {%- if description -%}
+                    , {{ description }}
+                  {%- endif -%}
+                  {% if marker.role is not none %}
+                      <span class="requirement__type-tag">({{ marker.role }})</span>
                   {% endif %}
                 </a>
               </li>
-            {%- endif -%}
+            {%- endfor -%}
           {%- endfor -%}
         </ul>
       </sdoc-requirement-field>

--- a/strictdoc/export/html/templates/screens/document/table/main.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/main.jinja
@@ -87,24 +87,15 @@
                     {%- if requirement_file_links %}
                       Source files:
                       <ul class="requirement__link">
-                        {%- for link, fwd_role_, opt_ranges in requirement_file_links %}
-                          {%- if opt_ranges -%}
-                            {%- for range in opt_ranges %}
-                              <li>
-                                <a class="requirement__link-file"
-                                    href="{{ view_object.link_renderer.render_source_file_link(requirement, link) }}#{{ requirement.reserved_uid }}#{{ range.ng_range_line_begin }}#{{ range.ng_range_line_end }}">
-                                  {{ link }}, <i>lines: {{ range.ng_range_line_begin }}-{{ range.ng_range_line_end }}</i>
-                                </a>
-                              </li>
-                            {%- endfor -%}
-                          {%- else -%}
+                        {%- for link, markers in requirement_file_links %}
+                          {%- for marker in markers %}
                             <li>
                               <a class="requirement__link-file"
-                                  href="{{ view_object.link_renderer.render_source_file_link(requirement, link) }}#{{ requirement.reserved_uid }}">
-                                {{ link }}
+                                  href="{{ view_object.link_renderer.render_source_file_link(requirement, link) }}#{{ requirement.reserved_uid }}#{{ marker.ng_range_line_begin }}#{{ marker.ng_range_line_end }}">
+                                {{ link }}, <i>lines: {{ marker.ng_range_line_begin }}-{{ marker.ng_range_line_end }}</i>
                               </a>
                             </li>
-                          {%- endif -%}
+                          {%- endfor -%}
                         {%- endfor -%}
                       </ul>
                     {%- endif %}

--- a/strictdoc/export/html/templates/screens/source_file_view/requirement.jinja
+++ b/strictdoc/export/html/templates/screens/source_file_view/requirement.jinja
@@ -21,58 +21,36 @@
  {%- set requirement_file_links = view_object.traceability_index.get_requirement_file_links(requirement) %}
  {%- if requirement_file_links %}
   <ul class="requirement-tree_downward">
-  {%- for link, fwd_role_, opt_ranges in requirement_file_links %}
+  {%- for link, markers in requirement_file_links %}
     {%- assert link.__class__.__name__ == "str", "Expected str" -%}
 
     {%- set this_file_or_other = view_object.source_file.in_doctree_source_file_rel_path_posix == link -%}
     {%- set traceability_file_type = "this_file" if this_file_or_other else "other_file" -%}
 
-    {%- if opt_ranges -%}
-      {%- for range in opt_ranges %}
-        <li class="requirement-tree_downward_node">
-          <div class="requirement-tree_downward_item">
-          <a
-            class="pointer"
-            data-begin="{{ range.ng_range_line_begin }}"
-            data-end="{{ range.ng_range_line_end }}"
-            data-traceability-file-type="{{ traceability_file_type }}"
-            href="{{ view_object.link_renderer.render_requirement_in_source_file_range_link(requirement, link, view_object.source_file, range) }}"
-            title="lines {{ range.ng_range_line_begin }}-{{ range.ng_range_line_end }} in file {{ link }}"
-          >
-            {% if range.is_range_marker() %}
-            <b>[ {{ range.ng_range_line_begin }}-{{ range.ng_range_line_end }} ]</b> {{ link }}
-            {%- set description = range.get_description() -%}
-            {%- if description -%}
-              , {{ description }}
-            {%- endif -%}
-            {% elif range.is_line_marker() %}
-            <b>[ {{ range.ng_range_line_begin }} ]</b> {{ link }}, line
-            {% endif %}
-          </a>
-          </div>
-        </li>
-      {%- endfor -%}
-    {%- else -%}
-      {%- if this_file_or_other -%}
-        <li class="requirement-tree_downward_node">
-          <div class="requirement-tree_downward_item">
-          <span class="current_file_pseudolink">
-              {{ link }}
-            </span>
-          </div>
-        </li>
-
-        {%- else -%}
-
+    {%- for marker in markers %}
       <li class="requirement-tree_downward_node">
-          <div class="requirement-tree_downward_item">
-          <a href="{{ view_object.link_renderer.render_requirement_in_source_file_link(requirement, link, view_object.source_file) }}" >
-          {{ link }}
-          </a>
-          </div>
-        </li>
-    {%- endif -%}
-    {%- endif -%}
+        <div class="requirement-tree_downward_item">
+        <a
+          class="pointer"
+          data-begin="{{ marker.ng_range_line_begin }}"
+          data-end="{{ marker.ng_range_line_end }}"
+          data-traceability-file-type="{{ traceability_file_type }}"
+          href="{{ view_object.link_renderer.render_requirement_in_source_file_range_link(requirement, link, view_object.source_file, marker) }}"
+          title="lines {{ marker.ng_range_line_begin }}-{{ marker.ng_range_line_end }} in file {{ link }}"
+        >
+          {% if marker.is_range_marker() %}
+          <b>[ {{ marker.ng_range_line_begin }}-{{ marker.ng_range_line_end }} ]</b> {{ link }}
+          {%- set description = marker.get_description() -%}
+          {%- if description -%}
+            , {{ description }}
+          {%- endif -%}
+          {% elif marker.is_line_marker() %}
+          <b>[ {{ marker.ng_range_line_begin }} ]</b> {{ link }}, line
+          {% endif %}
+        </a>
+        </div>
+      </li>
+    {%- endfor -%}
   {%- endfor -%}
   </ul>
 {%- endif %}

--- a/strictdoc/export/html/templates/screens/traceability_matrix/file.jinja
+++ b/strictdoc/export/html/templates/screens/traceability_matrix/file.jinja
@@ -6,22 +6,14 @@
 {%- set requirement_file_links = view_object.traceability_index.get_requirement_file_links(requirement) %}
 {%- if requirement_file_links %}
 
-  {%- for link, fwd_role_, opt_ranges in requirement_file_links %}
-    {%- if opt_ranges -%}
-      {%- for range in opt_ranges %}
-          <div class="traceability_matrix__file" with_relation="file">
-            <a data-turbo="false" class="" href="{{ view_object.link_renderer.render_source_file_link_from_root(link) }}#{{ requirement.reserved_uid }}#{{ range.ng_range_line_begin }}#{{ range.ng_range_line_end }}">
-              <b>[ {{ range.ng_range_line_begin }}-{{ range.ng_range_line_end }} ]</b> {{ link }}
-            </a>
-          </div>
-      {%- endfor -%}
-    {%- else -%}
+  {%- for link, markers in requirement_file_links %}
+    {%- for marker in markers %}
         <div class="traceability_matrix__file" with_relation="file">
-          <a data-turbo="false" href="{{ view_object.link_renderer.render_source_file_link_from_root(link) }}#{{ requirement.reserved_uid }}">
-            {{ link }}
+          <a data-turbo="false" class="" href="{{ view_object.link_renderer.render_source_file_link_from_root(link) }}#{{ requirement.reserved_uid }}#{{ marker.ng_range_line_begin }}#{{ marker.ng_range_line_end }}">
+            <b>[ {{ marker.ng_range_line_begin }}-{{ marker.ng_range_line_end }} ]</b> {{ link }}
           </a>
         </div>
-    {%- endif -%}
+    {%- endfor -%}
   {%- endfor -%}
 
 {%- endif %}

--- a/strictdoc/export/spdx/spdx_generator.py
+++ b/strictdoc/export/spdx/spdx_generator.py
@@ -314,7 +314,7 @@ class SPDXGenerator:
                     node_links = traceability_index.get_requirement_file_links(
                         node
                     )
-                    for node_link_path_, _role, _range_markers in node_links:
+                    for node_link_path_, _range_markers in node_links:
                         if node_link_path_ in lookup_file_name_to_spdx_file:
                             continue
 

--- a/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/input.sdoc
+++ b/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/input.sdoc
@@ -60,4 +60,4 @@ RELATIONS:
 - TYPE: File
   ROLE: Implementation
   VALUE: file.txt
-  LINE_RANGE: 1, 2
+  LINE_RANGE: 1, 1

--- a/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/test.itest
+++ b/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/test.itest
@@ -13,6 +13,10 @@ CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#1#1">
 CHECK-HTML: file.c, <i>lines: 1-1</i>, function foo
 CHECK-HTML: <span{{.*}}>(Implementation)</span>
 
+CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#1#11">
+CHECK-HTML: file.c, <i>lines: 1-11</i>, range
+CHECK-HTML: <span{{.*}}>(Implementation)</span>
+
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#8#8">
 CHECK-HTML: file.c, <i>lines: 8-8</i>, function foo
 CHECK-HTML: <span{{.*}}>(Implementation)</span>
@@ -23,6 +27,10 @@ CHECK-HTML: <span{{.*}}>(Implementation)</span>
 
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#1#2">
 CHECK-HTML: file.py, <i>lines: 1-2</i>, class Foo
+CHECK-HTML: <span{{.*}}">(Implementation)</span>
+
+CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#1#18">
+CHECK-HTML: file.py, <i>lines: 1-18</i>, range
 CHECK-HTML: <span{{.*}}">(Implementation)</span>
 
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#5#6">


### PR DESCRIPTION
strictdoc handled the simple forward file relation listed below special:

```
[REQUIREMENT]
UID: REQ-001
TITLE: Requirement Title 1
STATEMENT: >>>
Requirement with forward relations.
<<<
RELATIONS:
- TYPE: File
  VALUE: file.py
```

All other file references (to functions, classes, lines, ranges, file backwards) are represented as markers internally. Only the plain forward file reference was not a marker, but an entry to a separate dict.

Let's resolve the simple forward file relation to a range marker covering the whole file (1st line to last line) and get rid of the special handling. This is consistent with what we get when we use a @relation(..., scope=file) backward marker.

TODO:
- [ ] tests of course explode, since the generated source file html is now different (covering 1st to last line); will adjust once the approach is aggreed
- [ ] to be discussed: instead representing as range marker, we could also introduce a new FileMarker and ForwardFileMarker