### PR TITLE
pyproject.toml: switch to html2pdf4doc

### DIFF
--- a/developer/pyinstaller_hooks/hook-html2pdf4doc.py
+++ b/developer/pyinstaller_hooks/hook-html2pdf4doc.py
@@ -1,6 +1,6 @@
 # https://stackoverflow.com/a/64473931/598057
 from PyInstaller.utils.hooks import collect_data_files
 
-# The following ensures that the HTML2PDF.js file is present in the
+# The following ensures that the HTML2PDF4Doc.js file is present in the
 # PyInstaller bundle of StrictDoc.
-datas = collect_data_files("html2print")
+datas = collect_data_files("html2pdf4doc")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dependencies = [
     "WebSockets",
 
     # HTML2PDF dependencies
-    "html2print >= 0.0.17",
+    "html2pdf4doc >= 0.0.17",
 ]
 # @sdoc[/SDOC-SRS-89]
 

--- a/strictdoc/export/html/html_generator.py
+++ b/strictdoc/export/html/html_generator.py
@@ -4,7 +4,7 @@ from functools import partial
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
-from html2print.html2print import PATH_TO_HTML2PDF_JS
+from html2pdf4doc.html2pdf4doc import PATH_TO_HTML2PDF4DOC_JS
 
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.core.asset_manager import AssetDir
@@ -241,7 +241,7 @@ class HTMLGenerator:
         # Export HTML2PDF
         if project_config.is_feature_activated(ProjectFeature.HTML2PDF):
             sync_dir(
-                os.path.dirname(PATH_TO_HTML2PDF_JS),
+                os.path.dirname(PATH_TO_HTML2PDF4DOC_JS),
                 output_html_static_files,
                 message="Copying HTML2PDF.js",
             )

--- a/strictdoc/export/html/templates/screens/document/pdf/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/pdf/index.jinja
@@ -33,7 +33,7 @@
     data-page-break-before-selectors='H2'
     data-no-break-selectors='sdoc-section-title sdoc-meta sdoc-requirement-title .pdf-toc-row'
     data-no-hanging-selectors='sdoc-section-title sdoc-meta .admonition-title sdoc-requirement-title sdoc-requirement-field-label strong:only-child'
-  src="{{ view_object.render_static_url('html2pdf.min.js') }}"></script>
+  src="{{ view_object.render_static_url('html2pdf4doc.min.js') }}"></script>
   {%- endif -%}
 
   {{ super() }}

--- a/strictdoc/export/html2pdf/pdf_print_driver.py
+++ b/strictdoc/export/html2pdf/pdf_print_driver.py
@@ -13,20 +13,20 @@ class PDFPrintDriver:
         paths_to_print: List[Tuple[str, str]],
     ) -> None:
         assert isinstance(paths_to_print, list), paths_to_print
-        path_to_html2print_cache = os.path.join(
+        path_to_html2pdf4doc_cache = os.path.join(
             project_config.get_path_to_cache_dir(), "html2pdf"
         )
         cmd: List[str] = [
             # Using sys.executable instead of "python" is important because
             # venv subprocess call to python resolves to wrong interpreter,
             # https://github.com/python/cpython/issues/86207
-            # Switching back to calling html2print directly because the
+            # Switching back to calling html2pdf4doc directly because the
             # python -m doesn't work well with PyInstaller.
             # sys.executable, "-m"
-            "html2print",
+            "html2pdf4doc",
             "print",
             "--cache-dir",
-            path_to_html2print_cache,
+            path_to_html2pdf4doc_cache,
         ]
         if project_config.chromedriver is not None:
             cmd.extend(

--- a/tests/integration/features/html2pdf/01_empty_document/test.itest
+++ b/tests/integration/features/html2pdf/01_empty_document/test.itest
@@ -1,7 +1,8 @@
 REQUIRES: TEST_HTML2PDF
 
 RUN: %strictdoc export %S --formats=html2pdf --output-dir Output | filecheck %s --dump-input=fail
-CHECK: html2print: JS logs from the print session
+CHECK: html2pdf4doc: ChromeDriver available at path: {{.*}}
+CHECK: html2pdf4doc: JS logs from the print session
 
 RUN: %check_exists --file %S/Output/html2pdf/pdf/input.pdf
 

--- a/tests/integration/features/html2pdf/02_three_top_level_requirements/test.itest
+++ b/tests/integration/features/html2pdf/02_three_top_level_requirements/test.itest
@@ -1,7 +1,7 @@
 REQUIRES: TEST_HTML2PDF
 
 RUN: %strictdoc export %S --formats=html2pdf --output-dir Output | filecheck %s --dump-input=fail
-CHECK: html2print: JS logs from the print session
+CHECK: html2pdf4doc: JS logs from the print session
 
 RUN: %check_exists --file %S/Output/html2pdf/pdf/input.pdf
 RUN: %check_exists --file %S/Output/html2pdf/pdf/nested/input2.pdf

--- a/tests/integration/features/html2pdf/03_three_documents_with_assets/test.itest
+++ b/tests/integration/features/html2pdf/03_three_documents_with_assets/test.itest
@@ -1,7 +1,7 @@
 REQUIRES: TEST_HTML2PDF
 
 RUN: %strictdoc export %S --formats=html2pdf --output-dir Output | filecheck %s --dump-input=fail
-CHECK: html2print: JS logs from the print session
+CHECK: html2pdf4doc: JS logs from the print session
 
 RUN: %check_exists --file %S/Output/html2pdf/html/03_three_documents_with_assets/input.html
 RUN: %check_exists --file %S/Output/html2pdf/html/03_three_documents_with_assets/nested/input2.html

--- a/tests/integration/features/html2pdf/04_composable_document_with_assets/test.itest
+++ b/tests/integration/features/html2pdf/04_composable_document_with_assets/test.itest
@@ -1,7 +1,7 @@
 REQUIRES: TEST_HTML2PDF
 
 RUN: %strictdoc export %S --formats=html2pdf --included-documents --output-dir Output | filecheck %s --dump-input=fail
-CHECK: html2print: JS logs from the print session
+CHECK: html2pdf4doc: JS logs from the print session
 
 RUN: %check_exists --file %S/Output/html2pdf/html/04_composable_document_with_assets/input.html
 RUN: %check_exists --file %S/Output/html2pdf/html/04_composable_document_with_assets/nested/input2.html

--- a/tests/integration/features/html2pdf/05_generate_bundle_document/test.itest
+++ b/tests/integration/features/html2pdf/05_generate_bundle_document/test.itest
@@ -1,7 +1,7 @@
 REQUIRES: TEST_HTML2PDF
 
 RUN: %strictdoc export %S --formats=html2pdf --generate-bundle-document --output-dir Output | filecheck %s --dump-input=fail
-CHECK: html2print: JS logs from the print session
+CHECK: html2pdf4doc: JS logs from the print session
 
 RUN: %check_exists --file %S/Output/html2pdf/html/bundle.html
 RUN: %check_exists --file %S/Output/html2pdf/html/%THIS_TEST_FOLDER/input.html

--- a/tests/integration/features/html2pdf/06_system_chromedriver/test.itest
+++ b/tests/integration/features/html2pdf/06_system_chromedriver/test.itest
@@ -4,8 +4,8 @@ REQUIRES: SYSTEM_CHROMEDRIVER
 # GitHub images provide a chromedriver and export installed location, see
 # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#browsers-and-drivers
 RUN: %strictdoc export %S --formats=html2pdf --chromedriver="%chromedriver" --output-dir Output | filecheck %s --dump-input=fail
-CHECK: html2print: JS logs from the print session
-CHECK-NOT: HTML2PDF: Chrome Driver available at path: {{.*}}strictdoc_cache{{.*}}
+CHECK: html2pdf4doc: JS logs from the print session
+CHECK-NOT: html2pdf4doc: ChromeDriver available at path: {{.*}}strictdoc_cache{{.*}}
 
 RUN: %check_exists --file %S/Output/html2pdf/pdf/input.pdf
 


### PR DESCRIPTION
See https://github.com/mettta/html2pdf4doc_python/issues/37 for details.