### PR TITLE
tests/integration: redirect all build artifacts to build/tests_integration

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-target-version = "py37"
+target-version = "py38"
 line-length = 80
 
 [lint]

--- a/strictdoc/backend/sdoc/models/type_system.py
+++ b/strictdoc/backend/sdoc/models/type_system.py
@@ -199,7 +199,7 @@ class GrammarElementFieldTag(GrammarElementField):
 
 
 @auto_described
-class GrammarElementRelationParent:
+class GrammarElementRelationParent:  # noqa: PLW1641
     def __init__(
         self, parent, relation_type: str, relation_role: Optional[str]
     ):

--- a/strictdoc/helpers/coverage.py
+++ b/strictdoc/helpers/coverage.py
@@ -10,7 +10,7 @@ def register_code_coverage_hook() -> None:
         # This branch will never be checked by the coverage.
         return  # pragma: no cover
 
-    import coverage
+    import coverage  # noqa: PLC0415
 
     current_coverage = coverage.Coverage.current()
 

--- a/tasks.py
+++ b/tasks.py
@@ -109,7 +109,7 @@ def clean_itest_artifacts(context):
     run_invoke(
         context,
         """
-        git clean -dX --force --quiet tests/integration/
+        rm -rf build/tests_integration/
         """,
         warn=True,
     )
@@ -460,6 +460,7 @@ def test_integration(
         --param STRICTDOC_EXEC="{strictdoc_exec}"
         --param STRICTDOC_TMP_DIR="{STRICTDOC_TMP_DIR}"
         --timeout 180
+        --order smart
         {junit_xml_report_argument}
         {coverage_path_argument}
         {html2pdf_param}
@@ -1081,7 +1082,7 @@ def test_docker(context, image: str = "strictdoc:latest"):
     )
 
     def check_file_owner(filepath):
-        import pwd
+        import pwd  # noqa: PLC0415
 
         file_owner = pwd.getpwuid(os.stat(filepath).st_uid).pw_name
         current_user = os.environ.get("USER", "")

--- a/tests/end2end/helpers/components/node/requirement.py
+++ b/tests/end2end/helpers/components/node/requirement.py
@@ -243,7 +243,7 @@ class Requirement(Node):  # pylint: disable=invalid-name
             hover_by=By.XPATH,
             click_by=By.XPATH,
         )
-        from tests.end2end.helpers.screens.document.screen_document import (
+        from tests.end2end.helpers.screens.document.screen_document import (  # noqa: PLC0415
             Screen_Document,
         )
 

--- a/tests/integration/features/code_coverage_gcov/01_basic_gcov/test.itest
+++ b/tests/integration/features/code_coverage_gcov/01_basic_gcov/test.itest
@@ -1,15 +1,15 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: cd %S/Output && gcc --coverage -g -O0 -o main ../src/main.c
+RUN: cd %T && gcc --coverage -g -O0 -o main %S/src/main.c
 
-RUN: cd %S/Output && ./main | filecheck %s --check-prefix CHECK-C
+RUN: cd %T && ./main | filecheck %s --check-prefix CHECK-C
 CHECK-C: This function is covered
 
-RUN: cd %S/Output && gcovr --object-directory ./ --root ../ --html --html-details -o coverage.html
-RUN: cd %S/Output && gcovr --object-directory ./ --root ../ --json --json-pretty -o coverage.gcov.json
-RUN: cd %S/Output && mkdir docs/ && cp coverage.gcov.json docs/
-RUN: cp %S/strictdoc.toml %S/Output/docs/
-RUN: cp -r %S/src %S/Output/docs/
-RUN: cd %S/Output/docs && %strictdoc export .  | filecheck %s
+RUN: cd %T && gcovr --object-directory ./ --root ../ --html --html-details -o coverage.html
+RUN: cd %T && gcovr --object-directory ./ --root ../ --json --json-pretty -o coverage.gcov.json
+RUN: cd %T && mkdir docs/ && cp coverage.gcov.json docs/
+RUN: cp %S/strictdoc.toml %T/docs/
+RUN: cp -r %S/src %T/docs/
+RUN: cd %T/docs && %strictdoc export .  | filecheck %s
 
 CHECK: Published: Code coverage report

--- a/tests/integration/features/commands/bypass/00_basic_requirement_test/test.itest
+++ b/tests/integration/features/commands/bypass/00_basic_requirement_test/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 0 %strictdoc passthrough %S/input.sdoc --output-dir=%S/Output/
-RUN: %diff %S/input.sdoc %S/Output/sdoc/input.sdoc
+RUN: %expect_exit 0 %strictdoc passthrough %S/input.sdoc --output-dir=%T/
+RUN: %diff %S/input.sdoc %T/sdoc/input.sdoc

--- a/tests/integration/features/commands/bypass/01_empty_document_with_freetext/test.itest
+++ b/tests/integration/features/commands/bypass/01_empty_document_with_freetext/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 0 %strictdoc passthrough %S/input.sdoc --output-dir=%S/Output/
-RUN: %diff %S/input.sdoc %S/Output/sdoc/input.sdoc
+RUN: %expect_exit 0 %strictdoc passthrough %S/input.sdoc --output-dir=%T/
+RUN: %diff %S/input.sdoc %T/sdoc/input.sdoc

--- a/tests/integration/features/commands/bypass/03_basic_document_test/test.itest
+++ b/tests/integration/features/commands/bypass/03_basic_document_test/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 0 %strictdoc passthrough %S/input.sdoc --output-dir=%S/Output/
-RUN: %diff %S/input.sdoc %S/Output/sdoc/input.sdoc
+RUN: %expect_exit 0 %strictdoc passthrough %S/input.sdoc --output-dir=%T/
+RUN: %diff %S/input.sdoc %T/sdoc/input.sdoc

--- a/tests/integration/features/commands/bypass/10_multiple_documents/test.itest
+++ b/tests/integration/features/commands/bypass/10_multiple_documents/test.itest
@@ -1,3 +1,3 @@
-RUN: %expect_exit 0 %strictdoc passthrough %S/input --output-dir=%S/Output
-RUN: %diff %S/input/input1.sdoc %S/Output/sdoc/input1.sdoc
-RUN: %diff %S/input/nested/input2.sdoc %S/Output/sdoc/nested/input2.sdoc
+RUN: %expect_exit 0 %strictdoc passthrough %S/input --output-dir=%T
+RUN: %diff %S/input/input1.sdoc %T/sdoc/input1.sdoc
+RUN: %diff %S/input/nested/input2.sdoc %T/sdoc/nested/input2.sdoc

--- a/tests/integration/features/commands/bypass/20_filter_requirements/test.itest
+++ b/tests/integration/features/commands/bypass/20_filter_requirements/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 0 %strictdoc passthrough %S/input.sdoc --output-dir=%S/Output --filter-requirements '("2" in node["TITLE"] or "4" in node["TITLE"])' | filecheck %s --dump-input=fail
+RUN: %expect_exit 0 %strictdoc passthrough %S/input.sdoc --output-dir=%T --filter-requirements '("2" in node["TITLE"] or "4" in node["TITLE"])' | filecheck %s --dump-input=fail
 CHECK: Reading SDOC: input.sdoc
 
-RUN: %diff %S/expected/output.sdoc %S/Output/sdoc/input.sdoc
+RUN: %diff %S/expected/output.sdoc %T/sdoc/input.sdoc

--- a/tests/integration/features/commands/bypass/30_in_place_rewrite/test.itest
+++ b/tests/integration/features/commands/bypass/30_in_place_rewrite/test.itest
@@ -1,4 +1,4 @@
-RUN: mkdir %S/Output/sandbox
-RUN: cp input.sdoc %S/Output/sandbox/
-RUN: %expect_exit 0 %strictdoc passthrough %S/Output/sandbox/input.sdoc --output-dir=%S/Output/sandbox --filter-requirements='"2" not in node["TITLE"]'
-RUN: %diff %S/expected.sdoc %S/Output/sandbox/sdoc/input.sdoc
+RUN: mkdir %T/sandbox
+RUN: cp %S/input.sdoc %T/sandbox/
+RUN: %expect_exit 0 %strictdoc passthrough %T/sandbox/input.sdoc --output-dir=%T/sandbox --filter-requirements='"2" not in node["TITLE"]'
+RUN: %diff %S/expected.sdoc %T/sandbox/sdoc/input.sdoc

--- a/tests/integration/features/commands/bypass/40_generate_mid/test.itest
+++ b/tests/integration/features/commands/bypass/40_generate_mid/test.itest
@@ -1,7 +1,7 @@
-RUN: %expect_exit 0 %strictdoc passthrough %S/input.sdoc --output-dir=%S/Output | filecheck %s --dump-input=fail
+RUN: %expect_exit 0 %strictdoc passthrough %S/input.sdoc --output-dir=%T | filecheck %s --dump-input=fail
 CHECK: Reading SDOC: input.sdoc
 
-RUN: %cat %S/Output/sdoc/input.sdoc | filecheck %s --dump-input=fail --check-prefix=CHECK-OUT-SDOC
+RUN: %cat %T/sdoc/input.sdoc | filecheck %s --dump-input=fail --check-prefix=CHECK-OUT-SDOC
 NOTE: Ensure that the MIDs are generated for Document, Section and two Requirements.
 CHECK-OUT-SDOC: MID: {{[a-f0-9]+}}
 CHECK-OUT-SDOC: MID: {{[a-f0-9]+}}

--- a/tests/integration/features/commands/bypass/50_nested_document_from_file/test.itest
+++ b/tests/integration/features/commands/bypass/50_nested_document_from_file/test.itest
@@ -1,5 +1,5 @@
-RUN: %expect_exit 0 %strictdoc passthrough %S/ --output-dir=%S/Output/
+RUN: %expect_exit 0 %strictdoc passthrough %S/ --output-dir=%T/
 
-RUN: %diff %S/input.sdoc %S/Output/sdoc/input.sdoc
-RUN: %diff %S/nested/input2.sdoc %S/Output/sdoc/nested/input2.sdoc
-RUN: %diff %S/nested/subnested/input3.sdoc %S/Output/sdoc/nested/subnested/input3.sdoc
+RUN: %diff %S/input.sdoc %T/sdoc/input.sdoc
+RUN: %diff %S/nested/input2.sdoc %T/sdoc/nested/input2.sdoc
+RUN: %diff %S/nested/subnested/input3.sdoc %T/sdoc/nested/subnested/input3.sdoc

--- a/tests/integration/features/commands/dump-grammar/01_dump_grammar/test.itest
+++ b/tests/integration/features/commands/dump-grammar/01_dump_grammar/test.itest
@@ -1,6 +1,6 @@
-RUN: %mkdir %S/output/
-RUN: %strictdoc dump-grammar %S/output/output.tx
-RUN %cat %S/output/output.tx | filecheck %s --dump-input=fail
+RUN: %mkdir %T/
+RUN: %strictdoc dump-grammar %T/output.tx
+RUN %cat %T/output.tx | filecheck %s --dump-input=fail
 
 CHECK:   '[DOCUMENT]' '\n'
 CHECK:MultiLineStringEnd[noskipws]:

--- a/tests/integration/features/commands/manage/auto-uid/01_issue_1630_autouid_must_preserve_relations/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/01_issue_1630_autouid_must_preserve_relations/test.itest
@@ -1,7 +1,7 @@
-RUN: cp %S/input.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output/
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage auto-uid %T/
 
-RUN: %cat %S/Output/input.sdoc | filecheck %s
+RUN: %cat %T/input.sdoc | filecheck %s
 
 NOTE: This regression test ensures that the RELATIONS field of a requirement that got
       an auto-generated UID are NOT modified.

--- a/tests/integration/features/commands/manage/auto-uid/01_issue_1630_autouid_must_preserve_relations_DEPRECATED/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/01_issue_1630_autouid_must_preserve_relations_DEPRECATED/test.itest
@@ -1,7 +1,7 @@
-RUN: cp %S/input.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output/
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage auto-uid %T/
 
-RUN: %cat %S/Output/input.sdoc | filecheck %s
+RUN: %cat %T/input.sdoc | filecheck %s
 
 NOTE: This regression test ensures that the RELATIONS field of a requirement that got
       an auto-generated UID are NOT modified.

--- a/tests/integration/features/commands/manage/auto-uid/composable_documents/01_basic_check_all_elements/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/composable_documents/01_basic_check_all_elements/test.itest
@@ -1,15 +1,15 @@
-RUN: cp %S/*.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output/ | filecheck %s --dump-input=fail
+RUN: cp %S/*.sdoc %T/
+RUN: %strictdoc manage auto-uid %T/ | filecheck %s --dump-input=fail
 CHECK: Step 'Build traceability graph' took:
 
-RUN: %cat %S/Output/input.sdoc | filecheck %s --check-prefix CHECK-DOC
+RUN: %cat %T/input.sdoc | filecheck %s --check-prefix CHECK-DOC
 CHECK-DOC: UID: REQ-1
 CHECK-DOC: UID: REQ-2
 
-RUN: %cat %S/Output/nested.sdoc | filecheck %s --check-prefix CHECK-NESTED-DOC
+RUN: %cat %T/nested.sdoc | filecheck %s --check-prefix CHECK-NESTED-DOC
 CHECK-NESTED-DOC: UID: REQ-3
 CHECK-NESTED-DOC: UID: REQ-4
 
-RUN: %cat %S/Output/subnested.sdoc | filecheck %s --check-prefix CHECK-SUBNESTED-DOC
+RUN: %cat %T/subnested.sdoc | filecheck %s --check-prefix CHECK-SUBNESTED-DOC
 CHECK-SUBNESTED-DOC: UID: REQ-5
 CHECK-SUBNESTED-DOC: UID: REQ-6

--- a/tests/integration/features/commands/manage/auto-uid/composite_requirement_uids/01_default_behavior/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/composite_requirement_uids/01_default_behavior/test.itest
@@ -1,3 +1,3 @@
-RUN: cp %S/input.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output/
-RUN: %diff %S/input.expected.sdoc %S/Output/input.sdoc
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage auto-uid %T/
+RUN: %diff %S/input.expected.sdoc %T/input.sdoc

--- a/tests/integration/features/commands/manage/auto-uid/grammar_from_file/01_basic_grammar_from_file/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/grammar_from_file/01_basic_grammar_from_file/test.itest
@@ -1,6 +1,6 @@
-RUN: cp %S/*.sdoc %S/*.sgra %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output | filecheck %s --dump-input=fail
+RUN: cp %S/*.sdoc %S/*.sgra %T/
+RUN: %strictdoc manage auto-uid %T | filecheck %s --dump-input=fail
 CHECK: Step 'Build traceability graph' took
 
-RUN: %cat %S/Output/input.sdoc | filecheck %s --dump-input=fail --check-prefix CHECK-SDOC
+RUN: %cat %T/input.sdoc | filecheck %s --dump-input=fail --check-prefix CHECK-SDOC
 CHECK-SDOC: UID: REQ-1

--- a/tests/integration/features/commands/manage/auto-uid/grammar_from_file/02_ignores_junit_xml/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/grammar_from_file/02_ignores_junit_xml/test.itest
@@ -4,9 +4,9 @@
 # The scope of the auto_uid is only SDoc files. All other extensions must be ignored.
 #
 
-RUN: cp %S/*.xml %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output | filecheck %s --dump-input=fail
+RUN: cp %S/*.xml %T/
+RUN: %strictdoc manage auto-uid %T | filecheck %s --dump-input=fail
 
 CHECK: Step 'Build traceability graph' took
 
-RUN: %diff %S/tests_unit.gtest.junit.xml %S/Output/tests_unit.gtest.junit.xml
+RUN: %diff %S/tests_unit.gtest.junit.xml %T/tests_unit.gtest.junit.xml

--- a/tests/integration/features/commands/manage/auto-uid/requirement_uids/01_default_behavior/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/requirement_uids/01_default_behavior/test.itest
@@ -1,3 +1,3 @@
-RUN: cp %S/input.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output/
-RUN: %diff %S/input.expected.sdoc %S/Output/input.sdoc
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage auto-uid %T/
+RUN: %diff %S/input.expected.sdoc %T/input.sdoc

--- a/tests/integration/features/commands/manage/auto-uid/requirement_uids/02_some_requirements_already_have_uid/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/requirement_uids/02_some_requirements_already_have_uid/test.itest
@@ -1,3 +1,3 @@
-RUN: cp %S/input.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output/
-RUN: %diff %S/input.expected.sdoc %S/Output/input.sdoc
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage auto-uid %T/
+RUN: %diff %S/input.expected.sdoc %T/input.sdoc

--- a/tests/integration/features/commands/manage/auto-uid/requirement_uids/03_requirement_prefix_document_level/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/requirement_uids/03_requirement_prefix_document_level/test.itest
@@ -1,3 +1,3 @@
-RUN: cp %S/input.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output/
-RUN: %diff %S/input.expected.sdoc %S/Output/input.sdoc
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage auto-uid %T/
+RUN: %diff %S/input.expected.sdoc %T/input.sdoc

--- a/tests/integration/features/commands/manage/auto-uid/requirement_uids/04_requirement_prefix_section_level/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/requirement_uids/04_requirement_prefix_section_level/test.itest
@@ -1,3 +1,3 @@
-RUN: cp %S/input.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output/
-RUN: %diff %S/input.expected.sdoc %S/Output/input.sdoc
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage auto-uid %T/
+RUN: %diff %S/input.expected.sdoc %T/input.sdoc

--- a/tests/integration/features/commands/manage/auto-uid/requirement_uids/05_requirement_prefix_grammar_element_level/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/requirement_uids/05_requirement_prefix_grammar_element_level/test.itest
@@ -1,3 +1,3 @@
-RUN: cp %S/input.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output/
-RUN: %diff %S/input.expected.sdoc %S/Output/input.sdoc
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage auto-uid %T/
+RUN: %diff %S/input.expected.sdoc %T/input.sdoc

--- a/tests/integration/features/commands/manage/auto-uid/requirement_uids/06_works_against_single_files/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/requirement_uids/06_works_against_single_files/test.itest
@@ -1,3 +1,3 @@
-RUN: cp %S/input.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output/input.sdoc
-RUN: %diff %S/input.expected.sdoc %S/Output/input.sdoc
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage auto-uid %T/input.sdoc
+RUN: %diff %S/input.expected.sdoc %T/input.sdoc

--- a/tests/integration/features/commands/manage/auto-uid/requirement_uids/07_works_across_documents_default_prefix/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/requirement_uids/07_works_across_documents_default_prefix/test.itest
@@ -1,5 +1,5 @@
-RUN: cp %S/input1.sdoc %S/Output/
-RUN: cp %S/input2.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output/
-RUN: %diff %S/input1.expected.sdoc %S/Output/input1.sdoc
-RUN: %diff %S/input2.expected.sdoc %S/Output/input2.sdoc
+RUN: cp %S/input1.sdoc %T/
+RUN: cp %S/input2.sdoc %T/
+RUN: %strictdoc manage auto-uid %T/
+RUN: %diff %S/input1.expected.sdoc %T/input1.sdoc
+RUN: %diff %S/input2.expected.sdoc %T/input2.sdoc

--- a/tests/integration/features/commands/manage/auto-uid/requirement_uids/08_works_across_documents_custom_prefix/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/requirement_uids/08_works_across_documents_custom_prefix/test.itest
@@ -1,7 +1,7 @@
-RUN: cp %S/input1.sdoc %S/Output/
-RUN: cp %S/input2.sdoc %S/Output/
-RUN: cp %S/input3.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output/
-RUN: %diff %S/input1.expected.sdoc %S/Output/input1.sdoc
-RUN: %diff %S/input2.expected.sdoc %S/Output/input2.sdoc
-RUN: %diff %S/input3.expected.sdoc %S/Output/input3.sdoc
+RUN: cp %S/input1.sdoc %T/
+RUN: cp %S/input2.sdoc %T/
+RUN: cp %S/input3.sdoc %T/
+RUN: %strictdoc manage auto-uid %T/
+RUN: %diff %S/input1.expected.sdoc %T/input1.sdoc
+RUN: %diff %S/input2.expected.sdoc %T/input2.sdoc
+RUN: %diff %S/input3.expected.sdoc %T/input3.sdoc

--- a/tests/integration/features/commands/manage/auto-uid/requirement_uids/09_edge_grammar_UID_required/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/requirement_uids/09_edge_grammar_UID_required/test.itest
@@ -1,3 +1,3 @@
-RUN: cp %S/input.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid %S/Output/
-RUN: %diff %S/input.expected.sdoc %S/Output/input.sdoc
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage auto-uid %T/
+RUN: %diff %S/input.expected.sdoc %T/input.sdoc

--- a/tests/integration/features/commands/manage/auto-uid/section_uids/01_generates_section_uids/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/section_uids/01_generates_section_uids/test.itest
@@ -1,3 +1,3 @@
-RUN: cp %S/input.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid --include-sections %S/Output/input.sdoc
-RUN: %diff %S/input.expected.sdoc %S/Output/input.sdoc
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage auto-uid --include-sections %T/input.sdoc
+RUN: %diff %S/input.expected.sdoc %T/input.sdoc

--- a/tests/integration/features/commands/manage/auto-uid/section_uids/02_identical_titles_get_numeric_postfix/test.itest
+++ b/tests/integration/features/commands/manage/auto-uid/section_uids/02_identical_titles_get_numeric_postfix/test.itest
@@ -1,3 +1,3 @@
-RUN: cp %S/input.sdoc %S/Output/
-RUN: %strictdoc manage auto-uid --include-sections %S/Output/input.sdoc
-RUN: %diff %S/input.expected.sdoc %S/Output/input.sdoc
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage auto-uid --include-sections %T/input.sdoc
+RUN: %diff %S/input.expected.sdoc %T/input.sdoc

--- a/tests/integration/features/commands/passthrough/--view/01_view_option_is_provided/test.itest
+++ b/tests/integration/features/commands/passthrough/--view/01_view_option_is_provided/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc passthrough %S --view PRINT_VIEW --output-dir Output/
-RUN: %cat %S/Output/sdoc/input.sdoc | filecheck %s --check-prefix CHECK-SDOC
+RUN: %strictdoc passthrough %S --view PRINT_VIEW --output-dir %T
+RUN: %cat %T/sdoc/input.sdoc | filecheck %s --check-prefix CHECK-SDOC
 
 CHECK-SDOC: REQ-1
 CHECK-SDOC: Requirement statement.

--- a/tests/integration/features/commands/passthrough/--view/02_if_view_option_is_not_provided_then_default_view/test.itest
+++ b/tests/integration/features/commands/passthrough/--view/02_if_view_option_is_not_provided_then_default_view/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc passthrough %S --output-dir Output/
-RUN: %cat %S/Output/sdoc/input.sdoc | filecheck %s --check-prefix=CHECK-SDOC
+RUN: %strictdoc passthrough %S --output-dir %T
+RUN: %cat %T/sdoc/input.sdoc | filecheck %s --check-prefix=CHECK-SDOC
 
 CHECK-SDOC: REQ-1
 CHECK-SDOC: Requirement statement.

--- a/tests/integration/features/commands/server/validation/malformed_host/test.itest
+++ b/tests/integration/features/commands/server/validation/malformed_host/test.itest
@@ -1,4 +1,4 @@
-RUN: %mkdir %S/output/
+RUN: %mkdir %T/
 RUN: %expect_exit 1 %strictdoc server --host foo#bar . | filecheck %s --dump-input=fail
 
 CHECK: error: Provided 'host' argument is not a valid host: foo#bar

--- a/tests/integration/features/commands/version/01_print_version/test.itest
+++ b/tests/integration/features/commands/version/01_print_version/test.itest
@@ -1,4 +1,4 @@
-RUN: %mkdir %S/output/
+RUN: %mkdir %T/
 RUN: %strictdoc version | filecheck %s --dump-input=fail
 RUN: %strictdoc -v | filecheck %s --dump-input=fail
 RUN: %strictdoc --version | filecheck %s --dump-input=fail

--- a/tests/integration/features/deprecations/hello_world/deprecated_REQUIREMENT_IN_TOC/test.itest
+++ b/tests/integration/features/deprecations/hello_world/deprecated_REQUIREMENT_IN_TOC/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 CHECK: WARNING: REQUIREMENT_IN_TOC is deprecated. Replace it to NODE_IN_TOC.

--- a/tests/integration/features/deprecations/hello_world/deprecated_REQUIREMENT_STYLE/test.itest
+++ b/tests/integration/features/deprecations/hello_world/deprecated_REQUIREMENT_STYLE/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 CHECK: WARNING: REQUIREMENT_STYLE is deprecated. Replace it to VIEW_STYLE.

--- a/tests/integration/features/deprecations/hello_world/deprecated_SECTION/test.itest
+++ b/tests/integration/features/deprecations/hello_world/deprecated_SECTION/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 CHECK: WARNING: At least one document in this documentation tree uses a deprecated [SECTION] element.

--- a/tests/integration/features/diff/01__requirements__from_empty_doc_to_one_requirement/test.itest
+++ b/tests/integration/features/diff/01__requirements__from_empty_doc_to_one_requirement/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 NOTE: This ensures that the links are printed for static HTML export, not the web server links.
 CHECK-CHANGELOG:href="diff.html"

--- a/tests/integration/features/diff/02__requirements__from_requirement_to_requirement__add_uid/test.itest
+++ b/tests/integration/features/diff/02__requirements__from_requirement_to_requirement__add_uid/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-section">Summary of the changes</div>
 

--- a/tests/integration/features/diff/03__requirements__from_requirement_to_requirement__remove_uid/test.itest
+++ b/tests/integration/features/diff/03__requirements__from_requirement_to_requirement__remove_uid/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-section">Summary of the changes</div>
 

--- a/tests/integration/features/diff/04__requirements__rename_statement/test.itest
+++ b/tests/integration/features/diff/04__requirements__rename_statement/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
 NOTE: This ensures that the output HTML indeed contains a green diff line
       produced from comparing the old and the modified requirement statement.
 

--- a/tests/integration/features/diff/04a__requirements__rename_statement_contained_in_section/test.itest
+++ b/tests/integration/features/diff/04a__requirements__rename_statement_contained_in_section/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
 NOTE: This ensures that the output HTML indeed contains a green diff line
       produced from comparing the old and the modified requirement statement.
 

--- a/tests/integration/features/diff/05__requirements__remove_one_requirement/test.itest
+++ b/tests/integration/features/diff/05__requirements__remove_one_requirement/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>

--- a/tests/integration/features/diff/06__requirements__unmatched_requirement_content_changed/test.itest
+++ b/tests/integration/features/diff/06__requirements__unmatched_requirement_content_changed/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>2</div>

--- a/tests/integration/features/diff/07__requirements__matched_requirement_content_changed/test.itest
+++ b/tests/integration/features/diff/07__requirements__matched_requirement_content_changed/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>

--- a/tests/integration/features/diff/10__requirements_comments__add_comment/test.itest
+++ b/tests/integration/features/diff/10__requirements_comments__add_comment/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>

--- a/tests/integration/features/diff/110__document_fragments__basic/test.itest
+++ b/tests/integration/features/diff/110__document_fragments__basic/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>2</div>

--- a/tests/integration/features/diff/11__requirements_comments__modify_one_comment/test.itest
+++ b/tests/integration/features/diff/11__requirements_comments__modify_one_comment/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>

--- a/tests/integration/features/diff/120__escaping__basic/test.itest
+++ b/tests/integration/features/diff/120__escaping__basic/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/diff.html | filecheck %s --dump-input=fail --check-prefix=CHECK-DIFF
+RUN: cat %T/diff.html | filecheck %s --dump-input=fail --check-prefix=CHECK-DIFF
 
 CHECK-DIFF:<span class="document_title">Doc Title with special characters &lt;&gt;</span>
 CHECK-DIFF:<span>Doc Title with</span><span> special characters &lt;&gt;</span></div>

--- a/tests/integration/features/diff/12__requirements_comments__modify_second_of_three_comments/test.itest
+++ b/tests/integration/features/diff/12__requirements_comments__modify_second_of_three_comments/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>

--- a/tests/integration/features/diff/13__requirements_comments__insert_new_comment_between_two_comments/test.itest
+++ b/tests/integration/features/diff/13__requirements_comments__insert_new_comment_between_two_comments/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>

--- a/tests/integration/features/diff/14__requirements_comments__insert_two_similar_requirements/test.itest
+++ b/tests/integration/features/diff/14__requirements_comments__insert_two_similar_requirements/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>

--- a/tests/integration/features/diff/20__requirements_relations__same_document__add_parent_relation/test.itest
+++ b/tests/integration/features/diff/20__requirements_relations__same_document__add_parent_relation/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>
@@ -30,7 +30,7 @@ CHECK-CHANGELOG:System shall do 2.
 CHECK-CHANGELOG:text="relation"{{.*}}REQ-1
 CHECK-CHANGELOG:Requirement #1
 
-RUN: cat %S/Output/diff.html | filecheck %s --check-prefix=CHECK-DIFF
+RUN: cat %T/diff.html | filecheck %s --check-prefix=CHECK-DIFF
 
 CHECK-DIFF:<span class="badge" text="UID"></span><span class="sdoc_pre_content">REQ-1</span>
 CHECK-DIFF:<span class="badge" text="child-relation"></span><div class="sdoc_pre_content"><b>REQ-2</b>

--- a/tests/integration/features/diff/21__requirements_relations__same_document__remove_parent_relation/test.itest
+++ b/tests/integration/features/diff/21__requirements_relations__same_document__remove_parent_relation/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>
@@ -30,7 +30,7 @@ CHECK-CHANGELOG:REQ-2
 CHECK-CHANGELOG:Requirement #2
 CHECK-CHANGELOG:System shall do 2.
 
-RUN: cat %S/Output/diff.html | filecheck %s --check-prefix=CHECK-DIFF
+RUN: cat %T/diff.html | filecheck %s --check-prefix=CHECK-DIFF
 
 CHECK-DIFF:<span class="badge" text="UID"></span><span class="sdoc_pre_content">REQ-1</span>
 CHECK-DIFF:<span class="badge" text="child-relation"></span><div class="sdoc_pre_content"><b>REQ-2</b>

--- a/tests/integration/features/diff/22__requirements_relations__two_docs__add_child_relation/test.itest
+++ b/tests/integration/features/diff/22__requirements_relations__two_docs__add_child_relation/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>
@@ -30,7 +30,7 @@ CHECK-CHANGELOG:System shall do 1.
 CHECK-CHANGELOG:text="child-relation"{{.*}}REQ-2
 CHECK-CHANGELOG:Requirement #2
 
-RUN: cat %S/Output/diff.html | filecheck %s --check-prefix=CHECK-DIFF
+RUN: cat %T/diff.html | filecheck %s --check-prefix=CHECK-DIFF
 
 # The left document: no specific assertions.
 CHECK-DIFF: modified="left"

--- a/tests/integration/features/diff/50a__sections__from_empty_doc_to_one_section/test.itest
+++ b/tests/integration/features/diff/50a__sections__from_empty_doc_to_one_section/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
 NOTE: This ensures that the output HTML indeed contains a green diff line
       produced from comparing the old and the modified requirement statement.
 

--- a/tests/integration/features/diff/50b__sections__from_empty_doc_to_one_section/test.itest
+++ b/tests/integration/features/diff/50b__sections__from_empty_doc_to_one_section/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
 NOTE: This ensures that the output HTML indeed contains a green diff line
       produced from comparing the old and the modified requirement statement.
 

--- a/tests/integration/features/diff/51__sections__from_one_section_to_empty_doc/test.itest
+++ b/tests/integration/features/diff/51__sections__from_one_section_to_empty_doc/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
 NOTE: This ensures that the output HTML indeed contains a green diff line
       produced from comparing the old and the modified requirement statement.
 

--- a/tests/integration/features/diff/52__sections__modify_free_text/test.itest
+++ b/tests/integration/features/diff/52__sections__modify_free_text/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
 NOTE: This ensures that the output HTML indeed contains a green diff line
       produced from comparing the old and the modified requirement statement.
 

--- a/tests/integration/features/diff/53__sections__modify_free_text_unmatched/test.itest
+++ b/tests/integration/features/diff/53__sections__modify_free_text_unmatched/test.itest
@@ -1,9 +1,9 @@
 # FIXME
 UNSUPPORTED: true
 
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
 
 NOTE: The LHS and RHS Sections do not have a UID, so StrictDoc cannot match that
       it is just one node that is being changed. The expectation is that there

--- a/tests/integration/features/diff/54__sections__add_free_text/test.itest
+++ b/tests/integration/features/diff/54__sections__add_free_text/test.itest
@@ -1,9 +1,9 @@
 # FIXME
 UNSUPPORTED: true
 
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 NOTE: This ensures that the output HTML indeed contains a green diff line
       produced from comparing the old and the modified requirement statement.
 

--- a/tests/integration/features/diff/55__sections__change_title/test.itest
+++ b/tests/integration/features/diff/55__sections__change_title/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 NOTE: This ensures that the output HTML indeed contains a green diff line
       produced from comparing the old and the modified requirement statement.
 

--- a/tests/integration/features/diff/56__sections__remove_section/test.itest
+++ b/tests/integration/features/diff/56__sections__remove_section/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 NOTE: This ensures that the output HTML indeed contains a green diff line
       produced from comparing the old and the modified requirement statement.
 

--- a/tests/integration/features/diff/80__documents__changed_text_node/test.itest
+++ b/tests/integration/features/diff/80__documents__changed_text_node/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>2</div>

--- a/tests/integration/features/diff/81__documents__changed_free_text_and_renamed_document/test.itest
+++ b/tests/integration/features/diff/81__documents__changed_free_text_and_renamed_document/test.itest
@@ -1,9 +1,9 @@
 # FIXME
 UNSUPPORTED: true
 
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>2</div>

--- a/tests/integration/features/diff/82__documents__add_free_text/test.itest
+++ b/tests/integration/features/diff/82__documents__add_free_text/test.itest
@@ -1,9 +1,9 @@
 # FIXME
 UNSUPPORTED: true
 
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>

--- a/tests/integration/features/diff/83__documents__add_uid/test.itest
+++ b/tests/integration/features/diff/83__documents__add_uid/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>

--- a/tests/integration/features/diff/97__all_nodes__ensure_order_when_several_changes/test.itest
+++ b/tests/integration/features/diff/97__all_nodes__ensure_order_when_several_changes/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --dump-input=fail --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>4</div>

--- a/tests/integration/features/diff/_mid_match/01__mid_match__requirements__from_requirement_to_requirement_no_uid/test.itest
+++ b/tests/integration/features/diff/_mid_match/01__mid_match__requirements__from_requirement_to_requirement_no_uid/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>

--- a/tests/integration/features/diff/_mid_match/10__mid_match__sections__from_section_to_section_modify_title/test.itest
+++ b/tests/integration/features/diff/_mid_match/10__mid_match__sections__from_section_to_section_modify_title/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>

--- a/tests/integration/features/diff/_mid_match/20__mid_match__document__from_document_to_document_changed_path/test.itest
+++ b/tests/integration/features/diff/_mid_match/20__mid_match__document__from_document_to_document_changed_path/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>1</div>

--- a/tests/integration/features/diff/_mid_match/21__mid_match__document__from_document_to_document_changed_free_text/test.itest
+++ b/tests/integration/features/diff/_mid_match/21__mid_match__document__from_document_to_document_changed_free_text/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-key">Nodes modified</div>
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-value"{{.*}}>2</div>

--- a/tests/integration/features/diff/_mid_match/22__mid_match__document__from_document_to_document_changed_free_text_and_title/test.itest
+++ b/tests/integration/features/diff/_mid_match/22__mid_match__document__from_document_to_document_changed_free_text_and_title/test.itest
@@ -1,8 +1,8 @@
-RUN: %strictdoc diff %S/lhs %S/rhs --output-dir Output
+RUN: cd %S && %strictdoc diff %S/lhs %S/rhs --output-dir %T
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
-RUN: cat %S/Output/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
+RUN: cat %T/changelog.html | filecheck %s --check-prefix=CHECK-CHANGELOG
 
 CHECK-CHANGELOG:<div class="sdoc-table_key_value-section">Summary of the changes</div>
 

--- a/tests/integration/features/document_fragments/--included-documents/included_documents_option_not_provided/test.itest
+++ b/tests/integration/features/document_fragments/--included-documents/included_documents_option_not_provided/test.itest
@@ -1,19 +1,19 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/included_documents_option_not_provided/_assets/file.svg"
-RUN: %check_exists --file "%S/Output/html/included_documents_option_not_provided/nested/_assets/file.svg"
-RUN: %check_exists --file "%S/Output/html/included_documents_option_not_provided/nested/subnested/_assets/file.svg"
+RUN: %check_exists --file "%T/html/included_documents_option_not_provided/_assets/file.svg"
+RUN: %check_exists --file "%T/html/included_documents_option_not_provided/nested/_assets/file.svg"
+RUN: %check_exists --file "%T/html/included_documents_option_not_provided/nested/subnested/_assets/file.svg"
 
-RUN: %check_exists --file "%S/Output/html/included_documents_option_not_provided/input.html"
-RUN: %check_exists --invert --file "%S/Output/html/included_documents_option_not_provided/nested/nested.html"
-RUN: %check_exists --invert --file "%S/Output/html/included_documents_option_not_provided/nested/subnested/subnested.html"
+RUN: %check_exists --file "%T/html/included_documents_option_not_provided/input.html"
+RUN: %check_exists --invert --file "%T/html/included_documents_option_not_provided/nested/nested.html"
+RUN: %check_exists --invert --file "%T/html/included_documents_option_not_provided/nested/subnested/subnested.html"
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --check-prefix CHECK-PROJECT-TREE
+RUN: %cat %T/html/index.html | filecheck %s --check-prefix CHECK-PROJECT-TREE
 CHECK-PROJECT-TREE-NOT: nested
 CHECK-PROJECT-TREE-NOT: subnested
 
-RUN: %cat %S/Output/html/included_documents_option_not_provided/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/included_documents_option_not_provided/input.html | filecheck %s --check-prefix CHECK-HTML
 
 CHECK-HTML-NOT: nested
 CHECK-HTML-NOT: subnested

--- a/tests/integration/features/document_fragments/--included-documents/included_documents_option_provided/test.itest
+++ b/tests/integration/features/document_fragments/--included-documents/included_documents_option_provided/test.itest
@@ -1,15 +1,15 @@
-RUN: %strictdoc export %S --included-documents --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --included-documents --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/included_documents_option_provided/_assets/file.svg"
-RUN: %check_exists --file "%S/Output/html/included_documents_option_provided/nested/_assets/file.svg"
-RUN: %check_exists --file "%S/Output/html/included_documents_option_provided/nested/subnested/_assets/file.svg"
+RUN: %check_exists --file "%T/html/included_documents_option_provided/_assets/file.svg"
+RUN: %check_exists --file "%T/html/included_documents_option_provided/nested/_assets/file.svg"
+RUN: %check_exists --file "%T/html/included_documents_option_provided/nested/subnested/_assets/file.svg"
 
-RUN: %check_exists --file "%S/Output/html/included_documents_option_provided/input.html"
-RUN: %check_exists --file "%S/Output/html/included_documents_option_provided/nested/nested.html"
-RUN: %check_exists --file "%S/Output/html/included_documents_option_provided/nested/subnested/subnested.html"
+RUN: %check_exists --file "%T/html/included_documents_option_provided/input.html"
+RUN: %check_exists --file "%T/html/included_documents_option_provided/nested/nested.html"
+RUN: %check_exists --file "%T/html/included_documents_option_provided/nested/subnested/subnested.html"
 
-RUN: %cat %S/Output/html/included_documents_option_provided/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/included_documents_option_provided/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:data-level="0"
 CHECK-HTML:href="../included_documents_option_provided/input.html"
@@ -22,13 +22,13 @@ CHECK-HTML:data-level="1.1.1"
 CHECK-HTML:data-level="1.1.1.1"
 CHECK-HTML:data-level="1.1.1.1.1"
 
-RUN: %cat %S/Output/html/included_documents_option_provided/nested/nested.html | filecheck %s --dump-input=fail --check-prefix CHECK-NESTED-HTML
+RUN: %cat %T/html/included_documents_option_provided/nested/nested.html | filecheck %s --dump-input=fail --check-prefix CHECK-NESTED-HTML
 
 CHECK-NESTED-HTML:href="../../included_documents_option_provided/input.html"
 CHECK-NESTED-HTML:href="../../included_documents_option_provided/nested/nested.html"
 CHECK-NESTED-HTML:href="../../included_documents_option_provided/nested/subnested/subnested.html"
 
-RUN: %cat %S/Output/html/included_documents_option_provided/nested/subnested/subnested.html | filecheck %s --dump-input=fail --check-prefix CHECK-SUBNESTED-HTML
+RUN: %cat %T/html/included_documents_option_provided/nested/subnested/subnested.html | filecheck %s --dump-input=fail --check-prefix CHECK-SUBNESTED-HTML
 
 CHECK-SUBNESTED-HTML:href="../../../included_documents_option_provided/input.html"
 CHECK-SUBNESTED-HTML:href="../../../included_documents_option_provided/nested/nested.html"

--- a/tests/integration/features/document_fragments/04_nested_fragments/test.itest
+++ b/tests/integration/features/document_fragments/04_nested_fragments/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/04_nested_fragments/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/04_nested_fragments/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:data-level="1"
 CHECK-HTML:data-level="1.1"

--- a/tests/integration/features/document_fragments/05_nested_fragments_relations/test.itest
+++ b/tests/integration/features/document_fragments/05_nested_fragments_relations/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/05_nested_fragments_relations/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/05_nested_fragments_relations/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:data-level="1"
 CHECK-HTML:data-level="2"

--- a/tests/integration/features/document_fragments/10_nested_fragments_inserted_to_section/test.itest
+++ b/tests/integration/features/document_fragments/10_nested_fragments_inserted_to_section/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/10_nested_fragments_inserted_to_section/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/10_nested_fragments_inserted_to_section/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:data-level="1"
 CHECK-HTML:1.&nbsp;Section that nests a fragment

--- a/tests/integration/features/document_fragments/20_included_documents_in_nested_folders/test.itest
+++ b/tests/integration/features/document_fragments/20_included_documents_in_nested_folders/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --included-documents --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --included-documents --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/20_included_documents_in_nested_folders/_assets/file.svg"
-RUN: %check_exists --file "%S/Output/html/20_included_documents_in_nested_folders/nested/_assets/file.svg"
-RUN: %check_exists --file "%S/Output/html/20_included_documents_in_nested_folders/nested/subnested/_assets/file.svg"
+RUN: %check_exists --file "%T/html/20_included_documents_in_nested_folders/_assets/file.svg"
+RUN: %check_exists --file "%T/html/20_included_documents_in_nested_folders/nested/_assets/file.svg"
+RUN: %check_exists --file "%T/html/20_included_documents_in_nested_folders/nested/subnested/_assets/file.svg"
 
-RUN: %cat %S/Output/html/20_included_documents_in_nested_folders/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/20_included_documents_in_nested_folders/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:data-level="0"
 CHECK-HTML:href="../20_included_documents_in_nested_folders/input.html"
@@ -18,13 +18,13 @@ CHECK-HTML:data-level="1.1.1"
 CHECK-HTML:data-level="1.1.1.1"
 CHECK-HTML:data-level="1.1.1.1.1"
 
-RUN: %cat %S/Output/html/20_included_documents_in_nested_folders/nested/nested.html | filecheck %s --dump-input=fail --check-prefix CHECK-NESTED-HTML
+RUN: %cat %T/html/20_included_documents_in_nested_folders/nested/nested.html | filecheck %s --dump-input=fail --check-prefix CHECK-NESTED-HTML
 
 CHECK-NESTED-HTML:href="../../20_included_documents_in_nested_folders/input.html"
 CHECK-NESTED-HTML:href="../../20_included_documents_in_nested_folders/nested/nested.html"
 CHECK-NESTED-HTML:href="../../20_included_documents_in_nested_folders/nested/subnested/subnested.html"
 
-RUN: %cat %S/Output/html/20_included_documents_in_nested_folders/nested/subnested/subnested.html | filecheck %s --dump-input=fail --check-prefix CHECK-SUBNESTED-HTML
+RUN: %cat %T/html/20_included_documents_in_nested_folders/nested/subnested/subnested.html | filecheck %s --dump-input=fail --check-prefix CHECK-SUBNESTED-HTML
 
 CHECK-SUBNESTED-HTML:href="../../../20_included_documents_in_nested_folders/input.html"
 CHECK-SUBNESTED-HTML:href="../../../20_included_documents_in_nested_folders/nested/nested.html"

--- a/tests/integration/features/document_fragments/30_multiple_inclusion_of_document/test.itest
+++ b/tests/integration/features/document_fragments/30_multiple_inclusion_of_document/test.itest
@@ -1,8 +1,8 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/30_multiple_inclusion_of_document/input1.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-1
-RUN: %cat %S/Output/html/30_multiple_inclusion_of_document/input2.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-2
+RUN: %cat %T/html/30_multiple_inclusion_of_document/input1.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-1
+RUN: %cat %T/html/30_multiple_inclusion_of_document/input2.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-2
 
 CHECK-HTML-1:Hello world doc 1
 CHECK-HTML-1:Glossary...

--- a/tests/integration/features/document_fragments/_validations/01_document_file_path_must_be_sdoc/test.itest
+++ b/tests/integration/features/document_fragments/_validations/01_document_file_path_must_be_sdoc/test.itest
@@ -1,3 +1,3 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: [DOCUMENT_FROM_FILE]: A document file name must have ".sdoc" extension: nested.foo.

--- a/tests/integration/features/document_fragments/_validations/02_document_file_path_must_be_valid/test.itest
+++ b/tests/integration/features/document_fragments/_validations/02_document_file_path_must_be_valid/test.itest
@@ -1,3 +1,3 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: [DOCUMENT_FROM_FILE]: Path to a document file does not exist: nested.sdoc.

--- a/tests/integration/features/document_fragments/_validations/03_document_file_must_be_included_once/test.itest
+++ b/tests/integration/features/document_fragments/_validations/03_document_file_must_be_included_once/test.itest
@@ -1,3 +1,3 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: [DOCUMENT_FROM_FILE]: A multiple inclusion of a document is detected. A document that contains requirements or other nodes can be only included once: nested.sdoc.

--- a/tests/integration/features/doxygen/01_basic_export/test.itest
+++ b/tests/integration/features/doxygen/01_basic_export/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S --formats doxygen --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats doxygen --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Step 'Export SDoc' took: {{.*}} sec.
 
-RUN: %diff %S/strictdoc.tag %S/Output/doxygen/strictdoc.tag
+RUN: %diff %S/strictdoc.tag %T/doxygen/strictdoc.tag

--- a/tests/integration/features/excel/export/01_basic_excel_export/test.itest
+++ b/tests/integration/features/excel/export/01_basic_excel_export/test.itest
@@ -1,5 +1,5 @@
 RUN: %strictdoc export --formats=excel --output-dir=Output "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/excel/input.xlsx"
+RUN: %check_exists --file "%T/excel/input.xlsx"
 
-RUN: %excel_diff "%S/Output/excel/input.xlsx" "%S/expected/input.xlsx"
+RUN: %excel_diff "%T/excel/input.xlsx" "%S/expected/input.xlsx"

--- a/tests/integration/features/excel/export/02_no_reqs_to_export/test.itest
+++ b/tests/integration/features/excel/export/02_no_reqs_to_export/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=excel --output-dir Output "%S/input.sdoc" | filecheck %s
+RUN: %strictdoc export --formats=excel --output-dir %T "%S/input.sdoc" | filecheck %s
 
 CHECK: No requirement with UID, nothing to export into excel

--- a/tests/integration/features/excel/export/03_custom_fields_to_export/test.itest
+++ b/tests/integration/features/excel/export/03_custom_fields_to_export/test.itest
@@ -6,6 +6,6 @@ TODO: work with custom grammars.
 
 RUN: %strictdoc export --formats=excel --fields=uid,owner --output-dir=Output "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/excel/input.xlsx"
+RUN: %check_exists --file "%T/excel/input.xlsx"
 
-RUN: %excel_diff "%S/Output/excel/input.xlsx" "%S/expected/input.xlsx"
+RUN: %excel_diff "%T/excel/input.xlsx" "%S/expected/input.xlsx"

--- a/tests/integration/features/excel/export/04_custom_grammar_fields_to_export_fields_subset/test.itest
+++ b/tests/integration/features/excel/export/04_custom_grammar_fields_to_export_fields_subset/test.itest
@@ -1,6 +1,6 @@
 # Export only a subset of the fields
 RUN: %strictdoc export --formats=excel --fields=uid,owner --output-dir=Output "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/excel/input.xlsx"
+RUN: %check_exists --file "%T/excel/input.xlsx"
 
-RUN: %excel_diff "%S/Output/excel/input.xlsx" "%S/expected/input.xlsx"
+RUN: %excel_diff "%T/excel/input.xlsx" "%S/expected/input.xlsx"

--- a/tests/integration/features/excel/export/05_custom_grammar_fields_to_export_fields_default/test.itest
+++ b/tests/integration/features/excel/export/05_custom_grammar_fields_to_export_fields_default/test.itest
@@ -1,6 +1,6 @@
 ; export using --fields internal default (i.e. ["uid", "statement", "parent"])
 RUN: %strictdoc export --formats=excel --output-dir=Output "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/excel/input.xlsx"
+RUN: %check_exists --file "%T/excel/input.xlsx"
 
-RUN: %excel_diff "%S/Output/excel/input.xlsx" "%S/expected/input.xlsx"
+RUN: %excel_diff "%T/excel/input.xlsx" "%S/expected/input.xlsx"

--- a/tests/integration/features/excel/export/06_custom_grammar_fields_to_export_fields_all/test.itest
+++ b/tests/integration/features/excel/export/06_custom_grammar_fields_to_export_fields_all/test.itest
@@ -1,6 +1,6 @@
 ; Export all available fields
 RUN: %strictdoc export --formats=excel --fields="UID","RELATIONS","TITLE","STATEMENT","OWNER","PRIORITY" --output-dir=Output "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/excel/input.xlsx"
+RUN: %check_exists --file "%T/excel/input.xlsx"
 
-RUN: %excel_diff "%S/Output/excel/input.xlsx" "%S/expected/input.xlsx"
+RUN: %excel_diff "%T/excel/input.xlsx" "%S/expected/input.xlsx"

--- a/tests/integration/features/excel/export/07_custom_grammar_fields_to_export_fields_all_special/test.itest
+++ b/tests/integration/features/excel/export/07_custom_grammar_fields_to_export_fields_all_special/test.itest
@@ -1,6 +1,6 @@
 ; Export all available fields, extended with the special Parent and Comments variants
 RUN: %strictdoc export --formats=excel --fields="UID","RELATIONS","PARENT","TITLE","STATEMENT","OWNER","PRIORITY","COMMENTS" --output-dir=Output "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/excel/input.xlsx"
+RUN: %check_exists --file "%T/excel/input.xlsx"
 
-RUN: %excel_diff "%S/Output/excel/input.xlsx" "%S/expected/input.xlsx"
+RUN: %excel_diff "%T/excel/input.xlsx" "%S/expected/input.xlsx"

--- a/tests/integration/features/excel/export/20_excel_export_multiple_docs/test.itest
+++ b/tests/integration/features/excel/export/20_excel_export_multiple_docs/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export --formats=excel --output-dir=Output .
+RUN: %strictdoc export --formats=excel --output-dir=Output %S
 
-RUN: %check_exists --file "%S/Output/excel/input1.xlsx"
-RUN: %check_exists --file "%S/Output/excel/input2.xlsx"
+RUN: %check_exists --file "%T/excel/input1.xlsx"
+RUN: %check_exists --file "%T/excel/input2.xlsx"
 
-RUN: %excel_diff "%S/Output/excel/input1.xlsx" "%S/expected/input1.xlsx"
-RUN: %excel_diff "%S/Output/excel/input2.xlsx" "%S/expected/input2.xlsx"
+RUN: %excel_diff "%T/excel/input1.xlsx" "%S/expected/input1.xlsx"
+RUN: %excel_diff "%T/excel/input2.xlsx" "%S/expected/input2.xlsx"

--- a/tests/integration/features/excel/import/01_import_basic_e2e/test.itest
+++ b/tests/integration/features/excel/import/01_import_basic_e2e/test.itest
@@ -1,6 +1,6 @@
-RUN: %mkdir %S/output
-RUN: %strictdoc import excel basic %S/input.xls %S/output/
-RUN: %diff %S/output/input.sdoc %S/expected/expected.sdoc
-RUN: %mkdir %S/output_xlsx
-RUN: %strictdoc import excel basic %S/input.xlsx %S/output_xlsx/
-RUN: %diff %S/output_xlsx/input.sdoc %S/expected_xslx/expected.sdoc
+RUN: %mkdir %T
+RUN: %strictdoc import excel basic %S/input.xls %T/
+RUN: %diff %T/input.sdoc %S/expected/expected.sdoc
+RUN: %mkdir %T_xlsx
+RUN: %strictdoc import excel basic %S/input.xlsx %T_xlsx/
+RUN: %diff %T_xlsx/input.sdoc %S/expected_xslx/expected.sdoc

--- a/tests/integration/features/file_traceability/01_basic_req_to_file_link_full_path/test.itest
+++ b/tests/integration/features/file_traceability/01_basic_req_to_file_link_full_path/test.itest
@@ -1,12 +1,12 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/01_basic_req_to_file_link_full_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/01_basic_req_to_file_link_full_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#1#2">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 
 # Left/aside panel: The requirement cell has a link that correctly points to the document file.
 CHECK-SOURCE-FILE: href="../01_basic_req_to_file_link_full_path/input.html#REQ-001"

--- a/tests/integration/features/file_traceability/02_basic_req_to_file_link_cwd_dot/test.itest
+++ b/tests/integration/features/file_traceability/02_basic_req_to_file_link_cwd_dot/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export . --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/02_basic_req_to_file_link_cwd_dot/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/02_basic_req_to_file_link_cwd_dot/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <link rel="stylesheet" href="../_static/base.css"/>
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#1#2">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../02_basic_req_to_file_link_cwd_dot/input.html#REQ-001"

--- a/tests/integration/features/file_traceability/03_basic_req_to_file_link_range/test.itest
+++ b/tests/integration/features/file_traceability/03_basic_req_to_file_link_range/test.itest
@@ -1,13 +1,13 @@
-RUN: %strictdoc export . --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/03_basic_req_to_file_link_range/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/03_basic_req_to_file_link_range/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <link rel="stylesheet" href="../_static/base.css"/>
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#2#4">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 
 CHECK-SOURCE-FILE: href="../03_basic_req_to_file_link_range/input.html#REQ-001"
 

--- a/tests/integration/features/file_traceability/04_input_is_single_file/test.itest
+++ b/tests/integration/features/file_traceability/04_input_is_single_file/test.itest
@@ -1,10 +1,10 @@
-RUN: %strictdoc export %S/input.sdoc --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S/input.sdoc --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/04_input_is_single_file/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/04_input_is_single_file/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#1#2">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../04_input_is_single_file/input.html#REQ-001"

--- a/tests/integration/features/file_traceability/05_multiple_files_per_requirement/test.itest
+++ b/tests/integration/features/file_traceability/05_multiple_files_per_requirement/test.itest
@@ -1,12 +1,12 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/05_multiple_files_per_requirement/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/05_multiple_files_per_requirement/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#1#2">
 CHECK-HTML: <a{{.*}}href="../_source_files/file2.py.html#REQ-001#1#2">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-RUN: %cat %S/Output/html/_source_files/file2.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file2.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../05_multiple_files_per_requirement/input.html#REQ-001"

--- a/tests/integration/features/file_traceability/06_prints_file_export_lines/test.itest
+++ b/tests/integration/features/file_traceability/06_prints_file_export_lines/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 CHECK: Generating source files
 CHECK: File: file.py ............................................... {{.*}}

--- a/tests/integration/features/file_traceability/07_utf8_symbols_in_source_files/test.itest
+++ b/tests/integration/features/file_traceability/07_utf8_symbols_in_source_files/test.itest
@@ -1,12 +1,12 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/07_utf8_symbols_in_source_files/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/07_utf8_symbols_in_source_files/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: href="../_source_files/file.py.html#REQ-001#1#7"
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../07_utf8_symbols_in_source_files/input.html#REQ-001"
 
 CHECK-SOURCE-FILE: # © A line with UTF-8 produces

--- a/tests/integration/features/file_traceability/08_nosdoc_pragma/test.itest
+++ b/tests/integration/features/file_traceability/08_nosdoc_pragma/test.itest
@@ -1,8 +1,8 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE-NOT: 3-5
 CHECK-SOURCE-FILE: 7-9

--- a/tests/integration/features/file_traceability/09_files_not_referenced_are_not_generated/test.itest
+++ b/tests/integration/features/file_traceability/09_files_not_referenced_are_not_generated/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: cd %S && %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: Published: Hello world doc
 CHECK-NOT: {{.*}}file.py{{.*}}

--- a/tests/integration/features/file_traceability/11_paths_with_windows_backward_slashes/test.itest
+++ b/tests/integration/features/file_traceability/11_paths_with_windows_backward_slashes/test.itest
@@ -4,15 +4,15 @@
 # The assumption is that the forward slashes everywhere should work fine on
 # Windows.
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/subdir/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/subdir/file.py.html"
 
-RUN: %cat %S/Output/html/11_paths_with_windows_backward_slashes/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/11_paths_with_windows_backward_slashes/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: href="../_source_files/subdir/file.py.html#REQ-001#1#2"
 CHECK-HTML: subdir/file.py
 
-RUN: %cat %S/Output/html/_source_files/subdir/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/subdir/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../../11_paths_with_windows_backward_slashes/input.html#REQ-001"
 CHECK-SOURCE-FILE: subdir/file.py

--- a/tests/integration/features/file_traceability/12_basic_req_to_file_link_full_path/test.itest
+++ b/tests/integration/features/file_traceability/12_basic_req_to_file_link_full_path/test.itest
@@ -1,10 +1,10 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/12_basic_req_to_file_link_full_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/12_basic_req_to_file_link_full_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: href="../_source_files/file.py.html#REQ-001#1#2"
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../12_basic_req_to_file_link_full_path/input.html#REQ-001"

--- a/tests/integration/features/file_traceability/13_file_link_to_a_file_with_empty_first_string/test.itest
+++ b/tests/integration/features/file_traceability/13_file_link_to_a_file_with_empty_first_string/test.itest
@@ -2,13 +2,13 @@
 # Requirement-to-File links edge case: Pygments ignore the first empty line in a file
 # https://github.com/strictdoc-project/strictdoc/issues/877.
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/13_file_link_to_a_file_with_empty_first_string/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/13_file_link_to_a_file_with_empty_first_string/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: href="../_source_files/file.py.html#REQ-001#1#3"
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../13_file_link_to_a_file_with_empty_first_string/input.html#REQ-001"

--- a/tests/integration/features/file_traceability/14_difference_in_range_links_to_this_and_other_files/test.itest
+++ b/tests/integration/features/file_traceability/14_difference_in_range_links_to_this_and_other_files/test.itest
@@ -1,15 +1,15 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: TEST DOCUMENT
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file1.py.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/file2.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file1.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file2.py.html"
 
 # This test is a BUGFIX for #990. The test asserts that the links to the ranges
 # in this file and the ranges in the other file are marked accordingly:
 # See the data-traceability-file-type which can take this_file or other_file
 # below. This attribute difference is used by JavaScript code.
 
-RUN: %cat %S/Output/html/_source_files/file1.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file1.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE:data-begin="5"
 CHECK-SOURCE-FILE:data-end="7"
 CHECK-SOURCE-FILE:data-traceability-file-type="this_file"

--- a/tests/integration/features/file_traceability/17_empty_source_file/test.itest
+++ b/tests/integration/features/file_traceability/17_empty_source_file/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Hello world doc
 
-RUN: %check_exists "%S/Output/html/source_coverage.html"
+RUN: %check_exists "%T/html/source_coverage.html"
 
-RUN: %cat "%S/Output/html/source_coverage.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-SOURCE-COVERAGE
+RUN: %cat "%T/html/source_coverage.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: src1
 CHECK-SOURCE-COVERAGE: test1.py
 
-RUN: %cat "%S/Output/html/_source_files/src1/test1.py.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-SOURCE-FILE
+RUN: %cat "%T/html/_source_files/src1/test1.py.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: Source file is empty.

--- a/tests/integration/features/file_traceability/18_several_newlines_at_end_of_file/test.itest
+++ b/tests/integration/features/file_traceability/18_several_newlines_at_end_of_file/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Hello world doc
 
-RUN: %check_exists "%S/Output/html/source_coverage.html"
+RUN: %check_exists "%T/html/source_coverage.html"
 
-RUN: %cat "%S/Output/html/source_coverage.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-SOURCE-COVERAGE
+RUN: %cat "%T/html/source_coverage.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: src1
 CHECK-SOURCE-COVERAGE: test1.py
 
-RUN: %cat "%S/Output/html/_source_files/src1/test1.py.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-SOURCE-FILE
+RUN: %cat "%T/html/_source_files/src1/test1.py.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: &quot;I am a file with several empty newlines.&quot;

--- a/tests/integration/features/file_traceability/19_no_newline_at_end_of_file/test.itest
+++ b/tests/integration/features/file_traceability/19_no_newline_at_end_of_file/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/19_no_newline_at_end_of_file/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/19_no_newline_at_end_of_file/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: href="../_source_files/file.py.html#REQ-001#1#3"
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../19_no_newline_at_end_of_file/input.html#REQ-001"
 CHECK-SOURCE-FILE: <pre class="highlight"><span class="mi">123123</span>  <span class="c1"># noqa: W292, B018</span></pre>

--- a/tests/integration/features/file_traceability/20_skip_invalid_utf8/test.itest
+++ b/tests/integration/features/file_traceability/20_skip_invalid_utf8/test.itest
@@ -1,7 +1,7 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
 # invalid_file.* was created with echo "00 08 00 00" | xxd -r -p > file.bin
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: warning: Skip tracing binary file {{.*}}invalid_file.bin
 CHECK: Reading source: {{.*}}invalid_file.bin
 CHECK: warning: Skip tracing binary file {{.*}}invalid_file.c
@@ -12,7 +12,7 @@ CHECK: Reading source: {{.*}}invalid_file.py
 CHECK: Reading source: {{.*}}invalid_file.robot
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/20_skip_invalid_utf8/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/20_skip_invalid_utf8/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: href="../_source_files/file.py.html#REQ-001#1#2">

--- a/tests/integration/features/file_traceability/30_path_to_source_files_option/test.itest
+++ b/tests/integration/features/file_traceability/30_path_to_source_files_option/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/30_path_to_source_files_option/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/30_path_to_source_files_option/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: href="../_source_files/file.py.html#REQ-001#1#2"
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../30_path_to_source_files_option/input.html#REQ-001"
 CHECK-SOURCE-FILE: <span class="c1"># noqa: T201</span></pre>

--- a/tests/integration/features/file_traceability/31_relative_path_to_source_files_option/test.itest
+++ b/tests/integration/features/file_traceability/31_relative_path_to_source_files_option/test.itest
@@ -1,11 +1,11 @@
-RUN: (cd %S/root && %strictdoc export %S/root --output-dir Output | filecheck %s --dump-input=fail)
+RUN: (cd %S/root && %strictdoc export %S/root --output-dir %T | filecheck %s --dump-input=fail)
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/root/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/root/Output/html/root/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/root/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: href="../_source_files/file.py.html#REQ-001#1#2"
 
-RUN: %cat %S/root/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../root/input.html#REQ-001"
 CHECK-SOURCE-FILE: <span class="c1"># noqa: T201</span></pre>

--- a/tests/integration/features/file_traceability/35_path_to_source_files_does_not_exist/test.itest
+++ b/tests/integration/features/file_traceability/35_path_to_source_files_does_not_exist/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: error: strictdoc.toml: 'source_root_path': Provided path does not exist: DOES_NOT_EXIST/.

--- a/tests/integration/features/file_traceability/37_source_root_and_include_source_paths/test.itest
+++ b/tests/integration/features/file_traceability/37_source_root_and_include_source_paths/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Expecting a error because the test2.py is filtered out by the
 # "include_source_paths" option.

--- a/tests/integration/features/file_traceability/50_line_marker/test.itest
+++ b/tests/integration/features/file_traceability/50_line_marker/test.itest
@@ -1,8 +1,8 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: [ 3 ]
 CHECK-SOURCE-FILE: [ 5-8 ]

--- a/tests/integration/features/file_traceability/60_file_range_with_line_range/test.itest
+++ b/tests/integration/features/file_traceability/60_file_range_with_line_range/test.itest
@@ -1,18 +1,18 @@
 NOTE: The first link is created from a forward marker, the second from a backward markers.
       Ensure that both links are identical from the UI perspective.
 
-RUN: %strictdoc export . --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/60_file_range_with_line_range/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/60_file_range_with_line_range/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <link rel="stylesheet" href="../_static/base.css"/>
 
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#2#4">
 CHECK-HTML: <a{{.*}}href="../_source_files/file2.py.html#REQ-001#2#4">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 
 CHECK-SOURCE-FILE: href="../60_file_range_with_line_range/input.html#REQ-001"
 
@@ -28,6 +28,6 @@ CHECK-SOURCE-FILE: href="../_source_files/file2.py.html#REQ-001#2#4"
 CHECK-SOURCE-FILE: <b>[ 2-4 ]</b>
 CHECK-SOURCE-FILE: file2.py, range
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 42.9
 CHECK-SOURCE-COVERAGE: 100.0

--- a/tests/integration/features/file_traceability/70_unregistered_file_extensions/test.itest
+++ b/tests/integration/features/file_traceability/70_unregistered_file_extensions/test.itest
@@ -1,14 +1,14 @@
-RUN: %strictdoc export . --output-dir Output | filecheck %s
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.unknown_extension.html"
+RUN: %check_exists --file "%T/html/_source_files/file.unknown_extension.html"
 
-RUN: %cat %S/Output/html/70_unregistered_file_extensions/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/70_unregistered_file_extensions/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <link rel="stylesheet" href="../_static/base.css"/>
 
 CHECK-HTML: <a{{.*}}href="../_source_files/file.unknown_extension.html#REQ-001#2#4"
 
-RUN: %cat %S/Output/html/_source_files/file.unknown_extension.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.unknown_extension.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 
 CHECK-SOURCE-FILE: href="../70_unregistered_file_extensions/input.html#REQ-001"
 
@@ -20,7 +20,7 @@ CHECK-SOURCE-FILE: href="../_source_files/file.unknown_extension.html#REQ-001#2#
 CHECK-SOURCE-FILE: <b>[ 2-4 ]</b>
 CHECK-SOURCE-FILE: file.unknown_extension, range
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: file.unknown_extension
 CHECK-SOURCE-COVERAGE: strictdoc.toml
 CHECK-SOURCE-COVERAGE: test.itest

--- a/tests/integration/features/file_traceability/80_auto_finding_of_lexers/test.itest
+++ b/tests/integration/features/file_traceability/80_auto_finding_of_lexers/test.itest
@@ -1,14 +1,14 @@
-RUN: %strictdoc export . --output-dir Output | filecheck %s
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.ml.html"
+RUN: %check_exists --file "%T/html/_source_files/file.ml.html"
 
-RUN: %cat %S/Output/html/80_auto_finding_of_lexers/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/80_auto_finding_of_lexers/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <link rel="stylesheet" href="../_static/base.css"/>
 
 CHECK-HTML: href="../_source_files/file.ml.html#REQ-001#3#5"
 
-RUN: %cat %S/Output/html/_source_files/file.ml.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.ml.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 
 # Ensure that the lexer is recognized correctly.
 CHECK-SOURCE-FILE: OCaml
@@ -23,7 +23,7 @@ CHECK-SOURCE-FILE: href="../_source_files/file.ml.html#REQ-001#3#5"
 CHECK-SOURCE-FILE: <b>[ 3-5 ]</b>
 CHECK-SOURCE-FILE: file.ml, range
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: file.ml
 CHECK-SOURCE-COVERAGE: strictdoc.toml
 CHECK-SOURCE-COVERAGE: test.itest

--- a/tests/integration/features/file_traceability/90_relation_keyword/test.itest
+++ b/tests/integration/features/file_traceability/90_relation_keyword/test.itest
@@ -1,13 +1,13 @@
-RUN: %strictdoc export . --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <link rel="stylesheet" href="../_static/base.css"/>
 CHECK-HTML: href="../_source_files/file.py.html#REQ-001#2#4"
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 
 CHECK-SOURCE-FILE: href="../90_relation_keyword/input.html#REQ-001"
 

--- a/tests/integration/features/file_traceability/_language_parsers/c/01_c_range/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/c/01_c_range/test.itest
@@ -1,14 +1,14 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.c.html"
+RUN: %check_exists --file "%T/html/_source_files/file.c.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#2#4">
-RUN: %cat %S/Output/html/_source_files/file.c.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.c.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../{{.*}}/input.html#REQ-1"
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 60.0

--- a/tests/integration/features/file_traceability/_language_parsers/c/02_c_function/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/c/02_c_function/test.itest
@@ -1,11 +1,11 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.c.html"
+RUN: %check_exists --file "%T/html/_source_files/file.c.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#3#10">
 CHECK-HTML: file.c, <i>lines: 3-10</i>, function hello_world
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#21#28">
@@ -13,7 +13,7 @@ CHECK-HTML: file.c, <i>lines: 21-28</i>, function hello_world_3
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#30#38">
 CHECK-HTML: file.c, <i>lines: 30-38</i>, function hello_world_4
 
-RUN: %cat %S/Output/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 
 CHECK-SOURCE-FILE: href="../_source_files/file.c.html#REQ-1#3#10"
 CHECK-SOURCE-FILE: <b>[ 3-10 ]</b>
@@ -37,5 +37,5 @@ CHECK-SOURCE-FILE: Requirement Statement #2
 CHECK-SOURCE-FILE: @relation(REQ-2, scope=function)
 
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 97.1

--- a/tests/integration/features/file_traceability/_language_parsers/c/03_c_forward_function/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/c/03_c_forward_function/test.itest
@@ -1,18 +1,18 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.c.html"
+RUN: %check_exists --file "%T/html/_source_files/file.c.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#3#10">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#3#10">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#12#19">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#21#28">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#30#38">
 
-RUN: %cat %S/Output/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 # Left panel.
 CHECK-SOURCE-FILE: <b>[ 3-10 ]</b>
 CHECK-SOURCE-FILE: file.c, function hello_world()
@@ -31,5 +31,5 @@ CHECK-SOURCE-FILE: 12 - 19 | function hello_world_2()
 CHECK-SOURCE-FILE: 21 - 28 | function hello_world_3()
 CHECK-SOURCE-FILE: 30 - 38 | function hello_world_4()
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 97.1

--- a/tests/integration/features/file_traceability/_language_parsers/c/04_c_file/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/c/04_c_file/test.itest
@@ -1,15 +1,15 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.c.html"
+RUN: %check_exists --file "%T/html/_source_files/file.c.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#1#11">
 CHECK-HTML: file.c, <i>lines: 1-11</i>, entire file
 
-RUN: %cat %S/Output/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 
 #
 # Left panel.
@@ -27,5 +27,5 @@ CHECK-SOURCE-FILE: file.c, entire file
 #
 CHECK-SOURCE-FILE: 1 - 11 | entire file
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 100.0

--- a/tests/integration/features/file_traceability/_language_parsers/c/05_c_header_function/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/c/05_c_header_function/test.itest
@@ -1,17 +1,17 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.h.html"
+RUN: %check_exists --file "%T/html/_source_files/file.h.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.h.html#REQ-1#3#8">
 CHECK-HTML: file.h, <i>lines: 3-8</i>, function hello_world_1
 CHECK-HTML: <a{{.*}}href="../_source_files/file.h.html#REQ-2#10#15">
 CHECK-HTML: file.h, <i>lines: 10-15</i>, function hello_world_2
 
-RUN: %cat %S/Output/html/_source_files/file.h.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.h.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 
 CHECK-SOURCE-FILE: href="../_source_files/file.h.html#REQ-1#3#8"
 CHECK-SOURCE-FILE: <b>[ 3-8 ]</b>
@@ -21,5 +21,5 @@ CHECK-SOURCE-FILE: href="../_source_files/file.h.html#REQ-2#10#15"
 CHECK-SOURCE-FILE: <b>[ 10-15 ]</b>
 CHECK-SOURCE-FILE: file.h, function hello_world_2
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 92.3

--- a/tests/integration/features/file_traceability/_language_parsers/c/06_c_c_and_h_pair/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/c/06_c_c_and_h_pair/test.itest
@@ -1,17 +1,17 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.h.html"
+RUN: %check_exists --file "%T/html/_source_files/file.h.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.h.html#REQ-1#3#8">
 CHECK-HTML: file.h, <i>lines: 3-8</i>, function hello_world_1
 CHECK-HTML: <a{{.*}}href="../_source_files/file.h.html#REQ-2#10#15">
 CHECK-HTML: file.h, <i>lines: 10-15</i>, function hello_world_2
 
-RUN: %cat %S/Output/html/_source_files/file.h.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.h.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 
 CHECK-SOURCE-FILE: href="../_source_files/file.c.html#REQ-1#3#8"
 CHECK-SOURCE-FILE: <b>[ 3-8 ]</b>
@@ -33,5 +33,5 @@ CHECK-SOURCE-FILE: file.h, function hello_world_2
 CHECK-SOURCE-FILE: 3 - 8 | function hello_world_1()
 CHECK-SOURCE-FILE: 10 - 15 | function hello_world_2()
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 92.3

--- a/tests/integration/features/file_traceability/_language_parsers/c/07_c_definition_and_declaration_in_the_same_file/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/c/07_c_definition_and_declaration_in_the_same_file/test.itest
@@ -1,11 +1,11 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.c.html"
+RUN: %check_exists --file "%T/html/_source_files/file.c.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#3#8">
 CHECK-HTML: file.c, <i>lines: 3-8</i>, function hello_world_1
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#17#22">
@@ -15,7 +15,7 @@ CHECK-HTML: file.c, <i>lines: 10-15</i>, function hello_world_2
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-2#24#29">
 CHECK-HTML: file.c, <i>lines: 24-29</i>, function hello_world_2
 
-RUN: %cat %S/Output/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../_source_files/file.c.html#REQ-1#3#8"
 CHECK-SOURCE-FILE: <b>[ 3-8 ]</b>
 CHECK-SOURCE-FILE: file.c, function hello_world_1
@@ -33,5 +33,5 @@ CHECK-SOURCE-FILE: <b>[ 24-29 ]</b>
 CHECK-SOURCE-FILE: file.c, function hello_world_2
 
 FIXME: The coverage will change.
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 96.0

--- a/tests/integration/features/file_traceability/_language_parsers/c/08_c_static_definition_in_a_file/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/c/08_c_static_definition_in_a_file/test.itest
@@ -1,17 +1,17 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.c.html"
+RUN: %check_exists --file "%T/html/_source_files/file.c.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#3#10">
 CHECK-HTML: file.c, <i>lines: 3-10</i>, function hello_world_1
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-2#12#19">
 CHECK-HTML: file.c, <i>lines: 12-19</i>, function hello_world_2
 
-RUN: %cat %S/Output/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../_source_files/file.c.html#REQ-1#3#10"
 CHECK-SOURCE-FILE: <b>[ 3-10 ]</b>
 CHECK-SOURCE-FILE: file.c, function hello_world_1
@@ -20,5 +20,5 @@ CHECK-SOURCE-FILE: href="../_source_files/file.c.html#REQ-2#12#19"
 CHECK-SOURCE-FILE: <b>[ 12-19 ]</b>
 CHECK-SOURCE-FILE: file.c, function hello_world_2
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 94.1

--- a/tests/integration/features/file_traceability/_language_parsers/c/09_c_static_declaration_in_a_file/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/c/09_c_static_declaration_in_a_file/test.itest
@@ -1,17 +1,17 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.c.html"
+RUN: %check_exists --file "%T/html/_source_files/file.c.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#3#8">
 CHECK-HTML: file.c, <i>lines: 3-8</i>, function hello_world_1
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-2#10#15">
 CHECK-HTML: file.c, <i>lines: 10-15</i>, function hello_world_2
 
-RUN: %cat %S/Output/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../_source_files/file.c.html#REQ-1#3#8"
 CHECK-SOURCE-FILE: <b>[ 3-8 ]</b>
 CHECK-SOURCE-FILE: file.c, function hello_world_1
@@ -21,5 +21,5 @@ CHECK-SOURCE-FILE: <b>[ 10-15 ]</b>
 CHECK-SOURCE-FILE: file.c, function hello_world_2
 
 FIXME: The coverage will change.
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 92.3

--- a/tests/integration/features/file_traceability/_language_parsers/c/10_c_c_and_h_pair_static_declaration/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/c/10_c_c_and_h_pair_static_declaration/test.itest
@@ -1,18 +1,18 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file2.c.html"
-RUN: %check_exists --file --invert "%S/Output/html/_source_files/file.c.html"
+RUN: %check_exists --file "%T/html/_source_files/file2.c.html"
+RUN: %check_exists --file --invert "%T/html/_source_files/file.c.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file2.c.html#REQ-1#3#8">
 CHECK-HTML: file2.c, <i>lines: 3-8</i>, function hello_world_1
 CHECK-HTML: <a{{.*}}href="../_source_files/file2.c.html#REQ-2#10#15">
 CHECK-HTML: file2.c, <i>lines: 10-15</i>, function hello_world_2
 
-RUN: %cat %S/Output/html/_source_files/file2.c.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file2.c.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../_source_files/file2.c.html#REQ-1#3#8"
 CHECK-SOURCE-FILE: <b>[ 3-8 ]</b>
 CHECK-SOURCE-FILE: file2.c, function hello_world_1
@@ -21,5 +21,5 @@ CHECK-SOURCE-FILE: href="../_source_files/file2.c.html#REQ-2#10#15"
 CHECK-SOURCE-FILE: <b>[ 10-15 ]</b>
 CHECK-SOURCE-FILE: file2.c, function hello_world_2
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 92.3

--- a/tests/integration/features/file_traceability/_language_parsers/c/20_c_backward_and_forward_functions/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/c/20_c_backward_and_forward_functions/test.itest
@@ -1,23 +1,23 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Reproducer
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.c.html"
+RUN: %check_exists --file "%T/html/_source_files/file.c.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#1#55">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#1#55">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#3#10">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#32#32">
 CHECK-HTML: <a{{.*}}href="../_source_files/file2.c.html#REQ-1#1#8">
 
-RUN: %cat %S/Output/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: 1 - 55 | entire file
 CHECK-SOURCE-FILE: 3 - 10 | function foo()
 CHECK-SOURCE-FILE: 12 - 16 | range
 CHECK-SOURCE-FILE: 22 - 55 | function longFunctionName()
 CHECK-SOURCE-FILE: 32 - 32 | line
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 100.0

--- a/tests/integration/features/file_traceability/_language_parsers/cpp/01_cpp_class_function_declaration/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/cpp/01_cpp_class_function_declaration/test.itest
@@ -1,15 +1,15 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.hpp.html"
+RUN: %check_exists --file "%T/html/_source_files/file.hpp.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.hpp.html#REQ-1#4#5">
 
-RUN: %cat %S/Output/html/_source_files/file.hpp.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.hpp.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../{{.*}}/input.html#REQ-1"
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 33.3

--- a/tests/integration/features/file_traceability/_language_parsers/cpp/02_cpp_class_function_declaration_and_definition/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/cpp/02_cpp_class_function_declaration_and_definition/test.itest
@@ -1,16 +1,16 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.hpp.html"
+RUN: %check_exists --file "%T/html/_source_files/file.hpp.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.cpp.html#REQ-1#1#3">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.hpp.html#REQ-1#4#5">
 
-RUN: %cat %S/Output/html/_source_files/file.hpp.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.hpp.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../{{.*}}/input.html#REQ-1"
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 33.3

--- a/tests/integration/features/file_traceability/_language_parsers/cpp/03_cpp_overloaded_constructors/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/cpp/03_cpp_overloaded_constructors/test.itest
@@ -1,11 +1,11 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.hpp.html"
+RUN: %check_exists --file "%T/html/_source_files/file.hpp.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.cpp.html#REQ-1#3#5">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.cpp.html#REQ-1#7#9">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.cpp.html#REQ-1#11#13">
@@ -13,9 +13,9 @@ CHECK-HTML: <a{{.*}}href="../_source_files/file.hpp.html#REQ-1#4#5">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.hpp.html#REQ-1#6#7">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.hpp.html#REQ-1#8#9">
 
-RUN: %cat %S/Output/html/_source_files/file.hpp.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.hpp.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../{{.*}}/input.html#REQ-1"
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 90.0
 CHECK-SOURCE-COVERAGE: 60.0

--- a/tests/integration/features/file_traceability/_language_parsers/python/01_python_range/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/python/01_python_range/test.itest
@@ -1,19 +1,19 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#2#4">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../{{.*}}/input.html#REQ-1"
 CHECK-SOURCE-FILE: href="../_source_files/file.py.html#REQ-1#2#4"
 CHECK-SOURCE-FILE: title="lines 2-4 in file file.py"
 CHECK-SOURCE-FILE: <b>[ 2-4 ]</b>
 CHECK-SOURCE-FILE: file.py, range
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 75.0

--- a/tests/integration/features/file_traceability/_language_parsers/python/02_python_function/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/python/02_python_function/test.itest
@@ -1,19 +1,19 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#1#13">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#7#9">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#11#13">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: 1 - 13 | function hello_world()
 CHECK-SOURCE-FILE: 7 - 9 | range
 CHECK-SOURCE-FILE: 11 - 13 | range
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 85.7

--- a/tests/integration/features/file_traceability/_language_parsers/python/03_python_forward_function/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/python/03_python_forward_function/test.itest
@@ -1,20 +1,20 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#1#10">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#1#10">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#5#10">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#7#7">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: 1 - 10 | function hello_world()
 CHECK-SOURCE-FILE: 5 - 10 | range
 CHECK-SOURCE-FILE: 7 - 7 | line
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 83.3

--- a/tests/integration/features/file_traceability/_language_parsers/python/04_python_forward_function_in_class/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/python/04_python_forward_function_in_class/test.itest
@@ -1,18 +1,18 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#7#16">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#7#16">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#11#16">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#13#13">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-2#4#5">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 
 CHECK-SOURCE-FILE: <b>[ 7-16 ]</b>
 CHECK-SOURCE-FILE: file.py, function Foo.hello_world
@@ -29,5 +29,5 @@ CHECK-SOURCE-FILE: file.py, line
 CHECK-SOURCE-FILE: <b>[ 4-5 ]</b>
 CHECK-SOURCE-FILE: file.py, function Foo.Bar.Baz.hello_world
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 70.6

--- a/tests/integration/features/file_traceability/_language_parsers/python/05_python_class/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/python/05_python_class/test.itest
@@ -1,15 +1,15 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#1#9">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-2#1#9">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../_source_files/file.py.html#REQ-1#1#9"
 CHECK-SOURCE-FILE: <b>[ 1-9 ]</b>
 CHECK-SOURCE-FILE: file.py, class Foo
@@ -18,5 +18,5 @@ CHECK-SOURCE-FILE: href="../_source_files/file.py.html#REQ-2#1#9"
 CHECK-SOURCE-FILE: <b>[ 1-9 ]</b>
 CHECK-SOURCE-FILE: file.py, class Foo
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 80.0

--- a/tests/integration/features/file_traceability/_language_parsers/python/06_python_file/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/python/06_python_file/test.itest
@@ -1,16 +1,16 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output
+RUN: %strictdoc export %S --output-dir %T
 | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#1#14">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../_source_files/file.py.html#REQ-1#1#14"
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 100.0

--- a/tests/integration/features/file_traceability/_language_parsers/python/07_python_decorated/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/python/07_python_decorated/test.itest
@@ -1,14 +1,14 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#18#24">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../_source_files/file.py.html#REQ-1#18#24"
 CHECK-SOURCE-FILE: <b>[ 18-24 ]</b>
 CHECK-SOURCE-FILE: file.py, function Foo.hello_world
@@ -29,5 +29,5 @@ CHECK-SOURCE-FILE: href="../_source_files/file.py.html#REQ-5#60#66"
 CHECK-SOURCE-FILE: <b>[ 60-66 ]</b>
 CHECK-SOURCE-FILE: file.py, function Foo.hello_world_decorated_four_times
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 50.0

--- a/tests/integration/features/file_traceability/_language_parsers/python/08_python_nested/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/python/08_python_nested/test.itest
@@ -1,14 +1,14 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#4#18">
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../_source_files/file.py.html#REQ-1#4#18"
 CHECK-SOURCE-FILE: <b>[ 4-18 ]</b>
 CHECK-SOURCE-FILE: file.py, function Foo.hello_world
@@ -29,5 +29,5 @@ CHECK-SOURCE-FILE: href="../_source_files/file.py.html#REQ-5#38#42"
 CHECK-SOURCE-FILE: <b>[ 38-42 ]</b>
 CHECK-SOURCE-FILE: file.py, function Outer.Inner.hello_world
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 62.5

--- a/tests/integration/features/file_traceability/_language_parsers/robot/01_robot_range/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/robot/01_robot_range/test.itest
@@ -1,16 +1,16 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.robot.html"
+RUN: %check_exists --file "%T/html/_source_files/file.robot.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-1#5#7">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-1#12#15">
 
-RUN: %cat %S/Output/html/_source_files/file.robot.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.robot.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../{{.*}}/input.html#REQ-1"
 CHECK-SOURCE-FILE: href="../_source_files/file.robot.html##5#7"
 CHECK-SOURCE-FILE: href="../_source_files/file.robot.html##12#15"
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 50.0

--- a/tests/integration/features/file_traceability/_language_parsers/robot/02_robot_line/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/robot/02_robot_line/test.itest
@@ -1,16 +1,16 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.robot.html"
+RUN: %check_exists --file "%T/html/_source_files/file.robot.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-1#5#5">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-1#11#11">
 
-RUN: %cat %S/Output/html/_source_files/file.robot.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.robot.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../{{.*}}/input.html#REQ-1"
 CHECK-SOURCE-FILE: href="../_source_files/file.robot.html##5#5"
 CHECK-SOURCE-FILE: href="../_source_files/file.robot.html##11#11"
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 16.7

--- a/tests/integration/features/file_traceability/_language_parsers/robot/03_robot_function/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/robot/03_robot_function/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.robot.html"
+RUN: %check_exists --file "%T/html/_source_files/file.robot.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-1#5#8">
 CHECK-HTML: file.robot, <i>lines: 5-8</i>, function My Test()
 CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-1#10#12">
@@ -11,7 +11,7 @@ CHECK-HTML: file.robot, <i>lines: 10-12</i>, function My Other Test()
 CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-2#14#16">
 CHECK-HTML: file.robot, <i>lines: 14-16</i>, function Yet Another Test()
 
-RUN: %cat %S/Output/html/_source_files/file.robot.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.robot.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 # Left panel.
 CHECK-SOURCE-FILE: href="../_source_files/file.robot.html#REQ-1#5#8"
 CHECK-SOURCE-FILE: <b>[ 5-8 ]</b>
@@ -38,5 +38,5 @@ CHECK-SOURCE-FILE: Requirement Title #2
 CHECK-SOURCE-FILE: Yet Another Test
 CHECK-SOURCE-FILE: @relation(REQ-2, scope=function)
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 76.9

--- a/tests/integration/features/file_traceability/_language_parsers/robot/04_robot_forward_function/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/robot/04_robot_forward_function/test.itest
@@ -1,13 +1,13 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-1#5#7">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-1#9#11">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-2#5#7">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-2#9#11">
 
-RUN: %cat %S/Output/html/_source_files/file.robot.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.robot.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 # Left panel.
 CHECK-SOURCE-FILE: href="../_source_files/file.robot.html#REQ-1#5#7"
 CHECK-SOURCE-FILE: <b>[ 5-7 ]</b>
@@ -28,5 +28,5 @@ CHECK-SOURCE-FILE: 9 - 11 | function My Other Test()
 CHECK-SOURCE-FILE: 5 - 7 | function My Test()
 CHECK-SOURCE-FILE: 9 - 11 | function My Other Test()
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 66.7

--- a/tests/integration/features/file_traceability/_language_parsers/robot/05_robot_file/test.itest
+++ b/tests/integration/features/file_traceability/_language_parsers/robot/05_robot_file/test.itest
@@ -1,15 +1,15 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.robot.html"
+RUN: %check_exists --file "%T/html/_source_files/file.robot.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-1#1#9">
 CHECK-HTML: file.robot, <i>lines: 1-9</i>, entire file
 CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-2#1#9">
 CHECK-HTML: file.robot, <i>lines: 1-9</i>, entire file
 
-RUN: %cat %S/Output/html/_source_files/file.robot.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.robot.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 # Left panel.
 CHECK-SOURCE-FILE: href="../_source_files/file.robot.html#REQ-1#1#9"
 CHECK-SOURCE-FILE: <b>[ 1-9 ]</b>
@@ -21,5 +21,5 @@ CHECK-SOURCE-FILE: file.robot, entire file
 # Main source view.
 CHECK-SOURCE-FILE: 1 - 9 | entire file
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 100.0

--- a/tests/integration/features/file_traceability/_markers/01_basic_file_marker/test.itest
+++ b/tests/integration/features/file_traceability/_markers/01_basic_file_marker/test.itest
@@ -1,8 +1,8 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: [ 1-10 ]
 CHECK-SOURCE-FILE: [ 7-10 ]

--- a/tests/integration/features/file_traceability/_markers/02_file_marker_regression/test.itest
+++ b/tests/integration/features/file_traceability/_markers/02_file_marker_regression/test.itest
@@ -6,10 +6,10 @@ REQUIRES: PYTHON_39_OR_HIGHER
 # Bug: Source View screen: Entire file marker is one line off #2237
 # https://github.com/strictdoc-project/strictdoc/issues/2237
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: <span class="source__range-definition">1 - 9 | entire file</span>

--- a/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/test.itest
+++ b/tests/integration/features/file_traceability/_source_nodes/02_function_with_source_node/test.itest
@@ -1,12 +1,12 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
 
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/file.c.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/file.c.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: Test specification
 CHECK-HTML: TEST_DOC/tests/file.c/test_case_1
 CHECK-HTML: TEST_DOC/tests/file2.c/test_case_1
@@ -15,10 +15,10 @@ CHECK-HTML: tests/file.c, <i>lines: 3-20</i>, function test_case_1()
 CHECK-HTML: tests/file2.c, <i>lines: 3-20</i>, function test_case_1()
 CHECK-HTML: tests/subfolder/file3.c, <i>lines: 3-20</i>, function test_case_1()
 
-RUN: %cat %S/Output/html/_source_files/tests/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/tests/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 
 CHECK-SOURCE-FILE: TEST_DOC/tests/file.c/test_case_1
 CHECK-SOURCE-FILE: TEST_DOC/tests/file.c/test_case_2
 
-RUN: %cat %S/Output/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
+RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 97.3

--- a/tests/integration/features/file_traceability/error_handling/01_req_references_non_existing_file/test.itest
+++ b/tests/integration/features/file_traceability/error_handling/01_req_references_non_existing_file/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: error: Requirement REQ-001 references a file that does not exist: file.py.

--- a/tests/integration/features/file_traceability/error_handling/02_source_file_references_non_existing_req/test.itest
+++ b/tests/integration/features/file_traceability/error_handling/02_source_file_references_non_existing_req/test.itest
@@ -1,3 +1,3 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: Source file file.py references a requirement that does not exist: REQ-002.

--- a/tests/integration/features/file_traceability/file_roles/01_relations_with_role/test.itest
+++ b/tests/integration/features/file_traceability/file_roles/01_relations_with_role/test.itest
@@ -1,13 +1,13 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export . --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.c.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/file.txt.html"
+RUN: %check_exists --file "%T/html/_source_files/file.c.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.txt.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#1#2">
 CHECK-HTML: file.c, <i>lines: 1-2</i>, function extfoo

--- a/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/test.itest
+++ b/tests/integration/features/file_traceability/file_roles/02_forward_relations_with_role/test.itest
@@ -1,13 +1,13 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export . --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.c.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/file.py.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/file.txt.html"
+RUN: %check_exists --file "%T/html/_source_files/file.c.html"
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
+RUN: %check_exists --file "%T/html/_source_files/file.txt.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
 
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#1#1">
 CHECK-HTML: file.c, <i>lines: 1-1</i>, function foo

--- a/tests/integration/features/file_traceability/g1_file_types/10_tex/test.itest
+++ b/tests/integration/features/file_traceability/g1_file_types/10_tex/test.itest
@@ -1,10 +1,10 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Example: Traceability between requirements and source files
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.tex.html"
+RUN: %check_exists --file "%T/html/_source_files/file.tex.html"
 
-RUN: %cat %S/Output/html/10_tex/example.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/10_tex/example.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.tex.html#REQ-001#1#48">
 
-RUN: %cat %S/Output/html/_source_files/file.tex.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.tex.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../10_tex/example.html#REQ-001"

--- a/tests/integration/features/file_traceability/g1_file_types/20_jinja/test.itest
+++ b/tests/integration/features/file_traceability/g1_file_types/20_jinja/test.itest
@@ -1,12 +1,12 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Example: Traceability between requirements and source files
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.jinja2.html"
+RUN: %check_exists --file "%T/html/_source_files/file.jinja2.html"
 
-RUN: %cat %S/Output/html/20_jinja/example.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/20_jinja/example.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: href="../_source_files/file.jinja2.html#REQ-001#1#5">
 
-RUN: %cat %S/Output/html/_source_files/file.jinja2.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.jinja2.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 # Links to REQ-001, REQ-002, REQ-003 are correct.
 CHECK-SOURCE-FILE:href="../20_jinja/example.html#REQ-002"
 CHECK-SOURCE-FILE:href="../20_jinja/example.html#REQ-003"

--- a/tests/integration/features/file_traceability/g1_file_types/30_cc/test.itest
+++ b/tests/integration/features/file_traceability/g1_file_types/30_cc/test.itest
@@ -1,10 +1,10 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Example: Traceability between requirements and source files
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.cc.html"
+RUN: %check_exists --file "%T/html/_source_files/file.cc.html"
 
-RUN: %cat %S/Output/html/30_cc/example.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/30_cc/example.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: href="../_source_files/file.cc.html#REQ-001#1#8"
 
-RUN: %cat %S/Output/html/_source_files/file.cc.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.cc.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../30_cc/example.html#REQ-001"

--- a/tests/integration/features/file_traceability/g1_file_types/40_rst/test.itest
+++ b/tests/integration/features/file_traceability/g1_file_types/40_rst/test.itest
@@ -1,10 +1,10 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Example: Traceability between requirements and source files
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.rst.html"
+RUN: %check_exists --file "%T/html/_source_files/file.rst.html"
 
-RUN: %cat %S/Output/html/40_rst/example.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/40_rst/example.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.rst.html#REQ-001#1#6">
 
-RUN: %cat %S/Output/html/_source_files/file.rst.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.rst.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../40_rst/example.html#REQ-001"

--- a/tests/integration/features/file_traceability/g1_file_types/50_js/test.itest
+++ b/tests/integration/features/file_traceability/g1_file_types/50_js/test.itest
@@ -1,10 +1,10 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Example: Traceability between requirements and source files
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.js.html"
+RUN: %check_exists --file "%T/html/_source_files/file.js.html"
 
-RUN: %cat %S/Output/html/50_js/example.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/50_js/example.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.js.html#REQ-001#1#8">
 
-RUN: %cat %S/Output/html/_source_files/file.js.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.js.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../50_js/example.html#REQ-001"

--- a/tests/integration/features/file_traceability/g1_file_types/60_yaml/test.itest
+++ b/tests/integration/features/file_traceability/g1_file_types/60_yaml/test.itest
@@ -1,10 +1,10 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Example: Traceability between requirements and source files
 
-RUN: %check_exists --file "%S/Output/html/_source_files/file.yaml.html"
+RUN: %check_exists --file "%T/html/_source_files/file.yaml.html"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/example.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/example.html | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="../_source_files/file.yaml.html#REQ-001#1#5">
 
-RUN: %cat %S/Output/html/_source_files/file.yaml.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/file.yaml.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../60_yaml/example.html#REQ-001"

--- a/tests/integration/features/file_traceability/path_resolution/01_typical_docs_and_src_folders_setup/test.itest
+++ b/tests/integration/features/file_traceability/path_resolution/01_typical_docs_and_src_folders_setup/test.itest
@@ -4,13 +4,13 @@
 # src/ folder contains source files.
 # the .sdoc document references files in the src/ folder.
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: TEST DOCUMENT
 
-RUN: %check_exists --file "%S/Output/html/_source_files/src/file1.py.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/src/file2.py.html"
+RUN: %check_exists --file "%T/html/_source_files/src/file1.py.html"
+RUN: %check_exists --file "%T/html/_source_files/src/file2.py.html"
 
-RUN: %cat %S/Output/html/_source_files/src/file1.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/src/file1.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE:data-begin="5"
 CHECK-SOURCE-FILE:data-end="7"
 CHECK-SOURCE-FILE:data-traceability-file-type="this_file"

--- a/tests/integration/features/file_traceability/path_resolution/02_calling_project_with_sdoc_and_code_from_another_folder/test.itest
+++ b/tests/integration/features/file_traceability/path_resolution/02_calling_project_with_sdoc_and_code_from_another_folder/test.itest
@@ -6,13 +6,13 @@
 # - src/ folder contains source files.
 # the .sdoc document references files in the src/ folder.
 
-RUN: %strictdoc export %S/project --output-dir Output | filecheck %s
+RUN: %strictdoc export %S/project --output-dir %T | filecheck %s
 CHECK: Published: TEST DOCUMENT
 
-RUN: %check_exists --file "%S/Output/html/_source_files/src/file1.py.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/src/file2.py.html"
+RUN: %check_exists --file "%T/html/_source_files/src/file1.py.html"
+RUN: %check_exists --file "%T/html/_source_files/src/file2.py.html"
 
-RUN: %cat %S/Output/html/_source_files/src/file1.py.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+RUN: %cat %T/html/_source_files/src/file1.py.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE:data-begin="5"
 CHECK-SOURCE-FILE:data-end="7"
 CHECK-SOURCE-FILE:data-traceability-file-type="this_file"

--- a/tests/integration/features/html/--filter-requirements/01_basic_filter/test.itest
+++ b/tests/integration/features/html/--filter-requirements/01_basic_filter/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output --filter-requirements='("2" in node["TITLE"] or "4" in node["TITLE"])' | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T --filter-requirements='("2" in node["TITLE"] or "4" in node["TITLE"])' | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc
 
-RUN: %cat %S/Output/html/01_basic_filter/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
+RUN: %cat %T/html/01_basic_filter/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
 CHECK-HTML-DOC-NOT: Title #1
 CHECK-HTML-DOC: Title #2
 CHECK-HTML-DOC-NOT: Title #3

--- a/tests/integration/features/html/--filter-requirements/02_section_is_filtered_when_its_requirements_are_filtered/test.itest
+++ b/tests/integration/features/html/--filter-requirements/02_section_is_filtered_when_its_requirements_are_filtered/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output --filter-requirements='("1" in node["TITLE"] or "2" in node["TITLE"])' | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T --filter-requirements='("1" in node["TITLE"] or "2" in node["TITLE"])' | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc
 
-RUN: %cat %S/Output/html/02_section_is_filtered_when_its_requirements_are_filtered/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
+RUN: %cat %T/html/02_section_is_filtered_when_its_requirements_are_filtered/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
 CHECK-HTML-DOC: Title #1
 CHECK-HTML-DOC: Title #2
 CHECK-HTML-DOC-NOT: Title #3

--- a/tests/integration/features/html/--filter-requirements/03_all_parent_sections_are_filtered_when_its_requirements_are_filtered/test.itest
+++ b/tests/integration/features/html/--filter-requirements/03_all_parent_sections_are_filtered_when_its_requirements_are_filtered/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output --filter-requirements='("1" in node["TITLE"] or "2" in node["TITLE"])' | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T --filter-requirements='("1" in node["TITLE"] or "2" in node["TITLE"])' | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc
 
-RUN: %cat %S/Output/html/03_all_parent_sections_are_filtered_when_its_requirements_are_filtered/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
+RUN: %cat %T/html/03_all_parent_sections_are_filtered_when_its_requirements_are_filtered/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
 CHECK-HTML-DOC: Title #1
 CHECK-HTML-DOC: Title #2
 CHECK-HTML-DOC-NOT: Title #3

--- a/tests/integration/features/html/--filter-requirements/04_all_parent_sections_MUST_NOT_be_filtered_when_not_all_its_requirements_are_filtered/test.itest
+++ b/tests/integration/features/html/--filter-requirements/04_all_parent_sections_MUST_NOT_be_filtered_when_not_all_its_requirements_are_filtered/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output --filter-requirements='("1" in node["TITLE"] or "2" in node["TITLE"] or "5" in node["TITLE"])' | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T --filter-requirements='("1" in node["TITLE"] or "2" in node["TITLE"] or "5" in node["TITLE"])' | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc
 
-RUN: %cat %S/Output/html/04_all_parent_sections_MUST_NOT_be_filtered_when_not_all_its_requirements_are_filtered/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
+RUN: %cat %T/html/04_all_parent_sections_MUST_NOT_be_filtered_when_not_all_its_requirements_are_filtered/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
 CHECK-HTML-DOC: Title #1
 CHECK-HTML-DOC: Title #2
 CHECK-HTML-DOC: Title #5

--- a/tests/integration/features/html/--filter-requirements/_validations/01_incorrect_query/test.itest
+++ b/tests/integration/features/html/--filter-requirements/_validations/01_incorrect_query/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output --filter-requirements='BROKEN QUERY' | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T --filter-requirements='BROKEN QUERY' | filecheck %s --dump-input=fail
 CHECK: error: Cannot parse filter query.

--- a/tests/integration/features/html/--filter-sections/01_filter_non_nested_section/test.itest
+++ b/tests/integration/features/html/--filter-sections/01_filter_non_nested_section/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output --filter-sections='"MUST_BE_FILTERED" not in node["TITLE"]' | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T --filter-sections='"MUST_BE_FILTERED" not in node["TITLE"]' | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc
 
-RUN: %cat %S/Output/html/01_filter_non_nested_section/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
+RUN: %cat %T/html/01_filter_non_nested_section/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
 CHECK-HTML-DOC-NOT: MUST_BE_FILTERED
 CHECK-HTML-DOC-NOT: Title #1
 CHECK-HTML-DOC-NOT: Title #2

--- a/tests/integration/features/html/--filter-sections/02_filter_nested_section_parent/test.itest
+++ b/tests/integration/features/html/--filter-sections/02_filter_nested_section_parent/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc export %S --output-dir Output --filter-sections='"MUST_BE_FILTERED 2" not in node["TITLE"]' | filecheck %s --dump-input=fail
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
-RUN: %cat %S/Output/html/02_filter_nested_section_parent/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
+RUN: %strictdoc export %S --output-dir %T --filter-sections='"MUST_BE_FILTERED 2" not in node["TITLE"]' | filecheck %s --dump-input=fail
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/02_filter_nested_section_parent/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
 
 CHECK: Published: Hello world doc
 

--- a/tests/integration/features/html/--filter-sections/03_filter_nested_section/test.itest
+++ b/tests/integration/features/html/--filter-sections/03_filter_nested_section/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc export %S --output-dir Output --filter-sections='"MUST_BE_FILTERED 1" not in node["TITLE"]' | filecheck %s --dump-input=fail
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
-RUN: %cat %S/Output/html/03_filter_nested_section/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
+RUN: %strictdoc export %S --output-dir %T --filter-sections='"MUST_BE_FILTERED 1" not in node["TITLE"]' | filecheck %s --dump-input=fail
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/03_filter_nested_section/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
 
 CHECK: Published: Hello world doc
 

--- a/tests/integration/features/html/--filter-sections/_validations/01_incorrect_query/test.itest
+++ b/tests/integration/features/html/--filter-sections/_validations/01_incorrect_query/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output --filter-requirements='BROKEN QUERY' | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T --filter-requirements='BROKEN QUERY' | filecheck %s --dump-input=fail
 CHECK: error: Cannot parse filter query.

--- a/tests/integration/features/html/assets/01_asset_export/test.itest
+++ b/tests/integration/features/html/assets/01_asset_export/test.itest
@@ -1,10 +1,10 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --dir %S/Output/html/01_asset_export/_assets
-RUN: %check_exists --file %S/Output/html/01_asset_export/_assets/sandbox1.svg
+RUN: %check_exists --dir %T/html/01_asset_export/_assets
+RUN: %check_exists --file %T/html/01_asset_export/_assets/sandbox1.svg
 
-RUN: %check_exists --file %S/Output/html/01_asset_export/input.html
+RUN: %check_exists --file %T/html/01_asset_export/input.html
 
-RUN: %cat %S/Output/html/01_asset_export/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/01_asset_export/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <object class="image" data="_assets/sandbox1.svg" type="image/svg+xml">

--- a/tests/integration/features/html/assets/02_asset_export_single_sdoc_rel_path/test.itest
+++ b/tests/integration/features/html/assets/02_asset_export_single_sdoc_rel_path/test.itest
@@ -1,10 +1,10 @@
-RUN: %strictdoc export input.sdoc --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S/input.sdoc --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --dir %S/Output/html/02_asset_export_single_sdoc_rel_path/_assets
-RUN: %check_exists --file %S/Output/html/02_asset_export_single_sdoc_rel_path/_assets/sandbox1.svg
+RUN: %check_exists --dir %T/html/02_asset_export_single_sdoc_rel_path/_assets
+RUN: %check_exists --file %T/html/02_asset_export_single_sdoc_rel_path/_assets/sandbox1.svg
 
-RUN: %check_exists --file %S/Output/html/02_asset_export_single_sdoc_rel_path/input.html
+RUN: %check_exists --file %T/html/02_asset_export_single_sdoc_rel_path/input.html
 
-RUN: %cat %S/Output/html/02_asset_export_single_sdoc_rel_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/02_asset_export_single_sdoc_rel_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <object class="image" data="_assets/sandbox1.svg" type="image/svg+xml">

--- a/tests/integration/features/html/assets/03_asset_export_single_sdoc_full_path/test.itest
+++ b/tests/integration/features/html/assets/03_asset_export_single_sdoc_full_path/test.itest
@@ -1,10 +1,10 @@
-RUN: %strictdoc export %S/input.sdoc --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S/input.sdoc --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --dir %S/Output/html/03_asset_export_single_sdoc_full_path/_assets
-RUN: %check_exists --file %S/Output/html/03_asset_export_single_sdoc_full_path/_assets/sandbox1.svg
+RUN: %check_exists --dir %T/html/03_asset_export_single_sdoc_full_path/_assets
+RUN: %check_exists --file %T/html/03_asset_export_single_sdoc_full_path/_assets/sandbox1.svg
 
-RUN: %check_exists --file %S/Output/html/03_asset_export_single_sdoc_full_path/input.html
+RUN: %check_exists --file %T/html/03_asset_export_single_sdoc_full_path/input.html
 
-RUN: %cat %S/Output/html/03_asset_export_single_sdoc_full_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/03_asset_export_single_sdoc_full_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <object class="image" data="_assets/sandbox1.svg" type="image/svg+xml">

--- a/tests/integration/features/html/assets/05_asset_export_does_only_when_newer/test.itest
+++ b/tests/integration/features/html/assets/05_asset_export_does_only_when_newer/test.itest
@@ -1,14 +1,14 @@
-RUN: %strictdoc export %S/test_document --output-dir Output | filecheck %s --dump-input=fail --check-prefix=CHECK-FIRST-TIME
+RUN: %strictdoc export %S/test_document --output-dir %T | filecheck %s --dump-input=fail --check-prefix=CHECK-FIRST-TIME
 CHECK-FIRST-TIME: Copying StrictDoc's assets: {{.*}} files.
 CHECK-FIRST-TIME: Copying project assets "test_document{{.*}}_assets": 1 files.
 
-RUN: %check_exists --dir %S/Output/html/test_document/_assets
-RUN: %check_exists --file %S/Output/html/test_document/_assets/sandbox1.svg
+RUN: %check_exists --dir %T/html/test_document/_assets
+RUN: %check_exists --file %T/html/test_document/_assets/sandbox1.svg
 
-RUN: %cat %S/Output/html/test_document/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: %cat %T/html/test_document/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
 CHECK-HTML: <object class="image" data="_assets/sandbox1.svg" type="image/svg+xml">
 
 /// Not only sandbox1.svg but all other assets should not be copied again.
-RUN: %strictdoc export %S/test_document --output-dir Output | filecheck %s --dump-input=fail --check-prefix=CHECK-SECOND-TIME
+RUN: %strictdoc export %S/test_document --output-dir %T | filecheck %s --dump-input=fail --check-prefix=CHECK-SECOND-TIME
 CHECK-SECOND-TIME: Copying StrictDoc's assets: {{.*}} files ({{.*}} files skipped as non-modified).
 CHECK-SECOND-TIME: Copying project assets "test_document{{.*}}_assets": 1 files (1 files skipped as non-modified).

--- a/tests/integration/features/html/assets/20_asset_export_single_sdoc_double_includes_rel_path/test.itest
+++ b/tests/integration/features/html/assets/20_asset_export_single_sdoc_double_includes_rel_path/test.itest
@@ -1,10 +1,10 @@
-RUN: %strictdoc export . --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --dir %S/Output/html/20_asset_export_single_sdoc_double_includes_rel_path/_assets
-RUN: %check_exists --file %S/Output/html/20_asset_export_single_sdoc_double_includes_rel_path/_assets/sandbox1.svg
+RUN: %check_exists --dir %T/html/20_asset_export_single_sdoc_double_includes_rel_path/_assets
+RUN: %check_exists --file %T/html/20_asset_export_single_sdoc_double_includes_rel_path/_assets/sandbox1.svg
 
-RUN: %check_exists --file %S/Output/html/20_asset_export_single_sdoc_double_includes_rel_path/input.html
+RUN: %check_exists --file %T/html/20_asset_export_single_sdoc_double_includes_rel_path/input.html
 
-RUN: %cat %S/Output/html/20_asset_export_single_sdoc_double_includes_rel_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/20_asset_export_single_sdoc_double_includes_rel_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <object class="image" data="_assets/sandbox1.svg" type="image/svg+xml">

--- a/tests/integration/features/html/child_links/01_basic_compliance_matrix/test.itest
+++ b/tests/integration/features/html/child_links/01_basic_compliance_matrix/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail --check-prefix=CHECK
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail --check-prefix=CHECK
 CHECK: Published: Compliance matrix
 
 # The most important assertion of this test is that the supplier document is
 # rendered with all its requirements having the parent relations, even though
 # these parent relations do not exist in the supplier.sdoc file but are derived
 # from the child relations from the compliance_matrix.sdoc to this document
-RUN: cat %S/Output/html/01_basic_compliance_matrix/supplier.html | filecheck %s --dump-input=fail --check-prefix=CHECK-SUPPLIER
+RUN: cat %T/html/01_basic_compliance_matrix/supplier.html | filecheck %s --dump-input=fail --check-prefix=CHECK-SUPPLIER
 CHECK-SUPPLIER: <span class="requirement__parent-uid">REQ-COMPL-1</span>
 CHECK-SUPPLIER: Compliance to REQ-PARENT-1
 CHECK-SUPPLIER: <span class="requirement__parent-uid">REQ-COMPL-2</span>

--- a/tests/integration/features/html/child_links/02_child_link_not_registered_relation/test.itest
+++ b/tests/integration/features/html/child_links/02_child_link_not_registered_relation/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail --check-prefix=CHECK
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail --check-prefix=CHECK
 CHECK: Semantic error: Requirement relation type/role is not registered: Child.
 CHECK: Location: {{.*}}sample.sdoc:4:1
 CHECK: Hint: Problematic requirement: REQ-1.

--- a/tests/integration/features/html/child_links/03_child_link_does_not_exist/test.itest
+++ b/tests/integration/features/html/child_links/03_child_link_does_not_exist/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail --check-prefix=CHECK
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail --check-prefix=CHECK
 CHECK: error: [DocumentIndex.create] Requirement REQ-1 references a child requirement that doesn't exist: REQ-CHILD-1.

--- a/tests/integration/features/html/escaping/01_escape_input_from_sdoc/test.itest
+++ b/tests/integration/features/html/escaping/01_escape_input_from_sdoc/test.itest
@@ -1,16 +1,16 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail --check-prefix CHECK-EXPORT
+RUN: %strictdoc export %S --output-dir %T/ | filecheck %s --dump-input=fail --check-prefix CHECK-EXPORT
 CHECK-EXPORT: Published: <b>"escaping"&nbsp;'document title'</b>
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-INDEX
-RUN: %cat %S/Output/html/traceability_matrix.html | filecheck %s --dump-input=fail --check-prefix CHECK-TRACEABILITY-MATRIX
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-ALL
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-INPUT
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input-DEEP-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-ALL
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input-DEEP-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-DTR
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix CHECK-ALL
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix CHECK-TABLE
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-ALL
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-TRACE
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-INDEX
+RUN: %cat %T/html/traceability_matrix.html | filecheck %s --dump-input=fail --check-prefix CHECK-TRACEABILITY-MATRIX
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-ALL
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-INPUT
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input-DEEP-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-ALL
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input-DEEP-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-DTR
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix CHECK-ALL
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix CHECK-TABLE
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-ALL
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-TRACE
 
 # Project index: Document title.
 CHECK-INDEX: &lt;b&gt;&#34;escaping&#34;&amp;nbsp;&#39;document title&#39;&lt;/b&gt;

--- a/tests/integration/features/html/escaping/02_escape_input_from_src_file/test.itest
+++ b/tests/integration/features/html/escaping/02_escape_input_from_src_file/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail --check-prefix CHECK-EXPORT
+RUN: %strictdoc export %S --output-dir %T/ | filecheck %s --dump-input=fail --check-prefix CHECK-EXPORT
 CHECK-EXPORT: Published: HTML escaping of source file content
 
-RUN: %cat %S/Output/html/_source_files/file.py.html | filecheck %s --check-prefix CHECK-SRC
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --check-prefix CHECK-SRC
 
 # Line marker. Using a regex at the end to avoid StrictDoc's own documentation from tracing this file.
 CHECK-SRC: # &lt;b&gt;&quot;escaping&quot;&amp;nbsp;&#39;line mark&#39;&lt;/b&gt; {{.}}sdoc(REQ-1)

--- a/tests/integration/features/html/frontpage_document_meta/11_git_version_and_date/test.itest
+++ b/tests/integration/features/html/frontpage_document_meta/11_git_version_and_date/test.itest
@@ -13,7 +13,7 @@ RUN: echo $THIS_TMP_DIR
 RUN: cp %S/input.sdoc $THIS_TMP_DIR/
 
 RUN: git init --initial-branch=main
-RUN: %strictdoc export . --output-dir Output
+RUN: %strictdoc export . --output-dir Output/
 RUN: %cat "$THIS_TMP_DIR/Output/html/$THIS_TMP_DIR_NAME/input.html" | filecheck %s --dump-input=fail --check-prefix CHECK-1
 CHECK-1: N/A, N/A
 CHECK-1: N/A
@@ -23,14 +23,14 @@ RUN: git config user.email "test@example.com"
 RUN: git add .
 RUN: git commit -m "Initial commit"
 RUN: rm -rf Output/
-RUN: %strictdoc export . --output-dir Output
+RUN: %strictdoc export . --output-dir Output/
 RUN: %cat "$THIS_TMP_DIR/Output/html/$THIS_TMP_DIR_NAME/input.html" | filecheck %s --dump-input=fail --check-prefix CHECK-2
 CHECK-2: {{[a-f0-9]{7}}}, main
 CHECK-2: {{\d{4}-\d{2}-\d{2}}}, {{\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}}}
 
 RUN: git tag v1.0
 RUN: rm -rf Output/
-RUN: %strictdoc export . --output-dir Output
+RUN: %strictdoc export . --output-dir Output/
 RUN: %cat "$THIS_TMP_DIR/Output/html/$THIS_TMP_DIR_NAME/input.html" | filecheck %s --dump-input=fail --check-prefix CHECK-3
 CHECK-3: v1.0, main
 CHECK-3: {{\d{4}-\d{2}-\d{2}}}, {{\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}}}
@@ -39,7 +39,7 @@ RUN: touch foo
 RUN: git add .
 RUN: git commit -m "Second commit"
 RUN: rm -rf Output/
-RUN: %strictdoc export . --output-dir Output
+RUN: %strictdoc export . --output-dir Output/
 RUN: %cat "$THIS_TMP_DIR/Output/html/$THIS_TMP_DIR_NAME/input.html" | filecheck %s --dump-input=fail --check-prefix CHECK-4
 CHECK-4: v1.0-1-g{{[a-f0-9]{7}}}, main
 CHECK-4: {{\d{4}-\d{2}-\d{2}}}, {{\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}}}

--- a/tests/integration/features/html/grammar/01_custom_field/test.itest
+++ b/tests/integration/features/html/grammar/01_custom_field/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T/ | filecheck %s --dump-input=fail
 CHECK: Published: Test Document
 
-RUN: %cat %S/Output/html/01_custom_field/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/01_custom_field/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:META_TEST
 CHECK-HTML:Yes

--- a/tests/integration/features/html/grammar/02_custom_field_rendered_to_rst/test.itest
+++ b/tests/integration/features/html/grammar/02_custom_field_rendered_to_rst/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T/ | filecheck %s --dump-input=fail
 CHECK: Published: Test Document
 
-RUN: %cat %S/Output/html/02_custom_field_rendered_to_rst/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/02_custom_field_rendered_to_rst/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:<p>This custom field shall be rendered as RST:</p>
 CHECK-HTML:<a class="reference external" href="https://github.com/strictdoc-project/strictdoc">StrictDoc</a>

--- a/tests/integration/features/html/hello_world/01_minimal_document/test.itest
+++ b/tests/integration/features/html/hello_world/01_minimal_document/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc

--- a/tests/integration/features/html/hello_world/02_minimal_document_with_freetext/test.itest
+++ b/tests/integration/features/html/hello_world/02_minimal_document_with_freetext/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-CONTENT
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-CONTENT
 CHECK-CONTENT: Hello world!

--- a/tests/integration/features/html/incremental_generation/01_when_changes_regenerate_immediate_neighbours/test.itest
+++ b/tests/integration/features/html/incremental_generation/01_when_changes_regenerate_immediate_neighbours/test.itest
@@ -1,27 +1,27 @@
-RUN: %strictdoc export %S --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-FIRST
+RUN: %strictdoc export %S --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-FIRST
 CHECK-FIRST: Published: Child doc
 CHECK-FIRST: Published: Grandchild doc
 CHECK-FIRST: Published: Parent doc
 
-RUN: %strictdoc export %S --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-SECOND
+RUN: %strictdoc export %S --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-SECOND
 CHECK-SECOND: Skip: Child doc
 CHECK-SECOND: Skip: Grandchild doc
 CHECK-SECOND: Skip: Parent doc
 
 RUN: %touch %S/parent.sdoc
-RUN: %strictdoc export %S --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-THIRD
+RUN: %strictdoc export %S --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-THIRD
 CHECK-THIRD: Published: Child doc
 CHECK-THIRD: Skip: Grandchild doc
 CHECK-THIRD: Published: Parent doc
 
 RUN: %touch %S/child.sdoc
-RUN: %strictdoc export %S --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-FOURTH
+RUN: %strictdoc export %S --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-FOURTH
 CHECK-FOURTH: Published: Child doc
 CHECK-FOURTH: Published: Grandchild doc
 CHECK-FOURTH: Published: Parent doc
 
 RUN: %touch %S/grandchild.sdoc
-RUN: %strictdoc export %S --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-FIFTH
+RUN: %strictdoc export %S --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-FIFTH
 CHECK-FIFTH: Published: Child doc
 CHECK-FIFTH: Published: Grandchild doc
 CHECK-FIFTH: Skip: Parent doc

--- a/tests/integration/features/html/incremental_generation/03_when_new_child_generate_parents/test.itest
+++ b/tests/integration/features/html/incremental_generation/03_when_new_child_generate_parents/test.itest
@@ -2,28 +2,28 @@
 RUN: %mkdir %S/sandbox
 RUN: %cp %S/parent.sdoc %S/sandbox/
 
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-FIRST
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-FIRST
 CHECK-FIRST: Published: Parent doc
 
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-SECOND
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-SECOND
 CHECK-SECOND: Skip: Parent doc
 
 RUN: %cp %S/child.sdoc %S/sandbox/child.sdoc
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-THIRD
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-THIRD
 CHECK-THIRD: Published: Child doc
 CHECK-THIRD: Published: Parent doc
 
 RUN: %cp %S/grandchild.sdoc %S/sandbox/grandchild.sdoc
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-FOURTH
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-FOURTH
 CHECK-FOURTH: Published: Child doc
 CHECK-FOURTH: Published: Grandchild doc
 CHECK-FOURTH: Skip: Parent doc
 
 RUN: rm %S/sandbox/grandchild.sdoc
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-FIFTH
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-FIFTH
 CHECK-FIFTH: Published: Child doc
 CHECK-FIFTH: Skip: Parent doc
 
 RUN: rm %S/sandbox/child.sdoc
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-SIXTH
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-SIXTH
 CHECK-SIXTH: Published: Parent doc

--- a/tests/integration/features/html/incremental_generation/04_when_config_changes_generate_everything/test.itest
+++ b/tests/integration/features/html/incremental_generation/04_when_config_changes_generate_everything/test.itest
@@ -1,16 +1,16 @@
-RUN: %strictdoc export %S --no-parallelization --config %S/strictdoc.toml --output-dir Output | filecheck %s --dump-input=fail --check-prefix=CHECK-FIRST
+RUN: %strictdoc export %S --no-parallelization --config %S/strictdoc.toml --output-dir %T | filecheck %s --dump-input=fail --check-prefix=CHECK-FIRST
 CHECK-FIRST: Published: Parent doc
 CHECK-FIRST: Published: Child doc
 CHECK-FIRST: Published: Grandchild doc
 
-RUN: %strictdoc export %S --no-parallelization --config %S/strictdoc.toml --output-dir Output | filecheck %s --dump-input=fail --check-prefix=CHECK-SECOND
-RUN: %strictdoc export %S --no-parallelization --config %S/strictdoc.toml --output-dir Output | filecheck %s --dump-input=fail --check-prefix=CHECK-SECOND
+RUN: %strictdoc export %S --no-parallelization --config %S/strictdoc.toml --output-dir %T | filecheck %s --dump-input=fail --check-prefix=CHECK-SECOND
+RUN: %strictdoc export %S --no-parallelization --config %S/strictdoc.toml --output-dir %T | filecheck %s --dump-input=fail --check-prefix=CHECK-SECOND
 CHECK-SECOND: Skip: Parent doc
 CHECK-SECOND: Skip: Child doc
 CHECK-SECOND: Skip: Grandchild doc
 
 RUN: %touch %S/strictdoc.toml
-RUN: %strictdoc export %S --no-parallelization --config %S/strictdoc.toml --output-dir Output | filecheck %s --dump-input=fail --check-prefix=CHECK-THIRD
+RUN: %strictdoc export %S --no-parallelization --config %S/strictdoc.toml --output-dir %T | filecheck %s --dump-input=fail --check-prefix=CHECK-THIRD
 CHECK-THIRD: Published: Parent doc
 CHECK-THIRD: Published: Child doc
 CHECK-THIRD: Published: Grandchild doc

--- a/tests/integration/features/html/incremental_generation/20_sdoc_and_source_files_backward/test.itest
+++ b/tests/integration/features/html/incremental_generation/20_sdoc_and_source_files_backward/test.itest
@@ -7,26 +7,26 @@ RUN: %cp %S/child.sdoc %S/sandbox/
 RUN: %cp %S/grandchild.sdoc %S/sandbox/
 RUN: %cp %S/parent.sdoc %S/sandbox/
 
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-1
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-1
 CHECK-1: Published: Child doc
 CHECK-1: Published: Grandchild doc
 CHECK-1: Published: Parent doc
 
 RUN: %cp %S/src/file_refs_grandchild.py %S/sandbox/
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-2
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-2
 CHECK-2: Skip: Child doc
 CHECK-2: Published: Grandchild doc
 CHECK-2: Skip: Parent doc
 CHECK-2: File: file_refs_grandchild.py
 
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-3
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-3
 CHECK-3: Skip: Child doc
 CHECK-3: Skip: Grandchild doc
 CHECK-3: Skip: Parent doc
 CHECK-3: Skip: file_refs_grandchild.py
 
 RUN: rm %S/sandbox/file_refs_grandchild.py
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-4
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-4
 CHECK-4: Skip: Child doc
 CHECK-4: Published: Grandchild doc
 CHECK-4: Skip: Parent doc

--- a/tests/integration/features/html/incremental_generation/25_sdoc_and_source_files_forward/test.itest
+++ b/tests/integration/features/html/incremental_generation/25_sdoc_and_source_files_forward/test.itest
@@ -8,27 +8,27 @@ RUN: %cp %S/grandchild.sdoc %S/sandbox/
 RUN: %cp %S/parent.sdoc %S/sandbox/
 RUN: %cp %S/src/file_refs_grandchild.py %S/sandbox/
 
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-1
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-1
 CHECK-1: Published: Child doc
 CHECK-1: Published: Grandchild doc
 CHECK-1: Published: Parent doc
 CHECK-1-NOT: File: file_refs_grandchild.py
 
 RUN: %cp %S/grandchild_with_link.sdoc %S/sandbox/grandchild.sdoc
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-2
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-2
 CHECK-2: Published: Child doc
 CHECK-2: Published: Grandchild doc
 CHECK-2: Skip: Parent doc
 CHECK-2: File: file_refs_grandchild.py
 
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-3
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-3
 CHECK-3: Skip: Child doc
 CHECK-3: Skip: Grandchild doc
 CHECK-3: Skip: Parent doc
 CHECK-3: Skip: file_refs_grandchild.py
 
 RUN: %cp %S/grandchild.sdoc %S/sandbox/grandchild.sdoc
-RUN: %strictdoc export %S/sandbox --output-dir Output --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-4
+RUN: %strictdoc export %S/sandbox --output-dir %T --no-parallelization | filecheck %s --dump-input=fail --check-prefix=CHECK-4
 CHECK-4: Published: Child doc
 CHECK-4: Published: Grandchild doc
 CHECK-4: Skip: Parent doc

--- a/tests/integration/features/html/jinja/01_does_not_choke_on_ds_store_macos_files/test.itest
+++ b/tests/integration/features/html/jinja/01_does_not_choke_on_ds_store_macos_files/test.itest
@@ -3,9 +3,9 @@
 
 RUN: %check_exists --file "%strictdoc_root/strictdoc/export/html/templates/.DS_Store"
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc

--- a/tests/integration/features/html/markup/01_referencing_a_section_with_LINK/test.itest
+++ b/tests/integration/features/html/markup/01_referencing_a_section_with_LINK/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/01_referencing_a_section_with_LINK/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
+RUN: %cat %T/html/01_referencing_a_section_with_LINK/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
 CHECK-HTML-DOC: <a href="../01_referencing_a_section_with_LINK/section.html#SECTION">{{.*}}Referenced section</a></p>
 
-RUN: %cat %S/Output/html/01_referencing_a_section_with_LINK/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TABLE
+RUN: %cat %T/html/01_referencing_a_section_with_LINK/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TABLE
 CHECK-HTML-TABLE: <a href="../01_referencing_a_section_with_LINK/section-TABLE.html#SECTION">{{.*}}Referenced section</a></p>
 
-RUN: %cat %S/Output/html/01_referencing_a_section_with_LINK/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TRACE
+RUN: %cat %T/html/01_referencing_a_section_with_LINK/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TRACE
 CHECK-HTML-TRACE: <a href="../01_referencing_a_section_with_LINK/section-TRACE.html#SECTION">{{.*}}Referenced section</a></p>

--- a/tests/integration/features/html/markup/02_referencing_anchor_with_LINK_internal/test.itest
+++ b/tests/integration/features/html/markup/02_referencing_anchor_with_LINK_internal/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/02_referencing_anchor_with_LINK_internal/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
+RUN: %cat %T/html/02_referencing_anchor_with_LINK_internal/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
 CHECK-HTML-DOC: <p>Anchors start.</p>
 CHECK-HTML-DOC: <sdoc-anchor id="AD1"{{.*}}
 CHECK-HTML-DOC: <li>AD1. Software user manual.</li>

--- a/tests/integration/features/html/markup/03_referencing_anchor_with_LINK_external/test.itest
+++ b/tests/integration/features/html/markup/03_referencing_anchor_with_LINK_external/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/03_referencing_anchor_with_LINK_external/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
+RUN: %cat %T/html/03_referencing_anchor_with_LINK_external/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
 CHECK-HTML-DOC: <p>See the <a href="../03_referencing_anchor_with_LINK_external/input2.html#AD1">{{.*}}AD1</a> for more details.</p>
 CHECK-HTML-DOC: <p>See the <a href="../03_referencing_anchor_with_LINK_external/input2.html#AD2">{{.*}}Software requirements specification</a> for more details.</p>
 CHECK-HTML-DOC: <p>See the <a href="../03_referencing_anchor_with_LINK_external/input2.html#Interface_Control_Document">{{.*}}Interface_Control_Document</a> for more details.</p>
@@ -9,7 +9,7 @@ CHECK-HTML-DOC: <p>See the <a href="../03_referencing_anchor_with_LINK_external/
 CHECK-HTML-DOC: <p>See the <a href="../03_referencing_anchor_with_LINK_external/input2.html#AD5">{{.*}}Software Tests</a> for more details.</p>
 CHECK-HTML-DOC: <p>See the <a href="../03_referencing_anchor_with_LINK_external/input2.html#Supplemental-Guide">{{.*}}Supplemental Guide</a> for more details.</p>
 
-RUN: %cat %S/Output/html/03_referencing_anchor_with_LINK_external/input2.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC2
+RUN: %cat %T/html/03_referencing_anchor_with_LINK_external/input2.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC2
 CHECK-HTML-DOC2:<sdoc-anchor id="AD1"{{.*}}
 CHECK-HTML-DOC2:<li>AD1. Software user manual.</li>
 CHECK-HTML-DOC2:<sdoc-anchor id="AD2"{{.*}}

--- a/tests/integration/features/html/markup/04_referencing_a_section_with_LINK_node/test.itest
+++ b/tests/integration/features/html/markup/04_referencing_a_section_with_LINK_node/test.itest
@@ -1,14 +1,14 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/04_referencing_a_section_with_LINK_node/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
+RUN: %cat %T/html/04_referencing_a_section_with_LINK_node/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC
 CHECK-HTML-DOC: <a href="../04_referencing_a_section_with_LINK_node/nodes.html#CUSTOM-1">{{.*}}Foo Bar</a></p>
 CHECK-HTML-DOC: <a href="../04_referencing_a_section_with_LINK_node/nodes.html#CUSTOM-2">{{.*}}CUSTOM-2</a></p>
 
-RUN: %cat %S/Output/html/04_referencing_a_section_with_LINK_node/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TABLE
+RUN: %cat %T/html/04_referencing_a_section_with_LINK_node/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TABLE
 CHECK-HTML-TABLE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TABLE.html#CUSTOM-1">{{.*}}Foo Bar</a></p>
 CHECK-HTML-TABLE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TABLE.html#CUSTOM-2">{{.*}}CUSTOM-2</a></p>
 
-RUN: %cat %S/Output/html/04_referencing_a_section_with_LINK_node/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TRACE
+RUN: %cat %T/html/04_referencing_a_section_with_LINK_node/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-TRACE
 CHECK-HTML-TRACE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TRACE.html#CUSTOM-1">{{.*}}Foo Bar</a></p>
 CHECK-HTML-TRACE: <a href="../04_referencing_a_section_with_LINK_node/nodes-TRACE.html#CUSTOM-2">{{.*}}CUSTOM-2</a></p>

--- a/tests/integration/features/html/markup/10_node_LINK_references_a_section/test.itest
+++ b/tests/integration/features/html/markup/10_node_LINK_references_a_section/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML-DOC
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML-DOC
 
 # [LINK: ...] is used 6 times in the doc.
 CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#SECTION">🔗&nbsp;1. Referenced section</a>
@@ -12,7 +12,7 @@ CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#SECTI
 CHECK-HTML-DOC: <a href="../10_node_LINK_references_a_section/section.html#SECTION">🔗&nbsp;1. Referenced section</a>
 
 # The referenced section shall have 6 incoming links.
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/section.html | filecheck %s --check-prefix CHECK-HTML-DOC-REFERENCED-SECTION
+RUN: %cat %T/html/%THIS_TEST_FOLDER/section.html | filecheck %s --check-prefix CHECK-HTML-DOC-REFERENCED-SECTION
 
 CHECK-HTML-DOC-REFERENCED-SECTION: Incoming links from:
 CHECK-HTML-DOC-REFERENCED-SECTION: <a href="../10_node_LINK_references_a_section/input.html#{{.*}}">
@@ -22,8 +22,8 @@ CHECK-HTML-DOC-REFERENCED-SECTION: <a href="../10_node_LINK_references_a_section
 CHECK-HTML-DOC-REFERENCED-SECTION: <a href="../10_node_LINK_references_a_section/input.html#{{.*}}">
 CHECK-HTML-DOC-REFERENCED-SECTION: <a href="../10_node_LINK_references_a_section/input.html#{{.*}}">
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input-TABLE.html | filecheck %s --check-prefix CHECK-HTML-TABLE
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input-TABLE.html | filecheck %s --check-prefix CHECK-HTML-TABLE
 CHECK-HTML-TABLE: <a href="../10_node_LINK_references_a_section/section-TABLE.html#SECTION">{{.*}}Referenced section</a></p>
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input-TRACE.html | filecheck %s --check-prefix CHECK-HTML-TRACE
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input-TRACE.html | filecheck %s --check-prefix CHECK-HTML-TRACE
 CHECK-HTML-TRACE: <a href="../10_node_LINK_references_a_section/section-TRACE.html#SECTION">{{.*}}Referenced section</a></p>

--- a/tests/integration/features/html/markup/11_node_LINK_references_a_document/test.itest
+++ b/tests/integration/features/html/markup/11_node_LINK_references_a_document/test.itest
@@ -1,10 +1,10 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Document 1
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input1.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC1
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input1.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC1
 
 CHECK-HTML-DOC1: Read <a href="../11_node_LINK_references_a_document/input1.html#_TOP">🔗&nbsp;Document 1</a> then <a href="../11_node_LINK_references_a_document/input2.html#_TOP">🔗&nbsp;Document 2</a>.
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input2.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC2
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input2.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC2
 
 CHECK-HTML-DOC2: Read <a href="../11_node_LINK_references_a_document/input2.html#_TOP">🔗&nbsp;Document 2</a> then <a href="../11_node_LINK_references_a_document/input1.html#_TOP">🔗&nbsp;Document 1</a>.

--- a/tests/integration/features/html/parallelization/04_parallelization/test.itest
+++ b/tests/integration/features/html/parallelization/04_parallelization/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published:
 CHECK: Published:
 CHECK: Published:
@@ -10,18 +10,18 @@ CHECK: Published:
 CHECK: Published:
 CHECK: Published:
 
-RUN: %check_exists --file %S/Output/html/04_parallelization/input1.html
-RUN: %check_exists --file %S/Output/html/04_parallelization/input2.html
-RUN: %check_exists --file %S/Output/html/04_parallelization/input3.html
-RUN: %check_exists --file %S/Output/html/04_parallelization/input4.html
-RUN: %check_exists --file %S/Output/html/04_parallelization/input5.html
-RUN: %check_exists --file %S/Output/html/04_parallelization/input6.html
-RUN: %check_exists --file %S/Output/html/04_parallelization/input7.html
-RUN: %check_exists --file %S/Output/html/04_parallelization/input8.html
-RUN: %check_exists --file %S/Output/html/04_parallelization/input9.html
-RUN: %check_exists --file %S/Output/html/04_parallelization/input10.html
+RUN: %check_exists --file %T/html/04_parallelization/input1.html
+RUN: %check_exists --file %T/html/04_parallelization/input2.html
+RUN: %check_exists --file %T/html/04_parallelization/input3.html
+RUN: %check_exists --file %T/html/04_parallelization/input4.html
+RUN: %check_exists --file %T/html/04_parallelization/input5.html
+RUN: %check_exists --file %T/html/04_parallelization/input6.html
+RUN: %check_exists --file %T/html/04_parallelization/input7.html
+RUN: %check_exists --file %T/html/04_parallelization/input8.html
+RUN: %check_exists --file %T/html/04_parallelization/input9.html
+RUN: %check_exists --file %T/html/04_parallelization/input10.html
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Doc 1
 CHECK-HTML: input1.sdoc
 CHECK-HTML: Doc 10

--- a/tests/integration/features/html/parallelization/05_parallelization_no_macos_problem_regression/test.itest
+++ b/tests/integration/features/html/parallelization/05_parallelization_no_macos_problem_regression/test.itest
@@ -1,20 +1,20 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK-NOT: {{.*objc.*}}
 CHECK-NOT: {{.*fork.*}}
 
-RUN: %check_exists --file %S/Output/html/05_parallelization_no_macos_problem_regression/input1.html
-RUN: %check_exists --file %S/Output/html/05_parallelization_no_macos_problem_regression/input2.html
-RUN: %check_exists --file %S/Output/html/05_parallelization_no_macos_problem_regression/input3.html
-RUN: %check_exists --file %S/Output/html/05_parallelization_no_macos_problem_regression/input4.html
-RUN: %check_exists --file %S/Output/html/05_parallelization_no_macos_problem_regression/input5.html
-RUN: %check_exists --file %S/Output/html/05_parallelization_no_macos_problem_regression/input6.html
-RUN: %check_exists --file %S/Output/html/05_parallelization_no_macos_problem_regression/input7.html
-RUN: %check_exists --file %S/Output/html/05_parallelization_no_macos_problem_regression/input8.html
-RUN: %check_exists --file %S/Output/html/05_parallelization_no_macos_problem_regression/input9.html
-RUN: %check_exists --file %S/Output/html/05_parallelization_no_macos_problem_regression/input10.html
+RUN: %check_exists --file %T/html/05_parallelization_no_macos_problem_regression/input1.html
+RUN: %check_exists --file %T/html/05_parallelization_no_macos_problem_regression/input2.html
+RUN: %check_exists --file %T/html/05_parallelization_no_macos_problem_regression/input3.html
+RUN: %check_exists --file %T/html/05_parallelization_no_macos_problem_regression/input4.html
+RUN: %check_exists --file %T/html/05_parallelization_no_macos_problem_regression/input5.html
+RUN: %check_exists --file %T/html/05_parallelization_no_macos_problem_regression/input6.html
+RUN: %check_exists --file %T/html/05_parallelization_no_macos_problem_regression/input7.html
+RUN: %check_exists --file %T/html/05_parallelization_no_macos_problem_regression/input8.html
+RUN: %check_exists --file %T/html/05_parallelization_no_macos_problem_regression/input9.html
+RUN: %check_exists --file %T/html/05_parallelization_no_macos_problem_regression/input10.html
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Doc 1
 CHECK-HTML: input1.sdoc
 CHECK-HTML: Doc 10

--- a/tests/integration/features/html/parallelization/06_parallelization_sdoc_parsing_problem_in_child_process/test.itest
+++ b/tests/integration/features/html/parallelization/06_parallelization_sdoc_parsing_problem_in_child_process/test.itest
@@ -1,6 +1,6 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input1.sdoc.
 CHECK: TextXSyntaxError: {{.*}}input1.sdoc:1:1: Expected '[DOCUMENT]' => '*THIS DOCUM'
 CHECK: error: Parallelizer: One of the child processes has exited prematurely.
-CHECK-NEXT: error: Parallelizer: Failed child process: PID: {{.*}}, exit code: 1.
+CHECK: error: Parallelizer: Failed child process: PID: {{\d+}}, exit code: {{\d+}}.

--- a/tests/integration/features/html/path_resolution/03_input_dir_has_slash/test.itest
+++ b/tests/integration/features/html/path_resolution/03_input_dir_has_slash/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S/ --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S/ --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc
 
-RUN: %cat %S/Output/html/03_input_dir_has_slash/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-CONTENT
+RUN: %cat %T/html/03_input_dir_has_slash/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-CONTENT
 CHECK-CONTENT: Hello world!

--- a/tests/integration/features/html/path_resolution/07_input_is_single_file/test.itest
+++ b/tests/integration/features/html/path_resolution/07_input_is_single_file/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S/input.sdoc --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S/input.sdoc --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc
 
-RUN: %cat %S/Output/html/07_input_is_single_file/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-CONTENT
+RUN: %cat %T/html/07_input_is_single_file/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-CONTENT
 CHECK-CONTENT: Hello world!

--- a/tests/integration/features/html/path_resolution/08_finds_document_through_empty_intermediate_folders/test.itest
+++ b/tests/integration/features/html/path_resolution/08_finds_document_through_empty_intermediate_folders/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S/input --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S/input --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/index.html"
-RUN: %check_exists --file "%S/Output/html/input/intermediate/requirements/input.html"
+RUN: %check_exists --file "%T/html/index.html"
+RUN: %check_exists --file "%T/html/input/intermediate/requirements/input.html"
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc

--- a/tests/integration/features/html/path_resolution/09_does_not_find_documents_in_output_folder/test.itest
+++ b/tests/integration/features/html/path_resolution/09_does_not_find_documents_in_output_folder/test.itest
@@ -1,13 +1,7 @@
-RUN: %mkdir Output/
-RUN: %cp input2.sdoc_ Output/input2.sdoc
-RUN: %strictdoc export %S --no-parallelization --output-dir Output | filecheck %s --dump-input=fail
+RUN: %mkdir %T/input
+RUN: %mkdir %T/Output
+RUN: %cp %S/input/input.sdoc %T/input/input.sdoc
+RUN: %cp %S/input2.sdoc_ %T/Output/input2.sdoc
+RUN: %strictdoc export %T --no-parallelization --output-dir %T/Output | filecheck %s --dump-input=fail
 CHECK-NOT: Published: Hello world doc 2
 CHECK: Published: Hello world doc 1
-
-FIXME: RUNs
-UN: %check_exists --file "%S/Output/html/index.html"
-UN: %check_exists --file "%S/Output/html/input/intermediate/requirements/input.html"
-
-UN: cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
-CHECK-HTML: Hello world doc
-CHECK-HTML: input.sdoc

--- a/tests/integration/features/html/precompiled_jinja_templates/01_basic/test.itest
+++ b/tests/integration/features/html/precompiled_jinja_templates/01_basic/test.itest
@@ -2,12 +2,12 @@
 # large enough. This test SDoc file contains 10+ requirements to become a large
 # enough tree.
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Compile Jinja templates {{.*}}s
 CHECK: Published: Hello world doc
 
 RUN: rm -rf Output/html
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail --check-prefix=CHECK-SECOND
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail --check-prefix=CHECK-SECOND
 CHECK-SECOND-NOT: Compile Jinja templates {{.*}}s
 CHECK-SECOND: Published: Hello world doc

--- a/tests/integration/features/html/rst_markup_to_html/10_wildcard_enhanced_image/test.itest
+++ b/tests/integration/features/html/rst_markup_to_html/10_wildcard_enhanced_image/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S --formats=html --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
 RUN: cat Output/html/10_wildcard_enhanced_image/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML

--- a/tests/integration/features/html/rst_markup_to_html/11_wildcard_enhanced_image_nested/test.itest
+++ b/tests/integration/features/html/rst_markup_to_html/11_wildcard_enhanced_image_nested/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S --formats=html --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
 RUN: cat Output/html/11_wildcard_enhanced_image_nested/nested/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML

--- a/tests/integration/features/html/rst_markup_to_html/12_wildcard_enhanced_image_input_path_not_cwd/test.itest
+++ b/tests/integration/features/html/rst_markup_to_html/12_wildcard_enhanced_image_input_path_not_cwd/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S/nested --formats=html --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S/nested --formats=html --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
 RUN: cat Output/html/nested/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML

--- a/tests/integration/features/html/rst_markup_to_html/20_csv_table/test.itest
+++ b/tests/integration/features/html/rst_markup_to_html/20_csv_table/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --formats=html,rst --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html,rst --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Test
 
-RUN: %cat %S/Output/html/20_csv_table/path1/test.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-FILE
+RUN: %cat %T/html/20_csv_table/path1/test.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-FILE
 
 # csv-table directive gets expanded to CSV table.
 CHECK-HTML-FILE: <td>a</td>

--- a/tests/integration/features/html/rst_markup_to_html/30_code_block/test.itest
+++ b/tests/integration/features/html/rst_markup_to_html/30_code_block/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --formats=html --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Document with an code block
 
-RUN: %cat %S/Output/html/30_code_block/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-FILE
+RUN: %cat %T/html/30_code_block/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-FILE
 CHECK-HTML-FILE: Lorem Ipsum.
 CHECK-HTML-FILE: <span class="keyword">struct</span>
 CHECK-HTML-FILE: Lorem ipsum.

--- a/tests/integration/features/html/rst_markup_to_html/40_link/test.itest
+++ b/tests/integration/features/html/rst_markup_to_html/40_link/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --formats=html --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Links
 
-RUN: %cat %S/Output/html/40_link/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-FILE
+RUN: %cat %T/html/40_link/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-FILE
 CHECK-HTML-FILE: <a href="#THING-1">🔗&nbsp;Thing</a> may be followed by whitespace.
 CHECK-HTML-FILE: <a href="#THING-1">🔗&nbsp;Thing</a>  may be followed by tab.
 CHECK-HTML-FILE: Maybe punctuation like comma follows <a href="#THING-1">🔗&nbsp;Thing</a>, or dot follows <a href="#THING-1">🔗&nbsp;Thing</a>.

--- a/tests/integration/features/html/stable_node_url_links/01_basic/test.itest
+++ b/tests/integration/features/html/stable_node_url_links/01_basic/test.itest
@@ -3,14 +3,14 @@
 # - The URLs generated on the button (chain icon) that generates stable links
 #   are produced correctly .
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Stable URI Test
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Stable URI Test
 CHECK-HTML: index.sdoc
 
-RUN: %cat %S/Output/html/_static/project_map.js | filecheck %s --dump-input=fail --check-prefix CHECK-MAP
+RUN: %cat %T/html/_static/project_map.js | filecheck %s --dump-input=fail --check-prefix CHECK-MAP
 CHECK-MAP: "01_basic/subfolder/file_in_subfolder.html": [
 CHECK-MAP: "UID":"SUB-DOC-UID"
 CHECK-MAP: "UID":"SUB-ROOT-1"
@@ -32,7 +32,7 @@ CHECK-MAP: "UID":"SECTION-3"
 CHECK-MAP: "UID":"SECTION-3-1"
 CHECK-MAP: "UID":"REQ-WITHIN-SECTION-3-1"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-BUTTON
+RUN: %cat %T/html/%THIS_TEST_FOLDER/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-BUTTON
 CHECK-BUTTON: data-path="../#ROOT-1"
 CHECK-BUTTON: data-path="../#REQ-WITHIN-SECTION-THAT-HAS-NO-UID"
 CHECK-BUTTON: data-path="../#SECTION-1"
@@ -42,7 +42,7 @@ CHECK-BUTTON: data-path="../#SECTION-3"
 CHECK-BUTTON: data-path="../#SECTION-3-1"
 CHECK-BUTTON: data-path="../#REQ-WITHIN-SECTION-3-1"
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/subfolder/file_in_subfolder.html | filecheck %s --dump-input=fail --check-prefix CHECK-SUB-BUTTON
+RUN: %cat %T/html/%THIS_TEST_FOLDER/subfolder/file_in_subfolder.html | filecheck %s --dump-input=fail --check-prefix CHECK-SUB-BUTTON
 CHECK-SUB-BUTTON: data-path="../../#SUB-ROOT-1"
 CHECK-SUB-BUTTON: data-path="../../#SUB-REQ-WITHIN-SECTION-THAT-HAS-NO-UID"
 CHECK-SUB-BUTTON: data-path="../../#SUB-SECTION-1"

--- a/tests/integration/features/html/stable_node_url_links/02_custom_grammar/test.itest
+++ b/tests/integration/features/html/stable_node_url_links/02_custom_grammar/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Stable URI Test
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Stable URI Test
 CHECK-HTML: index.sdoc
 
-RUN: %cat %S/Output/html/_static/project_map.js | filecheck %s --dump-input=fail --check-prefix CHECK-MAP
+RUN: %cat %T/html/_static/project_map.js | filecheck %s --dump-input=fail --check-prefix CHECK-MAP
 CHECK-MAP: "02_custom_grammar/subfolder/file_in_subfolder.html": [
 CHECK-MAP: "UID":"SUB-ROOT-1"
 CHECK-MAP: "UID":"SUB-FEATURE-WITHIN-SECTION-THAT-HAS-NO-UID"

--- a/tests/integration/features/html/stable_node_url_links/03_custom_grammar_with_mids/test.itest
+++ b/tests/integration/features/html/stable_node_url_links/03_custom_grammar_with_mids/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Stable URI Test
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Stable URI Test
 CHECK-HTML: index.sdoc
 
-RUN: %cat %S/Output/html/_static/project_map.js | filecheck %s --dump-input=fail --check-prefix CHECK-MAP
+RUN: %cat %T/html/_static/project_map.js | filecheck %s --dump-input=fail --check-prefix CHECK-MAP
 CHECK-MAP: "03_custom_grammar_with_mids/subfolder/file_in_subfolder.html": [
 CHECK-MAP: {"MID":"46355ead6a8b4974b134b200eec4a885","UID":"SUB-ROOT-1"
 CHECK-MAP: {"MID":"9281cd61e9954ce68ec54f95bdc7f687","UID":"SUB-REQ-WITHIN-SECTION-THAT-HAS-NO-UID"

--- a/tests/integration/features/html/stable_node_url_links/04_sdoc_fragments/test.itest
+++ b/tests/integration/features/html/stable_node_url_links/04_sdoc_fragments/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Stable URI Test
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Stable URI Test
 CHECK-HTML: index.sdoc
 
-RUN: %cat %S/Output/html/_static/project_map.js | filecheck %s --dump-input=fail --check-prefix CHECK-MAP
+RUN: %cat %T/html/_static/project_map.js | filecheck %s --dump-input=fail --check-prefix CHECK-MAP
 CHECK-MAP: "04_sdoc_fragments/subfolder/file_in_subfolder.html": [
 CHECK-MAP: "UID":"SUB-ROOT-1"
 CHECK-MAP: "UID":"SUB-REQ-WITHIN-SECTION-THAT-HAS-NO-UID"

--- a/tests/integration/features/html/utf8/01_utf8_in_sdoc/test.itest
+++ b/tests/integration/features/html/utf8/01_utf8_in_sdoc/test.itest
@@ -1,14 +1,14 @@
 TODO: On Windows: Published: Hello world doc with UTF-8 symbols: \x96 ............ 0.35s\r\n
 REQUIRES: PLATFORM_IS_NOT_WINDOWS
 
-RUN: %strictdoc export %S --formats=html,rst --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html,rst --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc with UTF-8 symbols: –
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOCTREE
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOCTREE
 CHECK-HTML-DOCTREE: Hello world doc with UTF-8 symbols: –
 
-RUN: %cat %S/Output/html/01_utf8_in_sdoc/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-FILE
+RUN: %cat %T/html/01_utf8_in_sdoc/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-FILE
 CHECK-HTML-FILE: UTF-8 symbols: 😀😀😀 ✓✓✓ ☂☂☂
 
-RUN: %cat %S/Output/rst/input.rst | filecheck %s --dump-input=fail --check-prefix CHECK-RST-FILE
+RUN: %cat %T/rst/input.rst | filecheck %s --dump-input=fail --check-prefix CHECK-RST-FILE
 CHECK-RST-FILE: UTF-8 symbols: 😀😀😀 ✓✓✓ ☂☂☂

--- a/tests/integration/features/html2pdf/01_empty_document/test.itest
+++ b/tests/integration/features/html2pdf/01_empty_document/test.itest
@@ -1,11 +1,11 @@
 REQUIRES: TEST_HTML2PDF
 
-RUN: %strictdoc export %S --formats=html2pdf --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html2pdf --output-dir %T | filecheck %s --dump-input=fail
 CHECK: html2pdf4doc: ChromeDriver available at path: {{.*}}
 CHECK: html2pdf4doc: JS logs from the print session
 
-RUN: %check_exists --file %S/Output/html2pdf/pdf/input.pdf
+RUN: %check_exists --file %T/html2pdf/pdf/input.pdf
 
-RUN: %check_exists --file %S/Output/html2pdf/html/01_empty_document/input.html
+RUN: %check_exists --file %T/html2pdf/html/01_empty_document/input.html
 
 RUN: python %S/test_pdf.py

--- a/tests/integration/features/html2pdf/02_three_top_level_requirements/test.itest
+++ b/tests/integration/features/html2pdf/02_three_top_level_requirements/test.itest
@@ -1,14 +1,14 @@
 REQUIRES: TEST_HTML2PDF
 
-RUN: %strictdoc export %S --formats=html2pdf --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html2pdf --output-dir %T | filecheck %s --dump-input=fail
 CHECK: html2pdf4doc: JS logs from the print session
 
-RUN: %check_exists --file %S/Output/html2pdf/pdf/input.pdf
-RUN: %check_exists --file %S/Output/html2pdf/pdf/nested/input2.pdf
-RUN: %check_exists --file %S/Output/html2pdf/pdf/nested/subnested/input3.pdf
+RUN: %check_exists --file %T/html2pdf/pdf/input.pdf
+RUN: %check_exists --file %T/html2pdf/pdf/nested/input2.pdf
+RUN: %check_exists --file %T/html2pdf/pdf/nested/subnested/input3.pdf
 
-RUN: %check_exists --file %S/Output/html2pdf/html/02_three_top_level_requirements/input.html
-RUN: %check_exists --file %S/Output/html2pdf/html/02_three_top_level_requirements/nested/input2.html
-RUN: %check_exists --file %S/Output/html2pdf/html/02_three_top_level_requirements/nested/subnested/input3.html
+RUN: %check_exists --file %T/html2pdf/html/02_three_top_level_requirements/input.html
+RUN: %check_exists --file %T/html2pdf/html/02_three_top_level_requirements/nested/input2.html
+RUN: %check_exists --file %T/html2pdf/html/02_three_top_level_requirements/nested/subnested/input3.html
 
 RUN: python %S/test_pdf.py

--- a/tests/integration/features/html2pdf/03_three_documents_with_assets/test.itest
+++ b/tests/integration/features/html2pdf/03_three_documents_with_assets/test.itest
@@ -1,17 +1,17 @@
 REQUIRES: TEST_HTML2PDF
 
-RUN: %strictdoc export %S --formats=html2pdf --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html2pdf --output-dir %T | filecheck %s --dump-input=fail
 CHECK: html2pdf4doc: JS logs from the print session
 
-RUN: %check_exists --file %S/Output/html2pdf/html/03_three_documents_with_assets/input.html
-RUN: %check_exists --file %S/Output/html2pdf/html/03_three_documents_with_assets/nested/input2.html
-RUN: %check_exists --file %S/Output/html2pdf/html/03_three_documents_with_assets/nested/subnested/input3.html
+RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/input.html
+RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/nested/input2.html
+RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/nested/subnested/input3.html
 
-RUN: %check_exists --file %S/Output/html2pdf/html/03_three_documents_with_assets/_assets/file.svg
-RUN: %check_exists --file %S/Output/html2pdf/html/03_three_documents_with_assets/nested/_assets/file.svg
-RUN: %check_exists --file %S/Output/html2pdf/html/03_three_documents_with_assets/nested/subnested/_assets/file.svg
+RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/_assets/file.svg
+RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/nested/_assets/file.svg
+RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/nested/subnested/_assets/file.svg
 
-RUN: %cat %S/Output/html2pdf/html/03_three_documents_with_assets/nested/subnested/input3.html | filecheck %s --check-prefix CHECK-DOC-HTML
+RUN: %cat %T/html2pdf/html/03_three_documents_with_assets/nested/subnested/input3.html | filecheck %s --check-prefix CHECK-DOC-HTML
 CHECK-DOC-HTML:data="_assets/file.svg"
 
 RUN: python %S/test_pdf.py

--- a/tests/integration/features/html2pdf/04_composable_document_with_assets/test.itest
+++ b/tests/integration/features/html2pdf/04_composable_document_with_assets/test.itest
@@ -1,25 +1,25 @@
 REQUIRES: TEST_HTML2PDF
 
-RUN: %strictdoc export %S --formats=html2pdf --included-documents --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html2pdf --included-documents --output-dir %T | filecheck %s --dump-input=fail
 CHECK: html2pdf4doc: JS logs from the print session
 
-RUN: %check_exists --file %S/Output/html2pdf/html/04_composable_document_with_assets/input.html
-RUN: %check_exists --file %S/Output/html2pdf/html/04_composable_document_with_assets/nested/input2.html
-RUN: %check_exists --file %S/Output/html2pdf/html/04_composable_document_with_assets/nested/subnested/input3.html
+RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/input.html
+RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/nested/input2.html
+RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/nested/subnested/input3.html
 
-RUN: %check_exists --file %S/Output/html2pdf/html/04_composable_document_with_assets/_assets/file.svg
-RUN: %check_exists --file %S/Output/html2pdf/html/04_composable_document_with_assets/nested/_assets/file.svg
-RUN: %check_exists --file %S/Output/html2pdf/html/04_composable_document_with_assets/nested/subnested/_assets/file.svg
+RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/_assets/file.svg
+RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/nested/_assets/file.svg
+RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/nested/subnested/_assets/file.svg
 
 # By default, a bundle document is not generated.
-RUN: %check_exists --file --invert %S/Output/html2pdf/pdf/bundle.pdf
+RUN: %check_exists --file --invert %T/html2pdf/pdf/bundle.pdf
 
-RUN: %cat %S/Output/html2pdf/html/04_composable_document_with_assets/nested/subnested/input3.html | filecheck %s --check-prefix CHECK-DOC-HTML
+RUN: %cat %T/html2pdf/html/04_composable_document_with_assets/nested/subnested/input3.html | filecheck %s --check-prefix CHECK-DOC-HTML
 CHECK-DOC-HTML:data="_assets/file.svg"
 
 RUN: python %S/test_pdf.py
 
-RUN: %strictdoc export %S --formats=html2pdf --included-documents --generate-bundle-document --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html2pdf --included-documents --generate-bundle-document --output-dir %T | filecheck %s --dump-input=fail
 # With --generate-bundle-document, a bundle document is generated.
-RUN: %check_exists --file %S/Output/html2pdf/pdf/bundle.pdf
+RUN: %check_exists --file %T/html2pdf/pdf/bundle.pdf
 RUN: python %S/test_bundle_pdf.py

--- a/tests/integration/features/html2pdf/05_generate_bundle_document/test.itest
+++ b/tests/integration/features/html2pdf/05_generate_bundle_document/test.itest
@@ -1,14 +1,14 @@
 REQUIRES: TEST_HTML2PDF
 
-RUN: %strictdoc export %S --formats=html2pdf --generate-bundle-document --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html2pdf --generate-bundle-document --output-dir %T | filecheck %s --dump-input=fail
 CHECK: html2pdf4doc: JS logs from the print session
 
-RUN: %check_exists --file %S/Output/html2pdf/html/bundle.html
-RUN: %check_exists --file %S/Output/html2pdf/html/%THIS_TEST_FOLDER/input.html
-RUN: %check_exists --file %S/Output/html2pdf/html/%THIS_TEST_FOLDER/nested/input2.html
-RUN: %check_exists --file %S/Output/html2pdf/html/%THIS_TEST_FOLDER/nested/subnested/input3.html
+RUN: %check_exists --file %T/html2pdf/html/bundle.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/input.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/input2.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/subnested/input3.html
 
-RUN: %cat %S/Output/html2pdf/html/bundle.html | filecheck %s --check-prefix CHECK-DOC-HTML
+RUN: %cat %T/html2pdf/html/bundle.html | filecheck %s --check-prefix CHECK-DOC-HTML
 # This ensures that the link is resolved correctly.
 CHECK-DOC-HTML:<a href="#SEC-1">🔗&nbsp;1.1. Section #1</a>
 

--- a/tests/integration/features/html2pdf/06_system_chromedriver/test.itest
+++ b/tests/integration/features/html2pdf/06_system_chromedriver/test.itest
@@ -3,12 +3,12 @@ REQUIRES: SYSTEM_CHROMEDRIVER
 
 # GitHub images provide a chromedriver and export installed location, see
 # https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#browsers-and-drivers
-RUN: %strictdoc export %S --formats=html2pdf --chromedriver="%chromedriver" --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html2pdf --chromedriver="%chromedriver" --output-dir %T | filecheck %s --dump-input=fail
 CHECK: html2pdf4doc: JS logs from the print session
 CHECK-NOT: html2pdf4doc: ChromeDriver available at path: {{.*}}strictdoc_cache{{.*}}
 
-RUN: %check_exists --file %S/Output/html2pdf/pdf/input.pdf
+RUN: %check_exists --file %T/html2pdf/pdf/input.pdf
 
-RUN: %check_exists --file %S/Output/html2pdf/html/06_system_chromedriver/input.html
+RUN: %check_exists --file %T/html2pdf/html/06_system_chromedriver/input.html
 
 RUN: python %S/test_pdf.py

--- a/tests/integration/features/html_standalone/01_standalone_and_html/test.itest
+++ b/tests/integration/features/html_standalone/01_standalone_and_html/test.itest
@@ -1,12 +1,12 @@
-RUN: %strictdoc export %S --formats=html --no-parallelization --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html --no-parallelization --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
 /// Standalone file is generated
-RUN: %check_exists --file %S/Output/html/01_standalone_and_html/input.standalone.html
-RUN: %check_exists --file %S/Output/html/01_standalone_and_html/input.html
-RUN: %html_markup_validator %S/Output/html/01_standalone_and_html/input.standalone.html
+RUN: %check_exists --file %T/html/01_standalone_and_html/input.standalone.html
+RUN: %check_exists --file %T/html/01_standalone_and_html/input.html
+RUN: %html_markup_validator %T/html/01_standalone_and_html/input.standalone.html
 
 /// Index is generated
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc

--- a/tests/integration/features/html_standalone/02_embeds_default_assets/test.itest
+++ b/tests/integration/features/html_standalone/02_embeds_default_assets/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S --formats=html --no-parallelization --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=html --no-parallelization --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
 /// Standalone file is generated
-RUN: %check_exists --file %S/Output/html/02_embeds_default_assets/input.standalone.html
+RUN: %check_exists --file %T/html/02_embeds_default_assets/input.standalone.html
 
 /// Index is generated
-RUN: %cat %S/Output/html/02_embeds_default_assets/input.standalone.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/02_embeds_default_assets/input.standalone.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <link href="data:image/{{(x-icon|vnd.microsoft.icon)}};base64,AAABAAEAEBAAAAEAI{{.*}}rel="shortcut icon" type="image/x-icon"/>

--- a/tests/integration/features/json/01_basic_json_export/test.itest
+++ b/tests/integration/features/json/01_basic_json_export/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --formats=json --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=json --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Step 'Export SDoc' took:
 
-RUN: cat %S/Output/json/index.json | filecheck %s --check-prefix=CHECK-JSON
+RUN: cat %T/json/index.json | filecheck %s --check-prefix=CHECK-JSON
 
 CHECK-JSON: "TITLE": "Dummy Software Requirements Specification #1",
 CHECK-JSON: "TITLE": "Dummy Software Requirements Specification #2",

--- a/tests/integration/features/json/02_export_without_and_with_included_documents/test.itest
+++ b/tests/integration/features/json/02_export_without_and_with_included_documents/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --formats=json --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=json --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Step 'Export SDoc' took
 
-RUN: cat %S/Output/json/index.json | filecheck %s --check-prefix=CHECK-JSON
+RUN: cat %T/json/index.json | filecheck %s --check-prefix=CHECK-JSON
 
 CHECK-JSON: "_TOC": "3",
 CHECK-JSON: "_NODE_TYPE": "SECTION",
@@ -18,8 +18,8 @@ CHECK-JSON-NOT: "UID": "LREQ-3",
 CHECK-JSON-NOT: "TITLE": "Dummy low-level requirement #3",
 CHECK-JSON-NOT: "STATEMENT": "System ABC shall do 3."
 
-RUN: %strictdoc export %S --formats=json --included-documents --output-dir Output | filecheck %s --dump-input=fail
-RUN: cat %S/Output/json/index.json | filecheck %s --check-prefix=CHECK-JSON-INCLUDED
+RUN: %strictdoc export %S --formats=json --included-documents --output-dir %T | filecheck %s --dump-input=fail
+RUN: cat %T/json/index.json | filecheck %s --check-prefix=CHECK-JSON-INCLUDED
 
 CHECK-JSON-INCLUDED: "_TOC": "3",
 CHECK-JSON-INCLUDED: "_NODE_TYPE": "SECTION",

--- a/tests/integration/features/json/03_section/test.itest
+++ b/tests/integration/features/json/03_section/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --formats=json --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=json --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Step 'Export SDoc' took:
 
-RUN: cat %S/Output/json/index.json | filecheck %s --check-prefix=CHECK-JSON
+RUN: cat %T/json/index.json | filecheck %s --check-prefix=CHECK-JSON
 
 CHECK-JSON: "TITLE": "Dummy Software Requirements Specification #1",
 CHECK-JSON: "_TOC": "1"

--- a/tests/integration/features/json/03b_deprecated_section/test.itest
+++ b/tests/integration/features/json/03b_deprecated_section/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --formats=json --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=json --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Step 'Export SDoc' took:
 
-RUN: cat %S/Output/json/index.json | filecheck %s --check-prefix=CHECK-JSON
+RUN: cat %T/json/index.json | filecheck %s --check-prefix=CHECK-JSON
 
 CHECK-JSON: "TITLE": "Dummy Software Requirements Specification #1",
 CHECK-JSON: "_TOC": "1"

--- a/tests/integration/features/json/04_composite_node/test.itest
+++ b/tests/integration/features/json/04_composite_node/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --formats=json --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --formats=json --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Step 'Export SDoc' took:
 
-RUN: cat %S/Output/json/index.json | filecheck %s --check-prefix=CHECK-JSON
+RUN: cat %T/json/index.json | filecheck %s --check-prefix=CHECK-JSON
 
 CHECK-JSON: "TITLE": "Dummy Software Requirements Specification #1",
 CHECK-JSON: "_TOC": "1"

--- a/tests/integration/features/mathjax/01_mathjax_enabled/test.itest
+++ b/tests/integration/features/mathjax/01_mathjax_enabled/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export %S --enable-mathjax --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --enable-mathjax --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_static/mathjax/tex-mml-chtml.js"
-RUN: %check_exists --file "%S/Output/html/_static/mathjax/output/chtml/fonts/tex.js"
+RUN: %check_exists --file "%T/html/_static/mathjax/tex-mml-chtml.js"
+RUN: %check_exists --file "%T/html/_static/mathjax/output/chtml/fonts/tex.js"

--- a/tests/integration/features/mathjax/02_mathjax_disabled/test.itest
+++ b/tests/integration/features/mathjax/02_mathjax_disabled/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --invert --file "%S/Output/html/_static/mathjax/tex-mml-chtml.js"
-RUN: %check_exists --invert --file "%S/Output/html/_static/mathjax/output/chtml/fonts/tex.js"
+RUN: %check_exists --invert --file "%T/html/_static/mathjax/tex-mml-chtml.js"
+RUN: %check_exists --invert --file "%T/html/_static/mathjax/output/chtml/fonts/tex.js"

--- a/tests/integration/features/options/options_per_cli/--config/01_option_is_provided/test.itest
+++ b/tests/integration/features/options/options_per_cli/--config/01_option_is_provided/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S --config %S/custom/folder/strictdoc.toml --output-dir Output | filecheck %s --dump-input=fail
-RUN: %check_exists --file "%S/Output/html/project_statistics.html"
+RUN: %strictdoc export %S --config %S/custom/folder/strictdoc.toml --output-dir %T | filecheck %s --dump-input=fail
+RUN: %check_exists --file "%T/html/project_statistics.html"
 
 CHECK: Published: Hello world doc

--- a/tests/integration/features/options/options_per_cli/--no-parallelization/test.itest
+++ b/tests/integration/features/options/options_per_cli/--no-parallelization/test.itest
@@ -1,27 +1,27 @@
-RUN: %strictdoc export %S --output-dir=%S/Output | filecheck %s --dump-input=fail --check-prefix CHECK-PARAL
+RUN: %strictdoc export %S --output-dir=%T | filecheck %s --dump-input=fail --check-prefix CHECK-PARAL
 
 CHECK-PARAL: Parallelization: Enabled
 CHECK-PARAL: Published:
 CHECK-PARAL: Published:
 
-RUN: %check_exists --file %S/Output/html/--no-parallelization/input1.html
-RUN: %check_exists --file %S/Output/html/--no-parallelization/input2.html
+RUN: %check_exists --file %T/html/--no-parallelization/input1.html
+RUN: %check_exists --file %T/html/--no-parallelization/input2.html
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 /// Now without parallelization
-RUN: %rm %S/Output/html
+RUN: %rm %T/html
 
-RUN: %strictdoc export %S --no-parallelization --output-dir=%S/Output | filecheck %s --dump-input=fail --check-prefix CHECK-NO-PARAL
+RUN: %strictdoc export %S --no-parallelization --output-dir=%T | filecheck %s --dump-input=fail --check-prefix CHECK-NO-PARAL
 
 CHECK-NO-PARAL: Parallelization: Disabled
 CHECK-NO-PARAL: Published:
 CHECK-NO-PARAL: Published:
 
-RUN: %check_exists --file %S/Output/html/--no-parallelization/input1.html
-RUN: %check_exists --file %S/Output/html/--no-parallelization/input2.html
+RUN: %check_exists --file %T/html/--no-parallelization/input1.html
+RUN: %check_exists --file %T/html/--no-parallelization/input2.html
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML: Doc 1
 CHECK-HTML: input1.sdoc

--- a/tests/integration/features/options/options_per_cli/--output-dir/01_output_dir_full_path/test.itest
+++ b/tests/integration/features/options/options_per_cli/--output-dir/01_output_dir_full_path/test.itest
@@ -1,14 +1,14 @@
-RUN: %strictdoc export %S --output-dir %S/Output/CustomDir | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T/CustomDir | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/CustomDir/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/CustomDir/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
-RUN: %check_exists --dir %S/Output/CustomDir/html/_static/
-RUN: %check_exists --file %S/Output/CustomDir/html/_static/base.css
+RUN: %check_exists --dir %T/CustomDir/html/_static/
+RUN: %check_exists --file %T/CustomDir/html/_static/base.css
 
-RUN: %cat %S/Output/CustomDir/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/CustomDir/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc
 
-RUN: %cat %S/Output/CustomDir/html/01_output_dir_full_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-CONTENT
+RUN: %cat %T/CustomDir/html/01_output_dir_full_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-CONTENT
 CHECK-CONTENT: Hello world!

--- a/tests/integration/features/options/options_per_cli/--output-dir/02_output_dir_relative_path/test.itest
+++ b/tests/integration/features/options/options_per_cli/--output-dir/02_output_dir_relative_path/test.itest
@@ -1,12 +1,12 @@
 RUN: %strictdoc export %S --output-dir Output/CustomDir | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --dir %S/Output/CustomDir/html/_static/
-RUN: %check_exists --file %S/Output/CustomDir/html/_static/base.css
+RUN: %check_exists --dir Output/CustomDir/html/_static/
+RUN: %check_exists --file Output/CustomDir/html/_static/base.css
 
-RUN: %cat %S/Output/CustomDir/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/CustomDir/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc
 
-RUN: %cat %S/Output/CustomDir/html/02_output_dir_relative_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-CONTENT
+RUN: %cat %T/CustomDir/html/02_output_dir_relative_path/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-CONTENT
 CHECK-CONTENT: Hello world!

--- a/tests/integration/features/options/options_per_cli/--project-title/01_project_title_not_specified/test.itest
+++ b/tests/integration/features/options/options_per_cli/--project-title/01_project_title_not_specified/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export %S --output-dir %S/Output/CustomDir | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T/CustomDir | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/CustomDir/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/CustomDir/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Untitled Project

--- a/tests/integration/features/options/options_per_cli/--project-title/02_project_title_is_specified/test.itest
+++ b/tests/integration/features/options/options_per_cli/--project-title/02_project_title_is_specified/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export %S --output-dir %S/Output/CustomDir --project "Test Project" | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T/CustomDir --project "Test Project" | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/CustomDir/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/CustomDir/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Test Project

--- a/tests/integration/features/options/options_per_cli/--view/01_view_option_is_provided/test.itest
+++ b/tests/integration/features/options/options_per_cli/--view/01_view_option_is_provided/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export %S --view PRINT_VIEW --output-dir Output/
-RUN: %cat %S/Output/html/01_view_option_is_provided/input.html | filecheck %s --check-prefix=CHECK-HTML
+RUN: %strictdoc export %S --view PRINT_VIEW --output-dir %T
+RUN: %cat %T/html/01_view_option_is_provided/input.html | filecheck %s --check-prefix=CHECK-HTML
 
 CHECK-HTML: REQ-1
 CHECK-HTML: Requirement statement.

--- a/tests/integration/features/options/options_per_cli/--view/02_if_view_option_is_not_provided_then_default_view/test.itest
+++ b/tests/integration/features/options/options_per_cli/--view/02_if_view_option_is_not_provided_then_default_view/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export %S --output-dir Output/
-RUN: %cat %S/Output/html/02_if_view_option_is_not_provided_then_default_view/input.html | filecheck %s --check-prefix=CHECK-HTML
+RUN: %strictdoc export %S --output-dir %T
+RUN: %cat %T/html/02_if_view_option_is_not_provided_then_default_view/input.html | filecheck %s --check-prefix=CHECK-HTML
 
 CHECK-HTML: REQ-1
 CHECK-HTML: Requirement statement.

--- a/tests/integration/features/options/options_per_document/AUTO_LEVELS/01_option_is_on/test.itest
+++ b/tests/integration/features/options/options_per_document/AUTO_LEVELS/01_option_is_on/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/01_option_is_on/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/01_option_is_on/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:data-level="1"
 CHECK-HTML:data-level="1.1"

--- a/tests/integration/features/options/options_per_document/AUTO_LEVELS/02_option_is_off/test.itest
+++ b/tests/integration/features/options/options_per_document/AUTO_LEVELS/02_option_is_off/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/02_option_is_off/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/02_option_is_off/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:data-level="1.2.3"
 CHECK-HTML:data-level="4.5.6"

--- a/tests/integration/features/options/options_per_document/AUTO_LEVELS/03_section_level_is_not_provided_when_automatic_levels_is_off/test.itest
+++ b/tests/integration/features/options/options_per_document/AUTO_LEVELS/03_section_level_is_not_provided_when_automatic_levels_is_off/test.itest
@@ -1,3 +1,3 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: error: [SECTION].LEVEL field is not provided. This contradicts to the option [DOCUMENT].OPTIONS.AUTO_LEVELS set to Off.
 CHECK: error: Parallelizer: One of the child processes has exited prematurely.

--- a/tests/integration/features/options/options_per_document/AUTO_LEVELS/04_req_level_not_provided_when_auto_levels_off/test.itest
+++ b/tests/integration/features/options/options_per_document/AUTO_LEVELS/04_req_level_not_provided_when_auto_levels_off/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: error: [REQUIREMENT].LEVEL field is not provided. This contradicts to the option [DOCUMENT].OPTIONS.AUTO_LEVELS set to Off.

--- a/tests/integration/features/options/options_per_document/AUTO_LEVELS/05_composite_req_level_not_provided_when_auto_levels_off/test.itest
+++ b/tests/integration/features/options/options_per_document/AUTO_LEVELS/05_composite_req_level_not_provided_when_auto_levels_off/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: error: [[COMPOSITE_REQUIREMENT]].LEVEL field is not provided. This contradicts to the option [DOCUMENT].OPTIONS.AUTO_LEVELS set to Off.

--- a/tests/integration/features/options/options_per_document/AUTO_LEVELS/07_includes_w_option_on/test.itest
+++ b/tests/integration/features/options/options_per_document/AUTO_LEVELS/07_includes_w_option_on/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/07_includes_w_option_on/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/07_includes_w_option_on/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:data-level="1"
 CHECK-HTML:data-level="1.1"

--- a/tests/integration/features/options/options_per_document/AUTO_LEVELS/08_includes_w_option_off/test.itest
+++ b/tests/integration/features/options/options_per_document/AUTO_LEVELS/08_includes_w_option_off/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/08_includes_w_option_off/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/08_includes_w_option_off/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:data-level="1.2.3"
 CHECK-HTML:data-level="4.5.6"

--- a/tests/integration/features/options/options_per_document/AUTO_LEVELS/10_option_is_on_but_section_level_is_provided/test.itest
+++ b/tests/integration/features/options/options_per_document/AUTO_LEVELS/10_option_is_on_but_section_level_is_provided/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: error: [SECTION].LEVEL field is provided. This contradicts to the option [DOCUMENT].OPTIONS.AUTO_LEVELS set to On. Section: SDocSection{{.*}}.

--- a/tests/integration/features/options/options_per_document/AUTO_LEVELS/11_option_is_on_but_requirement_level_is_provided/test.itest
+++ b/tests/integration/features/options/options_per_document/AUTO_LEVELS/11_option_is_on_but_requirement_level_is_provided/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: error: [REQUIREMENT].LEVEL field is provided. This contradicts to the option [DOCUMENT].OPTIONS.AUTO_LEVELS set to On.

--- a/tests/integration/features/options/options_per_document/AUTO_LEVELS/12_option_is_on_but_composite_requirement_level_is_provided/test.itest
+++ b/tests/integration/features/options/options_per_document/AUTO_LEVELS/12_option_is_on_but_composite_requirement_level_is_provided/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: error: [[COMPOSITE_REQUIREMENT]].LEVEL field is provided. This contradicts to the option [DOCUMENT].OPTIONS.AUTO_LEVELS set to On. Node: SDocCompositeNode{{.*}}.

--- a/tests/integration/features/options/options_per_document/MARKUP/01_options_markup_is_default/test.itest
+++ b/tests/integration/features/options/options_per_document/MARKUP/01_options_markup_is_default/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/01_options_markup_is_default/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/01_options_markup_is_default/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 // ** ** is transformed to <strong> by RST
 CHECK-HTML: <strong>Hello world</strong>

--- a/tests/integration/features/options/options_per_document/MARKUP/02_options_markup_is_text/test.itest
+++ b/tests/integration/features/options/options_per_document/MARKUP/02_options_markup_is_text/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/02_options_markup_is_text/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/02_options_markup_is_text/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: **This text will not be converted to strong tag**
 CHECK-HTML: &lt;a href=&#34;url&#34;&gt;link&lt;/a&gt;

--- a/tests/integration/features/options/options_per_document/MARKUP/03_options_markup_is_html/test.itest
+++ b/tests/integration/features/options/options_per_document/MARKUP/03_options_markup_is_html/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/03_options_markup_is_html/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/03_options_markup_is_html/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: <b>This <a href="#">text</a> will be rendered directly as HTML!</b>

--- a/tests/integration/features/options/options_per_project/exclude_doc_paths/01_option_specified/test.itest
+++ b/tests/integration/features/options/options_per_project/exclude_doc_paths/01_option_specified/test.itest
@@ -1,14 +1,14 @@
-RUN: %strictdoc export %S --no-parallelization --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --no-parallelization --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: Published: Document 1
 CHECK: Published: Document 2
 CHECK-NOT: Published: Document 3
 
-RUN: %check_exists --file          "%S/Output/html/01_option_specified/docs1/document1.html"
-RUN: %check_exists --file          "%S/Output/html/01_option_specified/docs2/document2.html"
-RUN: %check_exists --file --invert "%S/Output/html/01_option_specified/docs3/document3.html"
+RUN: %check_exists --file          "%T/html/01_option_specified/docs1/document1.html"
+RUN: %check_exists --file          "%T/html/01_option_specified/docs2/document2.html"
+RUN: %check_exists --file --invert "%T/html/01_option_specified/docs3/document3.html"
 
-RUN: %cat "%S/Output/html/index.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-PROJECT-TREE
+RUN: %cat "%T/html/index.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-PROJECT-TREE
 CHECK-PROJECT-TREE: Document 1
 CHECK-PROJECT-TREE: Document 2
 CHECK-PROJECT-TREE-NOT: Document 3

--- a/tests/integration/features/options/options_per_project/exclude_source_paths/01_option_specified/test.itest
+++ b/tests/integration/features/options/options_per_project/exclude_source_paths/01_option_specified/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Expecting an error because the test3.py is filtered out by the
 # "exclude_source_paths" option.

--- a/tests/integration/features/options/options_per_project/features/MATHJAX/01_enabled/test.itest
+++ b/tests/integration/features/options/options_per_project/features/MATHJAX/01_enabled/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export %S --enable-mathjax --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --enable-mathjax --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_static/mathjax/tex-mml-chtml.js"
-RUN: %check_exists --file "%S/Output/html/_static/mathjax/output/chtml/fonts/tex.js"
+RUN: %check_exists --file "%T/html/_static/mathjax/tex-mml-chtml.js"
+RUN: %check_exists --file "%T/html/_static/mathjax/output/chtml/fonts/tex.js"

--- a/tests/integration/features/options/options_per_project/features/MATHJAX/02_disabled/test.itest
+++ b/tests/integration/features/options/options_per_project/features/MATHJAX/02_disabled/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --invert --file "%S/Output/html/_static/mathjax/tex-mml-chtml.js"
-RUN: %check_exists --invert --file "%S/Output/html/_static/mathjax/output/chtml/fonts/tex.js"
+RUN: %check_exists --invert --file "%T/html/_static/mathjax/tex-mml-chtml.js"
+RUN: %check_exists --invert --file "%T/html/_static/mathjax/output/chtml/fonts/tex.js"

--- a/tests/integration/features/options/options_per_project/features/MERMAID/01_enabled/test.itest
+++ b/tests/integration/features/options/options_per_project/features/MERMAID/01_enabled/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/_static/mermaid/mermaid.min.js"
+RUN: %check_exists --file "%T/html/_static/mermaid/mermaid.min.js"
 
-RUN: cat %S/Output/html/01_enabled/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
-RUN: cat %S/Output/html/01_enabled/input.standalone.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
-RUN: cat %S/Output/html/01_enabled/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
-RUN: cat %S/Output/html/01_enabled/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
-RUN: cat %S/Output/html/01_enabled/input-DEEP-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/01_enabled/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/01_enabled/input.standalone.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/01_enabled/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/01_enabled/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/01_enabled/input-DEEP-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
 CHECK-HTML: mermaid.initialize({ startOnLoad: true });

--- a/tests/integration/features/options/options_per_project/features/MERMAID/02_disabled/test.itest
+++ b/tests/integration/features/options/options_per_project/features/MERMAID/02_disabled/test.itest
@@ -1,12 +1,12 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --invert --file "%S/Output/html/_static/mermaid/mermaid.min.js"
+RUN: %check_exists --invert --file "%T/html/_static/mermaid/mermaid.min.js"
 
-RUN: cat %S/Output/html/02_disabled/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
-RUN: cat %S/Output/html/02_disabled/input.standalone.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
-RUN: cat %S/Output/html/02_disabled/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
-RUN: cat %S/Output/html/02_disabled/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
-RUN: cat %S/Output/html/02_disabled/input-DEEP-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/02_disabled/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/02_disabled/input.standalone.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/02_disabled/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/02_disabled/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/02_disabled/input-DEEP-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
 
 CHECK-HTML-NOT: mermaid.initialize({ startOnLoad: true });

--- a/tests/integration/features/options/options_per_project/features/RAPIDOC/01_enabled/test.itest
+++ b/tests/integration/features/options/options_per_project/features/RAPIDOC/01_enabled/test.itest
@@ -1,12 +1,12 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Rapidoc Openapi test
 
-RUN: %check_exists --file "%S/Output/html/_static/rapidoc/rapidoc-min.js"
+RUN: %check_exists --file "%T/html/_static/rapidoc/rapidoc-min.js"
 
-RUN: cat %S/Output/html/01_enabled/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
-RUN: cat %S/Output/html/01_enabled/input.standalone.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
-RUN: cat %S/Output/html/01_enabled/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
-RUN: cat %S/Output/html/01_enabled/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
-RUN: cat %S/Output/html/01_enabled/input-DEEP-TRACE.html 
+RUN: cat %T/html/01_enabled/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/01_enabled/input.standalone.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/01_enabled/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/01_enabled/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/01_enabled/input-DEEP-TRACE.html
 
 CHECK-HTML: <rapi-doc-mini

--- a/tests/integration/features/options/options_per_project/features/RAPIDOC/02_disabled/test.itest
+++ b/tests/integration/features/options/options_per_project/features/RAPIDOC/02_disabled/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Rapidoc Openapi test
 
-RUN: %check_exists --invert --file "%S/Output/html/_static/rapidoc/rapidoc-min.js"
+RUN: %check_exists --invert --file "%T/html/_static/rapidoc/rapidoc-min.js"

--- a/tests/integration/features/options/options_per_project/features/no_options/01_enabled/test.itest
+++ b/tests/integration/features/options/options_per_project/features/no_options/01_enabled/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S --enable-mathjax --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --enable-mathjax --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --invert --file "%S/Output/html/01_enabled/input-TABLE.html"
-RUN: %check_exists --invert --file "%S/Output/html/01_enabled/input-TRACE.html"
-RUN: %check_exists --invert --file "%S/Output/html/01_enabled/input-DEEP-TRACE.html"
+RUN: %check_exists --invert --file "%T/html/01_enabled/input-TABLE.html"
+RUN: %check_exists --invert --file "%T/html/01_enabled/input-TRACE.html"
+RUN: %check_exists --invert --file "%T/html/01_enabled/input-DEEP-TRACE.html"
 
-RUN: %check_exists --file "%S/Output/html/_static/mathjax/tex-mml-chtml.js"
-RUN: %check_exists --file "%S/Output/html/_static/mathjax/output/chtml/fonts/tex.js"
+RUN: %check_exists --file "%T/html/_static/mathjax/tex-mml-chtml.js"
+RUN: %check_exists --file "%T/html/_static/mathjax/output/chtml/fonts/tex.js"

--- a/tests/integration/features/options/options_per_project/features/no_options/02_disabled/test.itest
+++ b/tests/integration/features/options/options_per_project/features/no_options/02_disabled/test.itest
@@ -1,10 +1,10 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/02_disabled/input-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/02_disabled/input-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/02_disabled/input-DEEP-TRACE.html"
+RUN: %check_exists --file "%T/html/02_disabled/input-TABLE.html"
+RUN: %check_exists --file "%T/html/02_disabled/input-TRACE.html"
+RUN: %check_exists --file "%T/html/02_disabled/input-DEEP-TRACE.html"
 
-RUN: %check_exists --invert --file "%S/Output/html/_static/mathjax/tex-mml-chtml.js"
-RUN: %check_exists --invert --file "%S/Output/html/_static/mathjax/output/chtml/fonts/tex.js"
+RUN: %check_exists --invert --file "%T/html/_static/mathjax/tex-mml-chtml.js"
+RUN: %check_exists --invert --file "%T/html/_static/mathjax/output/chtml/fonts/tex.js"
 

--- a/tests/integration/features/options/options_per_project/html_assets_strictdoc_dir/01_option_specified/test.itest
+++ b/tests/integration/features/options/options_per_project/html_assets_strictdoc_dir/01_option_specified/test.itest
@@ -1,12 +1,12 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --dir "%S/Output/html/assets"
-RUN: %check_exists --file "%S/Output/html/assets/base.css"
-RUN: %check_exists --file "%S/Output/html/assets/pan_with_space.js"
+RUN: %check_exists --dir "%T/html/assets"
+RUN: %check_exists --file "%T/html/assets/base.css"
+RUN: %check_exists --file "%T/html/assets/pan_with_space.js"
 
-RUN: %cat "%S/Output/html/index.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-TREE
+RUN: %cat "%T/html/index.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-TREE
 CHECK-HTML-TREE: <link rel="stylesheet" href="assets/base.css"/>
 
-RUN: %cat "%S/Output/html/01_option_specified/input.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-DOC
+RUN: %cat "%T/html/01_option_specified/input.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-DOC
 CHECK-HTML-DOC: <link rel="stylesheet" href="../assets/base.css"/>

--- a/tests/integration/features/options/options_per_project/html_assets_strictdoc_dir/02_option_not_specified/test.itest
+++ b/tests/integration/features/options/options_per_project/html_assets_strictdoc_dir/02_option_not_specified/test.itest
@@ -1,12 +1,12 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --dir "%S/Output/html/_static"
-RUN: %check_exists --file "%S/Output/html/_static/base.css"
-RUN: %check_exists --file "%S/Output/html/_static/pan_with_space.js"
+RUN: %check_exists --dir "%T/html/_static"
+RUN: %check_exists --file "%T/html/_static/base.css"
+RUN: %check_exists --file "%T/html/_static/pan_with_space.js"
 
-RUN: %cat "%S/Output/html/index.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-TREE
+RUN: %cat "%T/html/index.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-TREE
 CHECK-HTML-TREE: <link rel="stylesheet" href="_static/base.css"/>
 
-RUN: %cat "%S/Output/html/02_option_not_specified/input.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-DOC
+RUN: %cat "%T/html/02_option_not_specified/input.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-DOC
 CHECK-HTML-DOC: <link rel="stylesheet" href="../_static/base.css"/>

--- a/tests/integration/features/options/options_per_project/include_doc_paths/01_option_specified/test.itest
+++ b/tests/integration/features/options/options_per_project/include_doc_paths/01_option_specified/test.itest
@@ -1,14 +1,14 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: Published: Document 1
 CHECK-NOT: Published: Document 2
 CHECK-NOT: Published: Document 3
 
-RUN: %check_exists --file          "%S/Output/html/01_option_specified/docs1/document1.html"
-RUN: %check_exists --file --invert "%S/Output/html/01_option_specified/docs2/document2.html"
-RUN: %check_exists --file --invert "%S/Output/html/01_option_specified/docs3/document3.html"
+RUN: %check_exists --file          "%T/html/01_option_specified/docs1/document1.html"
+RUN: %check_exists --file --invert "%T/html/01_option_specified/docs2/document2.html"
+RUN: %check_exists --file --invert "%T/html/01_option_specified/docs3/document3.html"
 
-RUN: %cat "%S/Output/html/index.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-PROJECT-TREE
+RUN: %cat "%T/html/index.html" | filecheck %s --dump-input=fail --check-prefix=CHECK-PROJECT-TREE
 CHECK-PROJECT-TREE: Document 1
 CHECK-PROJECT-TREE-NOT: Document 2
 CHECK-PROJECT-TREE-NOT: Document 3

--- a/tests/integration/features/options/options_per_project/include_doc_paths/02_invalid_option/test.itest
+++ b/tests/integration/features/options/options_per_project/include_doc_paths/02_invalid_option/test.itest
@@ -1,3 +1,3 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: strictdoc.toml: 'include_doc_paths': Path mask must start with an alphanumeric character or a wildcard symbol '*'. Provided string: ' '.

--- a/tests/integration/features/options/options_per_project/include_source_paths/01_option_specified/test.itest
+++ b/tests/integration/features/options/options_per_project/include_source_paths/01_option_specified/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Expecting a error because the test2.py is filtered out by the
 # "include_source_paths" option.

--- a/tests/integration/features/options/options_per_project/project_title/01_option_specified/test.itest
+++ b/tests/integration/features/options/options_per_project/project_title/01_option_specified/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML: Test Project title read from TOML file

--- a/tests/integration/features/options/options_per_project/project_title/02_option_not_specified/test.itest
+++ b/tests/integration/features/options/options_per_project/project_title/02_option_not_specified/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML: Untitled Project

--- a/tests/integration/features/options/options_per_project/validations/01_malformed_toml/test.itest
+++ b/tests/integration/features/options/options_per_project/validations/01_malformed_toml/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: error: Could not parse the config file {{.*}}strictdoc.toml: Key group not on a line by itself. (line 1 column 1 char 0).

--- a/tests/integration/features/options/options_per_project/validations/02_unknown_feature/test.itest
+++ b/tests/integration/features/options/options_per_project/validations/02_unknown_feature/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: error: strictdoc.toml: unknown feature declared: 'THIS_FEATURE_DOES_NOT_EXIST'.

--- a/tests/integration/features/options/options_per_project/validations/03_features_not_array/test.itest
+++ b/tests/integration/features/options/options_per_project/validations/03_features_not_array/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: error: strictdoc.toml: 'feature' parameter must be an array: 'broken'.

--- a/tests/integration/features/options/options_per_section/LEVEL/01_level_is_None/test.itest
+++ b/tests/integration/features/options/options_per_section/LEVEL/01_level_is_None/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/01_level_is_None/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/01_level_is_None/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:href="#1-Section-1"
 CHECK-HTML:href="#-Out-of-band-Section"

--- a/tests/integration/features/options/options_per_section/LEVEL/02_level_is_None_for_requirements/test.itest
+++ b/tests/integration/features/options/options_per_section/LEVEL/02_level_is_None_for_requirements/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/02_level_is_None_for_requirements/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/02_level_is_None_for_requirements/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:href="#1-First-section-numbered"
 CHECK-HTML:href="#-Second-section-unnumbered"

--- a/tests/integration/features/project_statistics/01_statistics_are_generated/test.itest
+++ b/tests/integration/features/project_statistics/01_statistics_are_generated/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/project_statistics.html"
+RUN: %check_exists --file "%T/html/project_statistics.html"
 
-RUN: %cat "%S/Output/html/project_statistics.html" | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat "%T/html/project_statistics.html" | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: Test project
 CHECK-HTML: Total documents
 CHECK-HTML: Total requirements

--- a/tests/integration/features/project_statistics/10_metric_sections_without_text/test.itest
+++ b/tests/integration/features/project_statistics/10_metric_sections_without_text/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/project_statistics.html"
+RUN: %check_exists --file "%T/html/project_statistics.html"
 
-RUN: %cat "%S/Output/html/project_statistics.html" | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat "%T/html/project_statistics.html" | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Total sections
 CHECK-HTML: 6
 CHECK-HTML: Sections without any text

--- a/tests/integration/features/project_statistics/20_requirement_metric_does_not_include_text_nodes/test.itest
+++ b/tests/integration/features/project_statistics/20_requirement_metric_does_not_include_text_nodes/test.itest
@@ -1,11 +1,11 @@
 # This test ensures that the TEXT nodes DO NOT contribute to the requirements statistics.
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/project_statistics.html"
+RUN: %check_exists --file "%T/html/project_statistics.html"
 
-RUN: %cat "%S/Output/html/project_statistics.html" | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat "%T/html/project_statistics.html" | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: Total requirements
 CHECK-HTML: 3
 CHECK-HTML: Requirements with no UID

--- a/tests/integration/features/project_statistics/30_requirements_status_breakdown/test.itest
+++ b/tests/integration/features/project_statistics/30_requirements_status_breakdown/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/project_statistics.html"
+RUN: %check_exists --file "%T/html/project_statistics.html"
 
-RUN: %cat "%S/Output/html/project_statistics.html" | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat "%T/html/project_statistics.html" | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Test project
 CHECK-HTML: Total documents
 CHECK-HTML: Total requirements

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/--reqif-enable-mid/01_cli_option/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/--reqif-enable-mid/01_cli_option/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc --reqif-enable-mid %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc --reqif-enable-mid %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc --reqif-enable-mid %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc --reqif-enable-mid %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/--reqif-enable-mid/02_toml_option/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/--reqif-enable-mid/02_toml_option/test.itest
@@ -1,3 +1,4 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: cd %S/
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/--reqif-import-markup/01_cli_option/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/--reqif-import-markup/01_cli_option/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc --reqif-import-markup=HTML %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc --reqif-import-markup=HTML %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/--reqif-import-markup/02_toml_option/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/--reqif-import-markup/02_toml_option/test.itest
@@ -1,3 +1,4 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: cd %S
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/--reqif-multiline-is-xhtml/01_cli_option/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/--reqif-multiline-is-xhtml/01_cli_option/test.itest
@@ -1,8 +1,8 @@
-RUN: %strictdoc export --formats=reqif-sdoc --reqif-multiline-is-xhtml %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc --reqif-multiline-is-xhtml %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc
 
-RUN: %cat %S/output/reqif/output.reqif | filecheck %s --check-prefix CHECK-EXPORTED-REQIF
+RUN: %cat %T/reqif/output.reqif | filecheck %s --check-prefix CHECK-EXPORTED-REQIF
 CHECK-EXPORTED-REQIF:<DATATYPE-DEFINITION-STRING IDENTIFIER="SDOC_DATATYPE_SINGLE_LINE_STRING"/>
 CHECK-EXPORTED-REQIF:<DATATYPE-DEFINITION-XHTML IDENTIFIER="SDOC_DATATYPE_MULTI_LINE_STRING"/>
 

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/--reqif-multiline-is-xhtml/02_toml_option/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/--reqif-multiline-is-xhtml/02_toml_option/test.itest
@@ -1,8 +1,8 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc
 
-RUN: %cat %S/output/reqif/output.reqif | filecheck %s --check-prefix CHECK-EXPORTED-REQIF
+RUN: %cat %T/reqif/output.reqif | filecheck %s --check-prefix CHECK-EXPORTED-REQIF
 CHECK-EXPORTED-REQIF:<DATATYPE-DEFINITION-STRING IDENTIFIER="SDOC_DATATYPE_SINGLE_LINE_STRING"/>
 CHECK-EXPORTED-REQIF:<DATATYPE-DEFINITION-XHTML IDENTIFIER="SDOC_DATATYPE_MULTI_LINE_STRING"/>
 

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/01_minimal_reqif/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/01_minimal_reqif/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc
 
-RUN: %cat %S/output/reqif/output.reqif | filecheck %s
+RUN: %cat %T/reqif/output.reqif | filecheck %s
 CHECK: <REQ-IF xmlns="http://www.omg.org/spec/ReqIF/20110401/reqif.xsd" xmlns:xhtml="http://www.w3.org/1999/xhtml">

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/02_one_requirement/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/02_one_requirement/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/03_one_section_one_requirement/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/03_one_section_one_requirement/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/04_one_section_one_subsection_one_requirement/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/04_one_section_one_subsection_one_requirement/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/05_two_sections/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/05_two_sections/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/06_three_sections/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/06_three_sections/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/07_one_nested_section/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/07_one_nested_section/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/08_two_nested_sections/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/08_two_nested_sections/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/09_next_requirement_drop_in_level/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/09_next_requirement_drop_in_level/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/100_export_reqif_header/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/100_export_reqif_header/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %cat %S/output/reqif/output.reqif | filecheck %s
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %cat %T/reqif/output.reqif | filecheck %s
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc
 
 CHECK:     <THE-HEADER>
 CHECK:       <REQ-IF-HEADER IDENTIFIER="REQ-IF-HEADER-{{.*}}">

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/10_next_requirement_drop_of_two_levels/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/10_next_requirement_drop_of_two_levels/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/11_exporting_sections_free_text/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/11_exporting_sections_free_text/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/12_multiline_statements/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/12_multiline_statements/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/14_document_freetext/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/14_document_freetext/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/15_composite_requirement/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/15_composite_requirement/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/20_comment_multiple/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/20_comment_multiple/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/30_custom_grammar/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/30_custom_grammar/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/31_custom_grammar_single_choice_type/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/31_custom_grammar_single_choice_type/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/32_custom_grammar_multi_choice_type/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/32_custom_grammar_multi_choice_type/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/33_custom_grammar_multiple_node_types/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/33_custom_grammar_multiple_node_types/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/40_specification_type/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/40_specification_type/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %cat %S/output/reqif/output.reqif | filecheck %s
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %cat %T/reqif/output.reqif | filecheck %s
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc
 
 CHECK:        <SPECIFICATION-TYPE IDENTIFIER="SDOC_SPECIFICATION_TYPE_SINGLETON" LAST-CHANGE="{{.*}}" LONG-NAME="SDOC_SPECIFICATION_TYPE_SINGLETON"/>
 CHECK:        <SPECIFICATION IDENTIFIER="SPECIFICATION-{{.*}}" LONG-NAME="sample">

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/50_reqifz_basic_roundtrip/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/50_reqifz_basic_roundtrip/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqifz-sdoc --output-dir %S/Output %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/Output/reqif/output.reqifz %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqifz-sdoc --output-dir %T %S/sample.sdoc
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqifz %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/60_multiple_documents/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/60_multiple_documents/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/Sample_1.sdoc %S/output/Sample_1.sdoc
-RUN: %diff %S/Sample_2.sdoc %S/output/Sample_2.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/ --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/Sample_1.sdoc %T/Sample_1.sdoc
+RUN: %diff %S/Sample_2.sdoc %T/Sample_2.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/70_relations/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/70_relations/test.itest
@@ -1,3 +1,3 @@
-RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/
-RUN: %diff %S/sample.sdoc %S/output/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %S/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/
+RUN: %diff %S/sample.sdoc %T/sample.sdoc

--- a/tests/integration/features/reqif/profiles/p01_sdoc/examples/01_sample/test.itest
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/examples/01_sample/test.itest
@@ -1,6 +1,5 @@
-RUN: %mkdir %S/output
-RUN: %strictdoc import reqif sdoc %S/sample.reqif %S/output/
-RUN: %cat %S/output/sample.sdoc | filecheck %s
+RUN: %strictdoc import reqif sdoc %S/sample.reqif %T/
+RUN: %cat %T/sample.sdoc | filecheck %s
 
 CHECK: [REQUIREMENT_TYPE]
 CHECK: UID: Anonymized-194ac1eb-d718-b59b-5d2a-c2b0ac0381ef
@@ -11,6 +10,6 @@ CHECK: COMMENT: >>>
 CHECK: Anonymized-6e95e816-6fc9-0fe1-8b1f-66340311da94
 CHECK: <<<
 
-RUN: %strictdoc export --formats=reqif-sdoc %S/output/sample.sdoc
-RUN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output2/
-RUN: %diff %S/output/sample.sdoc %S/output2/sample.sdoc
+RUN: %strictdoc export --formats=reqif-sdoc %T/sample.sdoc --output-dir %T
+RUN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T2/
+RUN: %diff %T/sample.sdoc %T2/sample.sdoc

--- a/tests/integration/features/rst/01_basic_rst_export/test.itest
+++ b/tests/integration/features/rst/01_basic_rst_export/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/02_folder_structure_is_preserved_for_nested/test.itest
+++ b/tests/integration/features/rst/02_folder_structure_is_preserved_for_nested/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S"
 
-RUN: %check_exists --file "%S/Output/rst/input_folder/input.rst"
+RUN: %check_exists --file "%T/rst/input_folder/input.rst"
 
-RUN: %diff "%S/Output/rst/input_folder/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input_folder/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/04_one_requirement_without_title/test.itest
+++ b/tests/integration/features/rst/04_one_requirement_without_title/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/05_requirement_without_title/test.itest
+++ b/tests/integration/features/rst/05_requirement_without_title/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/06_requirement_with_title/test.itest
+++ b/tests/integration/features/rst/06_requirement_with_title/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/07_requirement_comments/test.itest
+++ b/tests/integration/features/rst/07_requirement_comments/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/08_requirement_comments_then_section/test.itest
+++ b/tests/integration/features/rst/08_requirement_comments_then_section/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/09_requirement_rationale/test.itest
+++ b/tests/integration/features/rst/09_requirement_rationale/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/20_custom_field/test.itest
+++ b/tests/integration/features/rst/20_custom_field/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff -burp "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff -burp "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/30_requirement_references/test.itest
+++ b/tests/integration/features/rst/30_requirement_references/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/40_link_to_another_section/test.itest
+++ b/tests/integration/features/rst/40_link_to_another_section/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/41_link_to_node/test.itest
+++ b/tests/integration/features/rst/41_link_to_node/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/42_link_with_custom_grammar/test.itest
+++ b/tests/integration/features/rst/42_link_with_custom_grammar/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/50_link_to_anchor/test.itest
+++ b/tests/integration/features/rst/50_link_to_anchor/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/51_link_to_anchor_with_title/test.itest
+++ b/tests/integration/features/rst/51_link_to_anchor_with_title/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"

--- a/tests/integration/features/rst/52_link_to_document/test.itest
+++ b/tests/integration/features/rst/52_link_to_document/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc export %S --formats=rst --output-dir Output
+RUN: %strictdoc export %S --formats=rst --output-dir %T
 
-RUN: %check_exists --file "%S/Output/rst/input1.rst"
+RUN: %check_exists --file "%T/rst/input1.rst"
 
-RUN: %diff "%S/Output/rst/input1.rst" "%S/expected/input1.rst"
-RUN: %diff "%S/Output/rst/input2.rst" "%S/expected/input2.rst"
+RUN: %diff "%T/rst/input1.rst" "%S/expected/input1.rst"
+RUN: %diff "%T/rst/input2.rst" "%S/expected/input2.rst"

--- a/tests/integration/features/rst/60_field_human_titles/test.itest
+++ b/tests/integration/features/rst/60_field_human_titles/test.itest
@@ -1,8 +1,8 @@
-RUN: %strictdoc export --formats=rst --output-dir Output "%S/input.sdoc"
+RUN: %strictdoc export --formats=rst --output-dir %T "%S/input.sdoc"
 
-RUN: %check_exists --file "%S/Output/rst/input.rst"
+RUN: %check_exists --file "%T/rst/input.rst"
 
-RUN: %diff "%S/Output/rst/input.rst" "%S/expected/input.rst"
+RUN: %diff "%T/rst/input.rst" "%S/expected/input.rst"
 
 CHECK-HTML:Identifier
 CHECK-HTML:ABC-123

--- a/tests/integration/features/sdoc/composite_node_migration/00_migration_warning_shown_when_no_project_config_option/test.itest
+++ b/tests/integration/features/sdoc/composite_node_migration/00_migration_warning_shown_when_no_project_config_option/test.itest
@@ -1,2 +1,2 @@
-RUN: %strictdoc export %S/input.sdoc --formats=sdoc --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S/input.sdoc --formats=sdoc --output-dir %T | filecheck %s --dump-input=fail
 CHECK: WARNING: At least one document in this documentation tree uses a deprecated [SECTION] element.

--- a/tests/integration/features/sdoc/composite_node_migration/01_migration_path_with_project_config_option/test.itest
+++ b/tests/integration/features/sdoc/composite_node_migration/01_migration_path_with_project_config_option/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S/input.sdoc --formats=sdoc --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S/input.sdoc --formats=sdoc --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Step 'Export SDoc' took:
 
-RUN: %diff %S/Output/sdoc/input.sdoc %S/input.expected.sdoc
+RUN: %diff %T/sdoc/input.sdoc %S/input.expected.sdoc

--- a/tests/integration/features/sdoc/composite_node_migration/02_migration_path_included_documents/test.itest
+++ b/tests/integration/features/sdoc/composite_node_migration/02_migration_path_included_documents/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S/ --formats=sdoc --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S/ --formats=sdoc --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Step 'Export SDoc' took:
 
-RUN: %diff %S/Output/sdoc/subnested.sdoc %S/subnested.expected.sdoc_
+RUN: %diff %T/sdoc/subnested.sdoc %S/subnested.expected.sdoc_

--- a/tests/integration/features/sdoc/document_grammar/01_basic_grammar_declaration_and_valid_fields/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/01_basic_grammar_declaration_and_valid_fields/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
 CHECK: Published: Test document
 
-RUN: %cat %S/Output/html/01_basic_grammar_declaration_and_valid_fields/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/01_basic_grammar_declaration_and_valid_fields/input.html | filecheck %s --check-prefix CHECK-HTML
 
 CHECK-HTML:UID
 CHECK-HTML:ABC-123

--- a/tests/integration/features/sdoc/document_grammar/02_several_comments/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/02_several_comments/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Test document
 
-RUN: %cat %S/Output/html/02_several_comments/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/02_several_comments/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML:ONE
 CHECK-HTML:One-value
 CHECK-HTML:Comment #1

--- a/tests/integration/features/sdoc/document_grammar/03_non_required_grammar_fields_are_skipped/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/03_non_required_grammar_fields_are_skipped/test.itest
@@ -1,3 +1,3 @@
-RUN: %expect_exit 0 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 0 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK:Export completed.

--- a/tests/integration/features/sdoc/document_grammar/20_field_human_titles/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/20_field_human_titles/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Test document
 
-RUN: %cat %S/Output/html/20_field_human_titles/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/20_field_human_titles/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML:Identifier
 CHECK-HTML:ABC-123

--- a/tests/integration/features/sdoc/document_grammar/30_grammar_without_statement_but_with_description/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/30_grammar_without_statement_but_with_description/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Test document
 
-RUN: %cat %S/Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 CHECK-HTML: ABC-123
 CHECK-HTML: Title

--- a/tests/integration/features/sdoc/document_grammar/90_grammar_element_with_VIEW_STYLE/01_VIEW_STYLE_declaration_controls_html_layout/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/90_grammar_element_with_VIEW_STYLE/01_VIEW_STYLE_declaration_controls_html_layout/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S --output-dir Output/
+RUN: %strictdoc export %S --output-dir %T/
 
 RUN: cat Output/html/%THIS_TEST_FOLDER/input.html | filecheck %s
 

--- a/tests/integration/features/sdoc/document_grammar/_grammar_from_file/01_basic_grammar_from_file/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/_grammar_from_file/01_basic_grammar_from_file/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
 CHECK: Published: Test document
 
-RUN: %cat %S/Output/html/01_basic_grammar_from_file/input.html | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat %T/html/01_basic_grammar_from_file/input.html | filecheck %s --check-prefix CHECK-HTML
 
 CHECK-HTML:UID
 CHECK-HTML:ABC-123

--- a/tests/integration/features/sdoc/document_grammar/_grammar_from_file/_validations/01_grammar_file_not_found/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/_grammar_from_file/_validations/01_grammar_file_not_found/test.itest
@@ -1,2 +1,2 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: error: TraceabilityIndex: the document "Test document" imports a grammar from a file that does not exist: "grammar.sgra".

--- a/tests/integration/features/sdoc/document_grammar/_grammar_from_file/_validations/03_must_check_element_has_either_title_or_reserved_statement/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/_grammar_from_file/_validations/03_must_check_element_has_either_title_or_reserved_statement/test.itest
@@ -1,3 +1,3 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: StrictDocException: The grammar element REQUIREMENT must have at least one of the following fields: TITLE, STATEMENT, DESCRIPTION, CONTENT.

--- a/tests/integration/features/sdoc/document_grammar/type_system/multiple_single_choice/01_choice_declaration/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/type_system/multiple_single_choice/01_choice_declaration/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Test document
 
-RUN: %cat %S/Output/html/01_choice_declaration/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/01_choice_declaration/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML:CHOICE_FIELD
 CHECK-HTML:A, B

--- a/tests/integration/features/sdoc/document_grammar/type_system/multiple_single_choice/validation/01_invalid_value/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/type_system/multiple_single_choice/validation/01_invalid_value/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: Requirement field has an invalid MultipleChoice value: A, E.

--- a/tests/integration/features/sdoc/document_grammar/type_system/multiple_single_choice/validation/02_valid_value_but_no_whitespace/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/type_system/multiple_single_choice/validation/02_valid_value_but_no_whitespace/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: Requirement field of type MultipleChoice is invalid: A,E.

--- a/tests/integration/features/sdoc/document_grammar/type_system/single_choice/01_choice_declaration/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/type_system/single_choice/01_choice_declaration/test.itest
@@ -1,6 +1,6 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Test document
 
-RUN: %cat %S/Output/html/01_choice_declaration/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/01_choice_declaration/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML:CHOICE_FIELD
 CHECK-HTML:AAA

--- a/tests/integration/features/sdoc/document_grammar/type_system/single_choice/validation/01_invalid_value/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/type_system/single_choice/validation/01_invalid_value/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: Requirement field has an invalid SingleChoice value: E.

--- a/tests/integration/features/sdoc/document_grammar/type_system/tag/01_tag_declaration/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/type_system/tag/01_tag_declaration/test.itest
@@ -1,11 +1,11 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Test document
 
-RUN: %cat %S/Output/html/01_tag_declaration/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/01_tag_declaration/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML:TAGS
 CHECK-HTML:TAG1, TAG2, TAG3
 
-RUN: %cat %S/Output/html/01_tag_declaration/input-TABLE.html | filecheck %s --check-prefix CHECK-HTML-TABLE
+RUN: %cat %T/html/01_tag_declaration/input-TABLE.html | filecheck %s --check-prefix CHECK-HTML-TABLE
 CHECK-HTML-TABLE:TAG1<span class="tag_badge">1</span>
 CHECK-HTML-TABLE:TAG2<span class="tag_badge">1</span>
 CHECK-HTML-TABLE:TAG3<span class="tag_badge">1</span>

--- a/tests/integration/features/sdoc/document_grammar/type_system/tag/validation/01_invalid_value/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/type_system/tag/validation/01_invalid_value/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: Requirement field of type Tag is invalid: A#B#C.

--- a/tests/integration/features/sdoc/document_grammar/validation/01_unknown_requirement_type/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/validation/01_unknown_requirement_type/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: Invalid node type: UNKNOWN_REQUIREMENT.

--- a/tests/integration/features/sdoc/document_grammar/validation/02_invalid_field/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/validation/02_invalid_field/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: Invalid requirement field: UNREGISTERED

--- a/tests/integration/features/sdoc/document_grammar/validation/03_valid_field_but_incorrect_order/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/validation/03_valid_field_but_incorrect_order/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK:error: could not parse file: {{.*}}input.sdoc.
 CHECK:Semantic error: Wrong field order for requirement: [UID, TITLE].

--- a/tests/integration/features/sdoc/document_grammar/validation/03b_valid_field_but_incorrect_order_UID/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/validation/03b_valid_field_but_incorrect_order_UID/test.itest
@@ -1,9 +1,9 @@
-RUN: %expect_exit 1 %strictdoc passthrough %S/input.sdoc --output-dir %S/Output/ | filecheck %s
+RUN: %expect_exit 1 %strictdoc passthrough %S/input.sdoc --output-dir %T/ | filecheck %s
 
 # The same validation message should be produced even if the auto-uid command is executed.
 # https://github.com/strictdoc-project/strictdoc/issues/1896
-RUN: cp %S/input.sdoc %S/Output/
-RUN: %expect_exit 1 %strictdoc manage auto-uid %S/Output/
+RUN: cp %S/input.sdoc %T/
+RUN: %expect_exit 1 %strictdoc manage auto-uid %T/
 
 CHECK: error: could not parse file: {{.*}}/input.sdoc.
 CHECK: Semantic error: Wrong field order for requirement: [STATEMENT, UID].

--- a/tests/integration/features/sdoc/document_grammar/validation/04a_missing_required_grammar_field_node_has_less_fields_than_grammar/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/validation/04a_missing_required_grammar_field_node_has_less_fields_than_grammar/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK:error: could not parse file: {{.*}}input.sdoc.
 CHECK:Semantic error: Node is missing a field that is required by grammar: TWO.

--- a/tests/integration/features/sdoc/document_grammar/validation/04b_missing_required_grammar_field/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/validation/04b_missing_required_grammar_field/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc passthrough %S/input.sdoc --output-dir %S/Output/ | filecheck %s
+RUN: %expect_exit 1 %strictdoc passthrough %S/input.sdoc --output-dir %T/ | filecheck %s
 
 CHECK: error: could not parse file: {{.*}}/input.sdoc.
 CHECK: Semantic error: Node is missing a field that is required by grammar: UID.

--- a/tests/integration/features/sdoc/document_grammar/validation/05_unexpected_field_outside_grammar/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/validation/05_unexpected_field_outside_grammar/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK:error: could not parse file: {{.*}}input.sdoc.
 CHECK:Semantic error: Wrong field order for requirement: [ONE, TWO, ONE]

--- a/tests/integration/features/sdoc/document_grammar/validation/06_gef_reference_type_not_allowed/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/validation/06_gef_reference_type_not_allowed/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: Requirement relation type/role is not registered: File.

--- a/tests/integration/features/sdoc/document_grammar/validation/09_ENABLE_MID_enabled_but_missing_MID_field/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/validation/09_ENABLE_MID_enabled_but_missing_MID_field/test.itest
@@ -2,4 +2,4 @@
 # default implicit grammar and no validation is triggered about the
 # missing MID grammar element field declaration.
 
-RUN: %expect_exit 0 %strictdoc export %S --output-dir Output/
+RUN: %expect_exit 0 %strictdoc export %S --output-dir %T

--- a/tests/integration/features/sdoc/document_grammar/validation/30_composite_node_not_declared_in_grammar/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/validation/30_composite_node_not_declared_in_grammar/test.itest
@@ -2,7 +2,7 @@
 #        old [SECTION] is removed from the codebase.
 UNSUPPORTED: true
 
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: Invalid node type: SECTION.

--- a/tests/integration/features/sdoc/document_grammar/validation/31_composite_node_declared_in_grammar_but_composite_is_False/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/validation/31_composite_node_declared_in_grammar_but_composite_is_False/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: The composite node's grammar element is declared as non-composite: [[SECTION]].

--- a/tests/integration/features/sdoc/document_grammar/validation/32_non_composite_node_declared_in_grammar_but_composite_is_True/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/validation/32_non_composite_node_declared_in_grammar_but_composite_is_True/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: The non-composite node's grammar element is declared as composite: [[REQUIREMENT]].

--- a/tests/integration/features/source_coverage/01_links_to_files/test.itest
+++ b/tests/integration/features/source_coverage/01_links_to_files/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/source_coverage.html"
+RUN: %check_exists --file "%T/html/source_coverage.html"
 
-RUN: %cat "%S/Output/html/source_coverage.html" | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat "%T/html/source_coverage.html" | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: href="_source_files/file.py.html"

--- a/tests/integration/features/spdx/01_minimal_document_mid_enabled/test.itest
+++ b/tests/integration/features/spdx/01_minimal_document_mid_enabled/test.itest
@@ -1,7 +1,8 @@
-RUN: %strictdoc export %S --formats=html,spdx --output-dir Output | filecheck %s --dump-input=fail
+RUN: cd %S
+RUN: %strictdoc export %S --formats=html,spdx --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Step 'Export SDoc' took:
 
-RUN: cat %S/Output/spdx/output.spdx | filecheck %s --check-prefix=CHECK-SPDX
+RUN: cat %T/spdx/output.spdx | filecheck %s --check-prefix=CHECK-SPDX
 
 CHECK-SPDX: ## SPDX Document
 
@@ -9,9 +10,9 @@ CHECK-SPDX: Untitled Project
 CHECK-SPDX: Dummy high-level requirement #1
 CHECK-SPDX: Dummy low-level requirement #1
 
-RUN: cp %S/strictdoc.toml %S/Output/spdx/
-RUN: cp %S/input1.sdoc %S/Output/spdx/
-RUN: cp %S/input2.sdoc %S/Output/spdx/
-RUN: cp %S/file.py %S/Output/spdx/
-RUN: cd %S/Output/spdx/
-RUN: %strictdoc export %S/Output/spdx/output.spdx.sdoc --formats=html --output-dir Output
+RUN: cp %S/strictdoc.toml %T/spdx/
+RUN: cp %S/input1.sdoc %T/spdx/
+RUN: cp %S/input2.sdoc %T/spdx/
+RUN: cp %S/file.py %T/spdx/
+RUN: cd %T/spdx/
+RUN: %strictdoc export %T/spdx/output.spdx.sdoc --formats=html --output-dir %T

--- a/tests/integration/features/spdx/02_minimal_document_mid_disabled/test.itest
+++ b/tests/integration/features/spdx/02_minimal_document_mid_disabled/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --formats=spdx --output-dir Output | filecheck %s --dump-input=fail
+RUN: cd %S && %strictdoc export %S --formats=spdx --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Step 'Export SDoc' took:
 
-RUN: cat %S/Output/spdx/output.spdx | filecheck %s --check-prefix=CHECK-SPDX
+RUN: cat %T/spdx/output.spdx | filecheck %s --check-prefix=CHECK-SPDX
 
 CHECK-SPDX: ## SPDX Document
 
@@ -9,8 +9,8 @@ CHECK-SPDX: Untitled Project
 CHECK-SPDX: Dummy high-level requirement #1
 CHECK-SPDX: Dummy low-level requirement #1
 
-RUN: cp strictdoc.toml %S/Output/spdx/
-RUN: cp input1.sdoc %S/Output/spdx/
-RUN: cp input2.sdoc %S/Output/spdx/
-RUN: cp file.py %S/Output/spdx/
-RUN: %strictdoc export %S/Output/spdx/output.spdx.sdoc --formats=html --output-dir Output | filecheck %s --dump-input=fail
+RUN: cp strictdoc.toml %T/spdx/
+RUN: cp input1.sdoc %T/spdx/
+RUN: cp input2.sdoc %T/spdx/
+RUN: cp file.py %T/spdx/
+RUN: %strictdoc export %T/spdx/output.spdx.sdoc --formats=html --output-dir %T | filecheck %s --dump-input=fail

--- a/tests/integration/features/test_reports/junit_xml/ctest/01_passed_test/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/ctest/01_passed_test/test.itest
@@ -1,15 +1,15 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report: (empty)
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/test.cpp.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/test.cpp.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT:href="../../_source_files/tests/test.cpp.html#TestPrtMath.TransitionDistance#1#10">
 CHECK-TEST-REPORT: tests/test.cpp, <i>lines: 1-10</i>, function TEST_F(TestPrtMath, TransitionDistance)

--- a/tests/integration/features/test_reports/junit_xml/ctest/02_failed_test/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/ctest/02_failed_test/test.itest
@@ -1,16 +1,16 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report: (empty)
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/test.cpp.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/test.cpp.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT: FAILED
 CHECK-TEST-REPORT:href="../../_source_files/tests/test.cpp.html#TestPrtMath.TransitionDistance#1#10">
 CHECK-TEST-REPORT: tests/test.cpp, <i>lines: 1-10</i>, function TEST_F(TestPrtMath, TransitionDistance)

--- a/tests/integration/features/test_reports/junit_xml/ctest/03_skipped_test/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/ctest/03_skipped_test/test.itest
@@ -1,14 +1,14 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report: (empty)
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/test.cpp.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/test.cpp.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT: SKIPPED

--- a/tests/integration/features/test_reports/junit_xml/ctest/04_multiple_tests/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/ctest/04_multiple_tests/test.itest
@@ -3,18 +3,18 @@
 
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report: (empty)
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/test1.cpp.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/test2.cpp.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/test1.cpp.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/test2.cpp.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT:href="../../_source_files/tests/test1.cpp.html#Test1.TransitionDistance1#1#10">
 CHECK-TEST-REPORT: tests/test1.cpp, <i>lines: 1-10</i>, function TEST_F(Test1, TransitionDistance1)
 CHECK-TEST-REPORT:href="../../_source_files/tests/test1.cpp.html#Test1.TransitionDistance2#12#21">

--- a/tests/integration/features/test_reports/junit_xml/ctest/05_user_example/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/ctest/05_user_example/test.itest
@@ -3,17 +3,17 @@
 
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report: (empty)
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/test1.cpp.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/test1.cpp.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT:href="../../_source_files/tests/test1.cpp.html#MyTestSuiteName.TestName#17#21">
 CHECK-TEST-REPORT: tests/test1.cpp, <i>lines: 17-21</i>, function TEST(MyTestSuiteName, TestName)
 CHECK-TEST-REPORT:href="../../_source_files/tests/test1.cpp.html#MyTestHelper.TestName2#32#36">

--- a/tests/integration/features/test_reports/junit_xml/gtest/05_user_example/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/gtest/05_user_example/test.itest
@@ -3,17 +3,17 @@
 
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.gtest.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.gtest.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/test1.cpp.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/test1.cpp.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.gtest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.gtest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT:href="../../_source_files/tests/test1.cpp.html#MyTestSuiteName.TestName#17#21">
 CHECK-TEST-REPORT: tests/test1.cpp, <i>lines: 17-21</i>, function TEST(MyTestSuiteName, TestName)
 CHECK-TEST-REPORT:href="../../_source_files/tests/test1.cpp.html#MyTestHelper.TestName2#32#36">

--- a/tests/integration/features/test_reports/junit_xml/gtest/06_user_example_still_does_not_work/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/gtest/06_user_example_still_does_not_work/test.itest
@@ -3,17 +3,17 @@
 
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.gtest.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.gtest.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/test1.cpp.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/test1.cpp.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.gtest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.gtest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT:href="../../_source_files/tests/test1.cpp.html#TestCaseVc.TestCase#17#21">
 CHECK-TEST-REPORT: tests/test1.cpp, <i>lines: 17-21</i>, function TEST(TestCaseVc, TestCase)
 CHECK-TEST-REPORT:href="../../_source_files/tests/test1.cpp.html#TestCaseVc.Steering1#23#27">

--- a/tests/integration/features/test_reports/junit_xml/lit/01_minimal_document/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/lit/01_minimal_document/test.itest
@@ -1,12 +1,12 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report: StrictDoc integration tests
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_integration.lit.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_integration.lit.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/integration/foo/test.ignored.itest.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/integration/foo/test.ignored.itest.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_integration.lit.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_integration.lit.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT: href="../../_source_files/tests/integration/foo/test.ignored.itest.html#tests/integration/foo/test.ignored.itest#1#2">

--- a/tests/integration/features/test_reports/junit_xml/lit/02_failed_test/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/lit/02_failed_test/test.itest
@@ -1,13 +1,13 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report: StrictDoc integration tests
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_integration.lit.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_integration.lit.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/integration/foo/test.ignored.itest.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/integration/foo/test.ignored.itest.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_integration.lit.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_integration.lit.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT: FAILED
 CHECK-TEST-REPORT: href="../../_source_files/tests/integration/foo/test.ignored.itest.html#tests/integration/foo/test.ignored.itest#1#2">

--- a/tests/integration/features/test_reports/junit_xml/lit/03_skipped_test/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/lit/03_skipped_test/test.itest
@@ -1,14 +1,14 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report: StrictDoc integration tests
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_integration.lit.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_integration.lit.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/integration/foo/test.ignored.itest.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/integration/foo/test.ignored.itest.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_integration.lit.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_integration.lit.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT: <tr><td><strong>Number of skipped tests:</strong></td>
 CHECK-TEST-REPORT-NEXT:<td>1</td>
 CHECK-TEST-REPORT: SKIPPED

--- a/tests/integration/features/test_reports/junit_xml/pytest/01_minimal_document/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/pytest/01_minimal_document/test.itest
@@ -1,18 +1,18 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: cd %S && PYTHONPATH=$(pwd) pytest tests/ --junit-xml=%S/Output/tests_unit.pytest.junit.xml --rootdir=%S
-RUN: mkdir -p reports/ && cp %S/Output/tests_unit.pytest.junit.xml reports/tests_unit.pytest.junit.xml
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: cd %S && PYTHONPATH=$(pwd) pytest tests/ --junit-xml=%T/tests_unit.pytest.junit.xml --rootdir=%S
+RUN: mkdir -p reports/ && cp %T/tests_unit.pytest.junit.xml reports/tests_unit.pytest.junit.xml
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report: pytest
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/src/foo.py.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/test_foo.py.html"
+RUN: %check_exists --file "%T/html/_source_files/src/foo.py.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/test_foo.py.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT: href="../../_source_files/tests/test_foo.py.html#tests.test_foo.test_foo#4#8">
 CHECK-TEST-REPORT: tests/test_foo.py, <i>lines: 4-8</i>, function test_foo

--- a/tests/integration/features/test_reports/junit_xml/pytest/02_failed_test/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/pytest/02_failed_test/test.itest
@@ -1,20 +1,20 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
 # Failing test will exit with a non-zero code. Use "true" to make LIT continue running.
-RUN: cd %S && PYTHONPATH=$(pwd) pytest tests/ --junit-xml=%S/Output/tests_unit.pytest.junit.xml --rootdir=%S ; true
-RUN: mkdir -p reports/ && cp %S/Output/tests_unit.pytest.junit.xml reports/tests_unit.pytest.junit.xml
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: cd %S && PYTHONPATH=$(pwd) pytest tests/ --junit-xml=%T/tests_unit.pytest.junit.xml --rootdir=%S ; true
+RUN: mkdir -p reports/ && cp %T/tests_unit.pytest.junit.xml reports/tests_unit.pytest.junit.xml
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report: pytest
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/src/foo.py.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/test_foo.py.html"
+RUN: %check_exists --file "%T/html/_source_files/src/foo.py.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/test_foo.py.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT: FAILED
 CHECK-TEST-REPORT: href="../../_source_files/tests/test_foo.py.html#tests.test_foo.test_foo#3#7">
 CHECK-TEST-REPORT: tests/test_foo.py, <i>lines: 3-7</i>, function test_foo

--- a/tests/integration/features/test_reports/junit_xml/pytest/03_skipped_test/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/pytest/03_skipped_test/test.itest
@@ -1,18 +1,18 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
 # Failing test will exit with a non-zero code. Use "true" to make LIT continue running.
-RUN: cd %S && PYTHONPATH=$(pwd) pytest tests/ --junit-xml=%S/Output/tests_unit.pytest.junit.xml --rootdir=%S ; true
-RUN: mkdir -p reports/ && cp %S/Output/tests_unit.pytest.junit.xml reports/tests_unit.pytest.junit.xml
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: cd %S && PYTHONPATH=$(pwd) pytest tests/ --junit-xml=%T/tests_unit.pytest.junit.xml --rootdir=%S ; true
+RUN: mkdir -p reports/ && cp %T/tests_unit.pytest.junit.xml reports/tests_unit.pytest.junit.xml
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report: pytest
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/src/foo.py.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/test_foo.py.html"
+RUN: %check_exists --file "%T/html/_source_files/src/foo.py.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/test_foo.py.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT: SKIPPED

--- a/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/pytest/04_test_class/test.itest
@@ -1,19 +1,19 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: cd %S && PYTHONPATH=$(pwd) pytest tests/ --junit-xml=%S/Output/tests_unit.pytest.junit.xml --rootdir=%S
-RUN: mkdir -p reports/ && cp %S/Output/tests_unit.pytest.junit.xml reports/tests_unit.pytest.junit.xml
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: cd %S && PYTHONPATH=$(pwd) pytest tests/ --junit-xml=%T/tests_unit.pytest.junit.xml --rootdir=%S
+RUN: mkdir -p reports/ && cp %T/tests_unit.pytest.junit.xml reports/tests_unit.pytest.junit.xml
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 # Ensure that the test report document is generated.
 CHECK: Published: Test report: pytest
-RUN: %check_exists --file "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html"
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html"
 
 # Ensure that the source and test files are generated.
-RUN: %check_exists --file "%S/Output/html/_source_files/src/foo.py.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/test_foo.py.html"
+RUN: %check_exists --file "%T/html/_source_files/src/foo.py.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/test_foo.py.html"
 
 # Ensure that the test report document has the right content.
-RUN: %cat "%S/Output/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.pytest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT: href="../../_source_files/tests/test_foo.py.html#tests.test_foo.TestFoo.test_foo#7#11">
 CHECK-TEST-REPORT: tests/test_foo.py, <i>lines: 7-11</i>, function TestFoo.test_foo
 CHECK-TEST-REPORT: href="../../_source_files/tests/test_foo.py.html#tests.test_foo.TestFoo.test_second_method_in_class#13#17">

--- a/tests/integration/features/test_reports/robot_xml/01_basic/test.itest
+++ b/tests/integration/features/test_reports/robot_xml/01_basic/test.itest
@@ -2,10 +2,10 @@
 # $ pipx install robotframework
 # $ robot -o test_report/output.robot.xml -N "System Test" tests
 
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/01_basic/test_report/output.robot.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/feature1a.robot.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/feature1b.robot.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/tests/feature2/feature2.robot.html"
+RUN: %check_exists --file "%T/html/01_basic/test_report/output.robot.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/feature1a.robot.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/feature1b.robot.html"
+RUN: %check_exists --file "%T/html/_source_files/tests/feature2/feature2.robot.html"

--- a/tests/integration/features/text_nodes/01_minimal_document_with_text_node/test.itest
+++ b/tests/integration/features/text_nodes/01_minimal_document_with_text_node/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %cat %S/Output/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+RUN: %cat %T/html/index.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: Hello world doc
 CHECK-HTML: input.sdoc
 
-RUN: %cat %S/Output/html/01_minimal_document_with_text_node/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-CONTENT
+RUN: %cat %T/html/01_minimal_document_with_text_node/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-CONTENT
 CHECK-CONTENT: Text statement.

--- a/tests/integration/features/traceability_matrix/01_links_to_files/test.itest
+++ b/tests/integration/features/traceability_matrix/01_links_to_files/test.itest
@@ -1,7 +1,7 @@
-RUN: %strictdoc export %S --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/traceability_matrix.html"
+RUN: %check_exists --file "%T/html/traceability_matrix.html"
 
-RUN: %cat "%S/Output/html/traceability_matrix.html" | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat "%T/html/traceability_matrix.html" | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: <a{{.*}}href="_source_files/file.py.html#REQ-001#1#2">

--- a/tests/integration/features/traceability_matrix/10__columns__relations_with_roles/test.itest
+++ b/tests/integration/features/traceability_matrix/10__columns__relations_with_roles/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S/input --output-dir Output | filecheck %s
+RUN: %strictdoc export %S/input --output-dir %T | filecheck %s
 CHECK: Published: Hello world doc #1
 
-RUN: %check_exists --file "%S/Output/html/traceability_matrix.html"
+RUN: %check_exists --file "%T/html/traceability_matrix.html"
 
-RUN: %cat "%S/Output/html/traceability_matrix.html" | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat "%T/html/traceability_matrix.html" | filecheck %s --check-prefix CHECK-HTML
 
 CHECK-HTML:Hello world doc #1
 CHECK-HTML:Hello world doc #2

--- a/tests/integration/features/traceability_matrix/20__columns__file_relations/test.itest
+++ b/tests/integration/features/traceability_matrix/20__columns__file_relations/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S/input --output-dir Output | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S/input --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/traceability_matrix.html"
+RUN: %check_exists --file "%T/html/traceability_matrix.html"
 
-RUN: %cat "%S/Output/html/traceability_matrix.html" | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat "%T/html/traceability_matrix.html" | filecheck %s --check-prefix CHECK-HTML
 
 CHECK-HTML:Hello world doc
 CHECK-HTML:file1.py

--- a/tests/integration/features/traceability_matrix/50__config__sorting_relation_columns/test.itest
+++ b/tests/integration/features/traceability_matrix/50__config__sorting_relation_columns/test.itest
@@ -1,9 +1,9 @@
-RUN: %strictdoc export %S/input --output-dir Output | filecheck %s
+RUN: %strictdoc export %S/input --output-dir %T | filecheck %s
 CHECK: Published: Hello world doc
 
-RUN: %check_exists --file "%S/Output/html/traceability_matrix.html"
+RUN: %check_exists --file "%T/html/traceability_matrix.html"
 
-RUN: %cat "%S/Output/html/traceability_matrix.html" | filecheck %s --check-prefix CHECK-HTML
+RUN: %cat "%T/html/traceability_matrix.html" | filecheck %s --check-prefix CHECK-HTML
 CHECK-HTML: Node
 CHECK-HTML: Parent
 CHECK-HTML: Parent

--- a/tests/integration/features/views/--view/test.itest
+++ b/tests/integration/features/views/--view/test.itest
@@ -1,5 +1,5 @@
-RUN: %strictdoc export %S --view PRINT_VIEW --formats sdoc --output-dir Output/
-RUN: %cat %S/Output/sdoc/input.sdoc | filecheck %s --check-prefix CHECK-SDOC
+RUN: %strictdoc export %S --view PRINT_VIEW --formats sdoc --output-dir %T
+RUN: %cat %T/sdoc/input.sdoc | filecheck %s --check-prefix CHECK-SDOC
 
 CHECK-SDOC: REQ-1
 CHECK-SDOC: Requirement statement.

--- a/tests/integration/features/views/01_view_references_default_grammar_field/test.itest
+++ b/tests/integration/features/views/01_view_references_default_grammar_field/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: Export completed. Documentation tree can be found at:
 CHECK: Step 'Export SDoc' took:

--- a/tests/integration/features/views/02_view_references_custom_grammar_field/test.itest
+++ b/tests/integration/features/views/02_view_references_custom_grammar_field/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: Export completed. Documentation tree can be found at:
 CHECK: Step 'Export SDoc' took:

--- a/tests/integration/features/views/_validations/01_view_references_nonexisting_grammar_element/test.itest
+++ b/tests/integration/features/views/_validations/01_view_references_nonexisting_grammar_element/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: View element 'PRINT_VIEW' references a non-existing grammar element 'NON_EXISTING_OBJECT'.

--- a/tests/integration/features/views/_validations/02_view_references_existing_grammar_element/test.itest
+++ b/tests/integration/features/views/_validations/02_view_references_existing_grammar_element/test.itest
@@ -1,4 +1,4 @@
-RUN: %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: Export completed. Documentation tree can be found at:
 CHECK: Step 'Export SDoc' took:

--- a/tests/integration/features/views/_validations/03_view_references_nonexisting_field/test.itest
+++ b/tests/integration/features/views/_validations/03_view_references_nonexisting_field/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: View element 'PRINT_VIEW' references a non-existing field 'NON_EXISTING_FIELD' for grammar element 'REQUIREMENT'.

--- a/tests/integration/features/views/_validations/04_default_view_doesnt_exist/test.itest
+++ b/tests/integration/features/views/_validations/04_default_view_doesnt_exist/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: Default view 'NON_EXISTING_VIEW' does not exist in the document.

--- a/tests/integration/features/views/_validations/05_default_view_with_no_views_in_document/test.itest
+++ b/tests/integration/features/views/_validations/05_default_view_with_no_views_in_document/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir Output/ | filecheck %s --dump-input=fail
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
 CHECK: error: could not parse file: {{.*}}input.sdoc.
 CHECK: Semantic error: Default view 'NON_EXISTING_VIEW' does not exist in the document.

--- a/tests/integration/lit.cfg.py
+++ b/tests/integration/lit.cfg.py
@@ -12,6 +12,9 @@ lit_config: Any
 config.name = "StrictDoc integration tests"
 config.test_format = lit.formats.ShTest("0")
 
+# Where to output test temporary files.
+config.test_exec_root = "build/tests_integration"
+
 current_dir = os.getcwd()
 
 strictdoc_exec = lit_config.params["STRICTDOC_EXEC"]

--- a/tests/integration/scripting_examples/questionnaires/02_user_provided_example/test.itest
+++ b/tests/integration/scripting_examples/questionnaires/02_user_provided_example/test.itest
@@ -1,9 +1,9 @@
 # TBD: Figure out how to set PYTHONPATH on Windows.
 REQUIRES: PLATFORM_IS_NOT_WINDOWS
 
-RUN: %mkdir %S/output
-RUN: PYTHONPATH=%strictdoc_root python %S/export_questionnaires.py export . --output-dir=%S/output/
+RUN: cd %S
+RUN: PYTHONPATH=%strictdoc_root python %S/export_questionnaires.py export . --output-dir=%T/
 
-RUN: %check_exists --file "%S/output/tsrm_questionnaires.xlsx"
+RUN: %check_exists --file "%T/tsrm_questionnaires.xlsx"
 
-RUN: %excel_diff "%S/output/tsrm_questionnaires.xlsx" "%S/output/tsrm_questionnaires.xlsx"
+RUN: %excel_diff "%T/tsrm_questionnaires.xlsx" "%T/tsrm_questionnaires.xlsx"

--- a/tests/integration/scripting_examples/reqif/02_user_provided_example/test.itest
+++ b/tests/integration/scripting_examples/reqif/02_user_provided_example/test.itest
@@ -4,11 +4,11 @@ UNSUPPORTED: true
 # TBD: Figure out how to set PYTHONPATH on Windows.
 REQUIRES: PLATFORM_IS_NOT_WINDOWS
 
-RUN: %mkdir %S/output
-RUN: PYTHONPATH=%strictdoc_root python %S/script.py %S/sample.reqif %S/output/output.sdoc
+RUN: %mkdir %T
+RUN: PYTHONPATH=%strictdoc_root python %S/script.py %S/sample.reqif %T/output.sdoc
 
 # TBD
-UN: %cat %S/output/output.sdoc | filecheck %s
+UN: %cat %T/output.sdoc | filecheck %s
 
 CHECK: [REQUIREMENT]
 CHECK: UID: Anonymized-194ac1eb-d718-b59b-5d2a-c2b0ac0381ef
@@ -19,6 +19,6 @@ CHECK: COMMENT: >>>
 CHECK: Anonymized-6e95e816-6fc9-0fe1-8b1f-66340311da94
 CHECK: <<<
 
-UN: %strictdoc export --formats=reqif-sdoc %S/output/output.sdoc
-UN: %strictdoc import reqif sdoc %S/output/reqif/output.reqif %S/output/output_step2.sdoc
-UN: %diff %S/output/output.sdoc %S/output/output_step2.sdoc
+UN: %strictdoc export --formats=reqif-sdoc %T/output.sdoc
+UN: %strictdoc import reqif sdoc %T/reqif/output.reqif %T/output_step2.sdoc
+UN: %diff %T/output.sdoc %T/output_step2.sdoc

--- a/tests/integration/self_testing/commands/export/01_strictdoc_smoke_test/test.itest
+++ b/tests/integration/self_testing/commands/export/01_strictdoc_smoke_test/test.itest
@@ -1,110 +1,110 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 REQUIRES: PLATFORM_IS_NOT_WINDOWS
 
-RUN: cd "%strictdoc_root/" && %strictdoc export "%strictdoc_root/" --output-dir="%S/Output"
+RUN: cd "%strictdoc_root/" && %strictdoc export "%strictdoc_root/" --output-dir="%T"
 
-RUN: %check_exists --file "%S/Output/html/index.html"
-RUN: %check_exists --file %S/Output/html/strictdoc/docs/strictdoc_01_user_guide.html
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-DEEP-TRACE.html"
+RUN: %check_exists --file "%T/html/index.html"
+RUN: %check_exists --file %T/html/strictdoc/docs/strictdoc_01_user_guide.html
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_01_user_guide-TABLE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_01_user_guide-TRACE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_01_user_guide-DEEP-TRACE.html"
 
-RUN: %check_exists --file %S/Output/html/strictdoc/docs/strictdoc_02_feature_map.html
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_02_feature_map-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_02_feature_map-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_02_feature_map-DEEP-TRACE.html"
+RUN: %check_exists --file %T/html/strictdoc/docs/strictdoc_02_feature_map.html
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_02_feature_map-TABLE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_02_feature_map-TRACE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_02_feature_map-DEEP-TRACE.html"
 
-RUN: %check_exists --file %S/Output/html/strictdoc/docs/strictdoc_03_faq.html
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_03_faq-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_03_faq-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_03_faq-DEEP-TRACE.html"
+RUN: %check_exists --file %T/html/strictdoc/docs/strictdoc_03_faq.html
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_03_faq-TABLE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_03_faq-TRACE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_03_faq-DEEP-TRACE.html"
 
-RUN: %check_exists --file %S/Output/html/strictdoc/docs/strictdoc_10_contributing.html
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_10_contributing-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_10_contributing-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_10_contributing-DEEP-TRACE.html"
+RUN: %check_exists --file %T/html/strictdoc/docs/strictdoc_10_contributing.html
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_10_contributing-TABLE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_10_contributing-TRACE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_10_contributing-DEEP-TRACE.html"
 
-RUN: %check_exists --file %S/Output/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool.html
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-DEEP-TRACE.html"
+RUN: %check_exists --file %T/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool.html
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-TABLE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-TRACE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-DEEP-TRACE.html"
 
-RUN: %check_exists --file %S/Output/html/strictdoc/docs/strictdoc_24_development_plan.html
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_24_development_plan-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_24_development_plan-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_24_development_plan-DEEP-TRACE.html"
+RUN: %check_exists --file %T/html/strictdoc/docs/strictdoc_24_development_plan.html
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_24_development_plan-TABLE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_24_development_plan-TRACE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_24_development_plan-DEEP-TRACE.html"
 
-RUN: %check_exists --file %S/Output/html/strictdoc/docs/strictdoc_25_design.html
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_25_design-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_25_design-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_25_design-DEEP-TRACE.html"
+RUN: %check_exists --file %T/html/strictdoc/docs/strictdoc_25_design.html
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_25_design-TABLE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_25_design-TRACE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_25_design-DEEP-TRACE.html"
 
-RUN: %check_exists --file %S/Output/html/strictdoc/docs/strictdoc_30_credits.html
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_30_credits-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_30_credits-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_30_credits-DEEP-TRACE.html"
+RUN: %check_exists --file %T/html/strictdoc/docs/strictdoc_30_credits.html
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_30_credits-TABLE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_30_credits-TRACE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_30_credits-DEEP-TRACE.html"
 
 # Naive way to check that the server-related links are not enabled in the static export.
-RUN: %cat "%S/Output/html/index.html" | filecheck %s --check-prefix=CHECK-TREE
+RUN: %cat "%T/html/index.html" | filecheck %s --check-prefix=CHECK-TREE
 CHECK-TREE-NOT: ReqIF
 
-RUN: %cat "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide.html" | filecheck %s --check-prefix=CHECK-DOCUMENT
+RUN: %cat "%T/html/strictdoc/docs/strictdoc_01_user_guide.html" | filecheck %s --check-prefix=CHECK-DOCUMENT
 # When there is no positive check, filecheck will check all not-CHECKs.
 CHECK-DOCUMENT-NOT: Export to ReqIF
 CHECK-DOCUMENT-NOT: turbo.js
 
-RUN: %check_exists --file "%S/Output/html/index.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-DEEP-TRACE.html"
+RUN: %check_exists --file "%T/html/index.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_01_user_guide.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_01_user_guide-TABLE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_01_user_guide-TRACE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_01_user_guide-DEEP-TRACE.html"
 
 TODO: etree.parse fails on the "&nbsp;" surprisingly. Fix it later :(
-RUN: sed -i.bak 's/\&nbsp;/ /g' "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide.html"
-RUN: sed -i.bak 's/\&nbsp;/ /g' "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-TABLE.html"
-RUN: sed -i.bak 's/\&nbsp;/ /g' "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-TRACE.html"
-RUN: sed -i.bak 's/\&nbsp;/ /g' "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-DEEP-TRACE.html"
+RUN: sed -i.bak 's/\&nbsp;/ /g' "%T/html/strictdoc/docs/strictdoc_01_user_guide.html"
+RUN: sed -i.bak 's/\&nbsp;/ /g' "%T/html/strictdoc/docs/strictdoc_01_user_guide-TABLE.html"
+RUN: sed -i.bak 's/\&nbsp;/ /g' "%T/html/strictdoc/docs/strictdoc_01_user_guide-TRACE.html"
+RUN: sed -i.bak 's/\&nbsp;/ /g' "%T/html/strictdoc/docs/strictdoc_01_user_guide-DEEP-TRACE.html"
 
-RUN: %html_markup_validator "%S/Output/html/index.html"
-RUN: %html_markup_validator "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide.html"
-RUN: %html_markup_validator "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-TABLE.html"
-RUN: %html_markup_validator "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-TRACE.html"
-RUN: %html_markup_validator "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-DEEP-TRACE.html"
+RUN: %html_markup_validator "%T/html/index.html"
+RUN: %html_markup_validator "%T/html/strictdoc/docs/strictdoc_01_user_guide.html"
+RUN: %html_markup_validator "%T/html/strictdoc/docs/strictdoc_01_user_guide-TABLE.html"
+RUN: %html_markup_validator "%T/html/strictdoc/docs/strictdoc_01_user_guide-TRACE.html"
+RUN: %html_markup_validator "%T/html/strictdoc/docs/strictdoc_01_user_guide-DEEP-TRACE.html"
 
 TODO: etree.parse fails on the "&nbsp;" surprisingly. Fix it later :(
-RUN: sed -i.bak 's/\&nbsp;/ /g' "%S/Output/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool.html"
-RUN: sed -i.bak 's/\&nbsp;/ /g' "%S/Output/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-TABLE.html"
-RUN: sed -i.bak 's/\&nbsp;/ /g' "%S/Output/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-TRACE.html"
-RUN: sed -i.bak 's/\&nbsp;/ /g' "%S/Output/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-DEEP-TRACE.html"
+RUN: sed -i.bak 's/\&nbsp;/ /g' "%T/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool.html"
+RUN: sed -i.bak 's/\&nbsp;/ /g' "%T/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-TABLE.html"
+RUN: sed -i.bak 's/\&nbsp;/ /g' "%T/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-TRACE.html"
+RUN: sed -i.bak 's/\&nbsp;/ /g' "%T/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-DEEP-TRACE.html"
 
-RUN: %html_markup_validator "%S/Output/html/index.html"
-RUN: %html_markup_validator "%S/Output/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool.html"
-RUN: %html_markup_validator "%S/Output/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-TABLE.html"
-RUN: %html_markup_validator "%S/Output/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-TRACE.html"
-RUN: %html_markup_validator "%S/Output/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-DEEP-TRACE.html"
+RUN: %html_markup_validator "%T/html/index.html"
+RUN: %html_markup_validator "%T/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool.html"
+RUN: %html_markup_validator "%T/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-TABLE.html"
+RUN: %html_markup_validator "%T/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-TRACE.html"
+RUN: %html_markup_validator "%T/html/strictdoc/docs/strictdoc_20_L1_Open_Requirements_Tool-DEEP-TRACE.html"
 
-RUN: %check_exists --file %S/Output/html/strictdoc/docs/strictdoc_01_user_guide.html
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-DEEP-TRACE.html"
+RUN: %check_exists --file %T/html/strictdoc/docs/strictdoc_01_user_guide.html
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_01_user_guide-TABLE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_01_user_guide-TRACE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_01_user_guide-DEEP-TRACE.html"
 
-RUN: %check_exists --file %S/Output/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements-DEEP-TRACE.html"
+RUN: %check_exists --file %T/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements-TABLE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements-TRACE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements-DEEP-TRACE.html"
 
-RUN: %check_exists --file %S/Output/html/strictdoc/docs/strictdoc_24_development_plan.html
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_24_development_plan-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_24_development_plan-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_24_development_plan-DEEP-TRACE.html"
+RUN: %check_exists --file %T/html/strictdoc/docs/strictdoc_24_development_plan.html
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_24_development_plan-TABLE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_24_development_plan-TRACE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_24_development_plan-DEEP-TRACE.html"
 
-RUN: %check_exists --file "%S/Output/html/_source_files/strictdoc/core/tree_cycle_detector.py.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/strictdoc/core/traceability_index_builder.py.html"
+RUN: %check_exists --file "%T/html/_source_files/strictdoc/core/tree_cycle_detector.py.html"
+RUN: %check_exists --file "%T/html/_source_files/strictdoc/core/traceability_index_builder.py.html"
 
-RUN: %cat %S/Output/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html | filecheck %s --check-prefix CHECK-3-REQUIREMENTS
+RUN: %cat %T/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html | filecheck %s --check-prefix CHECK-3-REQUIREMENTS
 CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/traceability_index_builder.py.html#SDOC-SRS-30#{{.*}}#{{.*}}"
 CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/tree_cycle_detector.py.html#SDOC-SRS-30#{{.*}}#{{.*}}"
 
-RUN: %cat "%S/Output/html/_source_files/strictdoc/core/tree_cycle_detector.py.html" | filecheck %s --check-prefix CHECK-TREE-CYCLE-DETECTOR
+RUN: %cat "%T/html/_source_files/strictdoc/core/tree_cycle_detector.py.html" | filecheck %s --check-prefix CHECK-TREE-CYCLE-DETECTOR
 CHECK-TREE-CYCLE-DETECTOR: href="../../../strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html#SDOC-SRS-30"
 CHECK-TREE-CYCLE-DETECTOR: href="../../../_source_files/strictdoc/core/traceability_index_builder.py.html#SDOC-SRS-30

--- a/tests/integration/self_testing/commands/export/04_strictdoc_smoke_test_source_files_from_another_directory/test.itest
+++ b/tests/integration/self_testing/commands/export/04_strictdoc_smoke_test_source_files_from_another_directory/test.itest
@@ -2,21 +2,21 @@ REQUIRES: PYTHON_39_OR_HIGHER
 REQUIRES: PLATFORM_IS_NOT_WINDOWS
 
 # First run StrictDoc when CWD is the current test folder.
-RUN: %strictdoc export "%strictdoc_root/" --output-dir="%S/Output"
+RUN: %strictdoc export "%strictdoc_root/" --output-dir="%T"
 
-RUN: %check_exists --file "%S/Output/html/index.html"
-RUN: %check_exists --file %S/Output/html/strictdoc/docs/strictdoc_01_user_guide.html
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-TABLE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-TRACE.html"
-RUN: %check_exists --file "%S/Output/html/strictdoc/docs/strictdoc_01_user_guide-DEEP-TRACE.html"
+RUN: %check_exists --file "%T/html/index.html"
+RUN: %check_exists --file %T/html/strictdoc/docs/strictdoc_01_user_guide.html
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_01_user_guide-TABLE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_01_user_guide-TRACE.html"
+RUN: %check_exists --file "%T/html/strictdoc/docs/strictdoc_01_user_guide-DEEP-TRACE.html"
 
-RUN: %check_exists --file "%S/Output/html/_source_files/strictdoc/core/tree_cycle_detector.py.html"
-RUN: %check_exists --file "%S/Output/html/_source_files/strictdoc/core/traceability_index_builder.py.html"
+RUN: %check_exists --file "%T/html/_source_files/strictdoc/core/tree_cycle_detector.py.html"
+RUN: %check_exists --file "%T/html/_source_files/strictdoc/core/traceability_index_builder.py.html"
 
-RUN: %cat %S/Output/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html | filecheck %s --check-prefix CHECK-3-REQUIREMENTS
+RUN: %cat %T/html/strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html | filecheck %s --check-prefix CHECK-3-REQUIREMENTS
 CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/traceability_index_builder.py.html#SDOC-SRS-30#{{.*}}#{{.*}}"
 CHECK-3-REQUIREMENTS: href="../../_source_files/strictdoc/core/tree_cycle_detector.py.html#SDOC-SRS-30#{{.*}}#{{.*}}"
 
-RUN: %cat "%S/Output/html/_source_files/strictdoc/core/tree_cycle_detector.py.html" | filecheck %s --check-prefix CHECK-TREE-CYCLE-DETECTOR
+RUN: %cat "%T/html/_source_files/strictdoc/core/tree_cycle_detector.py.html" | filecheck %s --check-prefix CHECK-TREE-CYCLE-DETECTOR
 CHECK-TREE-CYCLE-DETECTOR: href="../../../strictdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.html#SDOC-SRS-30"
 CHECK-TREE-CYCLE-DETECTOR: href="../../../_source_files/strictdoc/core/traceability_index_builder.py.html#SDOC-SRS-30

--- a/tests/integration/self_testing/commands/passthrough/01_hello_world/test.itest
+++ b/tests/integration/self_testing/commands/passthrough/01_hello_world/test.itest
@@ -1,10 +1,10 @@
 REQUIRES: PYTHON_39_OR_HIGHER
 
-RUN: cd "%strictdoc_root/" && %strictdoc passthrough "%strictdoc_root/" --output-dir="%S/Output/"
+RUN: cd "%strictdoc_root/" && %strictdoc passthrough "%strictdoc_root/" --output-dir="%T/"
 
-RUN: %diff "%strictdoc_root/docs/strictdoc_01_user_guide.sdoc" "%S/Output/sdoc/docs/strictdoc_01_user_guide.sdoc"
-RUN: %diff "%strictdoc_root/docs/strictdoc_02_feature_map.sdoc" "%S/Output/sdoc/docs/strictdoc_02_feature_map.sdoc"
-RUN: %diff "%strictdoc_root/docs/strictdoc_03_faq.sdoc" "%S/Output/sdoc/docs/strictdoc_03_faq.sdoc"
-# _: %diff "%strictdoc_root/docs/strictdoc_21_L2_StrictDoc_Requirements.sdoc" "%S/Output/sdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.sdoc"
-# _: %diff "%strictdoc_root/docs/strictdoc_24_development_plan.sdoc" "%S/Output/sdoc/docs/strictdoc_24_development_plan.sdoc"
-# _: %diff "%strictdoc_root/docs/strictdoc_25_design.sdoc" "%S/Output/sdoc/docs/strictdoc_25_design.sdoc"
+RUN: %diff "%strictdoc_root/docs/strictdoc_01_user_guide.sdoc" "%T/sdoc/docs/strictdoc_01_user_guide.sdoc"
+RUN: %diff "%strictdoc_root/docs/strictdoc_02_feature_map.sdoc" "%T/sdoc/docs/strictdoc_02_feature_map.sdoc"
+RUN: %diff "%strictdoc_root/docs/strictdoc_03_faq.sdoc" "%T/sdoc/docs/strictdoc_03_faq.sdoc"
+# _: %diff "%strictdoc_root/docs/strictdoc_21_L2_StrictDoc_Requirements.sdoc" "%T/sdoc/docs/strictdoc_21_L2_StrictDoc_Requirements.sdoc"
+# _: %diff "%strictdoc_root/docs/strictdoc_24_development_plan.sdoc" "%T/sdoc/docs/strictdoc_24_development_plan.sdoc"
+# _: %diff "%strictdoc_root/docs/strictdoc_25_design.sdoc" "%T/sdoc/docs/strictdoc_25_design.sdoc"


### PR DESCRIPTION
This helps to avoid the PyCharm IDE continuously re-indexing the integration tests folder as the itests are run. Having a dedicated build folder for the test artifacts in a cleaner way of building the temporary test artifacts.