### PR TITLE
tests/end2end: switch to parallel = true when collecting coverage

### DIFF
--- a/.coveragerc.end2end
+++ b/.coveragerc.end2end
@@ -1,5 +1,6 @@
 [run]
 branch = True
+parallel = true
 # concurrency = multiprocessing
 omit =
     build/

--- a/tasks.py
+++ b/tasks.py
@@ -498,7 +498,7 @@ def coverage_combine(context):
             coverage combine
                 --data-file build/coverage/.coverage.combined
                 --keep
-                build/coverage/end2end_strictdoc/.coverage
+                build/coverage/end2end_strictdoc/.coverage.*
                 build/coverage/integration/.coverage.*
                 build/coverage/integration_html2pdf/.coverage.*
                 build/coverage/unit/.coverage

--- a/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_update/update_node_add_link_to_existing_section_anchor_from_clipboard/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_update/update_node_add_link_to_existing_section_anchor_from_clipboard/test_case.py
@@ -7,11 +7,9 @@ from tests.end2end.helpers.screens.project_index.screen_project_index import (
     Screen_ProjectIndex,
 )
 from tests.end2end.server import SDocTestServer
-from tests.end2end.test_helpers import available_systems
 
 
 class Test(E2ECase):
-    @available_systems(["macos", "windows"])
     def test(self):
         test_setup = End2EndTestSetup(path_to_test_file=__file__)
 

--- a/tests/end2end/screens/document/move_node/move_node_basic_moving_DEPRECATED/test_case.py
+++ b/tests/end2end/screens/document/move_node/move_node_basic_moving_DEPRECATED/test_case.py
@@ -7,15 +7,9 @@ from tests.end2end.helpers.screens.project_index.screen_project_index import (
     Screen_ProjectIndex,
 )
 from tests.end2end.server import SDocTestServer
-from tests.end2end.test_helpers import available_systems
 
 
 class Test(E2ECase):
-    """
-    FIXME: This drag and drop test does not work reliably on Linux.
-    """
-
-    @available_systems(["macos", "windows"])
     def test(self):
         test_setup = End2EndTestSetup(path_to_test_file=__file__)
 

--- a/tests/end2end/screens/document/move_node/move_node_move_node_to_composite_node/test_case.py
+++ b/tests/end2end/screens/document/move_node/move_node_move_node_to_composite_node/test_case.py
@@ -7,15 +7,9 @@ from tests.end2end.helpers.screens.project_index.screen_project_index import (
     Screen_ProjectIndex,
 )
 from tests.end2end.server import SDocTestServer
-from tests.end2end.test_helpers import available_systems
 
 
 class Test(E2ECase):
-    """
-    FIXME: This drag and drop test does not work reliably on Linux.
-    """
-
-    @available_systems(["macos", "windows"])
     def test(self):
         test_setup = End2EndTestSetup(path_to_test_file=__file__)
 

--- a/tests/end2end/server.py
+++ b/tests/end2end/server.py
@@ -315,7 +315,6 @@ class SDocTestServer:
                     "-m",
                     "coverage",
                     "run",
-                    "--append",
                     f"--rcfile={path_to_coverage_rc}",
                     f"--data-file={path_to_coverage}",
                 ]


### PR DESCRIPTION
This also enables a few tests that were previously deactivated for Linux.