### PR TITLE
Code climate: tree_cycle_detector and requirement_form_object: fix all mypy issues

### DIFF
--- a/strictdoc/backend/sdoc/errors/document_tree_error.py
+++ b/strictdoc/backend/sdoc/errors/document_tree_error.py
@@ -1,15 +1,19 @@
-# mypy: disable-error-code="no-untyped-call,no-untyped-def"
+from typing import List
+
+
 class DocumentTreeError(Exception):
-    def __init__(self, problem_uid, cycled_uids):
+    def __init__(self, problem_uid: str, cycled_uids: List[str]) -> None:
         super().__init__()
-        self.problem_uid = problem_uid
-        self.cycled_uids = cycled_uids
+        self.problem_uid: str = problem_uid
+        self.cycled_uids: List[str] = cycled_uids
 
     @staticmethod
-    def cycle_error(problem_uid, cycled_uids):
+    def cycle_error(
+        problem_uid: str, cycled_uids: List[str]
+    ) -> "DocumentTreeError":
         return DocumentTreeError(problem_uid, cycled_uids)
 
-    def to_print_message(self):
+    def to_print_message(self) -> str:
         cycled_uids = ", ".join(self.cycled_uids)
         message = (
             "error: document tree: "
@@ -19,7 +23,7 @@ class DocumentTreeError(Exception):
         )
         return message
 
-    def to_validation_message(self):
+    def to_validation_message(self) -> str:
         return (
             "A cycle detected: requirements in the document tree must not "
             "reference each other. "

--- a/strictdoc/backend/sdoc/models/type_system.py
+++ b/strictdoc/backend/sdoc/models/type_system.py
@@ -204,7 +204,7 @@ class GrammarElementRelationParent:
     ):
         assert relation_type == "Parent"
         self.parent = parent
-        self.relation_type = relation_type
+        self.relation_type: str = relation_type
         self.relation_role: Optional[str] = (
             relation_role
             if relation_role is not None and len(relation_role) > 0

--- a/strictdoc/core/transforms/update_requirement.py
+++ b/strictdoc/core/transforms/update_requirement.py
@@ -121,6 +121,7 @@ class CreateOrUpdateNodeCommand:
                     context_document=self.context_document,
                 ).write_with_validation(field_.field_value)
                 if parsed_html is None:
+                    assert rst_error is not None
                     form_object.add_error(field_.field_name, rst_error)
                 else:
                     try:

--- a/strictdoc/core/tree_cycle_detector.py
+++ b/strictdoc/core/tree_cycle_detector.py
@@ -1,30 +1,30 @@
-# mypy: disable-error-code="no-untyped-call,no-untyped-def"
 from collections import deque
-from typing import Deque, Tuple
+from typing import Callable, Deque, List, Set, Tuple
 
 from strictdoc.backend.sdoc.errors.document_tree_error import DocumentTreeError
-from strictdoc.backend.sdoc.models.model import SDocNodeIF
 
 BEFORE = 1
 AFTER = 2
 
 
 class TreeCycleDetector:
-    def __init__(self):
-        self.checked = set()
+    def __init__(self) -> None:
+        self.checked: Set[str] = set()
 
-    def check_node(self, node: SDocNodeIF, links_function):
+    def check_node(
+        self, node: str, links_function: Callable[[str], List[str]]
+    ) -> None:
         if node in self.checked:
             return
-        stack: Deque[Tuple[SDocNodeIF, int]] = deque()
+        stack: Deque[Tuple[str, int]] = deque()
         stack.append((node, BEFORE))
-        visited = set()
+        visited: Set[str] = set()
         while stack:
             current_node, token = stack[-1]
             if token == BEFORE:
                 visited.add(current_node)
                 stack[-1] = (current_node, AFTER)
-                node_links = links_function(current_node)
+                node_links: List[str] = links_function(current_node)
                 for node_link in reversed(node_links):
                     if node_link in visited:
                         cycled_nodes = []
@@ -45,10 +45,24 @@ class TreeCycleDetector:
 
 
 class SingleShotTreeCycleDetector:
-    def check_node(self, new_uid, node, links_function):
-        checked = set()
+    def check_node(
+        self,
+        new_uid: str,
+        node: str,
+        links_function: Callable[[str], List[str]],
+    ) -> None:
+        """
+        Detect if a newly added node would cause a link/relation cycle in the
+        traceability index.
 
-        stack: Deque[Tuple[SDocNodeIF, int]] = deque()
+        FIXME: Both cycle detector classes are very similar. Find a way to merge
+               them. The added value of this 'single shot' detector is that it
+               checks for cycles possibly added by a new node.
+        """
+
+        checked: Set[str] = set()
+
+        stack: Deque[Tuple[str, int]] = deque()
         stack.append((node, BEFORE))
         visited = {new_uid}
         while stack:

--- a/strictdoc/export/rst/rst_to_html_fragment_writer.py
+++ b/strictdoc/export/rst/rst_to_html_fragment_writer.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 
 from docutils.core import publish_parts
 from docutils.parsers.rst import directives, roles
@@ -145,7 +145,9 @@ class RstToHtmlFragmentWriter:
 
         return html
 
-    def write_with_validation(self, rst_fragment):
+    def write_with_validation(
+        self, rst_fragment
+    ) -> Tuple[Optional[str], Optional[str]]:
         # How do I convert a docutils document tree into an HTML string?
         # https://stackoverflow.com/a/32168938/598057
         # Use a io.StringIO as the warning stream to prevent warnings from

--- a/strictdoc/helpers/mid.py
+++ b/strictdoc/helpers/mid.py
@@ -11,5 +11,5 @@ class MID(str):
     def create() -> "MID":
         return MID(uuid.uuid4().hex)
 
-    def get_string_value(self):
+    def get_string_value(self) -> str:
         return str(self)

--- a/strictdoc/server/error_object.py
+++ b/strictdoc/server/error_object.py
@@ -1,16 +1,18 @@
-# mypy: disable-error-code="no-untyped-def"
+from typing import Dict, List
+
+
 class ErrorObject:
-    def __init__(self):
-        self.errors = {}
+    def __init__(self) -> None:
+        self.errors: Dict[str, List[str]] = {}
 
-    def any_errors(self):
-        return len(self.errors)
+    def any_errors(self) -> bool:
+        return len(self.errors) > 0
 
-    def get_errors(self, field_name):
+    def get_errors(self, field_name: str) -> List[str]:
         if field_name not in self.errors:
             return []
         return self.errors[field_name]
 
-    def add_error(self, field_name, error):
+    def add_error(self, field_name: str, error: str) -> None:
         error_container = self.errors.setdefault(field_name, [])
         error_container.append(error)

--- a/tests/integration/self_testing/commands/export/01_strictdoc_smoke_test/test.itest
+++ b/tests/integration/self_testing/commands/export/01_strictdoc_smoke_test/test.itest
@@ -103,7 +103,7 @@ RUN: %check_exists --file "%S/Output/html/_source_files/strictdoc/core/traceabil
 
 RUN: %cat %S/Output/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html | filecheck %s --check-prefix CHECK-3-REQUIREMENTS
 CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/traceability_index_builder.py.html#SDOC-SRS-30#{{.*}}#{{.*}}"
-CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/tree_cycle_detector.py.html#SDOC-SRS-30#1#75"
+CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/tree_cycle_detector.py.html#SDOC-SRS-30#{{.*}}#{{.*}}"
 
 RUN: %cat "%S/Output/html/_source_files/strictdoc/core/tree_cycle_detector.py.html" | filecheck %s --check-prefix CHECK-TREE-CYCLE-DETECTOR
 CHECK-TREE-CYCLE-DETECTOR: href="../../../strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html#SDOC-SRS-30"

--- a/tests/integration/self_testing/commands/export/04_strictdoc_smoke_test_source_files_from_another_directory/test.itest
+++ b/tests/integration/self_testing/commands/export/04_strictdoc_smoke_test_source_files_from_another_directory/test.itest
@@ -15,7 +15,7 @@ RUN: %check_exists --file "%S/Output/html/_source_files/strictdoc/core/traceabil
 
 RUN: %cat %S/Output/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html | filecheck %s --check-prefix CHECK-3-REQUIREMENTS
 CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/traceability_index_builder.py.html#SDOC-SRS-30#{{.*}}#{{.*}}"
-CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/tree_cycle_detector.py.html#SDOC-SRS-30#1#75"
+CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/tree_cycle_detector.py.html#SDOC-SRS-30#{{.*}}#{{.*}}"
 
 RUN: %cat "%S/Output/html/_source_files/strictdoc/core/tree_cycle_detector.py.html" | filecheck %s --check-prefix CHECK-TREE-CYCLE-DETECTOR
 CHECK-TREE-CYCLE-DETECTOR: href="../../../strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html#SDOC-SRS-30"


### PR DESCRIPTION

This PR finally fixes the missing/incorrect cycle detector types.

This is triggered by the performance investigation around how the DTR screen generates Jinja templates for very large documents.

At some point, I suspected a bug in the logic because the type annotations were off, but it turned out that the logic was fine.