### PR TITLE
code-climate: re-enable some disabled tests under windows

### DIFF
--- a/.github/workflows/ci-windows-powershell.yml
+++ b/.github/workflows/ci-windows-powershell.yml
@@ -44,6 +44,13 @@ jobs:
       run: |
         pip install -r requirements.check.txt
 
+    - name: " Windows specific: Install Tidy via Chocolatey, and add it to $PATH"
+      shell: pwsh
+      run: |
+        choco install html-tidy -y
+        $tidyPath = (Get-ChildItem "C:\ProgramData\chocolatey\lib\html-tidy" -Recurse -Filter tidy.exe | Select-Object -First 1).DirectoryName
+        echo "$tidyPath" | Out-File -Append -Encoding ascii $env:GITHUB_PATH
+
     - name: Run tests (Powershell)
       run: |
         invoke test

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -44,6 +44,13 @@ jobs:
       run: |
         pip install -r requirements.check.txt
 
+    - name: " Windows specific: Install Tidy via Chocolatey, and add it to $PATH"
+      shell: pwsh
+      run: |
+        choco install html-tidy -y
+        $tidyPath = (Get-ChildItem "C:\ProgramData\chocolatey\lib\html-tidy" -Recurse -Filter tidy.exe | Select-Object -First 1).DirectoryName
+        echo "$tidyPath" | Out-File -Append -Encoding ascii $env:GITHUB_PATH
+
     - name: Run Lint tasks
       run: |
         invoke lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dependencies = [
     "WebSockets",
 
     # HTML2PDF dependencies
-    "html2print >= 0.0.15",
+    "html2print >= 0.0.16",
 ]
 # @sdoc[/SDOC-SRS-89]
 

--- a/tasks.py
+++ b/tasks.py
@@ -422,6 +422,9 @@ def test_integration(
             #       the exists() check works.
             assert os.path.exists(chromedriver_path), chromedriver_path
             chromedriver_param = f"--param CHROMEDRIVER={os.path.join(chromedriver_path, 'chromedriver')}"
+            if os.name == "nt":
+                # On Windows, its chromdriver.exe
+                chromedriver_param = chromedriver_param + ".exe"
         test_folder = f"{cwd}/tests/integration/features/html2pdf"
 
     itest_command = f"""

--- a/tests/end2end/screens/deep_traceability/view_document/view_document_go_from_requirement_card_to_requirement_in_document_view_another_document/test_case.py
+++ b/tests/end2end/screens/deep_traceability/view_document/view_document_go_from_requirement_card_to_requirement_in_document_view_another_document/test_case.py
@@ -7,13 +7,8 @@ from tests.end2end.helpers.screens.project_index.screen_project_index import (
     Screen_ProjectIndex,
 )
 from tests.end2end.server import SDocTestServer
-from tests.end2end.test_helpers import available_systems
 
 
-# FIXME: This test fails on Windows with
-#        Element {(//sdoc-node[@data-testid='node-requirement'])[2]//*[@data-testid='requirement-find-in-document']} was not present after 10 seconds!
-#        We don't have a Windows machine to investigate this in detail.
-@available_systems(["macos", "linux"])
 class Test(E2ECase):
     def test(self):
         test_setup = End2EndTestSetup(path_to_test_file=__file__)
@@ -47,6 +42,6 @@ class Test(E2ECase):
                 requirement.do_go_to_this_requirement_in_document_view()
             )
             screen_document_.assert_on_screen_document()
-            screen_document_.assert_target_by_anchor("1-REQ-002")
+            screen_document_.assert_target_by_anchor("REQ-002")
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/integration/features/html2pdf/01_empty_document/test.itest
+++ b/tests/integration/features/html2pdf/01_empty_document/test.itest
@@ -1,8 +1,5 @@
 REQUIRES: TEST_HTML2PDF
 
-# FIXME: Getting timeouts on Windows CI all the time. Needs to be checked or tested by users.
-REQUIRES: PLATFORM_IS_NOT_WINDOWS
-
 RUN: %strictdoc export %S --formats=html2pdf --output-dir Output | filecheck %s --dump-input=fail
 CHECK: html2print: JS logs from the print session
 

--- a/tests/integration/features/html2pdf/02_three_top_level_requirements/test.itest
+++ b/tests/integration/features/html2pdf/02_three_top_level_requirements/test.itest
@@ -1,8 +1,5 @@
 REQUIRES: TEST_HTML2PDF
 
-# FIXME: Getting timeouts on Windows CI all the time. Needs to be checked or tested by users.
-REQUIRES: PLATFORM_IS_NOT_WINDOWS
-
 RUN: %strictdoc export %S --formats=html2pdf --output-dir Output | filecheck %s --dump-input=fail
 CHECK: html2print: JS logs from the print session
 

--- a/tests/integration/features/html2pdf/03_three_documents_with_assets/test.itest
+++ b/tests/integration/features/html2pdf/03_three_documents_with_assets/test.itest
@@ -1,8 +1,5 @@
 REQUIRES: TEST_HTML2PDF
 
-# FIXME: Getting timeouts on Windows CI all the time. Needs to be checked or tested by users.
-REQUIRES: PLATFORM_IS_NOT_WINDOWS
-
 RUN: %strictdoc export %S --formats=html2pdf --output-dir Output | filecheck %s --dump-input=fail
 CHECK: html2print: JS logs from the print session
 

--- a/tests/integration/features/html2pdf/04_composable_document_with_assets/test.itest
+++ b/tests/integration/features/html2pdf/04_composable_document_with_assets/test.itest
@@ -1,8 +1,5 @@
 REQUIRES: TEST_HTML2PDF
 
-# FIXME: Getting timeouts on Windows CI all the time. Needs to be checked or tested by users.
-REQUIRES: PLATFORM_IS_NOT_WINDOWS
-
 RUN: %strictdoc export %S --formats=html2pdf --included-documents --output-dir Output | filecheck %s --dump-input=fail
 CHECK: html2print: JS logs from the print session
 

--- a/tests/integration/features/html2pdf/05_generate_bundle_document/test.itest
+++ b/tests/integration/features/html2pdf/05_generate_bundle_document/test.itest
@@ -1,8 +1,5 @@
 REQUIRES: TEST_HTML2PDF
 
-# FIXME: Getting timeouts on Windows CI all the time. Needs to be checked or tested by users.
-REQUIRES: PLATFORM_IS_NOT_WINDOWS
-
 RUN: %strictdoc export %S --formats=html2pdf --generate-bundle-document --output-dir Output | filecheck %s --dump-input=fail
 CHECK: html2print: JS logs from the print session
 

--- a/tests/integration/features/html2pdf/06_system_chromedriver/test.itest
+++ b/tests/integration/features/html2pdf/06_system_chromedriver/test.itest
@@ -1,12 +1,9 @@
 REQUIRES: TEST_HTML2PDF
 REQUIRES: SYSTEM_CHROMEDRIVER
 
-# FIXME: Getting timeouts on Windows CI all the time. Needs to be checked or tested by users.
-REQUIRES: PLATFORM_IS_NOT_WINDOWS
-
 # GitHub images provide a chromedriver and export installed location, see
 # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#browsers-and-drivers
-RUN: %strictdoc export %S --formats=html2pdf --chromedriver=%chromedriver --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html2pdf --chromedriver="%chromedriver" --output-dir Output | filecheck %s --dump-input=fail
 CHECK: html2print: JS logs from the print session
 CHECK-NOT: HTML2PDF: Chrome Driver available at path: {{.*}}strictdoc_cache{{.*}}
 

--- a/tests/integration/features/html_standalone/01_standalone_and_html/test.itest
+++ b/tests/integration/features/html_standalone/01_standalone_and_html/test.itest
@@ -1,5 +1,3 @@
-REQUIRES: PLATFORM_IS_NOT_WINDOWS
-
 RUN: %strictdoc export %S --formats=html --no-parallelization --output-dir Output | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 

--- a/tests/integration/features/html_standalone/02_embeds_default_assets/test.itest
+++ b/tests/integration/features/html_standalone/02_embeds_default_assets/test.itest
@@ -1,5 +1,3 @@
-REQUIRES: PLATFORM_IS_NOT_WINDOWS
-
 RUN: %strictdoc export %S --formats=html --no-parallelization --output-dir Output | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 

--- a/tests/integration/lit.cfg
+++ b/tests/integration/lit.cfg
@@ -44,9 +44,18 @@ if not lit_config.isWindows:
 
 if "TEST_HTML2PDF" in lit_config.params:
     config.name = "StrictDoc HTML2PDF integration tests"
+    # In Linux CI, $HOME is required for Chrome as it needs to access things in ~/.local
+    config.environment['HOME'] = os.environ.get('HOME', '/tmp')
+
+    # In Windows CI, %ProgramW6432% is required for Selenium to properly detect browsers
+    config.environment['ProgramW6432'] = os.environ.get('ProgramW6432', '')
+    
     config.available_features.add('TEST_HTML2PDF')
     if "CHROMEDRIVER" in lit_config.params:
         chromedriver = lit_config.params['CHROMEDRIVER']
+        if lit_config.isWindows:
+            # On Windows, we need to escape the backward-slashes as lit runs this through another shell 
+            chromedriver = chromedriver.replace("\\", "\\\\")
         config.substitutions.append(('%chromedriver', chromedriver))
         config.available_features.add('SYSTEM_CHROMEDRIVER')
 


### PR DESCRIPTION
This PR re-enables some currently disabled tests on Windows to increase coverage for the automatic qualification data generation.

- The PR addresses a few platform-specific issues in the CI workflows.
- It should also allow us to judge whether the recent `html2print` changes bring any improvement.

If Windows CI remains difficult and flaky, we can always disable these tests again.

On a related note, it could be a good idea to turn the "REQUIRES: TEST_HTML2PDF" serialisation logic into a general "REQUIRES: NO_PARALLEL" mechanism.  That would allow tests that are heavy on parallelisation to be serialised as well. I hope to work on this soon...