### PR TITLE
parallelizer: improve handling of child processes

### DIFF
--- a/tests/end2end/exporter.py
+++ b/tests/end2end/exporter.py
@@ -89,7 +89,7 @@ class SDocTestHTMLExporter:
         sleep(test_environment.warm_up_interval_seconds)
         print(  # noqa: T201
             f"SDocTestHTMLExporter: "
-            f"Static HTML sucessfully exported to : {self.output_path}."
+            f"Static HTML successfully exported to : {self.output_path}."
         )
 
     def get_output_path_as_uri(self) -> str:


### PR DESCRIPTION
This change enables a more correct clean-up of child process if everything goes wrong and a more deterministic removal of child processes in case the parent process crashes.