### PR TITLE
html export: export project_map.js, add stable_uri_forwarder.js

### DIFF
--- a/strictdoc/core/document_tree_iterator.py
+++ b/strictdoc/core/document_tree_iterator.py
@@ -10,7 +10,7 @@ class DocumentTreeIterator:
         assert isinstance(document_tree, DocumentTree)
         self.document_tree: DocumentTree = document_tree
 
-    def is_empty_tree(self):
+    def is_empty_tree(self) -> bool:
         return len(self.document_tree.document_list) == 0
 
     def iterator(self):

--- a/strictdoc/export/html/_static/copy_stable_link_observer.js
+++ b/strictdoc/export/html/_static/copy_stable_link_observer.js
@@ -9,12 +9,31 @@
     button.addEventListener("click", (event) => {
       event.preventDefault();
 
-      const clip = button.dataset.path;
+      const link = button.dataset.path;
       const copyIcon = button.querySelector(".copy_to_clipboard-copy_icon");
       const doneIcon = button.querySelector(".copy_to_clipboard-done_icon");
 
-      updateClipboard(clip, confirmCopy(button, copyIcon, doneIcon));
+      // resolve any relative urls with respect to current URL
+      const resolved = isAbsoluteUrl(link)
+      ? link
+      : new URL(link, window.location.href).href;
+
+      // expand folder to index if we run from the local file system
+      const expanded = (window.location.protocol === 'file:')
+      ? resolved.replace(/#/, 'index.html#')
+      : resolved
+
+      updateClipboard(expanded, confirmCopy(button, copyIcon, doneIcon));
     });
+  }
+
+  function isAbsoluteUrl(url) {
+    try {
+      new URL(url); // throws if it's relative
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   function updateClipboard(newClip, callback) {

--- a/strictdoc/export/html/_static/stable_uri_forwarder.js
+++ b/strictdoc/export/html/_static/stable_uri_forwarder.js
@@ -1,0 +1,85 @@
+// stable_uri_forwarder.js
+//
+// this script is included from the project's index.html page (in static html export)
+// It checks for a known MID or UID in the #anchor, and then
+// redirects to the referenced section or node within the project.
+// 
+// Example: 
+//  http://strictdoc.company.com/#SDOC_UG will redirect to 
+//  http://strictdoc.company.com/strictdoc/docs/strictdoc_01_user_guide.html#SDOC_UG 
+//
+// Thanks to this mechanism, it becomes possible to export stable links to
+// nodes/requirements/sections for integration with external tools.
+// The external links remain stable, even if the node/requirement/section is moved
+// within the project.
+
+
+// resolve the MID / UID to the correct page / anchor using the projectMap
+function resolveStableUriRedirectUsingProjectMap(anchor) {
+    const anchorIsMID = /^[a-fA-F0-9]{32}$/.test(anchor);
+    for (const [page, nodes] of Object.entries(projectMap)) {
+        for (const node of nodes) {
+            const nodeHasMID = 'MID' in node && typeof node['MID'] === 'string';
+            if ( (anchorIsMID && nodeHasMID && node['MID']?.toLowerCase() === anchor.toLowerCase()) 
+                || (node['UID'] === anchor)
+            )
+            {
+                window.location.replace(page + "#" + node['UID']);
+                return;
+            }
+        }        
+    }
+}
+
+// dynamically load the projectMap an resolve MID / UID
+function loadProjectMapAndResolveStableUriRedirect(anchor) {
+    
+    // projectMap is loaded, no need to load it again
+    if (typeof projectMap !== 'undefined') {
+        resolveStableUriRedirectUsingProjectMap(anchor);
+        return;
+    }
+
+    // Get script URL and derive from it the url of project_map.js
+    const scriptUrl = new URL(document.getElementById("stable_uri_forwarder").src, window.location.href)
+    const projectMapUrl = new URL('project_map.js', scriptUrl).href;
+
+    // Dynamically load project map and resolve
+    const script = document.createElement("script");
+    script.src = projectMapUrl;
+    script.onload = () => resolveStableUriRedirectUsingProjectMap(anchor);
+    script.onerror = () => {
+        console.error(`Failed to load project map from ${projectMapUrl}`);
+    };
+    document.head.appendChild(script);
+}
+
+function processStableUriRedirect(anchor)
+{
+    const exportType = document.querySelector('meta[name="strictdoc-export-type"]')?.content;
+
+    if (exportType === 'devserver') {
+        // for the devserver, we let the main_router.py dynamically forward UID to node 
+        window.location.replace("/UID/" + anchor);
+    } else if (exportType === 'static') {
+        // for static exports, we use the project_map.js
+        loadProjectMapAndResolveStableUriRedirect(anchor)
+    }
+}
+
+
+// in case an anchor is present at content load time
+document.addEventListener("DOMContentLoaded", () => {
+    const anchor = window.location.hash.substring(1);
+    if (anchor) {
+        processStableUriRedirect(anchor)
+    }
+});
+
+// in case an anchor is added manually afterwards (eases testing)
+window.addEventListener("hashchange", () => {
+    const anchor = window.location.hash.substring(1);
+    if (anchor) {
+        processStableUriRedirect(anchor)
+    }
+});

--- a/strictdoc/export/html/generators/project_map.py
+++ b/strictdoc/export/html/generators/project_map.py
@@ -1,0 +1,24 @@
+from markupsafe import Markup
+
+from strictdoc.core.project_config import ProjectConfig
+from strictdoc.core.traceability_index import TraceabilityIndex
+from strictdoc.export.html.generators.view_objects.project_tree_view_object import (
+    ProjectTreeViewObject,
+)
+from strictdoc.export.html.html_templates import HTMLTemplates
+
+
+class ProjectMapGenerator:
+    @staticmethod
+    def export(
+        project_config: ProjectConfig,
+        traceability_index: TraceabilityIndex,
+        html_templates: HTMLTemplates,
+    ) -> Markup:
+        assert isinstance(html_templates, HTMLTemplates)
+
+        view_object = ProjectTreeViewObject(
+            traceability_index=traceability_index,
+            project_config=project_config,
+        )
+        return view_object.render_map(html_templates.jinja_environment())

--- a/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
@@ -349,10 +349,17 @@ class DocumentScreenViewObject:
 
     def should_display_stable_link(
         self, node: Union[SDocDocument, SDocSection, SDocNode]
-    ):
+    ) -> bool:
         assert isinstance(node, (SDocDocument, SDocSection, SDocNode)), node
         return node.reserved_uid is not None
 
-    def get_stable_link(self, node: Union[SDocDocument, SDocSection, SDocNode]):
+    def get_stable_link(
+        self, node: Union[SDocDocument, SDocSection, SDocNode]
+    ) -> str:
         assert isinstance(node, (SDocDocument, SDocSection, SDocNode)), node
-        return "#TBD"
+        base_url = self.link_renderer.render_url("")
+        if node.reserved_uid is not None:
+            return base_url + "#" + node.reserved_uid
+        if node.reserved_mid is not None and node.mid_permanent:
+            return base_url + "#" + node.reserved_mid
+        return base_url

--- a/strictdoc/export/html/generators/view_objects/project_tree_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/project_tree_view_object.py
@@ -1,5 +1,6 @@
-# mypy: disable-error-code="no-any-return,no-untyped-call,no-untyped-def"
 from dataclasses import dataclass
+
+from markupsafe import Markup
 
 from strictdoc import __version__
 from strictdoc.core.document_tree_iterator import DocumentTreeIterator
@@ -40,18 +41,23 @@ class ProjectTreeViewObject:
             traceability_index.contains_included_documents
         )
 
-    def render_screen(self, jinja_environment: JinjaEnvironment):
+    def render_screen(self, jinja_environment: JinjaEnvironment) -> Markup:
         return jinja_environment.render_template_as_markup(
             "screens/project_index/index.jinja", view_object=self
         )
 
-    def render_static_url(self, url: str):
+    def render_map(self, jinja_environment: JinjaEnvironment) -> Markup:
+        return jinja_environment.render_template_as_markup(
+            "screens/project_index/project_map.jinja.js", view_object=self
+        )
+
+    def render_static_url(self, url: str) -> str:
         return self.link_renderer.render_static_url(url)
 
-    def render_url(self, url: str):
+    def render_url(self, url: str) -> str:
         return self.link_renderer.render_url(url)
 
-    def render_static_url_with_prefix(self, url: str):
+    def render_static_url_with_prefix(self, url: str) -> str:
         return self.link_renderer.render_static_url_with_prefix(url)
 
     def is_empty_tree(self) -> bool:

--- a/strictdoc/export/html/html_generator.py
+++ b/strictdoc/export/html/html_generator.py
@@ -29,6 +29,9 @@ from strictdoc.export.html.generators.document_trace import (
 from strictdoc.export.html.generators.document_tree import (
     DocumentTreeHTMLGenerator,
 )
+from strictdoc.export.html.generators.project_map import (
+    ProjectMapGenerator,
+)
 from strictdoc.export.html.generators.project_statistics import (
     ProgressStatisticsGenerator,
 )
@@ -105,6 +108,9 @@ class HTMLGenerator:
         # well with the multiprocessing's processed-based parallelization.
         # _pickle.PicklingError: Can't pickle <function sync_do_first at 0x1077bdf80>: it's not the same object as jinja2.filters.sync_do_first
         self.export_project_tree_screen(traceability_index=traceability_index)
+
+        # Export JavaScript map of the document tree (project map)
+        self.export_project_map(traceability_index=traceability_index)
 
         # Export project statistics.
         if self.project_config.is_feature_activated(
@@ -479,6 +485,25 @@ class HTMLGenerator:
             self.project_config.export_output_html_root, "index.html"
         )
         writer = DocumentTreeHTMLGenerator()
+        output = writer.export(
+            self.project_config,
+            traceability_index=traceability_index,
+            html_templates=self.html_templates,
+        )
+        with open(output_file, "w", encoding="utf8") as file:
+            file.write(output)
+
+    def export_project_map(
+        self,
+        *,
+        traceability_index: TraceabilityIndex,
+    ):
+        assets_dir = os.path.join(
+            self.project_config.export_output_html_root,
+            self.project_config.dir_for_sdoc_assets,
+        )
+        output_file = os.path.join(assets_dir, "project_map.js")
+        writer = ProjectMapGenerator()
         output = writer.export(
             self.project_config,
             traceability_index=traceability_index,

--- a/strictdoc/export/html/renderers/link_renderer.py
+++ b/strictdoc/export/html/renderers/link_renderer.py
@@ -27,7 +27,7 @@ class LinkRenderer:
         self.local_anchor_cache = {}
         self.req_link_cache = {}
 
-    def render_url(self, url):
+    def render_url(self, url: str) -> str:
         url = html.escape(url)
         if len(self.root_path) == 0:
             return url
@@ -39,7 +39,7 @@ class LinkRenderer:
     # This rarely used helper adds slashes to the import statements within
     # <script type="module">, for example project_index/index.jinja.
     # Otherwise, scripts are not imported correctly.
-    def render_static_url_with_prefix(self, url):
+    def render_static_url_with_prefix(self, url: str) -> str:
         static_url = "/" + self.static_path + "/" + url
         return static_url
 

--- a/strictdoc/export/html/templates/base.jinja.html
+++ b/strictdoc/export/html/templates/base.jinja.html
@@ -5,6 +5,11 @@
   <meta charset="UTF-8"/>
   <meta name="keywords" content="strictdoc, documentation, documentation-tool, requirements-management, requirements, documentation-generator, requirement-specifications, requirements-engineering, technical-documentation, requirements-specification"/>
   <meta name="description" content="strictdoc. Software for technical documentation and requirements management."/>
+  {%- if view_object.project_config.is_running_on_server %}
+  <meta name="strictdoc-export-type" content="devserver">
+  {%- else -%}
+  <meta name="strictdoc-export-type" content="static">
+  {%- endif -%}
 
   <link rel="shortcut icon" href="{{ view_object.render_static_url('favicon.ico') }}" type="image/x-icon"/>
 

--- a/strictdoc/export/html/templates/components/node/index.jinja
+++ b/strictdoc/export/html/templates/components/node/index.jinja
@@ -40,7 +40,7 @@
 
     {% if view_object.should_display_stable_link(sdoc_entity) %}
       {% with path = view_object.get_stable_link(sdoc_entity) %}
-        {# {% include "components/node/copy_stable_link_button.jinja" %} #}
+        {% include "components/node/copy_stable_link_button.jinja" %}
       {% endwith %}
     {%- endif -%}
 

--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -21,7 +21,7 @@
     window.Controller = Controller;
   </script>
   <script type="module" src="{{ view_object.render_static_url('controllers/anchor_controller.js') }}"></script>
-  {# <script type="module" src="{{ view_object.render_static_url('controllers/copy_stable_link_button_controller.js') }}"></script> #}
+  <script type="module" src="{{ view_object.render_static_url('controllers/copy_stable_link_button_controller.js') }}"></script>
   <script type="module" src="{{ view_object.render_static_url('controllers/autocompletable_field_controller.js') }}"></script>
   {% if not view_object.has_included_document() %}
   <script type="module" src="{{ view_object.render_static_url('controllers/draggable_list_controller.js') }}"></script>

--- a/strictdoc/export/html/templates/screens/project_index/index.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/index.jinja
@@ -9,6 +9,7 @@
 
 {% block head_scripts %}
   <script type="text/javascript" src="{{ view_object.render_static_url('collapsible_tree.js') }}"></script>
+  <script type="text/javascript" src="{{ view_object.render_static_url('stable_uri_forwarder.js') }}" id="stable_uri_forwarder"></script>
 
   {# FIXME by @mettta:
        Right now, project_tree.js only contains a switch for

--- a/strictdoc/export/html/templates/screens/project_index/project_map.jinja.js
+++ b/strictdoc/export/html/templates/screens/project_index/project_map.jinja.js
@@ -1,0 +1,17 @@
+// map of the project for the stable_uri forwarder
+const projectMap = {
+{%- for root_tree_ in view_object.document_tree_iterator.document_tree.file_tree %}
+  {%- if root_tree_.root_folder_or_file.is_folder() %}
+    {%- if root_tree_.root_folder_or_file.has_sdoc_content %}
+      {%- with folder = root_tree_.root_folder_or_file %}
+        {%- include "screens/project_index/project_map_folder.jinja" %}
+      {%- endwith %}
+    {%- endif %}
+  {%- else %}
+    {%- with file = root_tree_.root_folder_or_file %}
+      {%- include "screens/project_index/project_map_file.jinja" %}
+    {%- endwith %}
+  {%- endif %}
+{%- endfor %}
+};
+

--- a/strictdoc/export/html/templates/screens/project_index/project_map_file.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/project_map_file.jinja
@@ -1,0 +1,7 @@
+{%- set document = view_object.traceability_index.document_tree.get_document_by_path(file.get_full_path()) %}
+{%- if not document.document_is_included() %}
+ "{{ document.meta.get_html_doc_link() }}": [
+{% with section = document -%}
+  {%- include "screens/project_index/project_map_section.jinja" %}  
+{%- endwith %} ],
+{%- endif -%}

--- a/strictdoc/export/html/templates/screens/project_index/project_map_folder.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/project_map_folder.jinja
@@ -1,0 +1,15 @@
+{%- assert folder is defined %}
+{%- for folder_ in folder.subfolder_trees %}
+  {%- if folder_.has_sdoc_content %}
+    {%- with folder = folder_ %}
+      {%- include "screens/project_index/project_map_folder.jinja" %}
+    {%- endwith %}
+  {%- endif %}
+{%- endfor %}
+{%- for file_ in folder.files %}
+  {%- if file_.has_extension(".sdoc") %}
+    {%- with file = file_ %}
+      {%- include "screens/project_index/project_map_file.jinja" %}
+    {%- endwith %}
+  {%- endif %}
+{%- endfor -%}

--- a/strictdoc/export/html/templates/screens/project_index/project_map_node.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/project_map_node.jinja
@@ -1,0 +1,13 @@
+{%- assert node is defined -%}
+{%- set mid = '' -%}
+{%- if node.reserved_mid is defined and node.mid_permanent is defined and node.mid_permanent -%}
+  {%- set mid = node.reserved_mid -%}
+{%- endif -%}
+
+{%- set uid = '' -%}
+{%- if node.reserved_uid is defined -%}
+  {%- set uid = node.reserved_uid -%}
+{%- endif -%}
+
+{%- if uid %}  { {%- if mid -%}"MID":"{{ mid }}",{%- endif -%} "UID":"{{ uid }}"},
+{% endif -%}

--- a/strictdoc/export/html/templates/screens/project_index/project_map_section.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/project_map_section.jinja
@@ -1,0 +1,16 @@
+{%- assert section is defined -%}
+{%- with node = section -%}
+  {%- include "screens/project_index/project_map_node.jinja" -%}
+{%- endwith -%}
+
+{%- for node_ in section.section_contents -%}  
+  {%- if node_.__class__.__name__ == "DocumentFromFile" or node_.is_section -%}
+    {%- with section = node_ -%}
+      {%- include "screens/project_index/project_map_section.jinja" -%}
+    {%- endwith -%}
+  {%- else -%}
+    {%- with node = node_ -%}
+      {%- include "screens/project_index/project_map_node.jinja" -%}
+    {%- endwith -%}
+  {%- endif  -%}
+{%- endfor -%}

--- a/tests/end2end/exporter.py
+++ b/tests/end2end/exporter.py
@@ -1,0 +1,104 @@
+import os
+import shutil
+import subprocess
+import tempfile
+from contextlib import ExitStack
+from pathlib import Path
+from time import sleep
+from typing import Optional
+
+from strictdoc.helpers.file_system import get_portable_temp_dir
+from tests.end2end.conftest import test_environment
+
+
+class SDocTestHTMLExporter:
+    def __init__(
+        self,
+        *,
+        input_path: str,
+        output_path: Optional[str] = None,
+        config_path: Optional[str] = None,
+    ):
+        assert os.path.isdir(input_path)
+        if config_path is not None:
+            assert os.path.exists(config_path)
+        if output_path is not None:
+            assert os.path.exists(output_path)
+            self.cleanup_output_path = False
+        else:
+            output_path = tempfile.mkdtemp()
+            self.cleanup_output_path = True
+
+        self.path_to_tdoc_folder = input_path
+        self.output_path: str = output_path
+        self.config_path: Optional[str] = config_path
+
+        path_to_tmp_dir = get_portable_temp_dir()
+        self.path_to_out_log = os.path.join(
+            path_to_tmp_dir, "strictdoc_export.out.log"
+        )
+        self.path_to_err_log = os.path.join(
+            path_to_tmp_dir, "strictdoc_export.err.log"
+        )
+        self.exit_stack = ExitStack()
+
+    def __enter__(self) -> None:
+        self.run()
+        return self
+
+    def __exit__(
+        self, type__, reason_exception: Optional[Exception], traceback
+    ) -> None:
+        self.close()
+
+    def run(self) -> None:
+        args = [
+            "python",
+            "strictdoc/cli/main.py",
+            "export",
+        ]
+        if self.config_path:
+            args.extend(["--config", self.config_path])
+        if self.output_path is not None:
+            args.extend(
+                [
+                    "--output-dir",
+                    self.output_path,
+                ]
+            )
+        args.extend([self.path_to_tdoc_folder])
+
+        self.log_file_out = open(  # pylint: disable=consider-using-with
+            self.path_to_out_log, "wb"
+        )
+        self.log_file_err = open(  # pylint: disable=consider-using-with
+            self.path_to_err_log, "wb"
+        )
+        self.exit_stack.enter_context(self.log_file_out)
+        self.exit_stack.enter_context(self.log_file_err)
+
+        process = subprocess.run(  # pylint: disable=consider-using-with
+            args,
+            check=True,
+            stdout=self.log_file_out.fileno(),
+            stderr=self.log_file_err.fileno(),
+            shell=False,
+        )
+        self.process = process
+
+        sleep(test_environment.warm_up_interval_seconds)
+        print(  # noqa: T201
+            f"SDocTestHTMLExporter: "
+            f"Static HTML sucessfully exported to : {self.output_path}."
+        )
+
+    def get_output_path_as_uri(self) -> str:
+        html_folder = Path(self.output_path) / "html"
+        return html_folder.resolve().as_uri() + "/"
+
+    def close(self) -> None:
+        self.exit_stack.close()
+        self.process = None
+
+        if self.output_path is not None and self.cleanup_output_path:
+            shutil.rmtree(self.output_path)

--- a/tests/end2end/project_index/stable_uri_forwarding/01_static_html_export/input/grammar.sgra
+++ b/tests/end2end/project_index/stable_uri_forwarding/01_static_html_export/input/grammar.sgra
@@ -1,0 +1,16 @@
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: MID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False

--- a/tests/end2end/project_index/stable_uri_forwarding/01_static_html_export/input/index.sdoc
+++ b/tests/end2end/project_index/stable_uri_forwarding/01_static_html_export/input/index.sdoc
@@ -1,0 +1,69 @@
+[DOCUMENT]
+MID: 6a8bc1d467c348dbad29707cd6a3f260
+TITLE: Stable URI Test
+OPTIONS:
+  ENABLE_MID: True
+
+[GRAMMAR]
+IMPORT_FROM_FILE: grammar.sgra
+
+[REQUIREMENT]
+MID: 7726fa20788c493ca8d02bccd2480a9c
+UID: ROOT-1
+TITLE: Requirement in root
+STATEMENT: lorem ipsum
+
+[SECTION]
+MID: 15fa7f4bd56a41eb9da62584961d73b4
+TITLE: Section without UID containing a requirement
+
+[REQUIREMENT]
+MID: 753286690619492fa9c3ae4f9bf5368d
+UID: REQ-WITHIN-SECTION-THAT-HAS-NO-UID
+TITLE: Requirment within a Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+MID: 82e3eec5e08146bd8fe213f5a1d8a355
+UID: SECTION-1
+TITLE: Section that has an UID
+
+[TEXT]
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+MID: 0915d681276c4f44a1e1930434edc5cf
+UID: SECTION-2
+TITLE: Section with UID containing a requirement
+
+[REQUIREMENT]
+MID: 63414e7641a8445b962c3c1edc91bf0f
+UID: REQ-WITHIN-SECTION-2
+TITLE: Requirement within a Section that has a UID
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+MID: 0dd59cda6a3a4ec784d7dc2b5791b92f
+UID: SECTION-3
+TITLE: Nested Sections Test
+
+[SECTION]
+MID: 9978c6da28744db89acbe5875caf5a5c
+UID: SECTION-3-1
+TITLE: Subsection for the nexted section test
+
+[REQUIREMENT]
+MID: 3e06d65b527d4cab87680232880a3430
+UID: REQ-WITHIN-SECTION-3-1
+TITLE: Requirement within a nested Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[/SECTION]

--- a/tests/end2end/project_index/stable_uri_forwarding/01_static_html_export/test_case.py
+++ b/tests/end2end/project_index/stable_uri_forwarding/01_static_html_export/test_case.py
@@ -1,0 +1,40 @@
+import os
+
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.exporter import SDocTestHTMLExporter
+from tests.end2end.helpers.screens.document.screen_document import (
+    Screen_Document,
+)
+
+path_to_this_test_file_folder = os.path.dirname(os.path.abspath(__file__))
+
+
+class Test(E2ECase):
+    def test_uid(self):
+        with SDocTestHTMLExporter(
+            input_path=path_to_this_test_file_folder
+        ) as exporter:
+            target = "REQ-WITHIN-SECTION-3-1"
+
+            # open the project index with a UID reference
+            self.open(
+                exporter.get_output_path_as_uri() + "index.html#" + target
+            )
+
+            # check that we are forwarded on the correct requirement
+            screen_document = Screen_Document(self)
+            screen_document.assert_target_by_anchor(target)
+
+    def test_mid(self):
+        with SDocTestHTMLExporter(
+            input_path=path_to_this_test_file_folder
+        ) as exporter:
+            target = "REQ-WITHIN-SECTION-3-1"
+            mid = "3e06d65b527d4cab87680232880a3430"
+
+            # open the project index with a UID reference
+            self.open(exporter.get_output_path_as_uri() + "index.html#" + mid)
+
+            # check that we are forwarded on the correct requirement
+            screen_document = Screen_Document(self)
+            screen_document.assert_target_by_anchor(target)

--- a/tests/end2end/project_index/stable_uri_forwarding/02_devserver/input/grammar.sgra
+++ b/tests/end2end/project_index/stable_uri_forwarding/02_devserver/input/grammar.sgra
@@ -1,0 +1,16 @@
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: MID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False

--- a/tests/end2end/project_index/stable_uri_forwarding/02_devserver/input/index.sdoc
+++ b/tests/end2end/project_index/stable_uri_forwarding/02_devserver/input/index.sdoc
@@ -1,0 +1,69 @@
+[DOCUMENT]
+MID: 6a8bc1d467c348dbad29707cd6a3f260
+TITLE: Stable URI Test
+OPTIONS:
+  ENABLE_MID: True
+
+[GRAMMAR]
+IMPORT_FROM_FILE: grammar.sgra
+
+[REQUIREMENT]
+MID: 7726fa20788c493ca8d02bccd2480a9c
+UID: ROOT-1
+TITLE: Requirement in root
+STATEMENT: lorem ipsum
+
+[SECTION]
+MID: 15fa7f4bd56a41eb9da62584961d73b4
+TITLE: Section without UID containing a requirement
+
+[REQUIREMENT]
+MID: 753286690619492fa9c3ae4f9bf5368d
+UID: REQ-WITHIN-SECTION-THAT-HAS-NO-UID
+TITLE: Requirment within a Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+MID: 82e3eec5e08146bd8fe213f5a1d8a355
+UID: SECTION-1
+TITLE: Section that has an UID
+
+[TEXT]
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+MID: 0915d681276c4f44a1e1930434edc5cf
+UID: SECTION-2
+TITLE: Section with UID containing a requirement
+
+[REQUIREMENT]
+MID: 63414e7641a8445b962c3c1edc91bf0f
+UID: REQ-WITHIN-SECTION-2
+TITLE: Requirement within a Section that has a UID
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+MID: 0dd59cda6a3a4ec784d7dc2b5791b92f
+UID: SECTION-3
+TITLE: Nested Sections Test
+
+[SECTION]
+MID: 9978c6da28744db89acbe5875caf5a5c
+UID: SECTION-3-1
+TITLE: Subsection for the nexted section test
+
+[REQUIREMENT]
+MID: 3e06d65b527d4cab87680232880a3430
+UID: REQ-WITHIN-SECTION-3-1
+TITLE: Requirement within a nested Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[/SECTION]

--- a/tests/end2end/project_index/stable_uri_forwarding/02_devserver/test_case.py
+++ b/tests/end2end/project_index/stable_uri_forwarding/02_devserver/test_case.py
@@ -1,0 +1,38 @@
+import os
+
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.helpers.screens.document.screen_document import (
+    Screen_Document,
+)
+from tests.end2end.server import SDocTestServer
+
+path_to_this_test_file_folder = os.path.dirname(os.path.abspath(__file__))
+
+
+class Test(E2ECase):
+    def test_uid(self):
+        with SDocTestServer(
+            input_path=path_to_this_test_file_folder
+        ) as test_server:
+            target = "REQ-WITHIN-SECTION-3-1"
+
+            # open the project index with a UID reference
+            self.open(test_server.get_host_and_port() + "#" + target)
+
+            # check that we are forwarded on the correct requirement
+            screen_document = Screen_Document(self)
+            screen_document.assert_target_by_anchor(target)
+
+    def test_mid(self):
+        with SDocTestServer(
+            input_path=path_to_this_test_file_folder
+        ) as test_server:
+            target = "REQ-WITHIN-SECTION-3-1"
+            mid = "3e06d65b527d4cab87680232880a3430"
+
+            # open the project index with a UID reference
+            self.open(test_server.get_host_and_port() + "#" + mid)
+
+            # check that we are forwarded on the correct requirement
+            screen_document = Screen_Document(self)
+            screen_document.assert_target_by_anchor(target)

--- a/tests/integration/features/html/stable_uri_forwarding/01_basic/index.sdoc
+++ b/tests/integration/features/html/stable_uri_forwarding/01_basic/index.sdoc
@@ -1,0 +1,55 @@
+[DOCUMENT]
+TITLE: Stable URI Test
+UID: DOC-UID
+
+[REQUIREMENT]
+UID: ROOT-1
+TITLE: Requirement in root
+STATEMENT: lorem ipsum
+
+[SECTION]
+TITLE: Section without UID containing a requirement
+
+[REQUIREMENT]
+UID: REQ-WITHIN-SECTION-THAT-HAS-NO-UID
+TITLE: Requirment within a Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SECTION-1
+TITLE: Section that has an UID
+
+[TEXT]
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SECTION-2
+TITLE: Section with UID containing a requirement
+
+[REQUIREMENT]
+UID: REQ-WITHIN-SECTION-2
+TITLE: Requirement within a Section that has a UID
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SECTION-3
+TITLE: Nested Sections Test
+
+[SECTION]
+UID: SECTION-3-1
+TITLE: Subsection for the nexted section test
+
+[REQUIREMENT]
+UID: REQ-WITHIN-SECTION-3-1
+TITLE: Requirement within a nested Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[/SECTION]

--- a/tests/integration/features/html/stable_uri_forwarding/01_basic/subfolder/file_in_subfolder.sdoc
+++ b/tests/integration/features/html/stable_uri_forwarding/01_basic/subfolder/file_in_subfolder.sdoc
@@ -1,0 +1,55 @@
+[DOCUMENT]
+TITLE: File In Subfolder
+UID: SUB-DOC-UID
+
+[REQUIREMENT]
+UID: SUB-ROOT-1
+TITLE: Requirement in root
+STATEMENT: lorem ipsum
+
+[SECTION]
+TITLE: Section without UID containing a requirement
+
+[REQUIREMENT]
+UID: SUB-REQ-WITHIN-SECTION-THAT-HAS-NO-UID
+TITLE: Requirment within a Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SUB-SECTION-1
+TITLE: Section that has an UID
+
+[TEXT]
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SUB-SECTION-2
+TITLE: Section with UID containing a requirement
+
+[REQUIREMENT]
+UID: SUB-REQ-WITHIN-SECTION-2
+TITLE: Requirement within a Section that has a UID
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SUB-SECTION-3
+TITLE: Nested Sections Test
+
+[SECTION]
+UID: SUB-SECTION-3-1
+TITLE: Subsection for the nexted section test
+
+[REQUIREMENT]
+UID: SUB-REQ-WITHIN-SECTION-3-1
+TITLE: Requirement within a nested Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[/SECTION]

--- a/tests/integration/features/html/stable_uri_forwarding/01_basic/test.itest
+++ b/tests/integration/features/html/stable_uri_forwarding/01_basic/test.itest
@@ -1,0 +1,28 @@
+RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+CHECK: Published: Stable URI Test
+
+RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+CHECK-HTML: Stable URI Test
+CHECK-HTML: index.sdoc
+
+RUN: %cat %S/Output/html/_static/project_map.js | filecheck %s --dump-input=fail --check-prefix CHECK-MAP
+CHECK-MAP: "01_basic/subfolder/file_in_subfolder.html": [
+CHECK-MAP: "UID":"SUB-DOC-UID"
+CHECK-MAP: "UID":"SUB-ROOT-1"
+CHECK-MAP: "UID":"SUB-REQ-WITHIN-SECTION-THAT-HAS-NO-UID"
+CHECK-MAP: "UID":"SUB-SECTION-1"
+CHECK-MAP: "UID":"SUB-SECTION-2"
+CHECK-MAP: "UID":"SUB-REQ-WITHIN-SECTION-2"
+CHECK-MAP: "UID":"SUB-SECTION-3"
+CHECK-MAP: "UID":"SUB-SECTION-3-1"
+CHECK-MAP: "UID":"SUB-REQ-WITHIN-SECTION-3-1"
+CHECK-MAP: "01_basic/index.html": [
+CHECK-MAP: "UID":"DOC-UID"
+CHECK-MAP: "UID":"ROOT-1"
+CHECK-MAP: "UID":"REQ-WITHIN-SECTION-THAT-HAS-NO-UID"
+CHECK-MAP: "UID":"SECTION-1"
+CHECK-MAP: "UID":"SECTION-2"
+CHECK-MAP: "UID":"REQ-WITHIN-SECTION-2"
+CHECK-MAP: "UID":"SECTION-3"
+CHECK-MAP: "UID":"SECTION-3-1"
+CHECK-MAP: "UID":"REQ-WITHIN-SECTION-3-1"

--- a/tests/integration/features/html/stable_uri_forwarding/02_custom_grammar/grammar.sgra
+++ b/tests/integration/features/html/stable_uri_forwarding/02_custom_grammar/grammar.sgra
@@ -1,0 +1,16 @@
+[GRAMMAR]
+ELEMENTS:
+- TAG: FEATURE
+  FIELDS:
+  - TITLE: MID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False

--- a/tests/integration/features/html/stable_uri_forwarding/02_custom_grammar/index.sdoc
+++ b/tests/integration/features/html/stable_uri_forwarding/02_custom_grammar/index.sdoc
@@ -1,0 +1,57 @@
+[DOCUMENT]
+TITLE: Stable URI Test with custom grammar
+
+[GRAMMAR]
+IMPORT_FROM_FILE: grammar.sgra
+
+[FEATURE]
+UID: ROOT-1
+TITLE: Custom Grammar Node in root
+STATEMENT: lorem ipsum
+
+[SECTION]
+TITLE: Section without UID containing a Custom Grammar Node
+
+[FEATURE]
+UID: FEATURE-WITHIN-SECTION-THAT-HAS-NO-UID
+TITLE: Custom Grammar Node within a Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SECTION-1
+TITLE: Section that has an UID
+
+[TEXT]
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SECTION-2
+TITLE: Section with UID containing a Custom Grammar Node
+
+[FEATURE]
+UID: FEATURE-WITHIN-SECTION-2
+TITLE: Custom Grammar Node within a Section that has a UID
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SECTION-3
+TITLE: Nested Sections Test
+
+[SECTION]
+UID: SECTION-3-1
+TITLE: Subsection for the nexted section test
+
+[FEATURE]
+UID: FEATURE-WITHIN-SECTION-3-1
+TITLE: Custom Grammar Node within a nested Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[/SECTION]

--- a/tests/integration/features/html/stable_uri_forwarding/02_custom_grammar/subfolder/file_in_subfolder.sdoc
+++ b/tests/integration/features/html/stable_uri_forwarding/02_custom_grammar/subfolder/file_in_subfolder.sdoc
@@ -1,0 +1,57 @@
+[DOCUMENT]
+TITLE: File In Subfolder
+
+[GRAMMAR]
+IMPORT_FROM_FILE: grammar.sgra
+
+[FEATURE]
+UID: SUB-ROOT-1
+TITLE: Custom Grammar Node in root
+STATEMENT: lorem ipsum
+
+[SECTION]
+TITLE: Section without UID containing a requirement
+
+[FEATURE]
+UID: SUB-FEATURE-WITHIN-SECTION-THAT-HAS-NO-UID
+TITLE: Custom Grammar Node within a Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SUB-SECTION-1
+TITLE: Section that has an UID
+
+[TEXT]
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SUB-SECTION-2
+TITLE: Section with UID containing a requirement
+
+[FEATURE]
+UID: SUB-FEATURE-WITHIN-SECTION-2
+TITLE: Custom Grammar Node within a Section that has a UID
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SUB-SECTION-3
+TITLE: Nested Sections Test
+
+[SECTION]
+UID: SUB-SECTION-3-1
+TITLE: Subsection for the nexted section test
+
+[FEATURE]
+UID: SUB-FEATURE-WITHIN-SECTION-3-1
+TITLE: Custom Grammar Node within a nested Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[/SECTION]

--- a/tests/integration/features/html/stable_uri_forwarding/02_custom_grammar/test.itest
+++ b/tests/integration/features/html/stable_uri_forwarding/02_custom_grammar/test.itest
@@ -1,0 +1,27 @@
+RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+CHECK: Published: Stable URI Test
+
+RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+CHECK-HTML: Stable URI Test
+CHECK-HTML: index.sdoc
+
+RUN: %cat %S/Output/html/_static/project_map.js | filecheck %s --dump-input=fail --check-prefix CHECK-MAP
+CHECK-MAP: "02_custom_grammar/subfolder/file_in_subfolder.html": [
+CHECK-MAP: "UID":"SUB-ROOT-1"
+CHECK-MAP: "UID":"SUB-FEATURE-WITHIN-SECTION-THAT-HAS-NO-UID"
+CHECK-MAP: "UID":"SUB-SECTION-1"
+CHECK-MAP: "UID":"SUB-SECTION-2"
+CHECK-MAP: "UID":"SUB-FEATURE-WITHIN-SECTION-2"
+CHECK-MAP: "UID":"SUB-SECTION-3"
+CHECK-MAP: "UID":"SUB-SECTION-3-1"
+CHECK-MAP: "UID":"SUB-FEATURE-WITHIN-SECTION-3-1"
+CHECK-MAP: "02_custom_grammar/index.html": [
+CHECK-MAP: "UID":"ROOT-1"
+CHECK-MAP: "UID":"FEATURE-WITHIN-SECTION-THAT-HAS-NO-UID"
+CHECK-MAP: "UID":"SECTION-1"
+CHECK-MAP: "UID":"SECTION-2"
+CHECK-MAP: "UID":"FEATURE-WITHIN-SECTION-2"
+CHECK-MAP: "UID":"SECTION-3"
+CHECK-MAP: "UID":"SECTION-3-1"
+CHECK-MAP: "UID":"FEATURE-WITHIN-SECTION-3-1"
+

--- a/tests/integration/features/html/stable_uri_forwarding/03_custom_grammar_with_mids/grammar.sgra
+++ b/tests/integration/features/html/stable_uri_forwarding/03_custom_grammar_with_mids/grammar.sgra
@@ -1,0 +1,16 @@
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: MID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False

--- a/tests/integration/features/html/stable_uri_forwarding/03_custom_grammar_with_mids/index.sdoc
+++ b/tests/integration/features/html/stable_uri_forwarding/03_custom_grammar_with_mids/index.sdoc
@@ -1,0 +1,69 @@
+[DOCUMENT]
+MID: 6a8bc1d467c348dbad29707cd6a3f260
+TITLE: Stable URI Test
+OPTIONS:
+  ENABLE_MID: True
+
+[GRAMMAR]
+IMPORT_FROM_FILE: grammar.sgra
+
+[REQUIREMENT]
+MID: 7726fa20788c493ca8d02bccd2480a9c
+UID: ROOT-1
+TITLE: Requirement in root
+STATEMENT: lorem ipsum
+
+[SECTION]
+MID: 15fa7f4bd56a41eb9da62584961d73b4
+TITLE: Section without UID containing a requirement
+
+[REQUIREMENT]
+MID: 753286690619492fa9c3ae4f9bf5368d
+UID: REQ-WITHIN-SECTION-THAT-HAS-NO-UID
+TITLE: Requirment within a Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+MID: 82e3eec5e08146bd8fe213f5a1d8a355
+UID: SECTION-1
+TITLE: Section that has an UID
+
+[TEXT]
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+MID: 0915d681276c4f44a1e1930434edc5cf
+UID: SECTION-2
+TITLE: Section with UID containing a requirement
+
+[REQUIREMENT]
+MID: 63414e7641a8445b962c3c1edc91bf0f
+UID: REQ-WITHIN-SECTION-2
+TITLE: Requirement within a Section that has a UID
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+MID: 0dd59cda6a3a4ec784d7dc2b5791b92f
+UID: SECTION-3
+TITLE: Nested Sections Test
+
+[SECTION]
+MID: 9978c6da28744db89acbe5875caf5a5c
+UID: SECTION-3-1
+TITLE: Subsection for the nexted section test
+
+[REQUIREMENT]
+MID: 3e06d65b527d4cab87680232880a3430
+UID: REQ-WITHIN-SECTION-3-1
+TITLE: Requirement within a nested Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[/SECTION]

--- a/tests/integration/features/html/stable_uri_forwarding/03_custom_grammar_with_mids/subfolder/file_in_subfolder.sdoc
+++ b/tests/integration/features/html/stable_uri_forwarding/03_custom_grammar_with_mids/subfolder/file_in_subfolder.sdoc
@@ -1,0 +1,71 @@
+[DOCUMENT]
+MID: d3457617ba0544beaccf913f547cd6dc
+TITLE: File In Subfolder
+OPTIONS:
+  ENABLE_MID: True
+
+[GRAMMAR]
+IMPORT_FROM_FILE: grammar.sgra
+
+[REQUIREMENT]
+MID: 46355ead6a8b4974b134b200eec4a885
+UID: SUB-ROOT-1
+TITLE: Requirement in root
+STATEMENT: >>>
+lorem ipsum
+<<<
+
+[SECTION]
+MID: ca56014cd79345a8bb098b757ea6f0c9
+TITLE: Section without UID containing a requirement
+
+[REQUIREMENT]
+MID: 9281cd61e9954ce68ec54f95bdc7f687
+UID: SUB-REQ-WITHIN-SECTION-THAT-HAS-NO-UID
+TITLE: Requirment within a Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+MID: 49def62923244e118129a4888ff0ace7
+UID: SUB-SECTION-1
+TITLE: Section that has an UID
+
+[TEXT]
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+MID: 0a9eee57cac44286ad3dc828687aa23e
+UID: SUB-SECTION-2
+TITLE: Section with UID containing a requirement
+
+[REQUIREMENT]
+MID: c1b59b53ef144d8981ce2b5e1c7ca315
+UID: SUB-REQ-WITHIN-SECTION-2
+TITLE: Requirement within a Section that has a UID
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+MID: 29718f836810479bb2f73b52df4c8968
+UID: SUB-SECTION-3
+TITLE: Nested Sections Test
+
+[SECTION]
+MID: 320bba79bded44528ccddd6c8c8ff08e
+UID: SUB-SECTION-3-1
+TITLE: Subsection for the nexted section test
+
+[REQUIREMENT]
+MID: 20459e2510ac41c5b79d4c18149fc1b1
+UID: SUB-REQ-WITHIN-SECTION-3-1
+TITLE: Requirement within a nested Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[/SECTION]

--- a/tests/integration/features/html/stable_uri_forwarding/03_custom_grammar_with_mids/test.itest
+++ b/tests/integration/features/html/stable_uri_forwarding/03_custom_grammar_with_mids/test.itest
@@ -1,0 +1,26 @@
+RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+CHECK: Published: Stable URI Test
+
+RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+CHECK-HTML: Stable URI Test
+CHECK-HTML: index.sdoc
+
+RUN: %cat %S/Output/html/_static/project_map.js | filecheck %s --dump-input=fail --check-prefix CHECK-MAP
+CHECK-MAP: "03_custom_grammar_with_mids/subfolder/file_in_subfolder.html": [
+CHECK-MAP: {"MID":"46355ead6a8b4974b134b200eec4a885","UID":"SUB-ROOT-1"
+CHECK-MAP: {"MID":"9281cd61e9954ce68ec54f95bdc7f687","UID":"SUB-REQ-WITHIN-SECTION-THAT-HAS-NO-UID"
+CHECK-MAP: {"MID":"49def62923244e118129a4888ff0ace7","UID":"SUB-SECTION-1"
+CHECK-MAP: {"MID":"0a9eee57cac44286ad3dc828687aa23e","UID":"SUB-SECTION-2"
+CHECK-MAP: {"MID":"c1b59b53ef144d8981ce2b5e1c7ca315","UID":"SUB-REQ-WITHIN-SECTION-2"
+CHECK-MAP: {"MID":"29718f836810479bb2f73b52df4c8968","UID":"SUB-SECTION-3"
+CHECK-MAP: {"MID":"320bba79bded44528ccddd6c8c8ff08e","UID":"SUB-SECTION-3-1"
+CHECK-MAP: {"MID":"20459e2510ac41c5b79d4c18149fc1b1","UID":"SUB-REQ-WITHIN-SECTION-3-1"
+CHECK-MAP: "03_custom_grammar_with_mids/index.html": [
+CHECK-MAP: {"MID":"7726fa20788c493ca8d02bccd2480a9c","UID":"ROOT-1"
+CHECK-MAP: {"MID":"753286690619492fa9c3ae4f9bf5368d","UID":"REQ-WITHIN-SECTION-THAT-HAS-NO-UID"
+CHECK-MAP: {"MID":"82e3eec5e08146bd8fe213f5a1d8a355","UID":"SECTION-1"
+CHECK-MAP: {"MID":"0915d681276c4f44a1e1930434edc5cf","UID":"SECTION-2"
+CHECK-MAP: {"MID":"63414e7641a8445b962c3c1edc91bf0f","UID":"REQ-WITHIN-SECTION-2"
+CHECK-MAP: {"MID":"0dd59cda6a3a4ec784d7dc2b5791b92f","UID":"SECTION-3"
+CHECK-MAP: {"MID":"9978c6da28744db89acbe5875caf5a5c","UID":"SECTION-3-1"
+CHECK-MAP: {"MID":"3e06d65b527d4cab87680232880a3430","UID":"REQ-WITHIN-SECTION-3-1"},

--- a/tests/integration/features/html/stable_uri_forwarding/04_sdoc_fragments/included_fragment.sdoc
+++ b/tests/integration/features/html/stable_uri_forwarding/04_sdoc_fragments/included_fragment.sdoc
@@ -1,0 +1,54 @@
+[DOCUMENT]
+TITLE: Included Fragment
+
+[REQUIREMENT]
+UID: ROOT-1
+TITLE: Requirement in root
+STATEMENT: lorem ipsum
+
+[SECTION]
+TITLE: Section without UID containing a requirement
+
+[REQUIREMENT]
+UID: REQ-WITHIN-SECTION-THAT-HAS-NO-UID
+TITLE: Requirment within a Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SECTION-1
+TITLE: Section that has an UID
+
+[TEXT]
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SECTION-2
+TITLE: Section with UID containing a requirement
+
+[REQUIREMENT]
+UID: REQ-WITHIN-SECTION-2
+TITLE: Requirement within a Section that has a UID
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SECTION-3
+TITLE: Nested Sections Test
+
+[SECTION]
+UID: SECTION-3-1
+TITLE: Subsection for the nexted section test
+
+[REQUIREMENT]
+UID: REQ-WITHIN-SECTION-3-1
+TITLE: Requirement within a nested Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[/SECTION]

--- a/tests/integration/features/html/stable_uri_forwarding/04_sdoc_fragments/index.sdoc
+++ b/tests/integration/features/html/stable_uri_forwarding/04_sdoc_fragments/index.sdoc
@@ -1,0 +1,5 @@
+[DOCUMENT]
+TITLE: Stable URI Test
+
+[DOCUMENT_FROM_FILE]
+FILE: included_fragment.sdoc

--- a/tests/integration/features/html/stable_uri_forwarding/04_sdoc_fragments/subfolder/file_in_subfolder.sdoc
+++ b/tests/integration/features/html/stable_uri_forwarding/04_sdoc_fragments/subfolder/file_in_subfolder.sdoc
@@ -1,0 +1,5 @@
+[DOCUMENT]
+TITLE: File In Subfolder
+
+[DOCUMENT_FROM_FILE]
+FILE: included_fragment_subfolder.sdoc

--- a/tests/integration/features/html/stable_uri_forwarding/04_sdoc_fragments/subfolder/included_fragment_subfolder.sdoc
+++ b/tests/integration/features/html/stable_uri_forwarding/04_sdoc_fragments/subfolder/included_fragment_subfolder.sdoc
@@ -1,0 +1,54 @@
+[DOCUMENT]
+TITLE: Included Fragment
+
+[REQUIREMENT]
+UID: SUB-ROOT-1
+TITLE: Requirement in root
+STATEMENT: lorem ipsum
+
+[SECTION]
+TITLE: Section without UID containing a requirement
+
+[REQUIREMENT]
+UID: SUB-REQ-WITHIN-SECTION-THAT-HAS-NO-UID
+TITLE: Requirment within a Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SUB-SECTION-1
+TITLE: Section that has an UID
+
+[TEXT]
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SUB-SECTION-2
+TITLE: Section with UID containing a requirement
+
+[REQUIREMENT]
+UID: SUB-REQ-WITHIN-SECTION-2
+TITLE: Requirement within a Section that has a UID
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SUB-SECTION-3
+TITLE: Nested Sections Test
+
+[SECTION]
+UID: SUB-SECTION-3-1
+TITLE: Subsection for the nexted section test
+
+[REQUIREMENT]
+UID: SUB-REQ-WITHIN-SECTION-3-1
+TITLE: Requirement within a nested Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[/SECTION]

--- a/tests/integration/features/html/stable_uri_forwarding/04_sdoc_fragments/test.itest
+++ b/tests/integration/features/html/stable_uri_forwarding/04_sdoc_fragments/test.itest
@@ -1,0 +1,26 @@
+RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+CHECK: Published: Stable URI Test
+
+RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+CHECK-HTML: Stable URI Test
+CHECK-HTML: index.sdoc
+
+RUN: %cat %S/Output/html/_static/project_map.js | filecheck %s --dump-input=fail --check-prefix CHECK-MAP
+CHECK-MAP: "04_sdoc_fragments/subfolder/file_in_subfolder.html": [
+CHECK-MAP: "UID":"SUB-ROOT-1"
+CHECK-MAP: "UID":"SUB-REQ-WITHIN-SECTION-THAT-HAS-NO-UID"
+CHECK-MAP: "UID":"SUB-SECTION-1"
+CHECK-MAP: "UID":"SUB-SECTION-2"
+CHECK-MAP: "UID":"SUB-REQ-WITHIN-SECTION-2"
+CHECK-MAP: "UID":"SUB-SECTION-3"
+CHECK-MAP: "UID":"SUB-SECTION-3-1"
+CHECK-MAP: "UID":"SUB-REQ-WITHIN-SECTION-3-1"
+CHECK-MAP: "04_sdoc_fragments/index.html": [
+CHECK-MAP: "UID":"ROOT-1"
+CHECK-MAP: "UID":"REQ-WITHIN-SECTION-THAT-HAS-NO-UID"
+CHECK-MAP: "UID":"SECTION-1"
+CHECK-MAP: "UID":"SECTION-2"
+CHECK-MAP: "UID":"REQ-WITHIN-SECTION-2"
+CHECK-MAP: "UID":"SECTION-3"
+CHECK-MAP: "UID":"SECTION-3-1"
+CHECK-MAP: "UID":"REQ-WITHIN-SECTION-3-1"

--- a/tests/integration/features/html/stable_uri_forwarding/05_copy_stable_link_button/index.sdoc
+++ b/tests/integration/features/html/stable_uri_forwarding/05_copy_stable_link_button/index.sdoc
@@ -1,0 +1,55 @@
+[DOCUMENT]
+TITLE: Stable URI Test
+UID: DOC-UID
+
+[REQUIREMENT]
+UID: ROOT-1
+TITLE: Requirement in root
+STATEMENT: lorem ipsum
+
+[SECTION]
+TITLE: Section without UID containing a requirement
+
+[REQUIREMENT]
+UID: REQ-WITHIN-SECTION-THAT-HAS-NO-UID
+TITLE: Requirment within a Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SECTION-1
+TITLE: Section that has an UID
+
+[TEXT]
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SECTION-2
+TITLE: Section with UID containing a requirement
+
+[REQUIREMENT]
+UID: REQ-WITHIN-SECTION-2
+TITLE: Requirement within a Section that has a UID
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SECTION-3
+TITLE: Nested Sections Test
+
+[SECTION]
+UID: SECTION-3-1
+TITLE: Subsection for the nexted section test
+
+[REQUIREMENT]
+UID: REQ-WITHIN-SECTION-3-1
+TITLE: Requirement within a nested Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[/SECTION]

--- a/tests/integration/features/html/stable_uri_forwarding/05_copy_stable_link_button/subfolder/file_in_subfolder.sdoc
+++ b/tests/integration/features/html/stable_uri_forwarding/05_copy_stable_link_button/subfolder/file_in_subfolder.sdoc
@@ -1,0 +1,55 @@
+[DOCUMENT]
+TITLE: File In Subfolder
+UID: SUB-DOC-UID
+
+[REQUIREMENT]
+UID: SUB-ROOT-1
+TITLE: Requirement in root
+STATEMENT: lorem ipsum
+
+[SECTION]
+TITLE: Section without UID containing a requirement
+
+[REQUIREMENT]
+UID: SUB-REQ-WITHIN-SECTION-THAT-HAS-NO-UID
+TITLE: Requirment within a Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SUB-SECTION-1
+TITLE: Section that has an UID
+
+[TEXT]
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SUB-SECTION-2
+TITLE: Section with UID containing a requirement
+
+[REQUIREMENT]
+UID: SUB-REQ-WITHIN-SECTION-2
+TITLE: Requirement within a Section that has a UID
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[SECTION]
+UID: SUB-SECTION-3
+TITLE: Nested Sections Test
+
+[SECTION]
+UID: SUB-SECTION-3-1
+TITLE: Subsection for the nexted section test
+
+[REQUIREMENT]
+UID: SUB-REQ-WITHIN-SECTION-3-1
+TITLE: Requirement within a nested Section
+STATEMENT: lorem ipsum
+
+[/SECTION]
+
+[/SECTION]

--- a/tests/integration/features/html/stable_uri_forwarding/05_copy_stable_link_button/test.itest
+++ b/tests/integration/features/html/stable_uri_forwarding/05_copy_stable_link_button/test.itest
@@ -1,0 +1,27 @@
+RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+CHECK: Published: Stable URI Test
+
+RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+CHECK-HTML: Stable URI Test
+CHECK-HTML: index.sdoc
+
+RUN: %cat %S/Output/html/05_copy_stable_link_button/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-BUTTON
+CHECK-BUTTON: data-path="../#ROOT-1"
+CHECK-BUTTON: data-path="../#REQ-WITHIN-SECTION-THAT-HAS-NO-UID"
+CHECK-BUTTON: data-path="../#SECTION-1"
+CHECK-BUTTON: data-path="../#SECTION-2"
+CHECK-BUTTON: data-path="../#REQ-WITHIN-SECTION-2"
+CHECK-BUTTON: data-path="../#SECTION-3"
+CHECK-BUTTON: data-path="../#SECTION-3-1"
+CHECK-BUTTON: data-path="../#REQ-WITHIN-SECTION-3-1"
+
+RUN: %cat %S/Output/html/05_copy_stable_link_button/subfolder/file_in_subfolder.html | filecheck %s --dump-input=fail --check-prefix CHECK-SUB
+CHECK-SUB: data-path="../../#SUB-ROOT-1"
+CHECK-SUB: data-path="../../#SUB-REQ-WITHIN-SECTION-THAT-HAS-NO-UID"
+CHECK-SUB: data-path="../../#SUB-SECTION-1"
+CHECK-SUB: data-path="../../#SUB-SECTION-2"
+CHECK-SUB: data-path="../../#SUB-REQ-WITHIN-SECTION-2"
+CHECK-SUB: data-path="../../#SUB-SECTION-3"
+CHECK-SUB: data-path="../../#SUB-SECTION-3-1"
+CHECK-SUB: data-path="../../#SUB-REQ-WITHIN-SECTION-3-1"
+


### PR DESCRIPTION
This PR addresses #2100 and adds:
- export of the project structure as /assets/project_map.js
- stable_uri_forwarder.js
- integration and end2end tests

How to use:
1) start strictdoc server or do a strictdoc export of the project
2) open project_index URL in browser and add UID or MID as anchor, e.g. http://localhost:5111/#SOME_UID
3) browser jumps to the given node within the project

Not yet there:
- UI to copy the requirement's stable link to the clipboard...