### PR TITLE
pdf export: fix pdf export with pictures

### DIFF
--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -2530,8 +2530,11 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
             MID(document_mid)
         )
 
+        root_path = document.meta.get_root_path_prefix()
+        relative_path = document.meta.output_document_dir_rel_path.relative_path
+
         link_renderer = LinkRenderer(
-            root_path="", static_path=project_config.dir_for_sdoc_assets
+            root_path=root_path, static_path=project_config.dir_for_sdoc_assets
         )
         markup_renderer = MarkupRenderer.create(
             "RST",
@@ -2558,7 +2561,7 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
             )
 
         path_to_output_html = os.path.join(
-            project_config.export_output_html_root, "_temp.html"
+            project_config.export_output_html_root, relative_path, "_temp.html"
         )
         path_to_output_pdf = os.path.join(
             project_config.export_output_html_root, "html", "_temp.pdf"

--- a/tests/end2end/screens/document/_export_to_pdf/export_to_pdf_with_picture/_assets/picture.svg
+++ b/tests/end2end/screens/document/_export_to_pdf/export_to_pdf_with_picture/_assets/picture.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-40 -40 80 80">
+  <circle r="39"/>
+  <path fill="#fff" d="M0,38a38,38 0 0 1 0,-76a19,19 0 0 1 0,38a19,19 0 0 0 0,38"/>
+  <circle r="5" cy="19" fill="#fff"/>
+  <circle r="5" cy="-19"/>
+</svg>

--- a/tests/end2end/screens/document/_export_to_pdf/export_to_pdf_with_picture/document.sdoc
+++ b/tests/end2end/screens/document/_export_to_pdf/export_to_pdf_with_picture/document.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[TEXT]
+STATEMENT: >>>
+.. image:: _assets/picture.*
+<<<

--- a/tests/end2end/screens/document/_export_to_pdf/export_to_pdf_with_picture/strictdoc.toml
+++ b/tests/end2end/screens/document/_export_to_pdf/export_to_pdf_with_picture/strictdoc.toml
@@ -1,0 +1,5 @@
+[project]
+
+features = [
+  "HTML2PDF",
+]

--- a/tests/end2end/screens/document/_export_to_pdf/export_to_pdf_with_picture/test_case.py
+++ b/tests/end2end/screens/document/_export_to_pdf/export_to_pdf_with_picture/test_case.py
@@ -1,0 +1,43 @@
+import os
+import shutil
+
+from tests.end2end.conftest import DOWNLOADED_FILES_PATH, test_environment
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+path_to_this_test_file_folder = os.path.dirname(os.path.abspath(__file__))
+path_to_expected_downloaded_file = os.path.join(
+    DOWNLOADED_FILES_PATH, "document.pdf"
+)
+
+
+class Test(E2ECase):
+    def test(self):
+        shutil.rmtree(DOWNLOADED_FILES_PATH, ignore_errors=True)
+
+        with SDocTestServer(
+            input_path=path_to_this_test_file_folder
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+
+            # TODO
+            shutil.rmtree(DOWNLOADED_FILES_PATH, ignore_errors=True)
+            assert not os.path.exists(path_to_expected_downloaded_file)
+
+            screen_document.do_export_pdf()
+
+            self.sleep(test_environment.download_file_timeout_seconds)
+            assert os.path.exists(path_to_expected_downloaded_file)


### PR DESCRIPTION
I've noticed an issue with the PDF export lately. When a document includes a picture, exporting it to PDF format no longer works.

This PR moves the location of the generated "_temp.html" file to the same subfolder as the original HTML document so that relative links to project assets (pictures) work.