### PR TITLE
tests/end2end: fix copy_stable_link failing when running with code coverage

### DIFF
--- a/tests/end2end/screens/document/copy_stable_link/test_case.py
+++ b/tests/end2end/screens/document/copy_stable_link/test_case.py
@@ -32,6 +32,8 @@ class Test(E2ECase):
             screen_document = Screen_Document(self)
             screen_document.assert_on_screen("document")
 
+            self.wait_for_ready_state_complete()
+
             # move mouse to hover over target, so that button becomes visible
             screen_document.test_case.hover_on_element(
                 f'//sdoc-field-content[sdoc-autogen[text()="{target}"]]'


### PR DESCRIPTION

This also refactors the server code a little.