### PR TITLE
pyproject.toml: bump html2print dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dependencies = [
     "WebSockets",
 
     # HTML2PDF dependencies
-    "html2print >= 0.0.16",
+    "html2print >= 0.0.17",
 ]
 # @sdoc[/SDOC-SRS-89]
 


### PR DESCRIPTION
This mainly integrates the new 0.2.2 release.