### PR TITLE
code-climate: #2217 fix get_requirement() depreciation warning

### DIFF
--- a/tests/end2end/navigation/toc/toc_navigation/test_case.py
+++ b/tests/end2end/navigation/toc/toc_navigation/test_case.py
@@ -32,7 +32,7 @@ class Test(E2ECase):
             section_without_uid = screen_document.get_section(1)
             section_with_uid = screen_document.get_section(2)
             # Requirement #1 has not a title and doesn't go in the TOC
-            requirement_with_title = screen_document.get_requirement(2)
+            requirement_with_title = screen_document.get_node(2)
 
             section_without_uid.assert_section_title("Section without UID")
             section_with_uid.assert_section_title("Section with UID")

--- a/tests/end2end/screens/deep_traceability/view_document/view_document_go_from_requirement_card_to_requirement_in_document_view/test_case.py
+++ b/tests/end2end/screens/deep_traceability/view_document/view_document_go_from_requirement_card_to_requirement_in_document_view/test_case.py
@@ -35,7 +35,7 @@ class Test(E2ECase):
             )
             screen_deep_traceability.assert_on_screen_deep_traceability()
 
-            requirement = screen_deep_traceability.get_requirement()
+            requirement = screen_deep_traceability.get_node()
 
             requirement.assert_requirement_uid("REQ-001")
 

--- a/tests/end2end/screens/deep_traceability/view_document/view_document_go_from_requirement_card_to_requirement_in_document_view_another_document/test_case.py
+++ b/tests/end2end/screens/deep_traceability/view_document/view_document_go_from_requirement_card_to_requirement_in_document_view_another_document/test_case.py
@@ -40,7 +40,7 @@ class Test(E2ECase):
             )
             screen_deep_traceability.assert_on_screen_deep_traceability()
 
-            requirement = screen_deep_traceability.get_requirement(2)
+            requirement = screen_deep_traceability.get_node(2)
             requirement.assert_requirement_uid("REQ-002")
 
             screen_document_ = (

--- a/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_delete/_validations/delete_node_that_has_incoming_links/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_delete/_validations/delete_node_that_has_incoming_links/test_case.py
@@ -24,7 +24,7 @@ class Test(E2ECase):
 
             screen_document.assert_on_screen_document()
 
-            section = screen_document.get_requirement(2)
+            section = screen_document.get_node(2)
             section.assert_requirement_title("Linked-to requirement")
             section.do_delete_node(proceed_with_confirm=False)
 

--- a/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_delete/_validations/delete_node_with_anchor_that_has_incoming_links/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_delete/_validations/delete_node_with_anchor_that_has_incoming_links/test_case.py
@@ -24,7 +24,7 @@ class Test(E2ECase):
 
             screen_document.assert_on_screen_document()
 
-            section = screen_document.get_requirement(2)
+            section = screen_document.get_node(2)
             section.assert_requirement_title("Linked-to requirement")
             section.do_delete_node(proceed_with_confirm=False)
 

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_included_grammar/update_included_document_with_included_grammar_create_requirement/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_included_grammar/update_included_document_with_included_grammar_create_requirement/test_case.py
@@ -44,7 +44,7 @@ class Test(E2ECase):
             )
             form_edit_requirement.do_form_submit()
 
-            requirement: Requirement = screen_document.get_requirement()
+            requirement: Requirement = screen_document.get_node()
 
             requirement.assert_requirement_title("Requirement title")
             requirement.assert_requirement_statement_contains(

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_requirement_above/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_requirement_above/test_case.py
@@ -45,7 +45,7 @@ class Test(E2ECase):
 
             form_edit_section.do_form_submit()
 
-            requirement: Requirement = screen_document.get_requirement(1)
+            requirement: Requirement = screen_document.get_node(1)
 
             requirement.assert_requirement_title("Requirement title")
 

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_requirement_above_but_below_another_section/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_requirement_above_but_below_another_section/test_case.py
@@ -45,7 +45,7 @@ class Test(E2ECase):
 
             form_edit_section.do_form_submit()
 
-            requirement: Requirement = screen_document.get_requirement(1)
+            requirement: Requirement = screen_document.get_node(1)
 
             requirement.assert_requirement_title("Requirement title")
 

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_requirement_below/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_requirement_below/test_case.py
@@ -45,7 +45,7 @@ class Test(E2ECase):
 
             form_edit_section.do_form_submit()
 
-            requirement: Requirement = screen_document.get_requirement(1)
+            requirement: Requirement = screen_document.get_node(1)
 
             requirement.assert_requirement_title("Requirement title")
 

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_requirement/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_requirement/test_case.py
@@ -44,7 +44,7 @@ class Test(E2ECase):
             )
             form_edit_requirement.do_form_submit()
 
-            requirement: Requirement = screen_document.get_requirement()
+            requirement: Requirement = screen_document.get_node()
 
             requirement.assert_requirement_title("Requirement title")
             requirement.assert_requirement_statement_contains(

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_delete_requirement/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_delete_requirement/test_case.py
@@ -25,7 +25,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement(1)
+            requirement = screen_document.get_node(1)
             requirement.do_delete_node()
 
             screen_document.get_root_node().assert_document_title_contains(

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_edit_requirement/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_edit_requirement/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement(1)
+            requirement = screen_document.get_node(1)
 
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()

--- a/tests/end2end/screens/document/clone_requirement/clone_requirement/test_case.py
+++ b/tests/end2end/screens/document/clone_requirement/clone_requirement/test_case.py
@@ -38,7 +38,7 @@ class Test(E2ECase):
                 by=By.XPATH,
             )
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             requirement.assert_requirement_title("Requirement title", "2")
             requirement.assert_requirement_uid_contains("REQ-1")
             requirement.assert_requirement_statement_contains(

--- a/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_after_test_element/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_after_test_element/test_case.py
@@ -45,7 +45,7 @@ class Test(E2ECase):
             )
             form_edit_requirement.do_form_submit()
 
-            node_2 = screen_document.get_requirement(node_order=2)
+            node_2 = screen_document.get_node(node_order=2)
 
             node_2.assert_requirement_title("Unit test 2 ABC", "2")
             screen_document.assert_toc_contains("Unit test 2 ABC")

--- a/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_in_section/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_in_section/test_case.py
@@ -52,7 +52,7 @@ class Test(E2ECase):
             Expected for Requirement.
             """
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
 
             requirement.assert_requirement_title("Unit test ABC", "1.1")
             screen_document.assert_toc_contains("Unit test ABC")

--- a/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_in_top_level_document/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_in_top_level_document/test_case.py
@@ -44,7 +44,7 @@ class Test(E2ECase):
             )
             form_edit_requirement.do_form_submit()
 
-            node_2 = screen_document.get_requirement(node_order=1)
+            node_2 = screen_document.get_node(node_order=1)
 
             node_2.assert_requirement_title("Unit test 1 ABC", "1")
             screen_document.assert_toc_contains("Unit test 1 ABC")

--- a/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_with_custom_field_in_top_level_document/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_with_custom_field_in_top_level_document/test_case.py
@@ -45,7 +45,7 @@ class Test(E2ECase):
             form_edit_requirement.do_fill_in("CUSTOM_FIELD", "New content.")
             form_edit_requirement.do_form_submit()
 
-            node_2 = screen_document.get_requirement(node_order=1)
+            node_2 = screen_document.get_node(node_order=1)
 
             node_2.assert_field_contains("CUSTOM_FIELD", "New content.")
 

--- a/tests/end2end/screens/document/create_requirement/_autouid/create_requirement_generate_autouid_first_and_second_requirement/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_autouid/create_requirement_generate_autouid_first_and_second_requirement/test_case.py
@@ -46,7 +46,7 @@ class Test(E2ECase):
 
             # Expected for Requirement 1:
 
-            requirement_1 = screen_document.get_requirement()
+            requirement_1 = screen_document.get_node()
 
             requirement_1.assert_requirement_title("Requirement title #1", "1")
             screen_document.assert_toc_contains("Requirement title #1")
@@ -67,7 +67,7 @@ class Test(E2ECase):
 
             # Expected for Requirement 2:
 
-            requirement_2 = screen_document.get_requirement(2)
+            requirement_2 = screen_document.get_node(2)
             requirement_2.assert_requirement_title("Requirement title #2", "2")
             screen_document.assert_toc_contains("Requirement title #2")
 

--- a/tests/end2end/screens/document/create_requirement/_autouid/create_requirement_generate_autouid_first_and_second_requirement_two_different_documents/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_autouid/create_requirement_generate_autouid_first_and_second_requirement_two_different_documents/test_case.py
@@ -46,7 +46,7 @@ class Test(E2ECase):
 
             # Expected for Requirement 1:
 
-            requirement_1 = screen_document.get_requirement()
+            requirement_1 = screen_document.get_node()
 
             requirement_1.assert_requirement_title("Requirement title #1", "1")
             screen_document.assert_toc_contains("Requirement title #1")
@@ -67,7 +67,7 @@ class Test(E2ECase):
 
             # Expected for Requirement 2:
 
-            requirement_2 = screen_document.get_requirement(2)
+            requirement_2 = screen_document.get_node(2)
             requirement_2.assert_requirement_title("Requirement title #2", "2")
             screen_document.assert_toc_contains("Requirement title #2")
 

--- a/tests/end2end/screens/document/create_requirement/_autouid/create_requirement_generate_autouid_when_requirement_with_another_prefix_exists/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_autouid/create_requirement_generate_autouid_when_requirement_with_another_prefix_exists/test_case.py
@@ -29,7 +29,7 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
 
             # Requirement 1
-            requirement_1 = screen_document.get_requirement(1)
+            requirement_1 = screen_document.get_node(1)
             assert requirement_1 is not None
             requirement_1.assert_requirement_uid_contains("ZEP-1")
 
@@ -52,7 +52,7 @@ class Test(E2ECase):
             # Expected for Requirement 2:
             screen_document.assert_toc_contains("Requirement title #1.2")
 
-            requirement_2 = screen_document.get_requirement(2)
+            requirement_2 = screen_document.get_node(2)
             requirement_2.assert_requirement_title(
                 "Requirement title #1.2", "2"
             )

--- a/tests/end2end/screens/document/create_requirement/_relations/_validations/create_requirement_validate_relation_parent_does_not_exist/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_relations/_validations/create_requirement_validate_relation_parent_does_not_exist/test_case.py
@@ -29,7 +29,7 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
 
             # Requirement 1
-            node_requirement1 = screen_document.get_requirement(1)
+            node_requirement1 = screen_document.get_node(1)
             node_menu_requirement1 = node_requirement1.do_open_node_menu()
             form_edit_requirement: Form_EditRequirement = (
                 node_menu_requirement1.do_node_add_requirement_below()

--- a/tests/end2end/screens/document/create_requirement/_relations/_validations/create_requirement_validate_relation_source_must_have_uid/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_relations/_validations/create_requirement_validate_relation_source_must_have_uid/test_case.py
@@ -29,7 +29,7 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
 
             # Requirement 1
-            node_requirement1 = screen_document.get_requirement(1)
+            node_requirement1 = screen_document.get_node(1)
             node_menu_requirement1 = node_requirement1.do_open_node_menu()
             form_edit_requirement: Form_EditRequirement = (
                 node_menu_requirement1.do_node_add_requirement_below()

--- a/tests/end2end/screens/document/create_requirement/_relations/create_requirement_with_relation_and_role_to_existing_requirement/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_relations/create_requirement_with_relation_and_role_to_existing_requirement/test_case.py
@@ -29,7 +29,7 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
 
             # Requirement 1
-            node_requirement1 = screen_document.get_requirement(1)
+            node_requirement1 = screen_document.get_node(1)
             node_menu_requirement1 = node_requirement1.do_open_node_menu()
             form_edit_requirement: Form_EditRequirement = (
                 node_menu_requirement1.do_node_add_requirement_below()

--- a/tests/end2end/screens/document/create_requirement/_relations/create_requirement_with_relation_to_existing_requirement/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_relations/create_requirement_with_relation_to_existing_requirement/test_case.py
@@ -29,7 +29,7 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
 
             # Requirement 1
-            node_requirement1 = screen_document.get_requirement(1)
+            node_requirement1 = screen_document.get_node(1)
             node_menu_requirement1 = node_requirement1.do_open_node_menu()
             form_edit_requirement: Form_EditRequirement = (
                 node_menu_requirement1.do_node_add_requirement_below()

--- a/tests/end2end/screens/document/create_requirement/_validation/create_requirement_validate_uid_already_exists/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_validation/create_requirement_validate_uid_already_exists/test_case.py
@@ -39,7 +39,7 @@ class Test(E2ECase):
 
             screen_document.assert_text("Hello world!")
 
-            requirement_node = screen_document.get_requirement(1)
+            requirement_node = screen_document.get_node(1)
             root_node_menu = requirement_node.do_open_node_menu()
             form_edit_requirement: Form_EditRequirement = (
                 root_node_menu.do_node_add_requirement_below()

--- a/tests/end2end/screens/document/create_requirement/create_requirement_after_section/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/create_requirement_after_section/test_case.py
@@ -46,7 +46,7 @@ class Test(E2ECase):
 
             # Expected for Requirement:
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             requirement.assert_requirement_title("Requirement title", "2")
             screen_document.assert_toc_contains("Requirement title")
 

--- a/tests/end2end/screens/document/create_requirement/create_requirement_in_section/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/create_requirement_in_section/test_case.py
@@ -46,7 +46,7 @@ class Test(E2ECase):
 
             # Expected for Requirement:
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
 
             requirement.assert_requirement_title("Requirement title", "1.1")
             screen_document.assert_toc_contains("Requirement title")

--- a/tests/end2end/screens/document/create_requirement/create_requirement_in_top_level_document/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/create_requirement_in_top_level_document/test_case.py
@@ -46,7 +46,7 @@ class Test(E2ECase):
 
             # Expected for Requirement 1:
 
-            requirement_1 = screen_document.get_requirement()
+            requirement_1 = screen_document.get_node()
 
             requirement_1.assert_requirement_title("Requirement title #1", "1")
             screen_document.assert_toc_contains("Requirement title #1")
@@ -68,7 +68,7 @@ class Test(E2ECase):
 
             # Expected for Requirement 2:
 
-            requirement_2 = screen_document.get_requirement(2)
+            requirement_2 = screen_document.get_node(2)
             requirement_2.assert_requirement_title("Requirement title #2", "2")
             screen_document.assert_toc_contains("Requirement title #2")
 
@@ -89,7 +89,7 @@ class Test(E2ECase):
 
             # Expected for Requirement 3:
 
-            requirement_3 = screen_document.get_requirement(3)
+            requirement_3 = screen_document.get_node(3)
 
             requirement_3.assert_requirement_title("Requirement title #3", "3")
             screen_document.assert_toc_contains("Requirement title #3")

--- a/tests/end2end/screens/document/create_requirement/create_requirement_sanitize_trailing_symbols/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/create_requirement_sanitize_trailing_symbols/test_case.py
@@ -43,7 +43,7 @@ class Test(E2ECase):
             form_edit_requirement.do_form_submit()
 
             # Check the resulting TOC.
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             requirement.assert_requirement_title("Requirement title #1", "1")
             screen_document.assert_toc_contains("Requirement title #1")
 

--- a/tests/end2end/screens/document/create_requirement/create_requirement_using_autocomplete/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/create_requirement_using_autocomplete/test_case.py
@@ -61,7 +61,7 @@ class Test(E2ECase):
 
             form_edit_requirement.do_form_submit()
 
-            node_2 = screen_document.get_requirement(node_order=2)
+            node_2 = screen_document.get_node(node_order=2)
 
             node_2.assert_requirement_title("Requirement 2 XYZ", "2")
             screen_document.assert_toc_contains("Requirement 2 XYZ")

--- a/tests/end2end/screens/document/create_section/create_section_after_requirement/test_case.py
+++ b/tests/end2end/screens/document/create_section/create_section_after_requirement/test_case.py
@@ -30,7 +30,7 @@ class Test(E2ECase):
 
             # Check Requirement
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             requirement.assert_requirement_title("Requirement title", "1")
 
             # Create Section after

--- a/tests/end2end/screens/document/delete_requirement/delete_requirement_delete_existing/test_case.py
+++ b/tests/end2end/screens/document/delete_requirement/delete_requirement_delete_existing/test_case.py
@@ -25,7 +25,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             requirement.assert_requirement_title("Requirement title")
             requirement.do_delete_node()  # confirm is inside
 

--- a/tests/end2end/screens/document/delete_requirement/delete_requirement_delete_newly_created/test_case.py
+++ b/tests/end2end/screens/document/delete_requirement/delete_requirement_delete_newly_created/test_case.py
@@ -50,7 +50,7 @@ class Test(E2ECase):
             """
             Delete requirement.
             """
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             requirement.assert_requirement_title("Requirement title")
             requirement.do_delete_node()  # confirm is inside
 

--- a/tests/end2end/screens/document/update_requirement/_arbitrary_elements/update_requirement_edit_custom_node_statement/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_arbitrary_elements/update_requirement_edit_custom_node_statement/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_comments/update_requirement_add_comment/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_comments/update_requirement_add_comment/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_comments/update_requirement_add_empty_to_two_existing_comments/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_comments/update_requirement_add_empty_to_two_existing_comments/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_comments/update_requirement_remove_comment/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_comments/update_requirement_remove_comment/test_case.py
@@ -30,7 +30,7 @@ class Test(E2ECase):
 
             screen_document.assert_text("Comment #1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_comments/update_requirement_remove_one_of_three_comments/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_comments/update_requirement_remove_one_of_three_comments/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_relations/_validations/_cycles/update_requirement_validate_2_requirements_add_child_link_with_cycle/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/_validations/_cycles/update_requirement_validate_2_requirements_add_child_link_with_cycle/test_case.py
@@ -32,7 +32,7 @@ class Test(E2ECase):
             added_requirement_1_level = "1"
             added_requirement_1_position = 1
 
-            requirement1 = screen_document.get_requirement(
+            requirement1 = screen_document.get_node(
                 added_requirement_1_position
             )
 
@@ -46,7 +46,7 @@ class Test(E2ECase):
             added_requirement_2_level = "2"
             added_requirement_2_position = 2
 
-            requirement2 = screen_document.get_requirement(
+            requirement2 = screen_document.get_node(
                 added_requirement_2_position
             )
 

--- a/tests/end2end/screens/document/update_requirement/_relations/_validations/_cycles/update_requirement_validate_2_requirements_add_parent_link_with_cycle/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/_validations/_cycles/update_requirement_validate_2_requirements_add_parent_link_with_cycle/test_case.py
@@ -32,7 +32,7 @@ class Test(E2ECase):
             added_requirement_1_level = "1"
             added_requirement_1_position = 1
 
-            requirement1 = screen_document.get_requirement(
+            requirement1 = screen_document.get_node(
                 added_requirement_1_position
             )
 
@@ -46,7 +46,7 @@ class Test(E2ECase):
             added_requirement_2_level = "2"
             added_requirement_2_position = 2
 
-            requirement2 = screen_document.get_requirement(
+            requirement2 = screen_document.get_node(
                 added_requirement_2_position
             )
 

--- a/tests/end2end/screens/document/update_requirement/_relations/_validations/_cycles/update_requirement_validate_3_requirements_add_child_link_with_cycle/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/_validations/_cycles/update_requirement_validate_3_requirements_add_child_link_with_cycle/test_case.py
@@ -32,7 +32,7 @@ class Test(E2ECase):
             added_requirement_1_level = "1"
             added_requirement_1_position = 1
 
-            requirement1 = screen_document.get_requirement(
+            requirement1 = screen_document.get_node(
                 added_requirement_1_position
             )
 
@@ -46,7 +46,7 @@ class Test(E2ECase):
             added_requirement_2_level = "2"
             added_requirement_2_position = 2
 
-            requirement2 = screen_document.get_requirement(
+            requirement2 = screen_document.get_node(
                 added_requirement_2_position
             )
 

--- a/tests/end2end/screens/document/update_requirement/_relations/_validations/_cycles/update_requirement_validate_3_requirements_add_parent_link_with_cycle/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/_validations/_cycles/update_requirement_validate_3_requirements_add_parent_link_with_cycle/test_case.py
@@ -32,7 +32,7 @@ class Test(E2ECase):
             added_requirement_1_level = "1"
             added_requirement_1_position = 1
 
-            requirement1 = screen_document.get_requirement(
+            requirement1 = screen_document.get_node(
                 added_requirement_1_position
             )
 
@@ -46,7 +46,7 @@ class Test(E2ECase):
             added_requirement_2_level = "2"
             added_requirement_2_position = 2
 
-            requirement2 = screen_document.get_requirement(
+            requirement2 = screen_document.get_node(
                 added_requirement_2_position
             )
 

--- a/tests/end2end/screens/document/update_requirement/_relations/_validations/_cycles/update_requirement_validate_not_possible_parent_and_child_relation_same_uid/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/_validations/_cycles/update_requirement_validate_not_possible_parent_and_child_relation_same_uid/test_case.py
@@ -32,7 +32,7 @@ class Test(E2ECase):
             added_requirement_1_level = "1"
             added_requirement_1_position = 1
 
-            requirement1 = screen_document.get_requirement(
+            requirement1 = screen_document.get_node(
                 added_requirement_1_position
             )
 
@@ -46,7 +46,7 @@ class Test(E2ECase):
             added_requirement_2_level = "2"
             added_requirement_2_position = 2
 
-            requirement2 = screen_document.get_requirement(
+            requirement2 = screen_document.get_node(
                 added_requirement_2_position
             )
 

--- a/tests/end2end/screens/document/update_requirement/_relations/_validations/update_requirement_linking_requirement_must_have_uid/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/_validations/update_requirement_linking_requirement_must_have_uid/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_relations/_validations/update_requirement_parent_uid_does_not_exist/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/_validations/update_requirement_parent_uid_does_not_exist/test_case.py
@@ -29,7 +29,7 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
 
             # Open form and add 1 field:
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_relations/_validations/update_requirement_parent_uid_must_not_be_empty/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/_validations/update_requirement_parent_uid_must_not_be_empty/test_case.py
@@ -29,7 +29,7 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
 
             # Open form and add 1 field:
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_one_child_link_with_role/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_one_child_link_with_role/test_case.py
@@ -29,7 +29,7 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
 
             # Existing Requirement 2:
-            requirement2 = screen_document.get_requirement(2)
+            requirement2 = screen_document.get_node(2)
             screen_document.assert_toc_contains("Requirement title #2")
 
             # Edit Requirement 2: add one relation

--- a/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_one_link/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_one_link/test_case.py
@@ -32,7 +32,7 @@ class Test(E2ECase):
             added_requirement_1_level = "1"
             added_requirement_1_position = 1
 
-            requirement1 = screen_document.get_requirement(
+            requirement1 = screen_document.get_node(
                 added_requirement_1_position
             )
 
@@ -46,7 +46,7 @@ class Test(E2ECase):
             added_requirement_2_level = "2"
             added_requirement_2_position = 2
 
-            requirement2 = screen_document.get_requirement(
+            requirement2 = screen_document.get_node(
                 added_requirement_2_position
             )
 

--- a/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_one_link_with_trailing_spaces/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_one_link_with_trailing_spaces/test_case.py
@@ -32,7 +32,7 @@ class Test(E2ECase):
             added_requirement_1_level = "1"
             added_requirement_1_position = 1
 
-            requirement1 = screen_document.get_requirement(
+            requirement1 = screen_document.get_node(
                 added_requirement_1_position
             )
 
@@ -46,7 +46,7 @@ class Test(E2ECase):
             added_requirement_2_level = "2"
             added_requirement_2_position = 2
 
-            requirement2 = screen_document.get_requirement(
+            requirement2 = screen_document.get_node(
                 added_requirement_2_position
             )
 

--- a/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_one_parent_link_with_role/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_one_parent_link_with_role/test_case.py
@@ -32,7 +32,7 @@ class Test(E2ECase):
             added_requirement_1_level = "1"
             added_requirement_1_position = 1
 
-            requirement1 = screen_document.get_requirement(
+            requirement1 = screen_document.get_node(
                 added_requirement_1_position
             )
 
@@ -46,7 +46,7 @@ class Test(E2ECase):
             added_requirement_2_level = "2"
             added_requirement_2_position = 2
 
-            requirement2 = screen_document.get_requirement(
+            requirement2 = screen_document.get_node(
                 added_requirement_2_position
             )
 

--- a/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_second_child_link_with_role/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_second_child_link_with_role/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement3 = screen_document.get_requirement(3)
+            requirement3 = screen_document.get_node(3)
 
             form_edit_requirement: Form_EditRequirement = (
                 requirement3.do_open_form_edit_requirement()

--- a/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_second_parent_link_with_role/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_second_parent_link_with_role/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement3 = screen_document.get_requirement(3)
+            requirement3 = screen_document.get_node(3)
             screen_document.assert_toc_contains("Requirement title #3")
 
             # Edit Requirement 2: add one relation

--- a/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_three_links/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/update_requirement_add_three_links/test_case.py
@@ -29,7 +29,7 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
 
             # Open form and add 3 fields:
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_relations/update_requirement_remove_child_link/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/update_requirement_remove_child_link/test_case.py
@@ -28,8 +28,8 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement1 = screen_document.get_requirement(1)
-            requirement2 = screen_document.get_requirement(2)
+            requirement1 = screen_document.get_node(1)
+            requirement2 = screen_document.get_node(2)
 
             # Make sure there is the reference to the child in Requirement 1:
             requirement1.assert_requirement_uid_contains("REQ-001")

--- a/tests/end2end/screens/document/update_requirement/_relations/update_requirement_remove_parent_link/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/update_requirement_remove_parent_link/test_case.py
@@ -28,8 +28,8 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement1 = screen_document.get_requirement(1)
-            requirement2 = screen_document.get_requirement(2)
+            requirement1 = screen_document.get_node(1)
+            requirement2 = screen_document.get_node(2)
 
             # Make sure there is the reference to the child in Requirement 1:
             requirement1.assert_requirement_uid_contains("REQ-001")

--- a/tests/end2end/screens/document/update_requirement/_relations/update_requirement_renaming_uid_when_child_links_exist/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/update_requirement_renaming_uid_when_child_links_exist/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_relations/update_requirement_renaming_uid_when_parent_links_exist/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/update_requirement_renaming_uid_when_parent_links_exist/test_case.py
@@ -29,7 +29,7 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
 
             # Open form and add 1 fields:
-            requirement = screen_document.get_requirement(2)
+            requirement = screen_document.get_node(2)
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_relations/update_requirement_two_documents_removing_link/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_relations/update_requirement_two_documents_removing_link/test_case.py
@@ -25,7 +25,7 @@ class Test(E2ECase):
             # First, go to first document and check that the first document's
             # requirement REQ-001 does contain a child relation to REQ-002.
             screen_document1 = screen_project_index.do_click_on_the_document(1)
-            requirement1 = screen_document1.get_requirement()
+            requirement1 = screen_document1.get_node()
             requirement1.assert_requirement_has_child_relation("REQ-002")
 
             # Go back to tree
@@ -34,7 +34,7 @@ class Test(E2ECase):
             # Go to second document and check that the first document's
             # requirement REQ-001 does contain a parent relation to REQ-001,
             screen_document2 = screen_project_index.do_click_on_the_document(2)
-            requirement2 = screen_document2.get_requirement()
+            requirement2 = screen_document2.get_node()
             requirement2.assert_requirement_has_parent_relation("REQ-001")
 
             # and remove the parent relation to REQ-001.
@@ -51,12 +51,12 @@ class Test(E2ECase):
             # Now check that the documents do not have the link anymore.
             self.open(test_server.get_host_and_port())
             screen_document1 = screen_project_index.do_click_on_the_document(1)
-            requirement1 = screen_document1.get_requirement()
+            requirement1 = screen_document1.get_node()
             requirement1.assert_requirement_has_not_child_relation("REQ-002")
 
             self.open(test_server.get_host_and_port())
             screen_document2 = screen_project_index.do_click_on_the_document(2)
-            requirement2 = screen_document2.get_requirement()
+            requirement2 = screen_document2.get_node()
             requirement2.assert_requirement_has_not_parent_relation("REQ-001")
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/update_requirement/_validation/update_requirement_empty_statement/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_validation/update_requirement_empty_statement/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_validation/update_requirement_empty_statement_DESCRIPTION_instead_STATEMENT/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_validation/update_requirement_empty_statement_DESCRIPTION_instead_STATEMENT/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_validation/update_requirement_must_not_save_INCORRECT_MultipleChoice_value/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_validation/update_requirement_must_not_save_INCORRECT_MultipleChoice_value/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_validation/update_requirement_must_not_save_INCORRECT_SingleChoice_value/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_validation/update_requirement_must_not_save_INCORRECT_SingleChoice_value/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_validation/update_requirement_must_not_save_empty_required_field/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_validation/update_requirement_must_not_save_empty_required_field/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_validation/update_requirement_must_sanitize_MultipleChoice_separation/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_validation/update_requirement_must_sanitize_MultipleChoice_separation/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/_validation/update_requirement_statement_malformed_rst/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_validation/update_requirement_statement_malformed_rst/test_case.py
@@ -29,7 +29,7 @@ class Test_UC07_G2_T02_StatementMalformedRST(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/update_requirement_cancel_edit_requirement/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/update_requirement_cancel_edit_requirement/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/update_requirement_edit_table_style_requirement/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/update_requirement_edit_table_style_requirement/test_case.py
@@ -25,7 +25,7 @@ class Test(E2ECase):
 
             screen_document = screen_project_index.do_click_on_first_document()
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             # Make sure that the table-based requirement is rendered.
             requirement.assert_requirement_style_table()
 

--- a/tests/end2end/screens/document/update_requirement/update_requirement_editing_statement_only/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/update_requirement_editing_statement_only/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/update_requirement_escape_html_in_statement/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/update_requirement_escape_html_in_statement/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/update_requirement_reescape_html_by_validations/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/update_requirement_reescape_html_by_validations/test_case.py
@@ -29,7 +29,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/update_requirement_remove_uid_then_create_new_requirement/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/update_requirement_remove_uid_then_create_new_requirement/test_case.py
@@ -36,7 +36,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement: Requirement = screen_document.get_requirement()
+            requirement: Requirement = screen_document.get_node()
 
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()

--- a/tests/end2end/screens/document/update_requirement/update_requirement_saves_empty_MultipleChoice_value/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/update_requirement_saves_empty_MultipleChoice_value/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/update_requirement_saves_empty_SingleChoice_value/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/update_requirement_saves_empty_SingleChoice_value/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/update_requirement_uid_reset_button/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/update_requirement_uid_reset_button/test_case.py
@@ -30,7 +30,7 @@ class Test(E2ECase):
 
             # Requirement 1 has UID.
             # It shouldn't have a reset button.
-            requirement1 = screen_document.get_requirement(1)
+            requirement1 = screen_document.get_node(1)
             requirement1.assert_requirement_uid_contains("REQ-1")
             form_edit_requirement1: Form_EditRequirement = (
                 requirement1.do_open_form_edit_requirement()
@@ -53,7 +53,7 @@ class Test(E2ECase):
 
             # Requirement 2 has UID.
             # It shouldn't have a reset button.
-            requirement2 = screen_document.get_requirement(2)
+            requirement2 = screen_document.get_node(2)
             requirement2.assert_requirement_has_no_uid()
             form_edit_requirement2: Form_EditRequirement = (
                 requirement2.do_open_form_edit_requirement()

--- a/tests/end2end/screens/document/update_requirement/update_requirement_update_title_statement_rationale/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/update_requirement_update_title_statement_rationale/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             requirement.assert_requirement_title("Requirement title", "1")
             requirement.assert_requirement_uid_contains("Requirement UID")
             requirement.assert_requirement_statement_contains(

--- a/tests/end2end/screens/document/update_requirement/update_requirement_using_autocomplete/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/update_requirement_using_autocomplete/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/update_requirement_when_HTML_markup/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/update_requirement_when_HTML_markup/test_case.py
@@ -28,7 +28,7 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            requirement = screen_document.get_requirement()
+            requirement = screen_document.get_node()
 
             requirement.assert_requirement_statement_contains(
                 "This text will be rendered directly as HTML!"


### PR DESCRIPTION
This PR addresses #2217; I replaced these with calls to get_node().