### PR TITLE
export/html: --included-documents: display or not display consistently

### DIFF
--- a/strictdoc/core/document_tree.py
+++ b/strictdoc/core/document_tree.py
@@ -11,7 +11,7 @@ class DocumentTree:
         self,
         file_tree,
         document_list,
-        map_docs_by_paths,
+        map_docs_by_paths: Dict[str, SDocDocument],
         map_docs_by_rel_paths,
         map_grammars_by_filenames: Dict[str, DocumentGrammar],
     ):
@@ -21,7 +21,7 @@ class DocumentTree:
         assert isinstance(map_docs_by_rel_paths, dict)
         self.file_tree = file_tree
         self.document_list: List[SDocDocument] = document_list
-        self.map_docs_by_paths = map_docs_by_paths
+        self.map_docs_by_paths: Dict[str, SDocDocument] = map_docs_by_paths
         self.map_docs_by_rel_paths: Dict[str, SDocDocument] = (
             map_docs_by_rel_paths
         )
@@ -40,11 +40,11 @@ class DocumentTree:
             f")"
         )
 
-    def get_document_by_path(self, doc_full_path):
+    def get_document_by_path(self, doc_full_path: str) -> SDocDocument:
         document = self.map_docs_by_paths[doc_full_path]
         return document
 
-    def get_document_by_rel_path(self, doc_rel_path: str):
+    def get_document_by_rel_path(self, doc_rel_path: str) -> SDocDocument:
         assert isinstance(doc_rel_path, str), doc_rel_path
         document = self.map_docs_by_rel_paths[doc_rel_path]
         return document

--- a/strictdoc/export/html/generators/view_objects/helpers.py
+++ b/strictdoc/export/html/generators/view_objects/helpers.py
@@ -1,0 +1,76 @@
+from strictdoc.core.file_tree import File, Folder
+from strictdoc.core.project_config import ProjectConfig
+from strictdoc.core.traceability_index import TraceabilityIndex
+
+
+def screen_should_display_folder(
+    folder: Folder,
+    traceability_index: TraceabilityIndex,
+    project_config: ProjectConfig,
+    must_only_include_non_included_sdoc: bool,
+) -> bool:
+    """
+    must_only_include_non_included_sdoc:
+        see screen_should_display_file() for a description of the purpose.
+    """
+    assert isinstance(folder, Folder), folder
+    assert traceability_index.document_tree is not None
+
+    if not folder.has_sdoc_content:
+        return False
+
+    for file_ in folder.files:
+        if screen_should_display_file(
+            file_,
+            traceability_index,
+            project_config,
+            must_only_include_non_included_sdoc,
+        ):
+            return True
+
+    for folder_ in folder.subfolder_trees:
+        if screen_should_display_folder(
+            folder_,
+            traceability_index,
+            project_config,
+            must_only_include_non_included_sdoc,
+        ):
+            return True
+
+    return False
+
+
+def screen_should_display_file(
+    file: File,
+    traceability_index: TraceabilityIndex,
+    project_config: ProjectConfig,
+    must_only_include_non_included_sdoc: bool,
+) -> bool:
+    """
+    must_only_include_non_included_sdoc:
+        the argument controls whether to only display non-included SDoc
+        documents or also included (fragment) documents. The Project Tree screen
+        uses this as False while Document screen uses it as False where the
+        standalone fragments are not printed, and instead the including documents
+        prints its included documents recursively.
+    """
+    assert isinstance(file, File), file
+    assert traceability_index.document_tree is not None
+
+    if file.has_extension(".junit.xml"):
+        return True
+
+    if file.has_extension(".sdoc"):
+        document = traceability_index.document_tree.get_document_by_path(
+            file.get_full_path()
+        )
+        if not document.document_is_included():
+            return True
+
+        if (
+            not must_only_include_non_included_sdoc
+            and project_config.export_included_documents
+        ):
+            return True
+
+    return False

--- a/strictdoc/export/html/generators/view_objects/project_tree_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/project_tree_view_object.py
@@ -3,8 +3,13 @@ from dataclasses import dataclass
 
 from strictdoc import __version__
 from strictdoc.core.document_tree_iterator import DocumentTreeIterator
+from strictdoc.core.file_tree import File, Folder
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.core.traceability_index import TraceabilityIndex
+from strictdoc.export.html.generators.view_objects.helpers import (
+    screen_should_display_file,
+    screen_should_display_folder,
+)
 from strictdoc.export.html.html_templates import JinjaEnvironment
 from strictdoc.export.html.renderers.link_renderer import LinkRenderer
 
@@ -51,3 +56,22 @@ class ProjectTreeViewObject:
 
     def is_empty_tree(self) -> bool:
         return self.document_tree_iterator.is_empty_tree()
+
+    def should_display_fragments_toggle(self) -> bool:
+        return self.project_config.export_included_documents
+
+    def should_display_folder(self, folder: Folder) -> bool:
+        return screen_should_display_folder(
+            folder,
+            self.traceability_index,
+            self.project_config,
+            must_only_include_non_included_sdoc=False,
+        )
+
+    def should_display_file(self, file: File) -> bool:
+        return screen_should_display_file(
+            file,
+            self.traceability_index,
+            self.project_config,
+            must_only_include_non_included_sdoc=False,
+        )

--- a/strictdoc/export/html/templates/screens/document/_shared/project_tree.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/project_tree.jinja
@@ -1,22 +1,20 @@
 
 {%- if not view_object.is_empty_tree() -%}
   <div class="tree">
-    {%- for folder_or_file in view_object.iterator_files_first() -%}
-      {%- if folder_or_file.is_folder() %}
-        {%- if view_object.folder_contains_including_documents(folder_or_file) %}
-          {%- if folder_or_file.files|length > 0 %}
-            <div
-              class="tree_folder"
-              data-level="{{ folder_or_file.level }}"
-              data-testid="tree-folder-item"
-            >
-            {#- {% include "_res/svg__separator.jinja.html" %} -#}
-            {# {%- include "_res/svg_ico16_folder.jinja" -%} #}
-            <span class="tree_folder_path">/{{- folder_or_file.rel_path -}}</span>
-            </div>
-          {% endif %}
+    {% for folder_or_file in view_object.iterator_files_first() -%}
+      {% if folder_or_file.is_folder() %}
+        {% if view_object.should_display_folder(folder_or_file) %}
+          <div
+            class="tree_folder"
+            data-level="{{ folder_or_file.level }}"
+            data-testid="tree-folder-item"
+          >
+          {#- {% include "_res/svg__separator.jinja.html" %} -#}
+          {# {%- include "_res/svg_ico16_folder.jinja" -%} #}
+          <span class="tree_folder_path">/{{- folder_or_file.rel_path -}}</span>
+          </div>
         {% endif %}
-      {% elif folder_or_file.has_extension(".sdoc") or folder_or_file.has_extension(".junit.xml") %}
+      {% elif view_object.should_display_file(folder_or_file) %}
         {%- set document_ = view_object.get_document_by_path(folder_or_file.get_full_path()) %}
         {% if not document_.document_is_included() %}
         <a

--- a/strictdoc/export/html/templates/screens/document/_shared/project_tree_child_documents.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/project_tree_child_documents.jinja
@@ -1,4 +1,4 @@
-{% if document.included_documents|length > 0 %}
+{% if view_object.should_display_included_documents_for_document(document) %}
 <ul class="tree_fragments">
 {% for child_document_ in document.included_documents %}
   <li>

--- a/strictdoc/export/html/templates/screens/project_index/main.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/main.jinja
@@ -4,7 +4,10 @@
       {% include "screens/project_index/frame_project_tree.jinja.html" %}
     </div>
     <div class="dashboard-aside">
+      {% if view_object.should_display_fragments_toggle() %}
       <div class="dashboard-block" id="project_tree_controls">{# must to be empty #}</div>
+      {% endif %}
+
       <div class="dashboard-block">
         {# {{ view_object.project_config.project_title }} #}
         {# ⛭ ⚙️ #}

--- a/strictdoc/export/html/templates/screens/project_index/project_tree.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/project_tree.jinja
@@ -3,15 +3,17 @@
     {% for root_tree_ in view_object.document_tree_iterator.document_tree.file_tree %}
 
       {% if root_tree_.root_folder_or_file.is_folder() %}
-        {% if root_tree_.root_folder_or_file.has_sdoc_content %}
+        {% if view_object.should_display_folder(root_tree_.root_folder_or_file) %}
           {% with folder = root_tree_.root_folder_or_file %}
             {% include "screens/project_index/project_tree_folder.jinja" %}
           {% endwith %}
         {% endif %}
       {% else %}
-        {% with file = root_tree_.root_folder_or_file %}
-          {% include "screens/project_index/project_tree_file.jinja" %}
-        {% endwith %}
+        {% if view_object.should_display_file(root_tree_.root_folder_or_file) %}
+          {% with file = root_tree_.root_folder_or_file %}
+            {% include "screens/project_index/project_tree_file.jinja" %}
+          {% endwith %}
+        {% endif %}
       {% endif %}
 
     {% endfor %}

--- a/strictdoc/export/html/templates/screens/project_index/project_tree_folder.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/project_tree_folder.jinja
@@ -11,7 +11,7 @@
 
   <div class="project_tree-folder-content">
     {% for folder_ in folder.subfolder_trees %}
-      {% if folder_.has_sdoc_content %}
+      {% if view_object.should_display_folder(folder_) %}
         {% with folder = folder_ %}
           {% include "screens/project_index/project_tree_folder.jinja" %}
         {% endwith %}
@@ -19,7 +19,7 @@
     {% endfor %}
 
     {% for file_ in folder.files %}
-      {% if file_.has_extension(".sdoc") or file_.has_extension(".junit.xml") %}
+      {% if view_object.should_display_file(file_) %}
         {% with file = file_ %}
           {% include "screens/project_index/project_tree_file.jinja" %}
         {% endwith %}

--- a/tests/integration/features/document_fragments/--included-documents/included_documents_option_not_provided/_assets/file.svg
+++ b/tests/integration/features/document_fragments/--included-documents/included_documents_option_not_provided/_assets/file.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-40 -40 80 80">
+  <circle r="39"/>
+  <path fill="#fff" d="M0,38a38,38 0 0 1 0,-76a19,19 0 0 1 0,38a19,19 0 0 0 0,38"/>
+  <circle r="5" cy="19" fill="#fff"/>
+  <circle r="5" cy="-19"/>
+</svg>

--- a/tests/integration/features/document_fragments/--included-documents/included_documents_option_not_provided/input.sdoc
+++ b/tests/integration/features/document_fragments/--included-documents/included_documents_option_not_provided/input.sdoc
@@ -1,0 +1,15 @@
+[DOCUMENT]
+TITLE: Hello world doc
+OPTIONS:
+  AUTO_LEVELS: On
+
+[TEXT]
+STATEMENT: >>>
+.. image:: _assets/file.svg
+   :alt: Test image
+   :class: image
+   :width: 100%
+<<<
+
+[DOCUMENT_FROM_FILE]
+FILE: nested/nested.sdoc

--- a/tests/integration/features/document_fragments/--included-documents/included_documents_option_not_provided/nested/nested.sdoc
+++ b/tests/integration/features/document_fragments/--included-documents/included_documents_option_not_provided/nested/nested.sdoc
@@ -1,0 +1,15 @@
+[DOCUMENT]
+TITLE: Hello world doc 2
+OPTIONS:
+  AUTO_LEVELS: On
+
+[TEXT]
+STATEMENT: >>>
+.. image:: _assets/file.svg
+   :alt: Test image
+   :class: image
+   :width: 100%
+<<<
+
+[DOCUMENT_FROM_FILE]
+FILE: subnested/subnested.sdoc

--- a/tests/integration/features/document_fragments/--included-documents/included_documents_option_not_provided/nested/subnested/subnested.sdoc
+++ b/tests/integration/features/document_fragments/--included-documents/included_documents_option_not_provided/nested/subnested/subnested.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Hello world doc 3
+OPTIONS:
+  AUTO_LEVELS: On
+
+[TEXT]
+STATEMENT: >>>
+.. image:: _assets/file.svg
+   :alt: Test image
+   :class: image
+   :width: 100%
+<<<
+
+[SECTION]
+TITLE: Section 1.2.3
+
+[COMPOSITE_REQUIREMENT]
+TITLE: Composite requirement 4.5.6
+
+[REQUIREMENT]
+TITLE: Requirement 7.8.9
+
+[/COMPOSITE_REQUIREMENT]
+
+[/SECTION]

--- a/tests/integration/features/document_fragments/--included-documents/included_documents_option_not_provided/test.itest
+++ b/tests/integration/features/document_fragments/--included-documents/included_documents_option_not_provided/test.itest
@@ -1,0 +1,28 @@
+RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%S/Output/html/included_documents_option_not_provided/_assets/file.svg"
+RUN: %check_exists --file "%S/Output/html/included_documents_option_not_provided/nested/_assets/file.svg"
+RUN: %check_exists --file "%S/Output/html/included_documents_option_not_provided/nested/subnested/_assets/file.svg"
+
+RUN: %check_exists --file "%S/Output/html/included_documents_option_not_provided/input.html"
+RUN: %check_exists --invert --file "%S/Output/html/included_documents_option_not_provided/nested/nested.html"
+RUN: %check_exists --invert --file "%S/Output/html/included_documents_option_not_provided/nested/subnested/subnested.html"
+
+RUN: %cat %S/Output/html/index.html | filecheck %s --check-prefix CHECK-PROJECT-TREE
+CHECK-PROJECT-TREE-NOT: nested
+CHECK-PROJECT-TREE-NOT: subnested
+
+RUN: %cat %S/Output/html/included_documents_option_not_provided/input.html | filecheck %s --check-prefix CHECK-HTML
+
+CHECK-HTML-NOT: nested
+CHECK-HTML-NOT: subnested
+CHECK-HTML:data-level="0"
+CHECK-HTML:href="../included_documents_option_not_provided/input.html"
+CHECK-HTML-NOT: nested
+CHECK-HTML-NOT: subnested
+CHECK-HTML:data-level="1"
+CHECK-HTML:data-level="1.1"
+CHECK-HTML:data-level="1.1.1"
+CHECK-HTML:data-level="1.1.1.1"
+CHECK-HTML:data-level="1.1.1.1.1"

--- a/tests/integration/features/document_fragments/--included-documents/included_documents_option_provided/_assets/file.svg
+++ b/tests/integration/features/document_fragments/--included-documents/included_documents_option_provided/_assets/file.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-40 -40 80 80">
+  <circle r="39"/>
+  <path fill="#fff" d="M0,38a38,38 0 0 1 0,-76a19,19 0 0 1 0,38a19,19 0 0 0 0,38"/>
+  <circle r="5" cy="19" fill="#fff"/>
+  <circle r="5" cy="-19"/>
+</svg>

--- a/tests/integration/features/document_fragments/--included-documents/included_documents_option_provided/input.sdoc
+++ b/tests/integration/features/document_fragments/--included-documents/included_documents_option_provided/input.sdoc
@@ -1,0 +1,15 @@
+[DOCUMENT]
+TITLE: Hello world doc
+OPTIONS:
+  AUTO_LEVELS: On
+
+[TEXT]
+STATEMENT: >>>
+.. image:: _assets/file.svg
+   :alt: Test image
+   :class: image
+   :width: 100%
+<<<
+
+[DOCUMENT_FROM_FILE]
+FILE: nested/nested.sdoc

--- a/tests/integration/features/document_fragments/--included-documents/included_documents_option_provided/nested/nested.sdoc
+++ b/tests/integration/features/document_fragments/--included-documents/included_documents_option_provided/nested/nested.sdoc
@@ -1,0 +1,15 @@
+[DOCUMENT]
+TITLE: Hello world doc 2
+OPTIONS:
+  AUTO_LEVELS: On
+
+[TEXT]
+STATEMENT: >>>
+.. image:: _assets/file.svg
+   :alt: Test image
+   :class: image
+   :width: 100%
+<<<
+
+[DOCUMENT_FROM_FILE]
+FILE: subnested/subnested.sdoc

--- a/tests/integration/features/document_fragments/--included-documents/included_documents_option_provided/nested/subnested/subnested.sdoc
+++ b/tests/integration/features/document_fragments/--included-documents/included_documents_option_provided/nested/subnested/subnested.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Hello world doc 3
+OPTIONS:
+  AUTO_LEVELS: On
+
+[TEXT]
+STATEMENT: >>>
+.. image:: _assets/file.svg
+   :alt: Test image
+   :class: image
+   :width: 100%
+<<<
+
+[SECTION]
+TITLE: Section 1.2.3
+
+[COMPOSITE_REQUIREMENT]
+TITLE: Composite requirement 4.5.6
+
+[REQUIREMENT]
+TITLE: Requirement 7.8.9
+
+[/COMPOSITE_REQUIREMENT]
+
+[/SECTION]

--- a/tests/integration/features/document_fragments/--included-documents/included_documents_option_provided/test.itest
+++ b/tests/integration/features/document_fragments/--included-documents/included_documents_option_provided/test.itest
@@ -1,0 +1,36 @@
+RUN: %strictdoc export %S --included-documents --output-dir Output/ | filecheck %s --dump-input=fail
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%S/Output/html/included_documents_option_provided/_assets/file.svg"
+RUN: %check_exists --file "%S/Output/html/included_documents_option_provided/nested/_assets/file.svg"
+RUN: %check_exists --file "%S/Output/html/included_documents_option_provided/nested/subnested/_assets/file.svg"
+
+RUN: %check_exists --file "%S/Output/html/included_documents_option_provided/input.html"
+RUN: %check_exists --file "%S/Output/html/included_documents_option_provided/nested/nested.html"
+RUN: %check_exists --file "%S/Output/html/included_documents_option_provided/nested/subnested/subnested.html"
+
+RUN: %cat %S/Output/html/included_documents_option_provided/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+
+CHECK-HTML:data-level="0"
+CHECK-HTML:href="../included_documents_option_provided/input.html"
+CHECK-HTML:href="../included_documents_option_provided/nested/nested.html"
+CHECK-HTML:href="../included_documents_option_provided/nested/subnested/subnested.html"
+
+CHECK-HTML:data-level="1"
+CHECK-HTML:data-level="1.1"
+CHECK-HTML:data-level="1.1.1"
+CHECK-HTML:data-level="1.1.1.1"
+CHECK-HTML:data-level="1.1.1.1.1"
+
+RUN: %cat %S/Output/html/included_documents_option_provided/nested/nested.html | filecheck %s --dump-input=fail --check-prefix CHECK-NESTED-HTML
+
+CHECK-NESTED-HTML:href="../../included_documents_option_provided/input.html"
+CHECK-NESTED-HTML:href="../../included_documents_option_provided/nested/nested.html"
+CHECK-NESTED-HTML:href="../../included_documents_option_provided/nested/subnested/subnested.html"
+
+RUN: %cat %S/Output/html/included_documents_option_provided/nested/subnested/subnested.html | filecheck %s --dump-input=fail --check-prefix CHECK-SUBNESTED-HTML
+
+CHECK-SUBNESTED-HTML:href="../../../included_documents_option_provided/input.html"
+CHECK-SUBNESTED-HTML:href="../../../included_documents_option_provided/nested/nested.html"
+CHECK-SUBNESTED-HTML:href="../../../included_documents_option_provided/nested/subnested/subnested.html"
+

--- a/tests/integration/features/document_fragments/30_multiple_inclusion_of_document/input1.sdoc
+++ b/tests/integration/features/document_fragments/30_multiple_inclusion_of_document/input1.sdoc
@@ -1,5 +1,5 @@
 [DOCUMENT]
-TITLE: Hello world doc
+TITLE: Hello world doc 1
 
 [DOCUMENT_FROM_FILE]
 FILE: glossary.sdoc

--- a/tests/integration/features/document_fragments/30_multiple_inclusion_of_document/input2.sdoc
+++ b/tests/integration/features/document_fragments/30_multiple_inclusion_of_document/input2.sdoc
@@ -1,5 +1,5 @@
 [DOCUMENT]
-TITLE: Hello world doc
+TITLE: Hello world doc 2
 
 [DOCUMENT_FROM_FILE]
 FILE: glossary.sdoc

--- a/tests/integration/features/document_fragments/30_multiple_inclusion_of_document/test.itest
+++ b/tests/integration/features/document_fragments/30_multiple_inclusion_of_document/test.itest
@@ -1,9 +1,11 @@
 RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/30_multiple_inclusion_of_document/input1.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
-RUN: %cat %S/Output/html/30_multiple_inclusion_of_document/input2.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %S/Output/html/30_multiple_inclusion_of_document/input1.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-1
+RUN: %cat %S/Output/html/30_multiple_inclusion_of_document/input2.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-2
 
-CHECK-HTML:glossary.sdoc
-CHECK-HTML:glossary.sdoc
+CHECK-HTML-1:Hello world doc 1
+CHECK-HTML-1:Glossary...
 
+CHECK-HTML-2:Hello world doc 2
+CHECK-HTML-2:Glossary...


### PR DESCRIPTION
When the option was not provided, the included documents were not generated as expected. However, the links to the included documents were still generated on the project index screen. This changeset fixes the issue and additionally improves and centralizes handling of the conditions whether to show the included documents or not.