### PR TITLE
backend/sdoc_source_code: parse SDoc nodes from source files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,8 @@ classifiers = [
 # @sdoc[SDOC-SRS-89]
 dependencies = [
     "textx >= 4.0.0, == 4.*",
+    "lark >= 1.2.2",
+
     "jinja2 >= 2.11.2",
     # Reading project config from strictdoc.toml file.
     "toml",

--- a/strictdoc/backend/sdoc/models/node.py
+++ b/strictdoc/backend/sdoc/models/node.py
@@ -487,7 +487,7 @@ class SDocNode(SDocNodeIF):
 
             # A field is considered singleline if it goes before the STATEMENT
             # field and vice versa.
-            if field_index > reference_field_index:
+            if field_index >= reference_field_index:
                 is_single_line_field = False
             else:
                 is_single_line_field = True

--- a/strictdoc/backend/sdoc_source_code/comment_parser/marker_lexer.py
+++ b/strictdoc/backend/sdoc_source_code/comment_parser/marker_lexer.py
@@ -1,0 +1,59 @@
+from lark import Lark, ParseTree, UnexpectedToken
+
+from strictdoc.backend.sdoc_source_code.constants import (
+    REGEX_REQ,
+    RESERVED_KEYWORDS,
+)
+
+GRAMMAR = f"""
+start: (relation_marker | node_field | _NORMAL_STRING | _WS)*
+
+relation_marker: "@relation" _BRACE_LEFT _WS? (relation_node_uid _SEP _WS)+ "scope=" relation_scope ("," _WS "role=" relation_role)? _WS? _BRACE_RIGHT
+
+relation_node_uid: /{REGEX_REQ}/
+relation_scope: /file|class|function|line|range_start|range_end/
+relation_role: ALPHANUMERIC_WORD
+
+node_field: node_name ":" _WS_INLINE node_multiline_value
+node_name: /(?!({RESERVED_KEYWORDS}))[A-Z_]+/
+node_multiline_value: (NORMAL_STRING_VALUE _NL)+
+NORMAL_STRING_VALUE.2: /[ ]*(?!\\s*@relation)(?![A-Z_]+:)[^\n\r]+/x
+
+NORMAL_STRING: /(?!\\s*@relation)((?![A-Z_]+:)|({RESERVED_KEYWORDS})).+/
+_NORMAL_STRING: NORMAL_STRING
+
+_BRACE_LEFT: /[\\(\\{{]/
+_BRACE_RIGHT: /[\\)\\}}]/
+
+_SEP: ","
+_NL : NL
+_WS : WS
+_WS_INLINE : WS_INLINE
+
+ALPHANUMERIC_WORD: /[a-zA-Z0-9_]+/
+NL: /\\r?\\n/
+
+%import common.WS -> WS
+%import common.WS_INLINE -> WS_INLINE
+"""
+
+
+class MarkerLexer:
+    @staticmethod
+    def parse(source_input: str) -> ParseTree:
+        parser: Lark = Lark(
+            GRAMMAR, parser="lalr", cache=True, propagate_positions=True
+        )
+
+        try:
+            # FIXME: Without rstrip, there is an edge case where the parser
+            #        breaks when resolving conflicts between multiline node
+            #        fields and normal strings.
+            #        See also test: test_31_single_node_field.
+            tree: ParseTree = parser.parse(source_input.rstrip() + "\n")
+        except UnexpectedToken as exception_:
+            print(  # noqa: T201
+                "error: could not parse source comment:\n" + source_input
+            )
+            raise exception_
+        return tree

--- a/strictdoc/backend/sdoc_source_code/constants.py
+++ b/strictdoc/backend/sdoc_source_code/constants.py
@@ -1,5 +1,9 @@
 from enum import Enum
 
+REGEX_REQ = r"(?!scope=)[A-Za-z][A-Za-z0-9_\/\.\\-]+"
+REGEX_ROLE = r"[A-Za-z][A-Za-z0-9\\-]+"
+RESERVED_KEYWORDS = "FIXME|NOTE|TODO|TBD|WARNING"
+
 
 class FunctionAttribute(Enum):
     STATIC = "static"

--- a/strictdoc/backend/sdoc_source_code/helpers/comment_preprocessor.py
+++ b/strictdoc/backend/sdoc_source_code/helpers/comment_preprocessor.py
@@ -7,15 +7,24 @@ WS = "[ \t]"
 def preprocess_source_code_comment(comment: str) -> str:
     """
     Remove all Doxygen/Python/etc comment markers for processing.
+
+    FIXME: Maybe there is a more efficient way of doing this with no two
+           re.sub() calls.
     """
 
     def replace_with_spaces(match: Match[str]) -> str:
         # Return a string of spaces with the same length as the matched text.
         return " " * len(match.group(0))
 
-    return re.sub(
+    replacement = re.sub(
         rf"(^/\*\*)|^{WS}*\*/?|(^///)|(^//)|(^#+)",
         replace_with_spaces,
         comment,
+        flags=re.MULTILINE,
+    )
+    return re.sub(
+        r"^[ \t]+$",
+        "",
+        replacement,
         flags=re.MULTILINE,
     )

--- a/strictdoc/backend/sdoc_source_code/marker_parser.py
+++ b/strictdoc/backend/sdoc_source_code/marker_parser.py
@@ -1,6 +1,10 @@
-import re
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
+from lark import ParseTree, Token, Tree
+
+from strictdoc.backend.sdoc_source_code.comment_parser.marker_lexer import (
+    MarkerLexer,
+)
 from strictdoc.backend.sdoc_source_code.helpers.comment_preprocessor import (
     preprocess_source_code_comment,
 )
@@ -12,14 +16,7 @@ from strictdoc.backend.sdoc_source_code.models.range_marker import (
     RangeMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.requirement_marker import Req
-
-REGEX_REQ = r"[A-Za-z][A-Za-z0-9_\/\.\\-]+"
-REGEX_ROLE = r"[A-Za-z][A-Za-z0-9\\-]+"
-
-# @relation(REQ-1, scope=function) or @relation{REQ-1, scope=function}
-REGEX_MARKER = re.compile(
-    rf"@relation[({{](\s*{REGEX_REQ}(?:,\s+{REGEX_REQ})*),\s+scope=(file|class|function|line|range_start|range_end)(?:,\s+role=({REGEX_ROLE}))?[\s*)}}]"
-)
+from strictdoc.backend.sdoc_source_code.models.source_node import SourceNode
 
 
 class MarkerParser:
@@ -31,7 +28,7 @@ class MarkerParser:
         comment_line_start: int,
         entity_name: Optional[str] = None,
         col_offset: int = 0,
-    ) -> List[Union[FunctionRangeMarker, RangeMarker, LineMarker]]:
+    ) -> SourceNode:
         """
         Parse relation markers from source file comments.
 
@@ -46,103 +43,170 @@ class MarkerParser:
         start of the range.
         """
 
-        markers: List[Union[FunctionRangeMarker, RangeMarker, LineMarker]] = []
+        node_fields: Dict[str, str] = {}
+        source_node: SourceNode = SourceNode(entity_name)
 
         input_string = preprocess_source_code_comment(input_string)
 
-        matches = REGEX_MARKER.finditer(input_string)
-        for match_ in matches:
-            assert match_.lastindex is not None
-            marker_type = match_.group(2)
-            marker_role = match_.group(3) if len(match_.groups()) >= 3 else None
-            req_list = match_.group(1)
+        tree: ParseTree = MarkerLexer.parse(input_string)
 
-            marker_start_index = match_.start(0)
-
-            marker_start_line = comment_line_start + input_string.count(
-                "\n", 0, marker_start_index
-            )
-
-            marker_line_start_index = input_string.rfind(
-                "\n", 0, marker_start_index
-            )
-            marker_line_start_index = (
-                0
-                if marker_line_start_index == -1
-                else marker_line_start_index + 1
-            )
-
-            marker_start_column = (
-                (marker_start_index - marker_line_start_index) + col_offset + 1
-            )
-
-            all_reqs_start_index = match_.start(1)
-
-            requirements = []
-            for req_match in re.finditer(REGEX_REQ, req_list):
-                req_start_index = all_reqs_start_index + req_match.start()
-                last_newline_pos = input_string.rfind("\n", 0, req_start_index)
-
-                line_start_index = (
-                    0 if last_newline_pos == -1 else last_newline_pos + 1
-                )
-
-                req_abs_line = comment_line_start + input_string.count(
-                    "\n", 0, req_start_index
-                )
-
-                first_requirement_index = match_.start(1)
-                first_requirement_column = (
-                    first_requirement_index - line_start_index
-                ) + 1
-
-                req_item = req_match.group(0)
-
-                start_index = req_match.start()
-                requirement = Req(None, req_item)
-                requirement.ng_source_line = req_abs_line
-                requirement.ng_source_column = (
-                    first_requirement_column + start_index
-                )
-                requirements.append(requirement)
-
-            if marker_type in ("file", "class", "function"):
-                function_marker = FunctionRangeMarker(
-                    None, requirements, scope=marker_type, role=marker_role
-                )
-                function_marker.ng_source_line_begin = marker_start_line
-                function_marker.ng_source_column_begin = marker_start_column
-                function_marker.ng_range_line_begin = line_start
-                function_marker.ng_range_line_end = line_end
-                if marker_type == "file":
-                    function_marker.set_description("entire file")
-                elif marker_type == "function":
-                    function_marker.set_description(f"function {entity_name}()")
-                elif marker_type == "class":
-                    function_marker.set_description(f"class {entity_name}")
-                markers.append(function_marker)
-            elif marker_type in ("range_start", "range_end"):
-                start_or_end = marker_type == "range_start"
-                range_marker = RangeMarker(
-                    None,
-                    "[" if start_or_end else "[/",
-                    requirements,
-                    role=marker_role,
-                )
-                range_marker.ng_source_line_begin = marker_start_line
-                range_marker.ng_source_column_begin = marker_start_column
-                range_marker.ng_range_line_begin = line_start
-                range_marker.ng_range_line_end = line_end
-                range_marker.ng_new_relation_keyword = True
-                markers.append(range_marker)
-            elif marker_type == "line":
-                line_marker = LineMarker(None, requirements, role=marker_role)
-                line_marker.ng_source_line_begin = marker_start_line
-                line_marker.ng_source_column_begin = marker_start_column
-                line_marker.ng_range_line_begin = line_start
-                line_marker.ng_range_line_end = line_end
-                markers.append(line_marker)
-            else:
+        for element_ in tree.children:
+            if not isinstance(element_, Tree):
                 continue
 
+            if element_.data == "relation_marker":
+                relation_markers = MarkerParser._parse_relation_marker(
+                    element_,
+                    line_start,
+                    line_end,
+                    comment_line_start,
+                    entity_name,
+                    col_offset,
+                )
+                source_node.markers.extend(relation_markers)
+
+            elif element_.data == "node_field":
+                node_name, node_value = MarkerParser._parse_node_field(
+                    element_,
+                )
+                node_fields[node_name] = node_value
+            else:
+                raise AssertionError
+
+        if len(node_fields) > 0:
+            source_node.fields = node_fields
+
+        return source_node
+
+    @staticmethod
+    def _parse_relation_marker(
+        element_: Tree[Token],
+        line_start: int,
+        line_end: int,
+        comment_line_start: int,
+        entity_name: Optional[str] = None,
+        col_offset: int = 0,
+    ) -> List[Union[FunctionRangeMarker, RangeMarker, LineMarker]]:
+        markers: List[Union[FunctionRangeMarker, RangeMarker, LineMarker]] = []
+
+        relation_uid_elements = []
+        relation_scope_element: Optional[Tree[Token]] = None
+        relation_role_element: Optional[Tree[Token]] = None
+        for relation_marker_element_ in element_.children:
+            assert isinstance(relation_marker_element_, Tree)
+            if relation_marker_element_.data == "relation_node_uid":
+                relation_uid_elements.append(relation_marker_element_)
+            elif relation_marker_element_.data == "relation_scope":
+                relation_scope_element = relation_marker_element_
+            elif relation_marker_element_.data == "relation_role":
+                relation_role_element = relation_marker_element_
+            else:
+                raise NotImplementedError
+
+        assert len(relation_uid_elements) > 0
+        assert relation_scope_element is not None
+
+        assert isinstance(relation_scope_element.children[0], Token)
+        relation_scope = relation_scope_element.children[0].value
+
+        relation_role = None
+        if relation_role_element is not None:
+            assert isinstance(relation_role_element.children[0], Token)
+            relation_role = relation_role_element.children[0].value
+
+        requirements = []
+        for relation_uid_token_ in relation_uid_elements:
+            assert isinstance(relation_uid_token_.children[0], Token)
+            relation_uid = relation_uid_token_.children[0].value
+
+            assert relation_uid_token_.children[0].line is not None
+            requirement = Req(None, relation_uid)
+            requirement.ng_source_line = (
+                comment_line_start + relation_uid_token_.children[0].line - 1
+            )
+            requirement.ng_source_column = relation_uid_token_.children[
+                0
+            ].column
+            requirements.append(requirement)
+
+        if relation_scope in ("file", "class", "function"):
+            function_marker = FunctionRangeMarker(
+                None, requirements, scope=relation_scope, role=relation_role
+            )
+            function_marker.ng_source_line_begin = (
+                comment_line_start + element_.meta.line - 1
+            )
+            function_marker.ng_source_column_begin = (
+                element_.meta.column + col_offset
+            )
+            function_marker.ng_range_line_begin = line_start
+            function_marker.ng_range_line_end = line_end
+            if relation_scope == "file":
+                function_marker.set_description("entire file")
+            elif relation_scope == "function":
+                function_marker.set_description(f"function {entity_name}()")
+            elif relation_scope == "class":
+                function_marker.set_description(f"class {entity_name}")
+            markers.append(function_marker)
+        elif relation_scope in ("range_start", "range_end"):
+            start_or_end = relation_scope == "range_start"
+            range_marker = RangeMarker(
+                None,
+                "[" if start_or_end else "[/",
+                requirements,
+                role=relation_role,
+            )
+            range_marker.ng_source_line_begin = (
+                comment_line_start + element_.meta.line - 1
+            )
+            range_marker.ng_source_column_begin = (
+                element_.meta.column + col_offset
+            )
+            range_marker.ng_range_line_begin = line_start
+            range_marker.ng_range_line_end = line_end
+            range_marker.ng_new_relation_keyword = True
+            markers.append(range_marker)
+        elif relation_scope == "line":
+            line_marker = LineMarker(None, requirements, role=relation_role)
+            line_marker.ng_source_line_begin = (
+                comment_line_start + element_.meta.line - 1
+            )
+            line_marker.ng_source_column_begin = (
+                element_.meta.column + col_offset
+            )
+            line_marker.ng_range_line_begin = line_start
+            line_marker.ng_range_line_end = line_end
+            markers.append(line_marker)
+        else:
+            raise NotImplementedError
+
         return markers
+
+    @staticmethod
+    def _parse_node_field(
+        element_: Tree[Token],
+    ) -> Tuple[str, str]:
+        node_name_node = element_.children[0]
+        assert isinstance(node_name_node, Tree)
+        assert node_name_node.data == "node_name"
+        assert isinstance(node_name_node.children[0], Token)
+        node_name = node_name_node.children[0].value
+
+        node_value_node = element_.children[1]
+        assert isinstance(node_value_node, Tree)
+        assert node_value_node.data == "node_multiline_value"
+
+        processed_node_values = []
+        for node_value_component_ in node_value_node.children:
+            assert isinstance(node_value_component_, Token)
+            processed_node_value = node_value_component_.value.strip()
+            if "\\n\\n" in processed_node_value:
+                processed_node_value = processed_node_value.replace(
+                    "\\n\\n", ""
+                )
+
+            processed_node_values.append(processed_node_value)
+
+        node_value = "\n".join(processed_node_values)
+
+        return node_name, node_value

--- a/strictdoc/backend/sdoc_source_code/models/source_file_info.py
+++ b/strictdoc/backend/sdoc_source_code/models/source_file_info.py
@@ -1,5 +1,5 @@
 # mypy: disable-error-code="no-untyped-def"
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Union
 
 from typing_extensions import TypeAlias
 
@@ -12,6 +12,7 @@ from strictdoc.backend.sdoc_source_code.models.range_marker import (
     LineMarker,
     RangeMarker,
 )
+from strictdoc.backend.sdoc_source_code.models.source_node import SourceNode
 from strictdoc.core.source_tree import SourceFile
 from strictdoc.helpers.auto_described import auto_described
 from strictdoc.helpers.file_stats import SourceFileStats
@@ -38,6 +39,7 @@ class SourceFileTraceabilityInfo:
         """
 
         self.source_file: Optional[SourceFile] = None
+        self.source_nodes: List[SourceNode] = []
         self.functions: List[Function] = []
 
         #
@@ -45,13 +47,9 @@ class SourceFileTraceabilityInfo:
         #  "REQ-001": [RangeMarker(...), ...],           # noqa: ERA001
         #  "REQ-002": [RangeMarker(...), ...],           # noqa: ERA001
         # }                                              # noqa: ERA001
-        self.ng_map_reqs_to_markers: Dict[
-            str, Sequence[RelationMarkerType]
-        ] = {}
+        self.ng_map_reqs_to_markers: Dict[str, List[RelationMarkerType]] = {}
 
-        self.ng_map_names_to_markers: Dict[
-            str, Sequence[RelationMarkerType]
-        ] = {}
+        self.ng_map_names_to_markers: Dict[str, List[RelationMarkerType]] = {}
         self.ng_map_names_to_definition_functions: Dict[str, Function] = {}
 
         #

--- a/strictdoc/backend/sdoc_source_code/models/source_node.py
+++ b/strictdoc/backend/sdoc_source_code/models/source_node.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Union
+
+from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
+    FunctionRangeMarker,
+)
+from strictdoc.backend.sdoc_source_code.models.range_marker import (
+    LineMarker,
+    RangeMarker,
+)
+
+
+@dataclass
+class SourceNode:
+    entity_name: Optional[str]
+    markers: List[Union[FunctionRangeMarker, RangeMarker, LineMarker]] = field(
+        default_factory=list
+    )
+    fields: Dict[str, str] = field(default_factory=dict)

--- a/strictdoc/backend/sdoc_source_code/reader_robot.py
+++ b/strictdoc/backend/sdoc_source_code/reader_robot.py
@@ -1,5 +1,5 @@
 import sys
-from typing import List, Union
+from typing import Union
 
 from robot.api.parsing import (
     Comment,
@@ -91,9 +91,7 @@ class SdocRelationVisitor(ModelVisitor):
 
             if isinstance(stmt, (Comment, Tags, Documentation)):
                 for token in filter(self._token_filter, stmt.tokens):
-                    markers: List[
-                        Union[FunctionRangeMarker, RangeMarker, LineMarker]
-                    ] = MarkerParser.parse(
+                    source_node = MarkerParser.parse(
                         token.value,
                         token.lineno,
                         token.lineno,
@@ -101,7 +99,7 @@ class SdocRelationVisitor(ModelVisitor):
                         node.name,
                         token.col_offset,
                     )
-                    tc_markers.extend(markers)
+                    tc_markers.extend(source_node.markers)
 
         function_markers = []
         for marker_ in tc_markers:
@@ -134,9 +132,7 @@ class SdocRelationVisitor(ModelVisitor):
         self, node: Union[Comment, Documentation, Tags]
     ) -> None:
         for token in filter(self._token_filter, node.tokens):
-            markers: List[
-                Union[FunctionRangeMarker, RangeMarker, LineMarker]
-            ] = MarkerParser.parse(
+            source_node = MarkerParser.parse(
                 token.value,
                 node.lineno,
                 node.lineno,
@@ -144,7 +140,7 @@ class SdocRelationVisitor(ModelVisitor):
                 None,
                 token.col_offset,
             )
-            for marker_ in markers:
+            for marker_ in source_node.markers:
                 if (
                     isinstance(marker_, FunctionRangeMarker)
                     and marker_.scope is RangeMarkerType.FILE

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -96,6 +96,7 @@ class ProjectConfig:
         include_source_paths: List[str],
         exclude_source_paths: List[str],
         test_report_root_dict: Dict[str, str],
+        source_nodes: List[Dict[str, str]],
         html2pdf_template: Optional[str],
         bundle_document_version: Optional[str],
         bundle_document_date: Optional[str],
@@ -144,6 +145,7 @@ class ProjectConfig:
         self.include_source_paths: List[str] = include_source_paths
         self.exclude_source_paths: List[str] = exclude_source_paths
         self.test_report_root_dict: Dict[str, str] = test_report_root_dict
+        self.source_nodes: List[Dict[str, str]] = source_nodes
 
         # Settings derived from the command-line parameters.
 
@@ -214,6 +216,7 @@ class ProjectConfig:
             include_source_paths=[],
             exclude_source_paths=[],
             test_report_root_dict={},
+            source_nodes=[],
             html2pdf_template=None,
             bundle_document_version=ProjectConfig.DEFAULT_BUNDLE_DOCUMENT_VERSION,
             bundle_document_date=ProjectConfig.DEFAULT_BUNDLE_DOCUMENT_COMMIT_DATE,
@@ -437,6 +440,7 @@ class ProjectConfigLoader:
         include_source_paths: List[str] = []
         exclude_source_paths: List[str] = []
         test_report_root_dict: Dict[str, str] = {}
+        source_nodes: List[Dict[str, str]] = []
         html2pdf_template: Optional[str] = None
         bundle_document_version = ProjectConfig.DEFAULT_BUNDLE_DOCUMENT_VERSION
         bundle_document_date = ProjectConfig.DEFAULT_BUNDLE_DOCUMENT_COMMIT_DATE
@@ -626,6 +630,21 @@ class ProjectConfigLoader:
             )
             assert section_behavior in ("[SECTION]", "[[SECTION]]")
 
+            if "source_nodes" in project_content:
+                source_nodes_config = project_content["source_nodes"]
+                assert isinstance(source_nodes_config, list)
+                for item_ in source_nodes_config:
+                    source_node_path = next(iter(item_))
+                    source_node_uid = item_[source_node_path]["uid"]
+                    source_node_node_type = item_[source_node_path]["node_type"]
+                    source_nodes.append(
+                        {
+                            "path": source_node_path,
+                            "uid": source_node_uid,
+                            "node_type": source_node_node_type,
+                        }
+                    )
+
         if "server" in config_dict:
             server_content = config_dict["server"]
             server_host = server_content.get("host", server_host)
@@ -679,6 +698,7 @@ class ProjectConfigLoader:
             include_source_paths=include_source_paths,
             exclude_source_paths=exclude_source_paths,
             test_report_root_dict=test_report_root_dict,
+            source_nodes=source_nodes,
             html2pdf_template=html2pdf_template,
             bundle_document_version=bundle_document_version,
             bundle_document_date=bundle_document_date,

--- a/strictdoc/core/traceability_index_builder.py
+++ b/strictdoc/core/traceability_index_builder.py
@@ -150,7 +150,9 @@ class TraceabilityIndexBuilder:
                     if len(traceability_info.markers) > 0:
                         source_file.is_referenced = True
 
-            file_tracability_index.validate_and_resolve(traceability_index)
+            file_tracability_index.validate_and_resolve(
+                traceability_index, project_config
+            )
 
             # Iterate again to resolve if the file is referenced.
             # FIXME: Not great to iterate two times.

--- a/strictdoc/export/html/templates/components/node_field/files/index.jinja
+++ b/strictdoc/export/html/templates/components/node_field/files/index.jinja
@@ -1,7 +1,7 @@
 {# needs sdoc_entity, see README.txt #}
   {%- if view_object.project_config.is_activated_requirements_to_source_traceability() -%}
     {%- set requirement_file_links = view_object.traceability_index.get_requirement_file_links(sdoc_entity) %}
-    {%- if requirement_file_links %}
+    {%- if requirement_file_links is not none and requirement_file_links|length > 0 %}
       <sdoc-node-field-label>file relations:</sdoc-node-field-label>
       <sdoc-node-field data-field-label="file relations">
         <ul class="requirement__link">

--- a/tests/integration/features/file_traceability/_language_parsers/c/20_c_backward_and_forward_functions/file.c
+++ b/tests/integration/features/file_traceability/_language_parsers/c/20_c_backward_and_forward_functions/file.c
@@ -29,7 +29,7 @@ void longFunctionName() {
   // boo
   // boo
   // boo
-  // boo // @relation(REQ-1, scope=line)
+  someFunc(); // @relation(REQ-1, scope=line)
   // boo
   // boo
   // @relation(REQ-4, scope=range_end)

--- a/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/description.sdoc
+++ b/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/description.sdoc
@@ -1,0 +1,39 @@
+[DOCUMENT]
+MID: c2d4542d5f1741c88dfcb4f68ad7dcbd
+TITLE: Test specification
+UID: TEST_DOC
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: TEST_SPEC
+  PROPERTIES:
+    VIEW_STYLE: Narrative
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  - TITLE: INTENTION
+    TYPE: String
+    REQUIRED: False
+  - TITLE: INPUT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: EXPECTED_RESULTS
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File

--- a/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/input.sdoc
+++ b/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/input.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ-1
+TITLE: Requirement Title
+STATEMENT: Requirement Statement
+
+[REQUIREMENT]
+UID: REQ-2
+TITLE: Requirement Title #2
+STATEMENT: Requirement Statement #2

--- a/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/strictdoc.toml
+++ b/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/strictdoc.toml
@@ -1,0 +1,10 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+  "SOURCE_FILE_LANGUAGE_PARSERS",
+]
+
+source_nodes = [
+  { "tests/" = { uid = "TEST_DOC", node_type = "TEST_SPEC" } }
+]

--- a/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/test.itest
+++ b/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/test.itest
@@ -1,0 +1,24 @@
+REQUIRES: PYTHON_39_OR_HIGHER
+
+RUN: %strictdoc export %S --output-dir Output | filecheck %s
+
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%S/Output/html/_source_files/tests/file.c.html"
+
+RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+CHECK-HTML: Test specification
+CHECK-HTML: TEST_DOC/tests/file.c/test_case_1
+CHECK-HTML: TEST_DOC/tests/file2.c/test_case_1
+CHECK-HTML: TEST_DOC/tests/subfolder/file3.c/test_case_1
+CHECK-HTML: tests/file.c, <i>lines: 3-20</i>, function test_case_1()
+CHECK-HTML: tests/file2.c, <i>lines: 3-20</i>, function test_case_1()
+CHECK-HTML: tests/subfolder/file3.c, <i>lines: 3-20</i>, function test_case_1()
+
+RUN: %cat %S/Output/html/_source_files/tests/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+
+CHECK-SOURCE-FILE: TEST_DOC/tests/file.c/test_case_1
+CHECK-SOURCE-FILE: TEST_DOC/tests/file.c/test_case_2
+
+RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+CHECK-SOURCE-COVERAGE: 97.3

--- a/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/tests/file.c
+++ b/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/tests/file.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-1, scope=function)
+ *
+ * INTENTION: Intention...
+ *
+ * INPUT: This
+ *        is
+ *        a statement
+ *        \n\n
+ *        And this is the same statement's another paragraph.
+ *
+ * EXPECTED_RESULTS: This is a comment.
+ */
+void test_case_1(void) {
+    print("hello world\n");
+}
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-2, scope=function)
+ *
+ * INTENTION: Intention...
+ *
+ * INPUT: This
+ *        is
+ *        a statement
+ *        \n\n
+ *        And this is the same statement's another paragraph.
+ *
+ * EXPECTED_RESULTS: This is a comment.
+ */
+void test_case_2(void) {
+    print("hello world\n");
+}

--- a/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/tests/file2.c
+++ b/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/tests/file2.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-1, scope=function)
+ *
+ * INTENTION: Intention...
+ *
+ * INPUT: This
+ *        is
+ *        a statement
+ *        \n\n
+ *        And this is the same statement's another paragraph.
+ *
+ * EXPECTED_RESULTS: This is a comment.
+ */
+void test_case_1(void) {
+    print("hello world\n");
+}
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-2, scope=function)
+ *
+ * INTENTION: Intention...
+ *
+ * INPUT: This
+ *        is
+ *        a statement
+ *        \n\n
+ *        And this is the same statement's another paragraph.
+ *
+ * EXPECTED_RESULTS: This is a comment.
+ */
+void test_case_2(void) {
+    print("hello world\n");
+}

--- a/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/tests/subfolder/file3.c
+++ b/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/tests/subfolder/file3.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-1, scope=function)
+ *
+ * INTENTION: Intention...
+ *
+ * INPUT: This
+ *        is
+ *        a statement
+ *        \n\n
+ *        And this is the same statement's another paragraph.
+ *
+ * EXPECTED_RESULTS: This is a comment.
+ */
+void test_case_1(void) {
+    print("hello world\n");
+}
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-2, scope=function)
+ *
+ * INTENTION: Intention...
+ *
+ * INPUT: This
+ *        is
+ *        a statement
+ *        \n\n
+ *        And this is the same statement's another paragraph.
+ *
+ * EXPECTED_RESULTS: This is a comment.
+ */
+void test_case_2(void) {
+    print("hello world\n");
+}

--- a/tests/unit/strictdoc/backend/sdoc_source_code/helpers/test_comment_preprocessor.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/helpers/test_comment_preprocessor.py
@@ -14,13 +14,12 @@ def test_001_doxygen_slashes_and_stars():
 
     preprocessed_comment = preprocess_source_code_comment(source_input)
 
-    # Note: There are invisible characters.
     assert (
         preprocessed_comment
         == """\
-   
+
    @relation(REQ-1, scope=function)
-   
+
 """
     )
 
@@ -34,13 +33,12 @@ def test_001_doxygen_three_slashes():
 
     preprocessed_comment = preprocess_source_code_comment(source_input)
 
-    # Note: There are invisible characters.
     assert (
         preprocessed_comment
         == """\
-   
+
     @relation(REQ-1, scope=function)
-   
+
 """
     )
 
@@ -58,9 +56,9 @@ def test_003_doxygen_two_slashes():
     assert (
         preprocessed_comment
         == """\
-  
+
    @relation(REQ-1, scope=function)
-  
+
 """
     )
 
@@ -74,12 +72,11 @@ def test_004_python():
 
     preprocessed_comment = preprocess_source_code_comment(source_input)
 
-    # Note: There are invisible characters.
     assert (
         preprocessed_comment
         == """\
- 
+
   @relation(REQ-1, scope=function)
- 
+
 """
     )

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_c.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_c.py
@@ -177,3 +177,37 @@ stilib_result_t stilib_smu_start_state_check(void);
     assert info.markers[0].reqs_objs[1].ng_source_column == 32
     assert info.markers[0].reqs_objs[2].ng_source_line == 11
     assert info.markers[0].reqs_objs[2].ng_source_column == 50
+
+
+def test_20_node_fields():
+    input_string = b"""\
+#include <stdio.h>
+
+/**
+ * Some text.
+ *
+ * INTENTION: This
+ *            is
+ *            the
+ *            intention.
+ *
+ * @relation(REQ-1, scope=function)
+ */
+void hello_world(void) {
+    print("hello world\\n");
+}
+"""
+
+    reader = SourceFileTraceabilityReader_C()
+
+    info: SourceFileTraceabilityInfo = reader.read(
+        input_string, file_path="foo.c"
+    )
+
+    assert isinstance(info, SourceFileTraceabilityInfo)
+    assert len(info.markers) == 1
+    assert info.markers[0].ng_source_line_begin == 11
+    assert info.markers[0].ng_range_line_begin == 3
+    assert info.markers[0].ng_range_line_end == 15
+    assert info.markers[0].reqs_objs[0].ng_source_line == 11
+    assert info.markers[0].reqs_objs[0].ng_source_column == 14

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_lexer.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_lexer.py
@@ -1,0 +1,399 @@
+from strictdoc.backend.sdoc_source_code.comment_parser.marker_lexer import (
+    MarkerLexer,
+)
+
+
+def test_01_basic_nominal():
+    tree = MarkerLexer.parse("")
+    assert len(tree.children) == 0
+    assert tree.data == "start"
+
+
+def test_02_single_marker():
+    input_strings = [
+        "@relation(REQ-1, REQ-2, scope=function)",
+        "@relation(REQ_1, REQ_2, scope=function)",
+        "@relation(REQ.1, REQ.2, scope=function)",
+        "@relation(REQ/1, REQ/2, scope=function)",
+    ]
+    for input_string_ in input_strings:
+        tree = MarkerLexer.parse(input_string_)
+        assert len(tree.children) == 1
+        assert tree.data == "start"
+        assert tree.children[0].data == "relation_marker"
+        assert tree.children[0].children[0].data == "relation_node_uid"
+        assert tree.children[0].children[0].children[0].value.startswith("REQ")
+        assert tree.children[0].children[1].data == "relation_node_uid"
+        assert tree.children[0].children[1].children[0].value.startswith("REQ")
+        assert tree.children[0].children[2].data == "relation_scope"
+        assert tree.children[0].children[2].children[0].value == "function"
+
+
+def test_03_single_marker_with_role():
+    tree = MarkerLexer.parse(
+        "@relation(REQ-1, scope=function, role=Implementation)"
+    )
+    assert len(tree.children) == 1
+    assert tree.data == "start"
+    assert tree.children[0].data == "relation_marker"
+    assert tree.children[0].children[0].data == "relation_node_uid"
+    assert tree.children[0].children[0].children[0].value == "REQ-1"
+    assert tree.children[0].children[1].data == "relation_scope"
+    assert tree.children[0].children[1].children[0].value == "function"
+    assert tree.children[0].children[2].data == "relation_role"
+    assert tree.children[0].children[2].children[0].value == "Implementation"
+
+
+def test_10_single_marker_with_newline():
+    input_string = "@relation(REQ-1, scope=function)\n"
+
+    tree = MarkerLexer.parse(input_string)
+    assert tree.data == "start"
+
+    assert len(tree.children) == 1
+    assert tree.children[0].data == "relation_marker"
+    assert tree.children[0].children[0].data == "relation_node_uid"
+    assert tree.children[0].children[0].children[0].value.startswith("REQ")
+    assert tree.children[0].children[1].data == "relation_scope"
+    assert tree.children[0].children[1].children[0].value == "function"
+
+
+def test_11_single_marker_with_newline():
+    input_string = """\
+@relation(
+    REQ-1,
+    scope=function
+)
+"""
+
+    tree = MarkerLexer.parse(input_string)
+    assert tree.data == "start"
+
+    assert len(tree.children) == 1
+    assert tree.children[0].data == "relation_marker"
+    assert tree.children[0].children[0].data == "relation_node_uid"
+    assert tree.children[0].children[0].children[0].value.startswith("REQ")
+    assert tree.children[0].children[1].data == "relation_scope"
+    assert tree.children[0].children[1].children[0].value == "function"
+
+
+def test_12_python_preprocessed_input():
+    input_string = """\
+  @relation(REQ-001, REQ-002, REQ-003, scope=range_start)
+"""
+
+    tree = MarkerLexer.parse(input_string)
+    assert tree.data == "start"
+
+    assert len(tree.children) == 1
+    assert tree.children[0].data == "relation_marker"
+    assert tree.children[0].children[0].data == "relation_node_uid"
+    assert tree.children[0].children[0].children[0].value.startswith("REQ")
+    assert tree.children[0].children[1].data == "relation_node_uid"
+    assert tree.children[0].children[1].children[0].value.startswith("REQ")
+    assert tree.children[0].children[2].data == "relation_node_uid"
+    assert tree.children[0].children[2].children[0].value.startswith("REQ")
+    assert tree.children[0].children[3].data == "relation_scope"
+    assert tree.children[0].children[3].children[0].value == "range_start"
+
+
+def test_13_python_preprocessed_input():
+    input_string = """\
+  @relation(REQ-001, REQ-002, REQ-003, scope=range_start)
+  print("Hello world")
+  @relation(REQ-001, REQ-002, REQ-003, scope=range_end)
+""".lstrip()
+
+    tree = MarkerLexer.parse(input_string)
+    assert tree.data == "start"
+
+    assert len(tree.children) == 2
+    assert tree.children[0].data == "relation_marker"
+    assert tree.children[0].children[0].data == "relation_node_uid"
+    assert tree.children[0].children[0].children[0].value.startswith("REQ")
+    assert tree.children[0].children[1].data == "relation_node_uid"
+    assert tree.children[0].children[1].children[0].value.startswith("REQ")
+    assert tree.children[0].children[2].data == "relation_node_uid"
+    assert tree.children[0].children[2].children[0].value.startswith("REQ")
+    assert tree.children[0].children[3].data == "relation_scope"
+    assert tree.children[0].children[3].children[0].value == "range_start"
+
+    assert tree.children[1].data == "relation_marker"
+    assert tree.children[1].children[0].data == "relation_node_uid"
+    assert tree.children[1].children[0].children[0].value.startswith("REQ")
+    assert tree.children[1].children[1].data == "relation_node_uid"
+    assert tree.children[1].children[1].children[0].value.startswith("REQ")
+    assert tree.children[1].children[2].data == "relation_node_uid"
+    assert tree.children[1].children[2].children[0].value.startswith("REQ")
+    assert tree.children[1].children[3].data == "relation_scope"
+    assert tree.children[1].children[3].children[0].value == "range_end"
+
+
+def test_20_single_marker_and_normal_line():
+    input_string = """\
+FOOBAR
+
+@relation(
+    REQ-1,
+    scope=function
+)
+
+FOOBAR
+"""
+
+    tree = MarkerLexer.parse(input_string)
+    assert tree.data == "start"
+
+    assert len(tree.children) == 1
+    assert tree.children[0].data == "relation_marker"
+    assert tree.children[0].children[0].data == "relation_node_uid"
+    assert tree.children[0].children[0].children[0].value.startswith("REQ")
+    assert tree.children[0].children[1].data == "relation_scope"
+    assert tree.children[0].children[1].children[0].value == "function"
+
+
+def test_30_relation_and_field():
+    input_string = """\
+FOOBAR
+
+@relation(
+    REQ-1,
+    scope=function
+)
+
+STATEMENT: When C,
+           The system A shall do B
+
+STATEMENT: When Z,
+           The system X shall do Y
+
+STATEMENT: When 1, The system 2 shall do 3
+
+STATEMENT: When 1, The system 2 shall do 3
+
+FOOBAR
+"""
+
+    tree = MarkerLexer.parse(input_string)
+    assert tree.data == "start"
+
+    assert len(tree.children) == 5
+    assert tree.children[0].data == "relation_marker"
+    assert tree.children[0].children[0].data == "relation_node_uid"
+    assert tree.children[0].children[0].children[0].value.startswith("REQ")
+    assert tree.children[0].children[1].data == "relation_scope"
+    assert tree.children[0].children[1].children[0].value == "function"
+
+    assert tree.children[1].data == "node_field"
+    assert tree.children[1].children[0].data == "node_name"
+    assert tree.children[1].children[0].children[0].value == "STATEMENT"
+    assert tree.children[1].children[1].data == "node_multiline_value"
+    assert len(tree.children[1].children[1].children) == 2
+    assert tree.children[1].children[1].children[0].value == "When C,"
+    assert (
+        tree.children[1].children[1].children[1].value
+        == "           The system A shall do B"
+    )
+
+    assert tree.children[2].data == "node_field"
+    assert tree.children[2].children[0].data == "node_name"
+    assert tree.children[2].children[0].children[0].value == "STATEMENT"
+    assert tree.children[2].children[1].data == "node_multiline_value"
+    assert len(tree.children[2].children[1].children) == 2
+    assert tree.children[2].children[1].children[0].value == "When Z,"
+    assert (
+        tree.children[2].children[1].children[1].value
+        == "           The system X shall do Y"
+    )
+
+    assert tree.children[3].data == "node_field"
+    assert tree.children[3].children[0].data == "node_name"
+    assert tree.children[3].children[0].children[0].value == "STATEMENT"
+    assert tree.children[3].children[1].data == "node_multiline_value"
+    assert len(tree.children[3].children[1].children) == 1
+    assert (
+        tree.children[3].children[1].children[0].value
+        == "When 1, The system 2 shall do 3"
+    )
+
+    assert tree.children[4].data == "node_field"
+    assert tree.children[4].children[0].data == "node_name"
+    assert tree.children[4].children[0].children[0].value == "STATEMENT"
+    assert tree.children[4].children[1].data == "node_multiline_value"
+    assert len(tree.children[4].children[1].children) == 1
+    assert (
+        tree.children[4].children[1].children[0].value
+        == "When 1, The system 2 shall do 3"
+    )
+
+
+def test_31_single_node_field():
+    """
+    Ensure that a single field can be parsed.
+
+    It turns out that this particular case is pretty sensitive with respect to
+    how the grammar is constructed.
+    """
+
+    input_string = """
+        STATEMENT: This can likely replace _weak below with no problem.
+    """
+
+    tree = MarkerLexer.parse(input_string)
+    assert tree.data == "start"
+
+    assert len(tree.children) == 1
+    assert tree.children[0].data == "node_field"
+    assert tree.children[0].children[0].data == "node_name"
+    assert tree.children[0].children[0].children[0].value == "STATEMENT"
+    assert tree.children[0].children[1].data == "node_multiline_value"
+    assert (
+        tree.children[0].children[1].children[0].value
+        == "This can likely replace _weak below with no problem."
+    )
+
+
+def test_31B_single_node_field():
+    """
+    Ensure that a single field can be parsed.
+
+    It turns out that this particular case is pretty sensitive with respect to
+    how the grammar is constructed.
+
+    NOTE: The input below contains random whitespace.
+    """
+
+    input_string = """\
+#include <stdio.h>
+
+   
+   Some text.
+  
+   INTENTION: Intention A.
+  
+  
+    """  # noqa: W293
+
+    tree = MarkerLexer.parse(input_string)
+    assert tree.data == "start"
+
+    assert len(tree.children) == 1
+    assert tree.children[0].data == "node_field"
+    assert tree.children[0].children[0].data == "node_name"
+    assert tree.children[0].children[0].children[0].value == "INTENTION"
+    assert tree.children[0].children[1].data == "node_multiline_value"
+    assert tree.children[0].children[1].children[0].value == "Intention A."
+
+
+def test_31C_single_node_field():
+    """
+    Ensure that a single field can be parsed.
+
+    It turns out that this particular case is pretty sensitive with respect to
+    how the grammar is constructed.
+
+    NOTE: The input below contains random whitespace.
+    """
+
+    input_string = """\
+#include <stdio.h>
+   
+    Some text.
+  
+   INTENTION: Intention A.
+   
+   @relation(REQ-1, scope=function)
+   
+void hello_world(void) {
+    print("hello world\\n");
+}
+"""  # noqa: W293
+
+    tree = MarkerLexer.parse(input_string)
+    assert tree.data == "start"
+
+    assert len(tree.children) == 2
+    assert tree.children[0].data == "node_field"
+    assert tree.children[0].children[0].data == "node_name"
+    assert tree.children[0].children[0].children[0].value == "INTENTION"
+    assert tree.children[0].children[1].data == "node_multiline_value"
+    assert tree.children[0].children[1].children[0].value == "Intention A."
+
+
+def test_32_two_single_line_fields():
+    """
+    Ensure that a single field can be parsed.
+
+    It turns out that this particular case is pretty sensitive with respect to
+    how the grammar is constructed.
+    """
+
+    input_string = """
+        STATEMENT: This can likely replace _weak below with no problem.
+
+        STATEMENT: This can likely replace _weak below with no problem.
+    """
+
+    tree = MarkerLexer.parse(input_string)
+    assert tree.data == "start"
+
+    assert len(tree.children) == 2
+    assert tree.children[0].data == "node_field"
+    assert tree.children[0].children[0].data == "node_name"
+    assert tree.children[0].children[0].children[0].value == "STATEMENT"
+    assert tree.children[0].children[1].data == "node_multiline_value"
+    assert (
+        tree.children[0].children[1].children[0].value
+        == "This can likely replace _weak below with no problem."
+    )
+
+
+def test_33_multiline_and_multiparagraph_fields():
+    input_string = """\
+FOOBAR
+
+STATEMENT: This
+           \\n\\n
+           is
+           \\n\\n
+           how we do paragraphs.
+
+FOOBAR
+"""
+
+    tree = MarkerLexer.parse(input_string)
+    assert tree.data == "start"
+
+    assert len(tree.children) == 1
+    assert tree.children[0].data == "node_field"
+    assert tree.children[0].children[0].data == "node_name"
+    assert tree.children[0].children[0].children[0].value == "STATEMENT"
+    assert tree.children[0].children[1].data == "node_multiline_value"
+    assert tree.children[0].children[1].children[0].value == "This"
+    assert tree.children[0].children[1].children[1].value == "           \\n\\n"
+    assert tree.children[0].children[1].children[2].value == "           is"
+    assert tree.children[0].children[1].children[3].value == "           \\n\\n"
+    assert (
+        tree.children[0].children[1].children[4].value
+        == "           how we do paragraphs."
+    )
+
+
+def test_60_exclude_reserved_keywords():
+    """
+    Ensure that a single field can be parsed.
+
+    It turns out that this particular case is pretty sensitive with respect to
+    how the grammar is constructed.
+    """
+
+    input_string = """
+        FIXME: This can likely replace _weak below with no problem.
+
+        TODO: This can likely replace _weak below with no problem.
+    """
+
+    tree = MarkerLexer.parse(input_string)
+    assert tree.data == "start"
+
+    assert len(tree.children) == 0

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
@@ -21,8 +21,8 @@ def test_01_basic_nominal():
     ]
 
     for input_string_ in input_strings:
-        function_ranges = MarkerParser.parse(input_string_, 1, 1, 1)
-        function_range = function_ranges[0]
+        source_node = MarkerParser.parse(input_string_, 1, 1, 1)
+        function_range = source_node.markers[0]
         assert isinstance(function_range, FunctionRangeMarker)
         assert function_range.ng_source_line_begin == 1
         assert function_range.ng_range_line_begin == 1
@@ -38,8 +38,8 @@ def test_10_parses_with_leading_newlines():
 @relation(REQ-1, scope=function)
 """
 
-    function_ranges = MarkerParser.parse(input_string, 1, 5, 1)
-    function_range = function_ranges[0]
+    source_node = MarkerParser.parse(input_string, 1, 5, 1)
+    function_range = source_node.markers[0]
 
     assert isinstance(function_range, FunctionRangeMarker)
     assert function_range.ng_source_line_begin == 3
@@ -56,8 +56,8 @@ def test_11_parses_with_leading_whitespace():
     @relation(REQ-1, scope=function)
 """
 
-    function_ranges = MarkerParser.parse(input_string, 1, 3, 1)
-    function_range = function_ranges[0]
+    source_node = MarkerParser.parse(input_string, 1, 3, 1)
+    function_range = source_node.markers[0]
 
     assert isinstance(function_range, FunctionRangeMarker)
     assert function_range.ng_source_line_begin == 3
@@ -76,8 +76,8 @@ def test_20_parses_within_doxygen_comment():
  */
 """
 
-    function_ranges = MarkerParser.parse(input_string, 1, 5, 1)
-    function_range = function_ranges[0]
+    source_node = MarkerParser.parse(input_string, 1, 5, 1)
+    function_range = source_node.markers[0]
 
     assert isinstance(function_range, FunctionRangeMarker)
     assert function_range.ng_source_line_begin == 4
@@ -97,8 +97,8 @@ def test_21_parses_within_doxygen_comment_two_markers():
  */
 """
 
-    function_ranges = MarkerParser.parse(input_string, 1, 6, 1)
-    function_range = function_ranges[0]
+    source_node = MarkerParser.parse(input_string, 1, 6, 1)
+    function_range = source_node.markers[0]
 
     assert isinstance(function_range, FunctionRangeMarker)
     assert function_range.ng_source_line_begin == 4
@@ -117,8 +117,8 @@ def test_22_parses_within_doxygen_comment_curly_braces():
  */
 """
 
-    function_ranges = MarkerParser.parse(input_string, 1, 5, 1)
-    function_range = function_ranges[0]
+    source_node = MarkerParser.parse(input_string, 1, 5, 1)
+    function_range = source_node.markers[0]
 
     assert isinstance(function_range, FunctionRangeMarker)
     assert function_range.ng_source_line_begin == 4
@@ -148,9 +148,9 @@ def test_23_parses_within_doxygen_comment():
  */
 """
 
-    function_ranges = MarkerParser.parse(input_string, 1, 16, 1)
+    source_node = MarkerParser.parse(input_string, 1, 16, 1)
 
-    function_range = function_ranges[0]
+    function_range = source_node.markers[0]
     assert isinstance(function_range, FunctionRangeMarker)
     assert function_range.ng_source_line_begin == 4
     assert function_range.ng_range_line_begin == 1
@@ -165,7 +165,7 @@ def test_23_parses_within_doxygen_comment():
     assert function_range.reqs_objs[2].ng_source_line == 7
     assert function_range.reqs_objs[2].ng_source_column == 8
 
-    function_range = function_ranges[1]
+    function_range = source_node.markers[1]
     assert isinstance(function_range, FunctionRangeMarker)
     assert function_range.ng_source_line_begin == 10
     assert function_range.ng_range_line_begin == 1


### PR DESCRIPTION
This addresses https://github.com/strictdoc-project/strictdoc/issues/2231 for C/C++.

1) Lark parser is introduced for parsing code comments. Besides `@relation` markers, now the arbitrary nodes can be parsed as well, for example:

```
/**
 * Some text.
 *
 * @relation(REQ-1, scope=function)
 *
 * INTENTION: Intention...
 *
 * INPUT: This
 *        is
 *        a statement
 *        \n\n
 *        And this is the same statement's another paragraph.
 *
 * EXPECTED_RESULTS: This is a comment.
 */
void test_case_1(void) {
    print("hello world\n");
}
```

2) Using `CAPITALIZED_NAME: <...>` was the most straightforward both in terms of parsing and interfacing with the existing SDoc convention where the field names are capitalized. I tested `\n\n` to work successfully for creating paragraphs in both Doxygen and SDoc HTML.

3) Note that the strictdoc.toml has this important config option now:

```
source_nodes = [
  { "tests/" = { uid = "TEST_DOC", node_type = "TEST_SPEC" } }
]
```

...which gives a hint to the source node parser where to inject the auto-generated nodes and which type they should be (in this case description.sdoc has TEST_DOC and defines a grammar with SECTION and TEST_SPEC).

4) I was not sure how to auto-generate sections, so I went with sorting them according to the source code function paths.

The feature is super-raw but I prefer to merge it and be testing the integration early.

Related to: #2231