### PR TITLE
ExportAction: make traceability_index non-optional

### DIFF
--- a/strictdoc/cli/main.py
+++ b/strictdoc/cli/main.py
@@ -73,7 +73,6 @@ def _main(parallelizer: Parallelizer) -> None:
             project_config=project_config,
             parallelizer=parallelizer,
         )
-        export_action.build_index()
         export_action.export()
 
     elif parser.is_server_command:

--- a/strictdoc/core/actions/export_action.py
+++ b/strictdoc/core/actions/export_action.py
@@ -33,10 +33,10 @@ class ExportAction:
         assert parallelizer
         self.project_config: ProjectConfig = project_config
         self.parallelizer = parallelizer
-        self.traceability_index: Optional[TraceabilityIndex] = None
+        self.traceability_index: TraceabilityIndex = self.build_index()
 
     @timing_decorator("Parse SDoc project tree")
-    def build_index(self) -> None:
+    def build_index(self) -> TraceabilityIndex:
         try:
             traceability_index: TraceabilityIndex = (
                 TraceabilityIndexBuilder.create(
@@ -48,6 +48,7 @@ class ExportAction:
             print(exc.to_print_message())  # noqa: T201
             sys.exit(1)
         self.traceability_index = traceability_index
+        return traceability_index
 
     @timing_decorator("Export SDoc")
     def export(self) -> None:

--- a/strictdoc/core/finders/source_files_finder.py
+++ b/strictdoc/core/finders/source_files_finder.py
@@ -1,4 +1,4 @@
-# mypy: disable-error-code="arg-type,no-untyped-call"
+# mypy: disable-error-code="no-untyped-call"
 import os
 from pathlib import Path
 from typing import List

--- a/strictdoc/export/html/form_objects/included_document_form_object.py
+++ b/strictdoc/export/html/form_objects/included_document_form_object.py
@@ -1,4 +1,4 @@
-# mypy: disable-error-code="arg-type,no-untyped-call,no-untyped-def"
+# mypy: disable-error-code="no-untyped-call,no-untyped-def"
 import re
 from collections import defaultdict
 from typing import Dict, List, Optional

--- a/strictdoc/export/html/generators/traceability_matrix.py
+++ b/strictdoc/export/html/generators/traceability_matrix.py
@@ -1,4 +1,4 @@
-# mypy: disable-error-code="arg-type,no-untyped-def,union-attr"
+# mypy: disable-error-code="no-untyped-def,union-attr"
 from typing import Dict, Optional
 
 from strictdoc.backend.sdoc.models.document import SDocDocument

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -148,7 +148,6 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
         project_config=project_config,
         parallelizer=parallelizer,
     )
-    export_action.build_index()
 
     is_small_project = export_action.traceability_index.is_small_project()
 


### PR DESCRIPTION
This mini-PR :

- proposes to make ExportAction.traceability_index a non-optional member, which addresses several Optional[TraceabilityIndex] vs TraceabilityIndex arg-type errors in the main_router.py.

- removes the arg-type flag where we don't have an arg-type error today...