### PR TITLE
code-climate: fix string-literal-comments

### DIFF
--- a/strictdoc/backend/reqif/p01_sdoc/sdoc_to_reqif_converter.py
+++ b/strictdoc/backend/reqif/p01_sdoc/sdoc_to_reqif_converter.py
@@ -445,10 +445,10 @@ class P01_SDocToReqIFObjectConverter:
         )
         attributes.append(title_attribute)
 
-        """
-        If MIDs is enabled and this section has an MID, use it for
-        SPEC-OBJECT IDENTIFIER.
-        """
+        #
+        # If MIDs is enabled and this section has an MID, use it for
+        # SPEC-OBJECT IDENTIFIER.
+        #
         enable_mid = context.enable_mid and parent_document.config.enable_mid
         section_identifier: str
         if enable_mid and section.reserved_mid is not None:

--- a/strictdoc/backend/sdoc_source_code/models/source_file_info.py
+++ b/strictdoc/backend/sdoc_source_code/models/source_file_info.py
@@ -29,12 +29,11 @@ class SourceFileTraceabilityInfo:
         self.source_file: Optional[SourceFile] = None
         self.functions: List[Function] = []
 
-        """
-        {
-         "REQ-001": [RangeMarker(...), ...],
-         "REQ-002": [RangeMarker(...), ...],
-        }
-        """
+        #
+        # {                                              # noqa: ERA001
+        #  "REQ-001": [RangeMarker(...), ...],           # noqa: ERA001
+        #  "REQ-002": [RangeMarker(...), ...],           # noqa: ERA001
+        # }                                              # noqa: ERA001
         self.ng_map_reqs_to_markers = {}
 
         self.ng_map_names_to_markers: Dict[str, List] = {}

--- a/strictdoc/backend/sdoc_source_code/test_reports/junit_xml_reader.py
+++ b/strictdoc/backend/sdoc_source_code/test_reports/junit_xml_reader.py
@@ -168,9 +168,9 @@ class JUnitXMLReader:
             )
             test_suite_section.section_contents.append(testcase_node)
 
-            """
-            Parse individual <testcase> elements.
-            """
+            #
+            # Parse individual <testcase> elements.
+            #
 
             xml_testcase_list: List[Any] = xml_testsuite_.find_all(
                 "testcase", recursive=False
@@ -216,16 +216,16 @@ class JUnitXMLReader:
                 elif xml_skipped_or_none is not None:
                     test_case_node_status = "SKIPPED"
 
-                """
-                Different tools produce different outputs when it comes to how
-                the test names and paths are stored. Each tool's output is
-                handled separately below.
-                """
+                #
+                # Different tools produce different outputs when it comes to how
+                # the test names and paths are stored. Each tool's output is
+                # handled separately below.
+                #
                 if xml_format == JUnitXMLFormat.LLVM_LIT:
-                    """
-                    Example produced by LLVM LIT:
-                    <testcase classname="StrictDoc integration tests.tests/integration" name="test.ignored.itest" time="5.50"/>
-                    """
+                    #
+                    # Example produced by LLVM LIT:
+                    # <testcase classname="StrictDoc integration tests.tests/integration" name="test.ignored.itest" time="5.50"/>
+                    #
 
                     rel_path_to_test_suite = (
                         project_config.test_report_root_dict.get(

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -145,7 +145,7 @@ class ProjectConfig:
 
         # Settings derived from the command-line parameters.
 
-        # Common settings
+        # Common settings.
         self.input_paths: Optional[List[str]] = None
         self.output_dir: str = "output"
 

--- a/strictdoc/core/traceability_index.py
+++ b/strictdoc/core/traceability_index.py
@@ -918,12 +918,12 @@ class TraceabilityIndex:  # pylint: disable=too-many-public-methods, too-many-in
         for node_anchor_ in node.get_anchors():
             existing_node_anchor_uids.add(node_anchor_.value)
 
-        """
-        Validation 1: Assert all UIDs are either:
-        a) new
-        b) exist in this node
-        c) raise a duplication error.
-        """
+        #
+        # Validation 1: Assert all UIDs are either:
+        # a) new
+        # b) exist in this node
+        # c) raise a duplication error.
+        #
         for anchor_uid in new_anchor_uids:
             if (
                 self.graph_database.has_link(
@@ -943,10 +943,10 @@ class TraceabilityIndex:  # pylint: disable=too-many-public-methods, too-many-in
                     f"{node_with_duplicate_anchor.get_display_title()}."
                 )
 
-        """
-        Validation 2: Check that removed anchors do not have any incoming
-        links.
-        """
+        #
+        # Validation 2: Check that removed anchors do not have any incoming
+        # links.
+        #
         to_be_removed_anchor_uids = existing_node_anchor_uids - new_anchor_uids
         for to_be_removed_anchor_uid_ in to_be_removed_anchor_uids:
             to_be_removed_anchor: Anchor = self.graph_database.get_link_value(

--- a/strictdoc/core/traceability_index_builder.py
+++ b/strictdoc/core/traceability_index_builder.py
@@ -188,10 +188,10 @@ class TraceabilityIndexBuilder:
 
             traceability_index.document_tree.attach_source_tree(source_tree)
 
-        """
-        Resolve all modification dates to support the incremental generation of
-        all artifacts.
-        """
+        #
+        # Resolve all modification dates to support the incremental generation of
+        # all artifacts.
+        #
 
         file_dependency_manager = traceability_index.file_dependency_manager
 
@@ -303,9 +303,9 @@ class TraceabilityIndexBuilder:
 
         document: SDocDocument
         for document in document_tree.document_list:
-            """
-            First, resolve all grammars that are imported from grammar files.
-            """
+            #
+            # First, resolve all grammars that are imported from grammar files.
+            #
             if document.grammar.import_from_file is not None:
                 document_grammar: Optional[DocumentGrammar] = (
                     document_tree.get_grammar_by_filename(
@@ -491,11 +491,11 @@ class TraceabilityIndexBuilder:
 
                 requirement: SDocNode = node
 
-                """
-                At this point, we resolve LINKs, and the expectation is that
-                all UIDs or ANCHORS (they also have UIDs) are registered at the
-                previous pass.
-                """
+                #
+                # At this point, we resolve LINKs, and the expectation is that
+                # all UIDs or ANCHORS (they also have UIDs) are registered at the
+                # previous pass.
+                #
                 for node_field_ in node.enumerate_fields():
                     for part in node_field_.parts:
                         if isinstance(part, InlineLink):

--- a/strictdoc/core/transforms/update_grammar_element.py
+++ b/strictdoc/core/transforms/update_grammar_element.py
@@ -49,16 +49,16 @@ class UpdateGrammarElementCommand:
             if field.field_name != existing_field.title:
                 renamed_fields_lookup[field.field_name] = existing_field.title
 
-        """
-        Convert the form object to an updated grammar element.
-        """
+        #
+        # Convert the form object to an updated grammar element.
+        #
         updated_element: GrammarElement = (
             form_object.convert_to_grammar_element(document.grammar)
         )
 
-        """
-        Compare if anything was changed in the new grammar.
-        """
+        #
+        # Compare if anything was changed in the new grammar.
+        #
         document_grammar_field_names = updated_element.get_field_titles()
 
         existing_document_grammar_field_names = (

--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -596,10 +596,10 @@ class RequirementFormObject(ErrorObject):
         assert isinstance(traceability_index, TraceabilityIndex)
         assert isinstance(context_document, SDocDocument)
 
-        """
-        MID uniqueness check.
-        FIXME: MID uniqueness if a node is updated.
-        """
+        #
+        # MID uniqueness check.
+        # FIXME: MID uniqueness if a node is updated.
+        #
         if self.is_new and "MID" in self.fields:
             new_node_mid = self.fields["MID"][0].field_value
             if len(new_node_mid) > 0:
@@ -616,9 +616,9 @@ class RequirementFormObject(ErrorObject):
                         ),
                     )
 
-        """
-        UID uniqueness check.
-        """
+        #
+        # UID uniqueness check.
+        #
         new_node_uid_or_none: Optional[str] = None
         if "UID" in self.fields:
             new_node_uid = self.fields["UID"][0].field_value
@@ -641,10 +641,10 @@ class RequirementFormObject(ErrorObject):
                     ),
                 )
 
-        """
-        Ensure that UID doesn't have any incoming links if it is going to be
-        renamed or removed.
-        """
+        #
+        # Ensure that UID doesn't have any incoming links if it is going to be
+        # renamed or removed.
+        #
         if self.existing_requirement_uid is not None:
             if (
                 new_node_uid_or_none is None
@@ -670,11 +670,11 @@ class RequirementFormObject(ErrorObject):
                         ),
                     )
 
-        """
-        STATEMENT or another content field (DESCRIPTION, CONTENT) checks:
-        - Must be not empty.
-        - Must be valid RST.
-        """
+        #
+        # STATEMENT or another content field (DESCRIPTION, CONTENT) checks:
+        # - Must be not empty.
+        # - Must be valid RST.
+        #
         requirement_element = self.grammar.elements_by_type[self.element_type]
         statement_field_name = requirement_element.content_field[0]
         requirement_statement = self.fields[statement_field_name][0].field_value

--- a/strictdoc/export/html/generators/traceability_matrix.py
+++ b/strictdoc/export/html/generators/traceability_matrix.py
@@ -48,17 +48,17 @@ class TraceabilityMatrixHTMLGenerator:
             if relation_type_ not in discovered_relation_types:
                 del known_relations[relation_type_]
 
-        """
-        Validate that all config-provided relation tuples are actually present
-        in the existing documents.
-        A typical config entry may look like this:
-        [
-            ("Parent", None),
-            ("Parent", "Refines"),
-            ("Parent", "REQUIREMENT_FOR"),
-            ("File", None)
-        ]
-        """
+        #
+        # Validate that all config-provided relation tuples are actually present
+        # in the existing documents.
+        # A typical config entry may look like this:
+        # [                                                   # noqa: ERA001
+        #     ("Parent", None),                               # noqa: ERA001
+        #     ("Parent", "Refines"),                          # noqa: ERA001
+        #     ("Parent", "REQUIREMENT_FOR"),                  # noqa: ERA001
+        #     ("File", None)                                  # noqa: ERA001
+        # ]                                                   # noqa: ERA001
+        #
         config_relation_tuples = (
             project_config.traceability_matrix_relation_columns
             if project_config.traceability_matrix_relation_columns is not None
@@ -69,11 +69,11 @@ class TraceabilityMatrixHTMLGenerator:
             bucket = known_relations[config_relation_tuple_[0]]
             assert config_relation_tuple_[1] in bucket
 
-        """
-        After the config values have been validated, merge both the
-        config-provided list of relation tuples with the list that was
-        discovered from the existing documents.
-        """
+        #
+        # After the config values have been validated, merge both the
+        # config-provided list of relation tuples with the list that was
+        # discovered from the existing documents.
+        #
         known_relations_list = list(config_relation_tuples)
         for relation_type_, bucket_ in known_relations.items():
             for relation_role_, _ in bucket_.items():

--- a/strictdoc/export/html/generators/view_objects/traceability_matrix_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/traceability_matrix_view_object.py
@@ -96,17 +96,17 @@ class TraceabilityMatrixHTMLGenerator:
             if relation_type_ not in discovered_relation_types:
                 del known_relations[relation_type_]
 
-        """
-        Validate that all config-provided relation tuples are actually present
-        in the existing documents.
-        A typical config entry may look like this:
-        [
-            ("Parent", None),
-            ("Parent", "Refines"),
-            ("Parent", "REQUIREMENT_FOR"),
-            ("File", None)
-        ]
-        """
+        #
+        # Validate that all config-provided relation tuples are actually present
+        # in the existing documents.
+        # A typical config entry may look like this:
+        # [                                                    # noqa: ERA001
+        #     ("Parent", None),                                # noqa: ERA001
+        #     ("Parent", "Refines"),                           # noqa: ERA001
+        #     ("Parent", "REQUIREMENT_FOR"),                   # noqa: ERA001
+        #     ("File", None)                                   # noqa: ERA001
+        # ]                                                    # noqa: ERA001
+        #
         config_relation_tuples = (
             project_config.traceability_matrix_relation_columns
             if project_config.traceability_matrix_relation_columns is not None
@@ -117,11 +117,11 @@ class TraceabilityMatrixHTMLGenerator:
             bucket = known_relations[config_relation_tuple_[0]]
             assert config_relation_tuple_[1] in bucket
 
-        """
-        After the config values have been validated, merge both the
-        config-provided list of relation tuples with the list that was
-        discovered from the existing documents.
-        """
+        #
+        # After the config values have been validated, merge both the
+        # config-provided list of relation tuples with the list that was
+        # discovered from the existing documents.
+        #
         known_relations_list = list(config_relation_tuples)
         for relation_type_, bucket_ in known_relations.items():
             for relation_role_, _ in bucket_.items():

--- a/strictdoc/export/json/json_generator.py
+++ b/strictdoc/export/json/json_generator.py
@@ -142,9 +142,9 @@ class JSONGenerator:
                         default_view
                     )
 
-        """
-        Grammar.
-        """
+        #
+        # Grammar.
+        #
         assert document.grammar is not None
         document_grammar: DocumentGrammar = document.grammar
 

--- a/strictdoc/export/spdx/spdx_generator.py
+++ b/strictdoc/export/spdx/spdx_generator.py
@@ -203,9 +203,9 @@ class SPDXGenerator:
         sdoc_spdx_converter: SDocToSPDXConverter = SDocToSPDXConverter()
         spdx_container: SPDXSDocContainer = SPDXSDocContainer()
 
-        """
-        SPDX Document and SPDX Package
-        """
+        #
+        # SPDX Document and SPDX Package
+        #
         spdx_document = sdoc_spdx_converter.create_document(project_config)
         spdx_container.document = spdx_document
 
@@ -238,9 +238,9 @@ class SPDXGenerator:
             with open(document_.meta.input_doc_full_path, "rb") as input_file_:
                 document_bytes = input_file_.read()
 
-            """
-            Create SPDX File from SDoc Document.
-            """
+            #
+            # Create SPDX File from SDoc Document.
+            #
             spdx_file = sdoc_spdx_converter.create_document_to_file(
                 document_, document_bytes
             )
@@ -275,9 +275,9 @@ class SPDXGenerator:
                         "The current implementation only supports requirements with a title."
                     )
 
-                    """
-                    Create SPDX Snippet from SDoc Requirement.
-                    """
+                    #
+                    # Create SPDX Snippet from SDoc Requirement.
+                    #
                     spdx_snippet: Snippet = (
                         sdoc_spdx_converter.convert_requirement_to_snippet(
                             node, document_bytes, spdx_file
@@ -351,9 +351,9 @@ class SPDXGenerator:
                             )
                         )
 
-        """
-        Now iterate over requirement nodes again
-        """
+        #
+        # Now iterate over requirement nodes again.
+        #
         for document_ in traceability_index.document_tree.document_list:
             document_iterator: DocumentCachingIterator = (
                 traceability_index.get_document_iterator(document_)
@@ -394,7 +394,9 @@ class SPDXGenerator:
                             )
                         )
 
-        """Output SPDX to a file"""
+        #
+        # Output SPDX to a file.
+        #
 
         output_path = os.path.join(output_spdx_root, "output.spdx")
         with open(output_path, "w", encoding="utf8") as file:

--- a/strictdoc/export/spdx/spdx_to_sdoc_converter.py
+++ b/strictdoc/export/spdx/spdx_to_sdoc_converter.py
@@ -48,9 +48,9 @@ class SPDXToSDocConverter:
         document.grammar = SPDXToSDocConverter.create_grammar_for_spdx()
         document.grammar.parent = document
 
-        """
-        Document
-        """
+        #
+        # Document.
+        #
         document_requirement: SDocNode = SPDXToSDocConverter._convert_document(
             spdx_container.document,
             sdoc_document=document,
@@ -58,9 +58,9 @@ class SPDXToSDocConverter:
         )
         document.section_contents.append(document_requirement)
 
-        """
-        Package
-        """
+        #
+        # Package.
+        #
         package_requirement = SPDXToSDocConverter._convert_package(
             spdx_container.package,
             sdoc_document=document,
@@ -68,9 +68,9 @@ class SPDXToSDocConverter:
         )
         document.section_contents.append(package_requirement)
 
-        """
-        Files.
-        """
+        #
+        # Files.
+        #
 
         file_section = SDocSection(
             parent=document,
@@ -91,9 +91,9 @@ class SPDXToSDocConverter:
             file_section.section_contents.append(requirement)
             map_spdxref_to_sdoc[file_.spdx_id] = requirement
 
-        """
-        Snippets.
-        """
+        #
+        # Snippets.
+        #
 
         snippets_section = SDocSection(
             parent=document,
@@ -349,9 +349,9 @@ class SPDXToSDocConverter:
     def create_grammar_for_spdx():
         elements = []
 
-        """
-        SPDX Document
-        """
+        #
+        # SPDX Document
+        #
         fields = [
             GrammarElementFieldString(
                 parent=None,
@@ -394,9 +394,9 @@ class SPDXToSDocConverter:
         )
         elements.append(document_element)
 
-        """
-        SPDX Package
-        """
+        #
+        # SPDX Package
+        #
         fields = [
             GrammarElementFieldString(
                 parent=None,
@@ -451,9 +451,9 @@ class SPDXToSDocConverter:
         )
         elements.append(package_element)
 
-        """
-        SPDX File.
-        """
+        #
+        # SPDX File.
+        #
         fields = [
             GrammarElementFieldString(
                 parent=None,
@@ -513,9 +513,9 @@ class SPDXToSDocConverter:
         )
         elements.append(file_element)
 
-        """
-        SPDX Snippet
-        """
+        #
+        # SPDX Snippet
+        #
         fields = [
             GrammarElementFieldString(
                 parent=None,
@@ -576,8 +576,8 @@ class SPDXToSDocConverter:
             )
         )
 
-        """
-        Create Grammar.
-        """
+        #
+        # Create Grammar.
+        #
         grammar = DocumentGrammar(parent=None, elements=elements)
         return grammar

--- a/strictdoc/git/git_client.py
+++ b/strictdoc/git/git_client.py
@@ -72,9 +72,9 @@ class GitClient:
             return git_client
 
     def is_clean_branch(self) -> bool:
-        """
-        https://unix.stackexchange.com/a/155077/77389
-        """
+        #
+        # https://unix.stackexchange.com/a/155077/77389
+        #
         result = subprocess.run(
             ["git", "status", "--porcelain"],
             cwd=self.path_to_git_root,

--- a/strictdoc/git/project_diff_analyzer.py
+++ b/strictdoc/git/project_diff_analyzer.py
@@ -315,17 +315,17 @@ class ChangeStats:
         assert side in ("left", "right")
 
         for document in index.document_tree.document_list:
-            """
-            The included documents are ignored. All their information should
-            be contained in the including documents at this point.
-            """
+            #
+            # The included documents are ignored. All their information should
+            # be contained in the including documents at this point.
+            #
             if document.document_is_included():
                 continue
 
-            """
-            First, take care of the document node itself. Check if the document
-            root-level free text (abstract) has changed.
-            """
+            #
+            # First, take care of the document node itself. Check if the document
+            # root-level free text (abstract) has changed.
+            #
             if document not in change_stats.map_nodes_to_changes:
                 other_document_or_none: Optional[SDocDocument]
 
@@ -409,13 +409,13 @@ class ChangeStats:
 
             document_iterator = DocumentCachingIterator(document)
 
-            """
-            Now iterate over all nodes and collect the diff information.
-
-            Note that document nodes appear when a document is included to
-            another document. We treat a document node as as a section node
-            because they both have FREETEXT.
-            """
+            #
+            # Now iterate over all nodes and collect the diff information.
+            #
+            # Note that document nodes appear when a document is included to
+            # another document. We treat a document node as as a section node
+            # because they both have FREETEXT.
+            #
             for node in document_iterator.all_content(
                 print_fragments=True, print_fragments_from_files=False
             ):
@@ -497,10 +497,10 @@ class ChangeStats:
                         else:
                             title_modified = True
 
-                        """
-                        Step: Create a section token that is used by JS to match
-                        the LHS nodes with RHS nodes.
-                        """
+                        #
+                        # Step: Create a section token that is used by JS to match
+                        # the LHS nodes with RHS nodes.
+                        #
                         section_token: Optional[str] = None
                         if other_section_or_none is not None:
                             section_token = MID.create()
@@ -534,11 +534,11 @@ class ChangeStats:
                         change_stats.add_change(section_change)
 
                 if isinstance(node, SDocNode):
-                    """
-                    Step: We check if a requirement was modified at all, or if
-                    it has already been checked before. Skipping the requirement
-                    if there is nothing to do.
-                    """
+                    #
+                    # Step: We check if a requirement was modified at all, or if
+                    # it has already been checked before. Skipping the requirement
+                    # if there is nothing to do.
+                    #
                     # FIXME: Is this 100% valid?
 
                     if node in change_stats.map_nodes_to_changes:
@@ -585,23 +585,23 @@ class ChangeStats:
                         change_stats.add_change(requirement_change)
                         continue
 
-                    """
-                    Step: Starting from here, we will be looking at the
-                    difference between this and the other requirement.
-                    """
+                    #
+                    # Step: Starting from here, we will be looking at the
+                    # difference between this and the other requirement.
+                    #
                     other_requirement: SDocNode = other_requirement_or_none
 
                     field_changes: List[RequirementFieldChange] = []
 
-                    """
-                    Step: Create a requirement token that is used by JS to match
-                    the LHS nodes with RHS nodes.
-                    """
+                    #
+                    # Step: Create a requirement token that is used by JS to match
+                    # the LHS nodes with RHS nodes.
+                    #
                     requirement_token: str = MID.create()
 
-                    """
-                    Iterate over requirement fields.
-                    """
+                    #
+                    # Iterate over requirement fields.
+                    #
                     requirement_fields_iter = iter(
                         requirement.enumerate_all_fields()
                     )

--- a/tests/end2end/helpers/form/form.py
+++ b/tests/end2end/helpers/form/form.py
@@ -14,7 +14,9 @@ class Form:  # pylint: disable=invalid-name
         assert isinstance(test_case, E2ECase)
         self.test_case: E2ECase = test_case
 
-    # Base
+    #
+    # Base.
+    #
 
     def assert_on_form(self) -> None:
         self.test_case.assert_element(
@@ -28,7 +30,9 @@ class Form:  # pylint: disable=invalid-name
             by=By.XPATH,
         )
 
-    # Assert field content
+    #
+    # Assert field content.
+    #
 
     def assert_error(self, message: str) -> None:
         self.test_case.assert_element(
@@ -50,7 +54,9 @@ class Form:  # pylint: disable=invalid-name
             f"//*[@{testid}][contains(., '{text}')]", by=By.XPATH
         )
 
-    # Open TAB
+    #
+    # Open TAB.
+    #
 
     def do_open_tab(self, tab_name: str = "") -> None:
         assert isinstance(tab_name, str)
@@ -73,7 +79,9 @@ class Form:  # pylint: disable=invalid-name
             by=By.XPATH,
         )
 
-    # Work with fields containers
+    #
+    # Work with fields containers.
+    #
 
     # TODO: update with mid
     def do_delete_field(self, field_name: str, field_order: int = 1) -> None:
@@ -83,7 +91,9 @@ class Form:  # pylint: disable=invalid-name
             f"[{field_order}]"
         )
 
-    # MOVE fields
+    #
+    # MOVE fields.
+    #
 
     def do_move_field_up(self, mid: MID, test_id: str) -> None:
         assert isinstance(mid, MID)
@@ -97,7 +107,9 @@ class Form:  # pylint: disable=invalid-name
             f"(//*[@data-testid='form-move-down-{field_name}-field-action'])"
         )
 
-    # Work with fields content
+    #
+    # Work with fields content.
+    #
 
     def do_fill_in(
         self, field_name: str, field_value: str, field_order: int = 1
@@ -199,9 +211,9 @@ class Form:  # pylint: disable=invalid-name
         this_field.send_keys(Keys.BACKSPACE)
         this_field.send_keys(Keys.BACKSPACE)
 
-    """
-    Save/Cancel
-    """
+    #
+    # Save/Cancel.
+    #
 
     def do_form_cancel(self) -> None:
         self.test_case.click_xpath('//*[@data-testid="form-cancel-action"]')

--- a/tests/end2end/helpers/screens/document/screen_document.py
+++ b/tests/end2end/helpers/screens/document/screen_document.py
@@ -15,7 +15,9 @@ class Screen_Document(Screen):  # pylint: disable=invalid-name
         assert isinstance(test_case, BaseCase)
         super().__init__(test_case)
 
-    # overridden for Screen_Document
+    #
+    # Overridden for Screen_Document.
+    #
 
     def assert_on_screen_document(self) -> None:
         super().assert_on_screen("document")
@@ -32,7 +34,9 @@ class Screen_Document(Screen):  # pylint: disable=invalid-name
         targeted_anchor = f"sdoc-anchor[id='{anchor}']:target"
         self.test_case.assert_element_present(targeted_anchor)
 
-    # Actions on the page
+    #
+    # Actions on the page.
+    #
 
     def do_export_reqif(self) -> None:
         self.test_case.click_xpath(
@@ -44,7 +48,9 @@ class Screen_Document(Screen):  # pylint: disable=invalid-name
             '(//*[@data-testid="document-export-html2pdf-action"])'
         )
 
-    # Open forms
+    #
+    # Open forms.
+    #
 
     def do_open_modal_form_edit_grammar(self) -> Form_EditGrammarElements:
         self.test_case.assert_element_not_present("//sdoc-modal", by=By.XPATH)
@@ -71,13 +77,13 @@ class Screen_Document(Screen):  # pylint: disable=invalid-name
             xpath_first_toc_node, xpath_second_toc_node
         )
 
-        """
-        Drag and drop action takes some time before server/Turbo sends
-        an updated AJAX HTML template back. Sometimes a
-        StaleElementReferenceException is thrown by Selenium because it still
-        finds an old element as it is being moved. To solve this, set a timeout
-        to wait some time until the new TOC is rendered.
-        """
+        #
+        # Drag and drop action takes some time before server/Turbo sends
+        # an updated AJAX HTML template back. Sometimes a
+        # StaleElementReferenceException is thrown by Selenium because it still
+        # finds an old element as it is being moved. To solve this, set a timeout
+        # to wait some time until the new TOC is rendered.
+        #
         start_time = datetime.now()
         while True:
             new_root_node = self.test_case.find_element(

--- a/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_create/create_section_with_uid_and_node_with_LINK/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_create/create_section_with_uid_and_node_with_LINK/test_case.py
@@ -34,7 +34,9 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            # Creating Section 1
+            #
+            # Creating Section 1.
+            #
 
             root_node = screen_document.get_root_node()
             root_node_menu = root_node.do_open_node_menu()
@@ -51,9 +53,9 @@ class Test(E2ECase):
             section_1.assert_section_title("First title", "1")
             screen_document.assert_toc_contains("First title")
 
-            """
-            Create requirement with a LINK.
-            """
+            #
+            # Create requirement with a LINK.
+            #
 
             section_1_node_menu = section_1.do_open_node_menu()
 

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_requirement_above_but_below_another_section/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_requirement_above_but_below_another_section/test_case.py
@@ -55,10 +55,10 @@ class Test(E2ECase):
                 "Document 1"
             )
 
-            """
-            A basic extra test that ensures that the requirement has a right
-            document parent (encountered this regression during implementation).
-            """
+            #
+            # A basic extra test that ensures that the requirement has a right
+            # document parent (encountered this regression during implementation).
+            #
             form_edit_requirement = requirement.do_open_form_edit_requirement()
             form_edit_requirement.do_form_submit()
 

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_above_but_below_another_section/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_above_but_below_another_section/test_case.py
@@ -52,10 +52,10 @@ class Test(E2ECase):
                 "Document 1"
             )
 
-            """
-            A basic extra test that ensures that the section has a right
-            document parent (encountered this regression during implementation).
-            """
+            #
+            # A basic extra test that ensures that the section has a right
+            # document parent (encountered this regression during implementation).
+            #
             form_edit_section = section.do_open_form_edit_section()
             form_edit_section.do_form_submit()
 

--- a/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_after_test_element/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_after_test_element/test_case.py
@@ -28,9 +28,9 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            """
-            Create a test case after the existing test case.
-            """
+            #
+            # Create a test case after the existing test case.
+            #
             test_case_node = screen_document.get_node(1)
 
             test_case_menu = test_case_node.do_open_node_menu()

--- a/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_in_section/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_in_section/test_case.py
@@ -28,16 +28,16 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            """
-            Section exists.
-            """
+            #
+            # Section exists.
+            #
 
             section = screen_document.get_section()
             section.assert_section_title("First title", "1")
 
-            """
-            Requirement is added as a child of the Section
-            """
+            #
+            # Requirement is added as a child of the Section.
+            #
 
             section_menu = section.do_open_node_menu()
             form_edit_requirement: Form_EditRequirement = (
@@ -48,9 +48,9 @@ class Test(E2ECase):
             form_edit_requirement.do_fill_in_field_statement("Shall test foo.")
             form_edit_requirement.do_form_submit()
 
-            """
-            Expected for Requirement.
-            """
+            #
+            # Expected for Requirement.
+            #
 
             requirement = screen_document.get_node()
 

--- a/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_in_top_level_document/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_in_top_level_document/test_case.py
@@ -28,9 +28,9 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            """
-            Create a test case after the existing test case.
-            """
+            #
+            # Create a test case after the existing test case.
+            #
 
             root_node_menu = screen_document.get_root_node().do_open_node_menu()
 

--- a/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_with_custom_field_in_top_level_document/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_with_custom_field_in_top_level_document/test_case.py
@@ -28,9 +28,9 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            """
-            Create a test case after the existing test case.
-            """
+            #
+            # Create a test case after the existing test case.
+            #
 
             root_node_menu = screen_document.get_root_node().do_open_node_menu()
 

--- a/tests/end2end/screens/document/create_requirement/create_requirement_after_section/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/create_requirement_after_section/test_case.py
@@ -28,12 +28,16 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            # Section exists
+            #
+            # Section exists.
+            #
 
             section = screen_document.get_section()
             section.assert_section_title("Section title", "1")
 
-            # Requirement is added below
+            #
+            # Requirement is added below.
+            #
             section_menu = section.do_open_node_menu()
             form_edit_requirement: Form_EditRequirement = (
                 section_menu.do_node_add_requirement_below()
@@ -44,7 +48,9 @@ class Test(E2ECase):
             )
             form_edit_requirement.do_form_submit()
 
+            #
             # Expected for Requirement:
+            #
 
             requirement = screen_document.get_node()
             requirement.assert_requirement_title("Requirement title", "2")

--- a/tests/end2end/screens/document/create_requirement/create_requirement_in_section/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/create_requirement_in_section/test_case.py
@@ -28,12 +28,16 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            # Section exists
+            #
+            # Section exists.
+            #
 
             section = screen_document.get_section()
             section.assert_section_title("First title", "1")
 
-            # Requirement is added as a child of the Section
+            #
+            # Requirement is added as a child of the Section.
+            #
             section_menu = section.do_open_node_menu()
             form_edit_requirement: Form_EditRequirement = (
                 section_menu.do_node_add_requirement_child()
@@ -44,7 +48,9 @@ class Test(E2ECase):
             )
             form_edit_requirement.do_form_submit()
 
+            #
             # Expected for Requirement:
+            #
 
             requirement = screen_document.get_node()
 

--- a/tests/end2end/screens/document/create_section/create_section_two_sibling_sections/test_case.py
+++ b/tests/end2end/screens/document/create_section/create_section_two_sibling_sections/test_case.py
@@ -29,7 +29,9 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            # Creating Section 1
+            #
+            # Creating Section 1.
+            #
 
             root_node = screen_document.get_root_node()
             root_node_menu = root_node.do_open_node_menu()
@@ -45,7 +47,9 @@ class Test(E2ECase):
             section_1.assert_section_title("First title", "1")
             screen_document.assert_toc_contains("First title")
 
-            # Creating Section 2 below
+            #
+            # Creating Section 2 below.
+            #
 
             section_1_node_menu = section_1.do_open_node_menu()
 

--- a/tests/end2end/screens/document/delete_requirement/delete_requirement_delete_newly_created/test_case.py
+++ b/tests/end2end/screens/document/delete_requirement/delete_requirement_delete_newly_created/test_case.py
@@ -28,9 +28,9 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            """
-            Create requirement.
-            """
+            #
+            # Create requirement.
+            #
 
             root_node = screen_document.get_root_node()
             root_node_menu = root_node.do_open_node_menu()
@@ -47,9 +47,9 @@ class Test(E2ECase):
             )
             form_edit_requirement.do_form_submit()
 
-            """
-            Delete requirement.
-            """
+            #
+            # Delete requirement.
+            #
             requirement = screen_document.get_node()
             requirement.assert_requirement_title("Requirement title")
             requirement.do_delete_node()  # confirm is inside

--- a/tests/end2end/screens/document/update_requirement/_arbitrary_elements/delete_node_delete_relation_between_two_custom_nodes/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_arbitrary_elements/delete_node_delete_relation_between_two_custom_nodes/test_case.py
@@ -30,15 +30,15 @@ class Test(E2ECase):
 
             node = screen_document.get_node()
 
-            """
-            Make sure there is the reference to the child in Requirement 1:
-            """
+            #
+            # Make sure there is the reference to the child in Requirement 1:
+            #
             node.assert_requirement_uid_contains("RUL-1")
             node.assert_requirement_has_parent_relation("OBJ-1")
 
-            """
-            Remove the relation.
-            """
+            #
+            # Remove the relation.
+            #
             form_edit_node: Form_EditRequirement = (
                 node.do_open_form_edit_requirement()
             )

--- a/tests/end2end/screens/document/update_requirement/update_requirement_when_HTML_markup/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/update_requirement_when_HTML_markup/test_case.py
@@ -34,9 +34,9 @@ class Test(E2ECase):
                 "This text will be rendered directly as HTML!"
             )
 
-            """
-            ACT
-            """
+            #
+            # ACT
+            #
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )
@@ -47,9 +47,9 @@ class Test(E2ECase):
             )
             form_edit_requirement.do_form_submit()
 
-            """
-            ASSERT
-            """
+            #
+            # ASSERT
+            #
             requirement.assert_requirement_statement_contains(
                 "UPDATED: "
                 "This text will be rendered directly as HTML!. "

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_python.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_python.py
@@ -381,9 +381,9 @@ def test_012_marker_not_first_line():
     assert markers[1].ng_range_line_end == 8
 
 
-"""
-LINE markers.
-"""
+#
+# LINE markers.
+#
 
 
 def test_050_line_marker():


### PR DESCRIPTION
This PR changes string literal comments (""") into normal python comments (#)