### PR TITLE
project_statistics: more precise calculation of statistics for REQUIREMENT

### DIFF
--- a/docs/strictdoc_21_L2_StrictDoc_Requirements.sdoc
+++ b/docs/strictdoc_21_L2_StrictDoc_Requirements.sdoc
@@ -836,7 +836,7 @@ RELATIONS:
 [REQUIREMENT]
 MID: d64f7a0f6ba54672a62634304c54e2d4
 UID: SDOC-SRS-96
-STATUS: Progress
+STATUS: Active
 TITLE: Auto-generate requirements UIDs
 STATEMENT: >>>
 StrictDoc's Document screen shall provide controls for automatic generation of requirements UIDs.
@@ -847,8 +847,10 @@ RELATIONS:
 - TYPE: Parent
   VALUE: SDOC-SSS-80
 - TYPE: File
+  FORMAT: Sourcecode
   VALUE: strictdoc/core/analyzers/document_uid_analyzer.py
 - TYPE: File
+  FORMAT: Sourcecode
   VALUE: strictdoc/commands/manage_autouid_command.py
 
 [REQUIREMENT]
@@ -1199,7 +1201,7 @@ TITLE: ReqIF
 [REQUIREMENT]
 MID: 2bf94015818e4770b2b1947b5fdbb969
 UID: SDOC-SRS-72
-STATUS: Progress
+STATUS: Active
 TITLE: Export/import from/to ReqIF
 STATEMENT: >>>
 StrictDoc shall support exporting/importing requirements content from/to ReqIF format.
@@ -1208,10 +1210,13 @@ RELATIONS:
 - TYPE: Parent
   VALUE: SDOC-SSS-58
 - TYPE: File
+  FORMAT: Sourcecode
   VALUE: strictdoc/backend/reqif/reqif_export.py
 - TYPE: File
+  FORMAT: Sourcecode
   VALUE: strictdoc/backend/reqif/reqif_import.py
 - TYPE: File
+  FORMAT: Sourcecode
   VALUE: strictdoc/backend/reqif/sdoc_reqif_fields.py
 
 [REQUIREMENT]

--- a/strictdoc/core/query_engine/query_object.py
+++ b/strictdoc/core/query_engine/query_object.py
@@ -200,7 +200,7 @@ class QueryObject:
         self, node, expression: NodeFieldExpression
     ) -> Optional[str]:
         field_name = expression.field_name
-        if node.is_requirement:
+        if node.is_requirement and node.node_type == "REQUIREMENT":
             requirement: SDocNode = assert_cast(node, SDocNode)
             requirement_document: SDocDocument = assert_cast(
                 requirement.get_document(), SDocDocument

--- a/strictdoc/export/html/generators/project_statistics.py
+++ b/strictdoc/export/html/generators/project_statistics.py
@@ -43,56 +43,59 @@ class ProgressStatisticsGenerator:
                         document_tree_stats.sections_without_text_nodes += 1
 
                 elif isinstance(node, SDocNode):
-                    requirement: SDocNode = assert_cast(node, SDocNode)
-                    if not requirement.is_text_node():
+                    if (
+                        node.is_normative_node()
+                        and node.node_type == "REQUIREMENT"
+                    ):
+                        requirement: SDocNode = assert_cast(node, SDocNode)
                         document_tree_stats.total_requirements += 1
 
-                    if requirement.reserved_uid is None:
-                        document_tree_stats.requirements_no_uid += 1
+                        if requirement.reserved_uid is None:
+                            document_tree_stats.requirements_no_uid += 1
 
-                    if requirement.reserved_status != "Backlog":
-                        if document.config.root:
-                            if (
-                                len(
-                                    traceability_index.get_children_requirements(
-                                        requirement
+                        if requirement.reserved_status != "Backlog":
+                            if document.config.root:
+                                if (
+                                    len(
+                                        traceability_index.get_children_requirements(
+                                            requirement
+                                        )
                                     )
-                                )
-                                == 0
-                            ):
-                                document_tree_stats.requirements_root_no_links += 1
-                        else:
-                            if (
-                                len(
-                                    traceability_index.get_parent_requirements(
-                                        requirement
+                                    == 0
+                                ):
+                                    document_tree_stats.requirements_root_no_links += 1
+                            else:
+                                if (
+                                    len(
+                                        traceability_index.get_parent_requirements(
+                                            requirement
+                                        )
                                     )
-                                )
-                                == 0
-                            ):
-                                document_tree_stats.requirements_no_links += 1
+                                    == 0
+                                ):
+                                    document_tree_stats.requirements_no_links += 1
 
-                    # RATIONALE
-                    if (
-                        requirement.ordered_fields_lookup.get("RATIONALE")
-                        is None
-                    ):
-                        document_tree_stats.requirements_no_rationale += 1
+                        # RATIONALE
+                        if (
+                            requirement.ordered_fields_lookup.get("RATIONALE")
+                            is None
+                        ):
+                            document_tree_stats.requirements_no_rationale += 1
 
-                    # STATUS
-                    if requirement.reserved_status is None:
-                        document_tree_stats.requirements_status_none += 1
-                    else:
-                        if requirement.reserved_status == "Backlog":
-                            document_tree_stats.requirements_status_backlog += 1
-                        elif requirement.reserved_status == "Draft":
-                            document_tree_stats.requirements_status_draft += 1
-                        elif requirement.reserved_status == "Active":
-                            document_tree_stats.requirements_status_active += 1
+                        # STATUS
+                        if requirement.reserved_status is None:
+                            document_tree_stats.requirements_status_none += 1
                         else:
-                            document_tree_stats.requirements_status_other += 1
+                            if requirement.reserved_status == "Backlog":
+                                document_tree_stats.requirements_status_backlog += 1
+                            elif requirement.reserved_status == "Draft":
+                                document_tree_stats.requirements_status_draft += 1
+                            elif requirement.reserved_status == "Active":
+                                document_tree_stats.requirements_status_active += 1
+                            else:
+                                document_tree_stats.requirements_status_other += 1
 
-                    for requirement_field_ in requirement.enumerate_fields():
+                    for requirement_field_ in node.enumerate_fields():
                         field_value = requirement_field_.get_text_value()
                         if field_value is not None:
                             if "TBD" in field_value:

--- a/tests/integration/features/project_statistics/20_requirement_metric_does_not_include_text_nodes/input.sdoc
+++ b/tests/integration/features/project_statistics/20_requirement_metric_does_not_include_text_nodes/input.sdoc
@@ -1,0 +1,22 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[TEXT]
+STATEMENT: >>>
+Text
+<<<
+
+[REQUIREMENT]
+STATEMENT: >>>
+Text
+<<<
+
+[REQUIREMENT]
+STATEMENT: >>>
+Text
+<<<
+
+[REQUIREMENT]
+STATEMENT: >>>
+Text
+<<<

--- a/tests/integration/features/project_statistics/20_requirement_metric_does_not_include_text_nodes/strictdoc.toml
+++ b/tests/integration/features/project_statistics/20_requirement_metric_does_not_include_text_nodes/strictdoc.toml
@@ -1,0 +1,6 @@
+[project]
+title = "Test project"
+
+features = [
+  "PROJECT_STATISTICS_SCREEN",
+]

--- a/tests/integration/features/project_statistics/20_requirement_metric_does_not_include_text_nodes/test.itest
+++ b/tests/integration/features/project_statistics/20_requirement_metric_does_not_include_text_nodes/test.itest
@@ -1,0 +1,20 @@
+# This test ensures that the TEXT nodes DO NOT contribute to the requirements statistics.
+
+RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%S/Output/html/project_statistics.html"
+
+RUN: %cat "%S/Output/html/project_statistics.html" | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+CHECK-HTML: Total requirements
+CHECK-HTML: 3
+CHECK-HTML: Requirements with no UID
+CHECK-HTML: 3
+CHECK-HTML: Root-level requirements not connected to by any requirement
+CHECK-HTML: 0
+CHECK-HTML: Requirements with no RATIONALE
+CHECK-HTML: 3
+CHECK-HTML: Requirements with no Status
+CHECK-HTML: 3
+CHECK-HTML: Requirements with status Active
+CHECK-HTML: 0


### PR DESCRIPTION
Previously, some statistics also counted in the TEXT nodes. Now that the TEXT nodes are clearly non-normative text, they must be excluded from all requirements-related statistics.