### PR TITLE
tests/end2end: helpers: ensure that most screens wait better for page load

### DIFF
--- a/tests/end2end/helpers/screens/project_index/screen_project_index.py
+++ b/tests/end2end/helpers/screens/project_index/screen_project_index.py
@@ -33,6 +33,7 @@ class Screen_ProjectIndex:  # pylint: disable=invalid-name
             '//body[@data-viewtype="document-tree"]',
             by=By.XPATH,
         )
+        self.test_case.wait_for_ready_state_complete()
         self.assert_no_js_and_404_errors()
 
     def assert_no_js_and_404_errors(self) -> None:

--- a/tests/end2end/helpers/screens/project_statistics/project_statistics.py
+++ b/tests/end2end/helpers/screens/project_statistics/project_statistics.py
@@ -20,6 +20,7 @@ class Screen_ProjectStatistics:  # pylint: disable=invalid-name
             '//body[@data-viewtype="project-statistics"]',
             by=By.XPATH,
         )
+        self.test_case.wait_for_ready_state_complete()
         self.assert_no_js_and_404_errors()
 
     def assert_no_js_and_404_errors(self) -> None:

--- a/tests/end2end/helpers/screens/requirements_coverage/screen_requirements_coverage.py
+++ b/tests/end2end/helpers/screens/requirements_coverage/screen_requirements_coverage.py
@@ -12,6 +12,7 @@ class Screen_RequirementsCoverage:  # pylint: disable=invalid-name
             '//body[@data-viewtype="traceability-matrix"]',
             by=By.XPATH,
         )
+        self.test_case.wait_for_ready_state_complete()
         self.assert_no_js_and_404_errors()
 
     def assert_no_js_and_404_errors(self) -> None:

--- a/tests/end2end/helpers/screens/screen.py
+++ b/tests/end2end/helpers/screens/screen.py
@@ -44,6 +44,7 @@ class Screen:  # pylint: disable=invalid-name, too-many-public-methods
             f'//body[@data-viewtype="{viewtype}"]',
             by=By.XPATH,
         )
+        self.test_case.wait_for_ready_state_complete()
 
     # Header.
     # Document title (all views)

--- a/tests/end2end/helpers/screens/source_coverage/screen_source_coverage.py
+++ b/tests/end2end/helpers/screens/source_coverage/screen_source_coverage.py
@@ -12,6 +12,7 @@ class Screen_SourceCoverage:  # pylint: disable=invalid-name
             '//body[@data-viewtype="coverage-tree"]',
             by=By.XPATH,
         )
+        self.test_case.wait_for_ready_state_complete()
         self.assert_no_js_and_404_errors()
 
     def assert_contains_text(self, text) -> None:


### PR DESCRIPTION
Similar to what was fixed to `copy_stable_link` [here](https://github.com/strictdoc-project/strictdoc/pull/2288), this PR could reduce the number of some flaky end2end tests.