### PR TITLE
junit-xml: support pytest unittest

### DIFF
--- a/strictdoc/backend/sdoc_source_code/test_reports/junit_xml_reader.py
+++ b/strictdoc/backend/sdoc_source_code/test_reports/junit_xml_reader.py
@@ -277,15 +277,32 @@ class JUnitXMLReader:
                     test_case_node_duration = xml_testcase_time
                     test_case_node_test_function = "#GTEST#" + google_test_name
                 elif xml_format == JUnitXMLFormat.PYTEST:
+                    xml_testcase_path_parts = xml_testcase_classname
+                    xml_testcase_class = ""
+                    # Heuristic: if last part of the classname attribute starts with "Test" and is
+                    # in CamelCase, then we assume it is the test class name:
+                    # - Remove it from the path.
+                    # - Prepend it to the function name.
+                    parts = xml_testcase_classname.split(".")
+                    if (
+                        parts
+                        and parts[-1].startswith("Test")
+                        and parts[-1][1:].lower() != parts[-1][1:]
+                    ):
+                        xml_testcase_path_parts = ".".join(parts[:-1])
+                        xml_testcase_class = parts[-1] + "."
                     test_case_node_uid = (
                         xml_testcase_classname + "." + xml_testcase_name
                     )
                     test_case_node_duration = xml_testcase_time
                     test_case_node_test_path = (
-                        xml_testcase_classname.replace(".", os.path.sep) + ".py"
+                        xml_testcase_path_parts.replace(".", os.path.sep)
+                        + ".py"
                     )
                     test_case_node_title = xml_testcase_classname
-                    test_case_node_test_function = xml_testcase_name
+                    test_case_node_test_function = (
+                        xml_testcase_class + xml_testcase_name
+                    )
                 else:
                     raise NotImplementedError("Unsupported JUnit XML format")
 

--- a/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/.gitignore
+++ b/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/.gitignore
@@ -1,0 +1,1 @@
+reports/

--- a/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/docs/input.sdoc
+++ b/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/docs/input.sdoc
@@ -1,0 +1,18 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ-1
+STATEMENT: Test statement 1.
+
+[REQUIREMENT]
+UID: REQ-2
+STATEMENT: Test statement 2.
+
+[REQUIREMENT]
+UID: REQ-3
+STATEMENT: Test statement 3.
+
+[REQUIREMENT]
+UID: REQ-4
+STATEMENT: Test statement 4.

--- a/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/src/foo.py
+++ b/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/src/foo.py
@@ -1,0 +1,5 @@
+def foo():
+    """
+    @relation(REQ-1, scope=function)
+    """
+    return True

--- a/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/strictdoc.toml
+++ b/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/strictdoc.toml
@@ -1,0 +1,6 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+  "SOURCE_FILE_LANGUAGE_PARSERS",
+]

--- a/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/test.itest
@@ -1,0 +1,24 @@
+REQUIRES: PYTHON_39_OR_HIGHER
+
+RUN: cd %S && PYTHONPATH=$(pwd) pytest tests/ --junit-xml=%S/Output/tests_unit.pytest.junit.xml --rootdir=%S
+RUN: mkdir -p reports/ && cp %S/Output/tests_unit.pytest.junit.xml reports/tests_unit.pytest.junit.xml
+RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+
+# Ensure that the test report document is generated.
+CHECK: Published: Test report: pytest
+RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html"
+
+# Ensure that the source and test files are generated.
+RUN: %check_exists --file "%S/Output/html/_source_files/src/foo.py.html"
+RUN: %check_exists --file "%S/Output/html/_source_files/tests/test_foo.py.html"
+
+# Ensure that the test report document has the right content.
+RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+CHECK-TEST-REPORT: href="../../_source_files/tests/test_foo.py.html#tests.test_foo.TestFoo.test_foo#7#11">
+CHECK-TEST-REPORT: tests/test_foo.py, <i>lines: 7-11</i>, function TestFoo.test_foo
+CHECK-TEST-REPORT: href="../../_source_files/tests/test_foo.py.html#tests.test_foo.TestFoo.test_second_method_in_class#13#17">
+CHECK-TEST-REPORT: tests/test_foo.py, <i>lines: 13-17</i>, function TestFoo.test_second_method_in_class
+CHECK-TEST-REPORT: href="../../_source_files/tests/test_foo.py.html#tests.test_foo.TestFoo.test_with_decorator#20#24">
+CHECK-TEST-REPORT: tests/test_foo.py, <i>lines: 20-24</i>, function TestFoo.test_with_decorator
+CHECK-TEST-REPORT: href="../../_source_files/tests/test_foo.py.html#tests.test_foo.TestFoo.test_with_multiple_decorators#28#32">
+CHECK-TEST-REPORT: tests/test_foo.py, <i>lines: 28-32</i>, function TestFoo.test_with_multiple_decorators

--- a/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/tests/test_foo.py
+++ b/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/tests/test_foo.py
@@ -1,0 +1,32 @@
+import unittest
+
+from src.foo import foo
+
+
+class TestFoo(unittest.TestCase):
+    def test_foo(self):
+        """
+        @relation(REQ-1, scope=function)
+        """
+        assert foo()
+
+    def test_second_method_in_class(self):
+        """
+        @relation(REQ-2, scope=function)
+        """
+        assert foo()
+
+    @unittest.skipIf(False, "This test is never skipped")
+    def test_with_decorator(self):
+        """
+        @relation(REQ-3, scope=function)
+        """
+        assert foo()
+
+    @unittest.skipIf(False, "This test is never skipped")
+    @unittest.skipUnless(True, "This test is never skipped")
+    def test_with_multiple_decorators(self):
+        """
+        @relation(REQ-4, scope=function)
+        """
+        assert foo()


### PR DESCRIPTION
This PR adds a new heuristic to junit_xml_reader.py for pytest to correctly derive the path and fully qualified function names for situations where tests are methods (e.g., a TestClass deriving from unittest.TestCase).