### PR TITLE
server: improve configuring the --reload option for StrictDoc's development

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -46,6 +46,14 @@ This release includes the following enhancements.
 5\) The command ``strictdoc server`` command has been extended to support the ``--host`` parameter. A user requested this feature to allow changing the server host which enables running the server within the StrictDoc Docker container.
 
 6\) Minor fixes to the main document view interface.
+
+7\) The long-standing warning from the Uvicorn server has finally been resolved. The warning was harmless and came from Uvicorn's opinionated handling of the reload configuration. The reload feature is used only during StrictDoc development and was never intended for end users, but Uvicorn still issued a warning because some parts of StrictDoc's configuration code weren't fully disabled for end-user environments:
+
+.. code-block::
+
+    WARNING:  Current configuration will not reload as not all conditions are met, please refer to documentation.
+
+Thanks to @MartyLake for pointing it out – it helped us prioritize fixing the issue.
 <<<
 
 [/SECTION]

--- a/strictdoc/cli/command_parser_builder.py
+++ b/strictdoc/cli/command_parser_builder.py
@@ -356,20 +356,31 @@ class CommandParserBuilder:
     def add_server_command(parent_command_parser):
         command_parser_server = parent_command_parser.add_parser(
             "server",
-            help="Run StrictDoc Web server.",
-            description="Run StrictDoc Web server.",
+            help="Run StrictDoc web server.",
+            description="Run StrictDoc web server.",
             formatter_class=formatter,
         )
         command_parser_server.add_argument("input_path")
         command_parser_server.add_argument("--output-path", type=str)
-        command_parser_server.add_argument(
-            "--reload", default=False, action="store_true"
-        )
-        command_parser_server.add_argument(
-            "--no-reload", dest="reload", action="store_false"
-        )
         command_parser_server.add_argument("--host", type=str)
         command_parser_server.add_argument("--port", type=IntRange(1024, 65000))
+        # The --reload and --no-reload options are currently used only for
+        # StrictDoc's own development. We may want to revisit this for the end
+        # users in the future but for now they are excluded from the help
+        # messages.
+        command_parser_server.add_argument(
+            "--reload",
+            default=False,
+            action="store_true",
+            help=argparse.SUPPRESS,
+        )
+        command_parser_server.add_argument(
+            "--no-reload",
+            dest="reload",
+            action="store_false",
+            help=argparse.SUPPRESS,
+        )
+
         add_config_argument(command_parser_server)
 
     @staticmethod

--- a/strictdoc/server/reload_config.py
+++ b/strictdoc/server/reload_config.py
@@ -1,0 +1,118 @@
+import os
+from dataclasses import dataclass
+from typing import List, Optional
+
+from strictdoc.cli.cli_arg_parser import ServerCommandConfig
+from strictdoc.core.project_config import ProjectConfig
+
+
+@dataclass
+class UvicornReloadConfig:
+    """
+    Uvicorn has an opinionated system for configuring the reloading of a server
+    when the specified files are changed on the file system. This class
+    centralized the reload configuration details in one place.
+
+    One responsibility of this class is to give a correct configuration when
+    the files must be reloaded and give a completely empty configuration when
+    the reload is False. In particular, if a configuration specifies reload=False
+    but the reload_dirs or reload_includes or reload_excludes are specified,
+    then the following warning is shown.
+    WARNING:  Current configuration will not reload as not all conditions are met, please refer to documentation.
+    The create() method of this class ensures that uvicorn is happy and the
+    warning does not appear.
+    """
+
+    reload: bool
+    reload_dirs: Optional[List[str]]
+    reload_includes: Optional[List[str]]
+    reload_excludes: Optional[List[str]]
+
+    @classmethod
+    def create(
+        cls, project_config: ProjectConfig, server_config: ServerCommandConfig
+    ) -> "UvicornReloadConfig":
+        reload: bool = server_config.reload
+        reload_dirs: Optional[List[str]] = None
+        reload_includes: Optional[List[str]] = None
+        reload_excludes: Optional[List[str]] = None
+
+        if server_config.reload:
+            # This doesn't seem to be effect because we still must provide the
+            # reload_excludes outside this folder. Maybe it has to do with the
+            # presence of reload_includes that includes all files with given
+            # file extensions below. Anyway this works well enough with the
+            # given reload_excludes.
+            reload_dirs = [
+                os.path.join(
+                    project_config.get_strictdoc_root_path(), "strictdoc"
+                )
+            ]
+            # It is important that StrictDoc's artifacts are excluded because
+            # StrictDoc's web server will be triggered to restart every time the
+            # contents of these folders changes.
+            reload_excludes = (
+                cls.expand_folder("build", max_depth=15)
+                + cls.expand_folder("docs", max_depth=3)
+                + cls.expand_folder("dist", max_depth=3)
+                + cls.expand_folder("tests", max_depth=15)
+                + cls.expand_folder("output", max_depth=15)
+            )
+
+            # Changing typical StrictDoc's own source code files should trigger
+            # restarting of the web server. Whitelisting them here.
+            reload_includes = [
+                "*.py",
+                "*.html",
+                "*.jinja",
+                "*.css",
+                "*.js",
+                "*.toml",
+            ]
+        return UvicornReloadConfig(
+            reload=reload,
+            reload_dirs=reload_dirs,
+            reload_includes=reload_includes,
+            reload_excludes=reload_excludes,
+        )
+
+    @classmethod
+    def expand_folder(cls, folder: str, max_depth: int) -> List[str]:
+        """
+        It looks like the regex engine of the uvicorn file watching library
+        does not support proper ** globs.
+
+        Examples:
+        "tests",  # Doesn't work.
+        "tests/",  # Doesn't work.
+        "tests/*",  # Doesn't work.
+        "tests/**",  # Makes the process hang, server doesn't start.
+
+        Example of a possible StrictDoc path that must be excluded:
+        output/cache/server/html/_source_files/strictdoc/backend/reqif/sdoc_reqif_fields.py.html
+
+        This function produces output like this:
+        [
+            "output/*.*",
+            "output/*/*.*",
+            "output/*/*/*.*",
+            "output/*/*/*/*.*",
+            "output/*/*/*/*/*.*",
+            "output/*/*/*/*/*/*.*",
+            "output/*/*/*/*/*/*/*.*",
+            "output/*/*/*/*/*/*/*/*.*",
+            "output/*/*/*/*/*/*/*/*/*.*",
+            "output/*/*/*/*/*/*/*/*/*/*.*",
+            "output/*/*/*/*/*/*/*/*/*/*/*.*",
+            "output/*/*/*/*/*/*/*/*/*/*/*/*.*",
+            "output/*/*/*/*/*/*/*/*/*/*/*/*/*.*",
+            "output/*/*/*/*/*/*/*/*/*/*/*/*/*/*.*",
+            "output/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*.*",
+        ]
+        """
+
+        patterns = []
+        for depth in range(1, max_depth + 1):
+            pattern = folder + "/" + "*/" * (depth - 1) + "*.*"
+            patterns.append(pattern)
+        return patterns


### PR DESCRIPTION
This fixes the uvicorn warning besides other things when the option `--reload` is not provided.

```
WARNING:  Current configuration will not reload as not all conditions are met, please refer to documentation.
```

Related to #2124