### PR TITLE
CI: add partitioning for integration tests

### DIFF
--- a/.github/workflows/ci-windows-powershell.yml
+++ b/.github/workflows/ci-windows-powershell.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9"]
+        shard: ["1/2", "2/2"]
 
     steps:
     - uses: actions/checkout@v3
@@ -53,4 +54,4 @@ jobs:
 
     - name: Run tests (Powershell)
       run: |
-        invoke test
+        invoke test --shard=${{ matrix.shard }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.12"]
+        shard: ["1/2", "2/2"]
 
     steps:
     - uses: actions/checkout@v3
@@ -57,5 +58,5 @@ jobs:
 
     - name: Run tests (Bash)
       run: |
-        invoke test
+        invoke test --shard=${{ matrix.shard }}
       shell: bash


### PR DESCRIPTION
This PR proposes to partition the Windows integration tests. I saw that we are spending about 25min in these tests, compared to about 9min for the others.