### PR TITLE
Robot Framework part 2: Test report reader

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -3610,14 +3610,39 @@ This feature is not enabled by default because it has not received enough testin
 [[/SECTION]]
 
 [[SECTION]]
+MID: 74291dc6cfae47d2bae33066024f3807
+TITLE: Test report integration
+
+[TEXT]
+MID: 07e78a4847554fbd87c44d7b11133f68
+STATEMENT: >>>
+StrictDoc can read test report files from several testing tools as SDoc content which allows establishing traceability between requirements, test cases, and test results.
+
+The project must have the following features activated for StrictDoc to provide language-aware parsing of C/C++, Python or Robot Framework. It is recommended to provide a dedicated folder for test report XML files to not mix human-written SDoc content and auto-generated test reports.
+
+.. code-block::
+
+    [project]
+
+    features = [
+      "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+      "SOURCE_FILE_LANGUAGE_PARSERS",
+    ]
+
+    include_doc_paths = [
+      "docs/**",
+      # A dedicated folder where StrictDoc could find JUnit XML.
+      "reports/**",
+    ]
+<<<
+
+[[SECTION]]
 MID: e9c94abacb12425980aec8ed7ee752cb
-TITLE: JUnit XML report integration
+TITLE: JUnit XML
 
 [TEXT]
 MID: eba63ebd45624139a8773cf42fe7d670
 STATEMENT: >>>
-StrictDoc can read JUnit XML files as SDoc content which allows establishing traceability between requirements, test cases, and test results.
-
 JUnit XML format is mostly identical between different tools that produce it but there are subtle differences that must be handled case by case. StrictDoc supports several JUnit XML flavors. To be discovered by StrictDoc, the XML files must have one of the following extensions:
 
 .. list-table:: Supported JUnit XML formats
@@ -3640,27 +3665,12 @@ JUnit XML format is mostly identical between different tools that produce it but
 
     After the existing JUnit XML flavors have been implemented, it should be easy to add more tools in case their output differs.
 
-The project must have the following features activated for StrictDoc to provide language-aware parsing of C/C++ and Python. It is recommended to provide a dedicated folder for JUnit XML to not mix human-written SDoc content and auto-generated test reports.
-
-.. code-block::
-
-    [project]
-
-    features = [
-      "REQUIREMENT_TO_SOURCE_TRACEABILITY",
-      "SOURCE_FILE_LANGUAGE_PARSERS",
-    ]
-
-    include_doc_paths = [
-      "docs/**",
-      # A dedicated folder where StrictDoc could find JUnit XML.
-      "reports/**",
-    ]
-
 .. warning::
 
     The JUnit XML feature's status is experimental. The functionality has been implemented and passes basic integration tests but it has not received enough testing by the users. StrictDoc's own documentation is already using this feature and the JUnit XML traceability will be part of StrictDoc's own qualification package. It is expected that the JUnit XML will become a stable feature by no late than 2025 Q4.
 <<<
+
+[[/SECTION]]
 
 [[SECTION]]
 MID: 06d9dbbeca204f5e8d0042e142b615bd
@@ -3685,6 +3695,22 @@ Specifically for LLVM Integrated Tester-produced JUnit XML, an extra config opti
     ]
 
 In this example, the expectation is that a user has generated a JUnit XML with LLVM LIT and the output XML is at ``reports/tests_integration.lit.junit.xml``. The config line tells StrictDoc that this JUnit XML was produced by LIT from the ``tests/integration`` root folder.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+MID: c7f5451905bf4fdb9a3a7dc97bb0e853
+TITLE: Robot Framework XML
+
+[TEXT]
+MID: 6c3d98ca65cc40d585953237693ff2c6
+STATEMENT: >>>
+Robot Framework has its own native XML test report schema, sometimes referred to as ``output.xml``. Files must end with ``.robot.xml`` to be recognized as such.
+
+.. warning::
+
+    The Robot Framework test report feature's status is experimental.
 <<<
 
 [[/SECTION]]

--- a/strictdoc/backend/sdoc_source_code/test_reports/robot_xml_reader.py
+++ b/strictdoc/backend/sdoc_source_code/test_reports/robot_xml_reader.py
@@ -1,0 +1,232 @@
+from typing import Dict, Optional, Union
+
+import robot.result
+from robot.api import ExecutionResult, ResultVisitor
+
+from strictdoc.backend.sdoc.document_reference import DocumentReference
+from strictdoc.backend.sdoc.models.document import SDocDocument
+from strictdoc.backend.sdoc.models.document_grammar import DocumentGrammar
+from strictdoc.backend.sdoc.models.node import SDocNode, SDocNodeField
+from strictdoc.backend.sdoc.models.reference import FileReference
+from strictdoc.backend.sdoc.models.section import SDocSection
+from strictdoc.backend.sdoc.models.type_system import FileEntry, FileEntryFormat
+from strictdoc.core.file_tree import File
+from strictdoc.core.project_config import ProjectConfig
+from strictdoc.helpers.paths import path_to_posix_path
+
+
+class SdocVisitor(ResultVisitor):
+    def __init__(self, project_config: ProjectConfig):
+        self.project_config = project_config
+        self.suites: Dict[str, Union[SDocDocument, SDocSection]] = {}
+        self.document: Optional[SDocDocument] = None
+
+    def visit_suite(self, suite: robot.result.TestSuite) -> None:
+        """Create document for top level suite and sections for nested suites."""
+        assert suite.full_name not in self.suites
+
+        if suite.parent is None:
+            self.document = SDocDocument(
+                mid=None,
+                title=f"Test report: {suite.name}",
+                config=None,
+                view=None,
+                grammar=None,
+                section_contents=[],
+            )
+            self.document.ng_including_document_reference = DocumentReference()
+            grammar = DocumentGrammar.create_for_test_report(self.document)
+            self.document.grammar = grammar
+            self.document.config.requirement_style = "Table"
+            self.suites[suite.full_name] = self.document
+            summary = self.summary_from_suite(suite, self.document)
+            self.document.section_contents.append(summary)
+        else:
+            assert self.document
+            assert suite.parent.full_name in self.suites, (
+                "depth-first traversal expected"
+            )
+            parent_sdoc_node = self.suites[suite.parent.full_name]
+            section = SDocSection(
+                parent=parent_sdoc_node,
+                mid=None,
+                uid=None,
+                custom_level=None,
+                title=suite.name,
+                requirement_prefix=None,
+                section_contents=[],
+            )
+            section.ng_including_document_reference = DocumentReference()
+            section.ng_document_reference = DocumentReference()
+            section.ng_document_reference.set_document(self.document)
+            self.suites[suite.full_name] = section
+            parent_sdoc_node.section_contents.append(section)
+            summary_sdoc_node = self.summary_from_suite(suite, section)
+            section.section_contents.append(summary_sdoc_node)
+
+        super().visit_suite(suite)
+
+    def visit_test(self, test: robot.result.TestCase) -> None:
+        """Create TEST_RESULT node for each test case."""
+        assert self.document
+        assert test.parent and test.parent.full_name in self.suites, (
+            "depth-first traversal expected"
+        )
+        parent_section = self.suites[test.parent.full_name]
+        testcase_node = SDocNode(
+            parent=parent_section,
+            node_type="TEST_RESULT",
+            fields=[],
+            relations=[],
+        )
+        testcase_node.ng_document_reference = DocumentReference()
+        testcase_node.ng_document_reference.set_document(self.document)
+        testcase_node.ng_including_document_reference = DocumentReference()
+
+        # Only executed tests will become traceable.
+        if not test.skipped:
+            testcase_node.set_field_value(
+                field_name="UID",
+                form_field_index=0,
+                value=SDocNodeField(
+                    parent=testcase_node,
+                    field_name="UID",
+                    parts=[test.full_name.upper()],
+                    multiline__=None,
+                ),
+            )
+
+        # Absolute path will be replaced with relative path to strictdoc root
+        # in FileTraceabilityIndex.
+        abs_path_on_exec_machine = path_to_posix_path(str(test.source))
+        if test.source is not None:
+            testcase_node.set_field_value(
+                field_name="TEST_PATH",
+                form_field_index=0,
+                value=SDocNodeField(
+                    parent=testcase_node,
+                    field_name="TEST_PATH",
+                    parts=[abs_path_on_exec_machine],
+                    multiline__=None,
+                ),
+            )
+
+        testcase_node.set_field_value(
+            field_name="TEST_FUNCTION",
+            form_field_index=0,
+            value=SDocNodeField(
+                parent=testcase_node,
+                field_name="TEST_FUNCTION",
+                parts=[test.name],
+                multiline__=None,
+            ),
+        )
+
+        testcase_node.set_field_value(
+            field_name="DURATION",
+            form_field_index=0,
+            value=SDocNodeField(
+                parent=testcase_node,
+                field_name="DURATION",
+                parts=[str(test.elapsed_time.total_seconds())],
+                multiline__=None,
+            ),
+        )
+
+        testcase_node.set_field_value(
+            field_name="STATUS",
+            form_field_index=0,
+            value=SDocNodeField(
+                parent=testcase_node,
+                field_name="STATUS",
+                parts=[test.status],
+                multiline__=None,
+            ),
+        )
+
+        testcase_node.set_field_value(
+            field_name="TITLE",
+            form_field_index=0,
+            value=SDocNodeField(
+                parent=testcase_node,
+                field_name="TITLE",
+                parts=[test.name],
+                multiline__=None,
+            ),
+        )
+
+        if not test.skipped:
+            # File path will be resolved in FileTraceabilityIndex.
+            testcase_node.relations.append(
+                FileReference(
+                    parent=testcase_node,
+                    g_file_entry=FileEntry(
+                        parent=None,
+                        g_file_format=FileEntryFormat.SOURCECODE,
+                        g_file_path="#FORWARD#",
+                        g_line_range=None,
+                        function=test.name,
+                        clazz=None,
+                    ),
+                )
+            )
+
+        parent_section.section_contents.append(testcase_node)
+
+    def summary_from_suite(
+        self,
+        suite: robot.result.TestSuite,
+        parent: Union[SDocDocument, SDocSection],
+    ) -> SDocNode:
+        assert self.document
+        summary_table = f"""\
+.. list-table:: Test suite summary
+    :widths: 25 10
+    :header-rows: 0
+
+    * - **Number of tests:**
+      - {suite.statistics.total}
+    * - **Number of successful tests:**
+      - {suite.statistics.passed}
+    * - **Number of failed tests:**
+      - {suite.statistics.failed}
+    * - **Number of skipped tests:**
+      - {suite.statistics.skipped}
+"""
+        summary_node = SDocNode(
+            parent=parent,
+            node_type="TEXT",
+            fields=[],
+            relations=[],
+        )
+        summary_node.ng_document_reference = DocumentReference()
+        summary_node.ng_document_reference.set_document(self.document)
+        summary_node.ng_including_document_reference = DocumentReference()
+        summary_node.set_field_value(
+            field_name="STATEMENT",
+            form_field_index=0,
+            value=SDocNodeField(
+                parent=summary_node,
+                field_name="STATEMENT",
+                parts=[summary_table],
+                multiline__="True",
+            ),
+        )
+        return summary_node
+
+
+class RobotOutputXMLReader:
+    @classmethod
+    def read_from_file(
+        cls: "RobotOutputXMLReader",
+        doc_file: File,
+        project_config: ProjectConfig,
+    ) -> SDocDocument:
+        execution_result = ExecutionResult(doc_file.get_full_path())
+        sdoc_visitor = SdocVisitor(project_config)
+        execution_result.visit(sdoc_visitor)
+        if sdoc_visitor.document is None:
+            raise RuntimeError(
+                f"No test suite could be parsed from {doc_file.get_full_path()}"
+            )
+        return sdoc_visitor.document

--- a/strictdoc/core/document_finder.py
+++ b/strictdoc/core/document_finder.py
@@ -13,6 +13,9 @@ from strictdoc.backend.sdoc_source_code.coverage_reports.gcov import (
 from strictdoc.backend.sdoc_source_code.test_reports.junit_xml_reader import (
     JUnitXMLReader,
 )
+from strictdoc.backend.sdoc_source_code.test_reports.robot_xml_reader import (
+    RobotOutputXMLReader,
+)
 from strictdoc.core.asset_manager import AssetManager
 from strictdoc.core.document_meta import DocumentMeta
 from strictdoc.core.document_tree import DocumentTree
@@ -95,6 +98,11 @@ class DocumentFinder:
                     doc_file, project_config
                 )
                 assert isinstance(document_or_grammar, SDocDocument)
+            elif doc_full_path.endswith(".robot.xml"):
+                robot_reader = RobotOutputXMLReader()
+                document_or_grammar = robot_reader.read_from_file(
+                    doc_file, project_config
+                )
             else:
                 raise NotImplementedError  # pragma: no cover
         drop_textx_meta(document_or_grammar)
@@ -269,7 +277,13 @@ class DocumentFinder:
                 file_tree_structure = FileFinder.find_files_with_extensions(
                     root_path=path_to_doc_root,
                     ignored_dirs=[project_config.output_dir],
-                    extensions=[".sdoc", ".sgra", ".junit.xml", ".gcov.json"],
+                    extensions=[
+                        ".sdoc",
+                        ".sgra",
+                        ".junit.xml",
+                        ".gcov.json",
+                        ".robot.xml",
+                    ],
                     include_paths=project_config.include_doc_paths,
                     exclude_paths=project_config.exclude_doc_paths,
                 )

--- a/strictdoc/export/html/generators/view_objects/helpers.py
+++ b/strictdoc/export/html/generators/view_objects/helpers.py
@@ -57,7 +57,11 @@ def screen_should_display_file(
     assert isinstance(file, File), file
     assert traceability_index.document_tree is not None
 
-    if file.has_extension(".junit.xml") or file.has_extension(".gcov.json"):
+    if (
+        file.has_extension(".junit.xml")
+        or file.has_extension(".gcov.json")
+        or file.has_extension(".robot.xml")
+    ):
         return True
 
     if file.has_extension(".sdoc"):

--- a/tests/integration/features/test_reports/robot_xml/01_basic/input.sdoc
+++ b/tests/integration/features/test_reports/robot_xml/01_basic/input.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ-A
+TITLE: Feature A
+STATEMENT: The system shall do A.
+
+[REQUIREMENT]
+UID: REQ-B
+TITLE: Feature B
+STATEMENT: The system shall do B.

--- a/tests/integration/features/test_reports/robot_xml/01_basic/strictdoc.toml
+++ b/tests/integration/features/test_reports/robot_xml/01_basic/strictdoc.toml
@@ -1,0 +1,10 @@
+[project]
+
+include_source_paths = [
+  "tests/**.robot",
+]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+  "SOURCE_FILE_LANGUAGE_PARSERS",
+]

--- a/tests/integration/features/test_reports/robot_xml/01_basic/test.itest
+++ b/tests/integration/features/test_reports/robot_xml/01_basic/test.itest
@@ -1,0 +1,11 @@
+# To reproduce the test report run the test suite
+# $ pipx install robotframework
+# $ robot -o test_report/output.robot.xml -N "System Test" tests
+
+RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%S/Output/html/01_basic/test_report/output.robot.html"
+RUN: %check_exists --file "%S/Output/html/_source_files/tests/feature1a.robot.html"
+RUN: %check_exists --file "%S/Output/html/_source_files/tests/feature1b.robot.html"
+RUN: %check_exists --file "%S/Output/html/_source_files/tests/feature2/feature2.robot.html"

--- a/tests/integration/features/test_reports/robot_xml/01_basic/test_report/output.robot.xml
+++ b/tests/integration/features/test_reports/robot_xml/01_basic/test_report/output.robot.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 7.2.2 (Python 3.11.2 on linux)" generated="2025-05-15T22:23:03.446474" rpa="false" schemaversion="5">
+<suite id="s1" name="System Test" source="/home/user/strictdoc/tests/integration/features/test_reports/robot_xml/01_basic/tests">
+<suite id="s1-s1" name="Feature1A" source="/home/user/strictdoc/tests/integration/features/test_reports/robot_xml/01_basic/tests/feature1a.robot">
+<test id="s1-s1-t1" name="Foo Feature 1a" line="3">
+<kw name="Log To Console" owner="BuiltIn">
+<arg>Let it pass</arg>
+<doc>Logs the given message to the console.</doc>
+<status status="PASS" start="2025-05-15T22:23:03.464943" elapsed="0.000157"/>
+</kw>
+<doc>Test following requirements
+@relation(REQ-A, scope=function)</doc>
+<status status="PASS" start="2025-05-15T22:23:03.464352" elapsed="0.000884"/>
+</test>
+<test id="s1-s1-t2" name="Bar Feature 1a" line="8">
+<kw name="Fail" owner="BuiltIn">
+<msg time="2025-05-15T22:23:03.465856" level="FAIL">Let it fail</msg>
+<arg>Let it fail</arg>
+<doc>Fails the test with the given message and optionally alters its tags.</doc>
+<status status="FAIL" start="2025-05-15T22:23:03.465656" elapsed="0.000405">Let it fail</status>
+</kw>
+<doc>Test following requirements
+@relation(REQ-A, scope=function)</doc>
+<status status="FAIL" start="2025-05-15T22:23:03.465393" elapsed="0.000835">Let it fail</status>
+</test>
+<status status="FAIL" start="2025-05-15T22:23:03.463504" elapsed="0.003037"/>
+</suite>
+<suite id="s1-s2" name="Feature1B" source="/home/user/strictdoc/tests/integration/features/test_reports/robot_xml/01_basic/tests/feature1b.robot">
+<test id="s1-s2-t1" name="Foo Feature 1b" line="3">
+<kw name="Log To Console" owner="BuiltIn">
+<arg>Let it pass</arg>
+<doc>Logs the given message to the console.</doc>
+<status status="PASS" start="2025-05-15T22:23:03.467857" elapsed="0.000128"/>
+</kw>
+<doc>Test following requirements
+@relation(REQ-A, scope=function)</doc>
+<status status="PASS" start="2025-05-15T22:23:03.467588" elapsed="0.000502"/>
+</test>
+<test id="s1-s2-t2" name="Bar Feature 1b" line="8">
+<kw name="Fail" owner="BuiltIn">
+<msg time="2025-05-15T22:23:03.468645" level="FAIL">Let it fail</msg>
+<arg>Let it fail</arg>
+<doc>Fails the test with the given message and optionally alters its tags.</doc>
+<status status="FAIL" start="2025-05-15T22:23:03.468476" elapsed="0.000236">Let it fail</status>
+</kw>
+<doc>Test following requirements
+@relation(REQ-A, scope=function)</doc>
+<status status="FAIL" start="2025-05-15T22:23:03.468227" elapsed="0.000635">Let it fail</status>
+</test>
+<status status="FAIL" start="2025-05-15T22:23:03.466827" elapsed="0.002240"/>
+</suite>
+<suite id="s1-s3" name="Feature2" source="/home/user/strictdoc/tests/integration/features/test_reports/robot_xml/01_basic/tests/feature2">
+<suite id="s1-s3-s1" name="Feature2" source="/home/user/strictdoc/tests/integration/features/test_reports/robot_xml/01_basic/tests/feature2/feature2.robot">
+<test id="s1-s3-s1-t1" name="Foo Feature B" line="3">
+<kw name="Log To Console" owner="BuiltIn">
+<arg>Let it pass</arg>
+<doc>Logs the given message to the console.</doc>
+<status status="PASS" start="2025-05-15T22:23:03.471051" elapsed="0.000120"/>
+</kw>
+<doc>Test following requirements
+@relation(REQ-B, scope=function)</doc>
+<status status="PASS" start="2025-05-15T22:23:03.470792" elapsed="0.000486"/>
+</test>
+<test id="s1-s3-s1-t2" name="Bar Feature B" line="8">
+<kw name="Fail" owner="BuiltIn">
+<msg time="2025-05-15T22:23:03.471813" level="FAIL">Let it fail</msg>
+<arg>Let it fail</arg>
+<doc>Fails the test with the given message and optionally alters its tags.</doc>
+<status status="FAIL" start="2025-05-15T22:23:03.471645" elapsed="0.000236">Let it fail</status>
+</kw>
+<doc>Test following requirements
+@relation(REQ-B, scope=function)</doc>
+<status status="FAIL" start="2025-05-15T22:23:03.471412" elapsed="0.000618">Let it fail</status>
+</test>
+<status status="FAIL" start="2025-05-15T22:23:03.470110" elapsed="0.002121"/>
+</suite>
+<status status="FAIL" start="2025-05-15T22:23:03.469337" elapsed="0.003219"/>
+</suite>
+<status status="FAIL" start="2025-05-15T22:23:03.447306" elapsed="0.025562"/>
+</suite>
+<statistics>
+<total>
+<stat pass="3" fail="3" skip="0">All Tests</stat>
+</total>
+<tag>
+</tag>
+<suite>
+<stat name="System Test" id="s1" pass="3" fail="3" skip="0">System Test</stat>
+<stat name="Feature1A" id="s1-s1" pass="1" fail="1" skip="0">System Test.Feature1A</stat>
+<stat name="Feature1B" id="s1-s2" pass="1" fail="1" skip="0">System Test.Feature1B</stat>
+<stat name="Feature2" id="s1-s3" pass="1" fail="1" skip="0">System Test.Feature2</stat>
+<stat name="Feature2" id="s1-s3-s1" pass="1" fail="1" skip="0">System Test.Feature2.Feature2</stat>
+</suite>
+</statistics>
+<errors>
+</errors>
+</robot>

--- a/tests/integration/features/test_reports/robot_xml/01_basic/tests/feature1a.robot
+++ b/tests/integration/features/test_reports/robot_xml/01_basic/tests/feature1a.robot
@@ -1,0 +1,11 @@
+*** Test Cases ***
+
+Foo Feature 1a
+    [Documentation]    Test following requirements
+    ...                @relation(REQ-A, scope=function)
+    Log To Console    Let it pass
+
+Bar Feature 1a
+    [Documentation]    Test following requirements
+    ...                @relation(REQ-A, scope=function)
+    Fail    Let it fail

--- a/tests/integration/features/test_reports/robot_xml/01_basic/tests/feature1b.robot
+++ b/tests/integration/features/test_reports/robot_xml/01_basic/tests/feature1b.robot
@@ -1,0 +1,11 @@
+*** Test Cases ***
+
+Foo Feature 1b
+    [Documentation]    Test following requirements
+    ...                @relation(REQ-A, scope=function)
+    Log To Console    Let it pass
+
+Bar Feature 1b
+    [Documentation]    Test following requirements
+    ...                @relation(REQ-A, scope=function)
+    Fail    Let it fail

--- a/tests/integration/features/test_reports/robot_xml/01_basic/tests/feature2/feature2.robot
+++ b/tests/integration/features/test_reports/robot_xml/01_basic/tests/feature2/feature2.robot
@@ -1,0 +1,11 @@
+*** Test Cases ***
+
+Foo Feature B
+    [Documentation]    Test following requirements
+    ...                @relation(REQ-B, scope=function)
+    Log To Console    Let it pass
+
+Bar Feature B
+    [Documentation]    Test following requirements
+    ...                @relation(REQ-B, scope=function)
+    Fail    Let it fail


### PR DESCRIPTION
This adds test report integration for the Robot Framework native output.xml format.

A new in-memory document is created for the main test suite. All other suites go into sub sections. Section hierarchy follows suite hierarchy.

Every robot test case result is turned into a sdoc node of type `TEST_RESULT` and goes to the section that was created for the parent suite.

`TEST_RESULT` nodes for executed tests are automatically linked through a file function relation to the associated test case in the `*.robot` source code.

`TEST_RESULT` nodes are further automatically linked through a parent/child relation to 1..n requirements. Related requirements are those that were already linked to the test case. The link gets a role Satisfies/IsSatisfiedBy assigned.

Note: Robot Framework could also produce xunit.xml. Here we follow the tip from [robotframework.org](https://docs.robotframework.org/docs/parsing_results)

> Don't try to parse the .xml files using some python xml module. Instead, use the Robot Framework API which allows you to get details about the executed tests, keywords, their data and the results much easier.

The related dependency is already in pyproject.toml.