### PR TITLE
UI: autocomplete-for-tags

### DIFF
--- a/strictdoc/backend/sdoc/models/model.py
+++ b/strictdoc/backend/sdoc/models/model.py
@@ -101,7 +101,10 @@ class SDocDocumentFromFileIF(ABC):
     ng_resolved_custom_level: Optional[str]
 
     @abstractmethod
-    def has_any_requirements(self) -> bool:
+    def iterate_nodes(
+        self,
+        element_type: Optional[str] = None,
+    ) -> Generator[SDocNodeIF, None, None]:
         raise NotImplementedError  # pragma: no cover
 
     @property

--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -77,10 +77,14 @@ class RequirementFormField:
         return self.field_gef_type in (
             RequirementFieldType.SINGLE_CHOICE,
             RequirementFieldType.MULTIPLE_CHOICE,
+            RequirementFieldType.TAG,
         )
 
     def is_multiplechoice(self) -> bool:
-        return self.field_gef_type == RequirementFieldType.MULTIPLE_CHOICE
+        return self.field_gef_type in (
+            RequirementFieldType.MULTIPLE_CHOICE,
+            RequirementFieldType.TAG,
+        )
 
     def get_input_field_name(self):
         return f"requirement[fields][{self.field_mid}][value]"

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -2772,7 +2772,7 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
         field_name: Optional[str] = None,
     ):
         """
-        Returns matches of possible values of a SingleChoice or MultiChoice field.
+        Returns matches of possible values of a SingleChoice, MultiChoice or tag field.
         The field is identified by the document_mid, the element_type, and the field_name.
         """
         output = ""
@@ -2787,7 +2787,7 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
                 )
             )
             if document:
-                all_options = document.get_options_for_choice(
+                all_options = document.get_options_for_field(
                     element_type, field_name
                 )
                 field: GrammarElementField = (
@@ -2796,8 +2796,11 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
                     )
                 )
 
-                if field.gef_type == RequirementFieldType.MULTIPLE_CHOICE:
-                    # MultipleChoice: We split the query into its parts:
+                if field.gef_type in (
+                    RequirementFieldType.MULTIPLE_CHOICE,
+                    RequirementFieldType.TAG,
+                ):
+                    # MultipleChoice/Tag: We split the query into its parts:
                     #
                     # Example User input: "Some Value, Another Value, Yet ano|".
                     # parts = ['some value', 'another value', 'yet ano']                # noqa: ERA001

--- a/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_using_autocomplete/expected_output/document.sdoc
+++ b/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_using_autocomplete/expected_output/document.sdoc
@@ -1,0 +1,63 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: LEVEL
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TAGS
+    TYPE: Tag
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: RATIONALE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File
+
+[REQUIREMENT]
+UID: REQ-1
+TAGS: Tag1
+TITLE: Requirement 1 ABC
+STATEMENT: >>>
+Shall test foo.
+<<<
+
+[REQUIREMENT]
+UID: REQ-2
+TAGS: Tag2
+TITLE: Requirement 2 XYZ
+STATEMENT: >>>
+Shall test bar.
+<<<
+
+[REQUIREMENT]
+UID: REQ-3
+TAGS: Tag1, Tag2
+TITLE: New Requirement
+STATEMENT: >>>
+Shall test foo 2.
+<<<

--- a/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_using_autocomplete/input/document.sdoc
+++ b/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_using_autocomplete/input/document.sdoc
@@ -1,0 +1,55 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: LEVEL
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TAGS
+    TYPE: Tag
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: RATIONALE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File
+
+[REQUIREMENT]
+UID: REQ-1
+TAGS: Tag1
+TITLE: Requirement 1 ABC
+STATEMENT: >>>
+Shall test foo.
+<<<
+
+[REQUIREMENT]
+UID: REQ-2
+TITLE: Requirement 2 XYZ
+STATEMENT: >>>
+Shall test bar.
+<<<
+

--- a/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_using_autocomplete/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_using_autocomplete/test_case.py
@@ -1,0 +1,84 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.document.form_edit_requirement import (
+    Form_EditRequirement,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+
+            #
+            # Edit the requirement 2 and set "TAGS: Tag2".
+            #
+            requirement = screen_document.get_node(2)
+            form_edit_requirement_2: Form_EditRequirement = (
+                requirement.do_open_form_edit_requirement()
+            )
+            form_edit_requirement_2.assert_on_form()
+
+            form_edit_requirement_2.do_fill_in("TAGS", "Tag2")
+            form_edit_requirement_2.do_form_submit()
+
+            #
+            # Create a requirement after the existing requirements.
+            #
+            test_case_node = screen_document.get_node(2)
+
+            test_case_menu = test_case_node.do_open_node_menu()
+
+            form_edit_requirement_new: Form_EditRequirement = (
+                test_case_menu.do_node_add_element_below("REQUIREMENT")
+            )
+
+            form_edit_requirement_new.do_fill_in_field_uid("REQ-3")
+            form_edit_requirement_new.do_fill_in_field_title("New Requirement")
+            form_edit_requirement_new.do_fill_in_field_statement(
+                "Shall test foo 2."
+            )
+
+            #
+            # Typing 'tag' in field TAGS should be autocompleted to 'Tag1'.
+            #
+            form_edit_requirement_new.do_fill_in_field_and_autocomplete(
+                "TAGS", "tag"
+            )
+
+            #
+            # Typing 'tag' in field TAGS should be autocompleted to 'Tag2',
+            # the next matching choice that is not yet selected.
+            #
+            form_edit_requirement_new.do_fill_in_field_and_autocomplete_again(
+                "TAGS", "tag"
+            )
+
+            form_edit_requirement_new.do_form_submit()
+
+            node_2 = screen_document.get_node(node_order=3)
+
+            node_2.assert_requirement_title("New Requirement", "3")
+            screen_document.assert_toc_contains("New Requirement")
+
+            screen_document.assert_text("Tag1, Tag2")
+
+        assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/update_requirement/_Tag/update_requirement_Tag_field_using_autocomplete/expected_output/document.sdoc
+++ b/tests/end2end/screens/document/update_requirement/_Tag/update_requirement_Tag_field_using_autocomplete/expected_output/document.sdoc
@@ -1,0 +1,63 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: LEVEL
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TAGS
+    TYPE: Tag
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: RATIONALE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File
+
+[REQUIREMENT]
+UID: REQ-1
+TAGS: Tag1, Tag2
+TITLE: Unit test ABC
+STATEMENT: >>>
+Shall do foo.
+<<<
+
+[REQUIREMENT]
+UID: REQ-2
+TAGS: Tag1
+TITLE: Unit Test XZY
+STATEMENT: >>>
+Shall do bar.
+<<<
+
+[REQUIREMENT]
+UID: REQ-3
+TAGS: Tag2
+TITLE: Unit Test XZY
+STATEMENT: >>>
+Shall do foobar.
+<<<

--- a/tests/end2end/screens/document/update_requirement/_Tag/update_requirement_Tag_field_using_autocomplete/input/document.sdoc
+++ b/tests/end2end/screens/document/update_requirement/_Tag/update_requirement_Tag_field_using_autocomplete/input/document.sdoc
@@ -1,0 +1,54 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: LEVEL
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TAGS
+    TYPE: Tag
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: RATIONALE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File
+
+[REQUIREMENT]
+UID: REQ-1
+TITLE: Unit test ABC
+STATEMENT: >>>
+Shall do foo.
+<<<
+
+[REQUIREMENT]
+UID: REQ-2
+TAGS: Tag1
+TITLE: Unit Test XZY
+STATEMENT: >>>
+Shall do bar.
+<<<
+
+[REQUIREMENT]
+UID: REQ-3
+TAGS: Tag2
+TITLE: Unit Test XZY
+STATEMENT: >>>
+Shall do foobar.
+<<<

--- a/tests/end2end/screens/document/update_requirement/_Tag/update_requirement_Tag_field_using_autocomplete/test_case.py
+++ b/tests/end2end/screens/document/update_requirement/_Tag/update_requirement_Tag_field_using_autocomplete/test_case.py
@@ -1,0 +1,57 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.document.form_edit_requirement import (
+    Form_EditRequirement,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+
+            requirement = screen_document.get_node()
+            form_edit_requirement: Form_EditRequirement = (
+                requirement.do_open_form_edit_requirement()
+            )
+
+            form_edit_requirement.assert_on_form()
+
+            #
+            # Fill 'tag' in field TAGS should be autocompleted to 'Tag1'.
+            #
+            form_edit_requirement.do_fill_in_field_and_autocomplete(
+                "TAGS", "tag"
+            )
+
+            #
+            # fill 'tag' in field TAGS should be autocompleted to 'Tag2',
+            # the next matching choice that is not yet selected
+            #
+            form_edit_requirement.do_fill_in_field_and_autocomplete_again(
+                "TAGS", "tag"
+            )
+
+            form_edit_requirement.do_form_submit()
+
+            screen_document.assert_text("Tag1, Tag2")
+
+        assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
This PR generalises the autocomplete feature to work for "Tag" fields (#2230)

The autocomplete options are collected from the contents of all the same fields of the current document.
I wonder whether we should also allow specifying optional default values in the grammar:

```
  - TITLE: TAGS
    TYPE: Tag
    REQUIRED: False 

  - TITLE: TAGS_WITH_DEFAULTS
    TYPE: Tag(Derived, Safety-relevant, Security-relevant)
    REQUIRED: False 
```

It could help with consistency. Let me know what you think...