### PR TITLE
UI: add web form support for existing TAG grammar field type

### DIFF
--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -117,6 +117,7 @@ class RequirementFormField:
             RequirementFieldType.STRING,
             RequirementFieldType.SINGLE_CHOICE,
             RequirementFieldType.MULTIPLE_CHOICE,
+            RequirementFieldType.TAG,
         ):
             field_value = requirement_field.get_text_value()
             return RequirementFormField(


### PR DESCRIPTION
StrictDoc crashed when rendering the edit form for requirements containing the `TAG` field. This was due to missing handling in the `create_existing_from_grammar_field()` method for `GrammarElementFieldTag`.

This patch adds support for the TAG field type in the web form, preventing `NotImplementedError` and allowing full edit functionality.