### PR TITLE
code-climate: mypy: address type-arg

### DIFF
--- a/strictdoc/export/html/form_objects/grammar_element_form_object.py
+++ b/strictdoc/export/html/form_objects/grammar_element_form_object.py
@@ -1,5 +1,5 @@
-# mypy: disable-error-code="arg-type,no-untyped-call,no-untyped-def,union-attr,type-arg"
-from typing import Dict, List, Optional, Set, Tuple, Union
+# mypy: disable-error-code="arg-type,no-untyped-call,no-untyped-def,union-attr"
+from typing import List, Optional, Set, Tuple, Union
 
 from jinja2 import Template
 from starlette.datastructures import FormData
@@ -26,7 +26,7 @@ from strictdoc.export.html.form_objects.form_object import (
 from strictdoc.export.html.html_templates import JinjaEnvironment
 from strictdoc.helpers.auto_described import auto_described
 from strictdoc.helpers.cast import assert_cast
-from strictdoc.helpers.form_data import parse_form_data
+from strictdoc.helpers.form_data import ParsedFormData, parse_form_data
 from strictdoc.helpers.mid import MID
 from strictdoc.helpers.string import is_uppercase_underscore_string
 from strictdoc.server.error_object import ErrorObject
@@ -135,15 +135,20 @@ class GrammarElementFormObject(ErrorObject):
             (field_name, field_value)
             for field_name, field_value in request_form_data.multi_items()
         ]
-        request_form_dict: Dict = assert_cast(
+        request_form_dict: ParsedFormData = assert_cast(
             parse_form_data(request_form_data_as_list), dict
         )
 
         element_mid = request_form_dict["element_mid"]
 
+        #
         # Grammar fields.
+        #
         document_grammar_fields = request_form_dict["document_grammar_field"]
         for field_mid, field_dict in document_grammar_fields.items():
+            if not isinstance(field_dict, dict):
+                raise TypeError(f"Expected a dict, but got {type(field_dict)}")
+
             field_name = field_dict["field_name"]
             field_human_title = field_dict.get("field_human_title")
             if field_human_title is not None:
@@ -159,13 +164,19 @@ class GrammarElementFormObject(ErrorObject):
             )
             form_object_fields.append(form_object_field)
 
+        #
         # Grammar relations.
+        #
         document_grammar_relations = request_form_dict.get(
             "document_grammar_relation", {}
         )
         for field_mid, field_dict in document_grammar_relations.items():
+            if not isinstance(field_dict, dict):
+                raise TypeError(f"Expected a dict, but got {type(field_dict)}")
+
             field_type = field_dict["type"]
             field_role = field_dict["role"].strip()
+
             form_object_relation = GrammarFormRelation(
                 relation_mid=field_mid,
                 relation_type=field_type,

--- a/strictdoc/export/html/form_objects/grammar_form_object.py
+++ b/strictdoc/export/html/form_objects/grammar_form_object.py
@@ -1,5 +1,5 @@
-# mypy: disable-error-code="arg-type,no-untyped-call,no-untyped-def,type-arg"
-from typing import Dict, List, Optional, Set
+# mypy: disable-error-code="arg-type,no-untyped-call,no-untyped-def"
+from typing import List, Optional, Set
 
 from markupsafe import Markup
 from starlette.datastructures import FormData
@@ -16,7 +16,10 @@ from strictdoc.export.html.form_objects.rows.row_with_grammar_element_form_objec
 from strictdoc.export.html.html_templates import JinjaEnvironment
 from strictdoc.helpers.auto_described import auto_described
 from strictdoc.helpers.cast import assert_cast
-from strictdoc.helpers.form_data import parse_form_data
+from strictdoc.helpers.form_data import (
+    ParsedFormData,
+    parse_form_data,
+)
 from strictdoc.helpers.mid import MID
 from strictdoc.helpers.string import is_uppercase_underscore_string
 from strictdoc.server.error_object import ErrorObject
@@ -93,14 +96,23 @@ class GrammarFormObject(ErrorObject):
             (field_name, field_value)
             for field_name, field_value in request_form_data.multi_items()
         ]
-        request_form_dict: Dict = assert_cast(
+        request_form_dict: ParsedFormData = assert_cast(
             parse_form_data(request_form_data_as_list), dict
         )
 
         document_grammar_fields = request_form_dict[
             "document_grammar_element_field"
         ]
+
+        if not isinstance(document_grammar_fields, dict):
+            raise TypeError(
+                f"Expected a dict, but got {type(document_grammar_fields)}"
+            )
+
         for field_mid, field_dict in document_grammar_fields.items():
+            if not isinstance(field_dict, dict):
+                raise TypeError(f"Expected a dict, but got {type(field_dict)}")
+
             is_new = field_dict["is_new"] == "true"
             field_name = field_dict["field_name"]
 

--- a/strictdoc/export/html/form_objects/included_document_form_object.py
+++ b/strictdoc/export/html/form_objects/included_document_form_object.py
@@ -1,4 +1,4 @@
-# mypy: disable-error-code="arg-type,no-untyped-call,no-untyped-def,type-arg"
+# mypy: disable-error-code="arg-type,no-untyped-call,no-untyped-def"
 import re
 from collections import defaultdict
 from typing import Dict, List, Optional
@@ -9,7 +9,7 @@ from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.export.html.html_templates import JinjaEnvironment
 from strictdoc.helpers.auto_described import auto_described
 from strictdoc.helpers.cast import assert_cast
-from strictdoc.helpers.form_data import parse_form_data
+from strictdoc.helpers.form_data import ParsedFormData, parse_form_data
 from strictdoc.helpers.string import sanitize_html_form_field
 from strictdoc.server.error_object import ErrorObject
 from strictdoc.server.helpers.turbo import render_turbo_stream
@@ -42,11 +42,13 @@ class IncludedDocumentFormObject(ErrorObject):
             (field_name, field_value)
             for field_name, field_value in request_form_data.multi_items()
         ]
-        request_form_dict: Dict = assert_cast(
+        request_form_dict: ParsedFormData = assert_cast(
             parse_form_data(request_form_data_as_list), dict
         )
-        document_mid: str = request_form_dict["document_mid"]
-        context_document_mid: str = request_form_dict["context_document_mid"]
+        document_mid: str = assert_cast(request_form_dict["document_mid"], str)
+        context_document_mid: str = assert_cast(
+            request_form_dict["context_document_mid"], str
+        )
 
         # FIXME: Rewrite the legacy way of parsing by also use data from
         #        request_form_dict above.

--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -1,4 +1,4 @@
-# mypy: disable-error-code="arg-type,attr-defined,no-untyped-call,no-untyped-def,union-attr,type-arg"
+# mypy: disable-error-code="arg-type,attr-defined,no-untyped-call,no-untyped-def,union-attr"
 from collections import defaultdict
 from enum import Enum
 from typing import Dict, Iterable, List, Optional, Set, Union
@@ -39,7 +39,7 @@ from strictdoc.export.rst.rst_to_html_fragment_writer import (
 )
 from strictdoc.helpers.auto_described import auto_described
 from strictdoc.helpers.cast import assert_cast
-from strictdoc.helpers.form_data import parse_form_data
+from strictdoc.helpers.form_data import ParsedFormData, parse_form_data
 from strictdoc.helpers.mid import MID
 from strictdoc.helpers.string import sanitize_html_form_field
 from strictdoc.server.error_object import ErrorObject
@@ -221,7 +221,7 @@ class RequirementFormObject(ErrorObject):
         self.requirement_mid: str = requirement_mid
         self.document_mid: str = document_mid
         self.context_document_mid: str = context_document_mid
-        fields_dict: dict = {}
+        fields_dict: Dict[str, List[RequirementFormField]] = {}
         for field in fields:
             fields_dict.setdefault(field.field_name, []).append(field)
 
@@ -246,18 +246,21 @@ class RequirementFormObject(ErrorObject):
             (field_name, field_value)
             for field_name, field_value in request_form_data.multi_items()
         ]
-        request_form_dict: Dict = assert_cast(
+        request_form_dict: ParsedFormData = assert_cast(
             parse_form_data(request_form_data_as_list), dict
         )
         requirement_fields = defaultdict(list)
         form_ref_fields: List[RequirementReferenceFormField] = []
 
         context_document_mid = request_form_dict["context_document_mid"]
-        requirement_dict = request_form_dict["requirement"]
+        requirement_dict = assert_cast(request_form_dict["requirement"], dict)
 
-        element_type = request_form_dict["element_type"]
-        requirement_fields_dict = requirement_dict["fields"]
+        element_type = assert_cast(request_form_dict["element_type"], str)
+        requirement_fields_dict = assert_cast(requirement_dict["fields"], dict)
         for _, field_dict in requirement_fields_dict.items():
+            if not isinstance(field_dict, dict):
+                raise TypeError(f"Expected a dict, but got {type(field_dict)}")
+
             field_name = field_dict["name"]
             field_value = field_dict["value"]
             requirement_fields[field_name].append(field_value)

--- a/strictdoc/helpers/form_data.py
+++ b/strictdoc/helpers/form_data.py
@@ -1,11 +1,18 @@
-# mypy: disable-error-code="no-untyped-call,no-untyped-def,type-arg,union-attr"
+# mypy: disable-error-code="no-untyped-call,no-untyped-def,union-attr"
 import re
 from typing import Dict, List, Tuple, Union
 
 from typing_extensions import TypeAlias
 
-FormDataDictType: TypeAlias = Union[
-    Dict[str, "FormDataDictType"], List["FormDataDictType"]
+ParsedFormDataLeaf: TypeAlias = str
+
+ParsedFormDataContainer: TypeAlias = Union[
+    Dict[str, Union[ParsedFormDataLeaf, "ParsedFormDataContainer"]],
+    List[Union[ParsedFormDataLeaf, "ParsedFormDataContainer"]],
+]
+
+ParsedFormData: TypeAlias = Dict[
+    str, Union[ParsedFormDataLeaf, ParsedFormDataContainer]
 ]
 
 
@@ -57,8 +64,10 @@ def _set_value_by_key_path(obj, parts, value):
 FIELD_NAME = "[A-Za-z0-9_]*"
 
 
-def parse_form_data(form_data: List[Tuple]) -> Dict[str, FormDataDictType]:
-    result_dict: Dict[str, FormDataDictType] = {}
+def parse_form_data(
+    form_data: List[Tuple[str, str]],
+) -> ParsedFormData:
+    result_dict: ParsedFormData = {}
 
     for key, value in form_data:
         first_match = re.match(rf"({FIELD_NAME})", key)


### PR DESCRIPTION
This PR  addresses the bullet "mypy: fix remaining type-arg issues" of the #2068 code climate type epic.

Something I am not sure about:

- I introduced a new ParsedFormData type in form_data.py, allowing for nesting of lists / dicts of str. This works, but it requires introducing runtime type narrowing. I'm not sure if the type as proposed covers everything that the form handling needs.
