### PR TITLE
backend/sdoc_source_code: enable parsing of source nodes if a config is provided

### DIFF
--- a/strictdoc/backend/sdoc_source_code/caching_reader.py
+++ b/strictdoc/backend/sdoc_source_code/caching_reader.py
@@ -73,7 +73,8 @@ class SourceFileTraceabilityCachingReader:
                 or path_to_file.endswith(".hpp")
                 or path_to_file.endswith(".cpp")
             ):
-                return SourceFileTraceabilityReader_C()
+                parse_nodes = project_config.shall_parse_nodes(path_to_file)
+                return SourceFileTraceabilityReader_C(parse_nodes=parse_nodes)
             if path_to_file.endswith(".robot"):
                 return SourceFileTraceabilityReader_Robot()
         return SourceFileTraceabilityReader()

--- a/strictdoc/backend/sdoc_source_code/marker_parser.py
+++ b/strictdoc/backend/sdoc_source_code/marker_parser.py
@@ -28,6 +28,7 @@ class MarkerParser:
         comment_line_start: int,
         entity_name: Optional[str] = None,
         col_offset: int = 0,
+        parse_nodes: bool = False,
     ) -> SourceNode:
         """
         Parse relation markers from source file comments.
@@ -48,7 +49,9 @@ class MarkerParser:
 
         input_string = preprocess_source_code_comment(input_string)
 
-        tree: ParseTree = MarkerLexer.parse(input_string)
+        tree: ParseTree = MarkerLexer.parse(
+            input_string, parse_nodes=parse_nodes
+        )
 
         for element_ in tree.children:
             if not isinstance(element_, Tree):

--- a/strictdoc/backend/sdoc_source_code/reader_c.py
+++ b/strictdoc/backend/sdoc_source_code/reader_c.py
@@ -1,4 +1,3 @@
-# mypy: disable-error-code="no-untyped-call,no-untyped-def"
 import sys
 import traceback
 from typing import List, Optional, Sequence
@@ -38,8 +37,13 @@ from strictdoc.helpers.file_stats import SourceFileStats
 
 
 class SourceFileTraceabilityReader_C:
+    def __init__(self, parse_nodes: bool = False) -> None:
+        self.parse_nodes: bool = parse_nodes
+
     def read(
-        self, input_buffer: bytes, file_path=None
+        self,
+        input_buffer: bytes,
+        file_path: str,
     ) -> SourceFileTraceabilityInfo:
         assert isinstance(input_buffer, bytes)
 
@@ -84,6 +88,7 @@ class SourceFileTraceabilityReader_C:
                             if input_buffer[-1] == 10
                             else node_.end_point[0] + 1,
                             node_.start_point[0] + 1,
+                            parse_nodes=self.parse_nodes,
                         )
                         for marker_ in source_node.markers:
                             if not isinstance(marker_, FunctionRangeMarker):
@@ -181,6 +186,7 @@ class SourceFileTraceabilityReader_C:
                         function_last_line,
                         function_comment_node.start_point[0] + 1,
                         entity_name=function_display_name,
+                        parse_nodes=self.parse_nodes,
                     )
                     for marker_ in source_node.markers:
                         if isinstance(marker_, FunctionRangeMarker) and (
@@ -285,6 +291,7 @@ class SourceFileTraceabilityReader_C:
                         function_last_line,
                         function_comment_node.start_point[0] + 1,
                         entity_name=function_display_name,
+                        parse_nodes=self.parse_nodes,
                     )
                     traceability_info.source_nodes.append(source_node)
                     for marker_ in source_node.markers:
@@ -338,6 +345,7 @@ class SourceFileTraceabilityReader_C:
                     node_.start_point[0] + 1,
                     node_.end_point[0] + 1,
                     node_.start_point[0] + 1,
+                    parse_nodes=False,
                 )
 
                 for marker_ in source_node.markers:
@@ -387,7 +395,9 @@ class SourceFileTraceabilityReader_C:
             sys.exit(1)
 
     @staticmethod
-    def _get_function_name_node(function_declarator_node: Node):
+    def _get_function_name_node(
+        function_declarator_node: Node,
+    ) -> Optional[Node]:
         assert function_declarator_node.type == "function_declarator"
         function_identifier_node = ts_find_child_node_by_type(
             function_declarator_node,

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -406,6 +406,20 @@ class ProjectConfig:
     def get_extra_static_files_path(self) -> str:
         return self.environment.get_extra_static_files_path()
 
+    def shall_parse_nodes(self, path_to_file: str) -> bool:
+        for sdoc_source_config_entry_ in self.source_nodes:
+            # FIXME: Move the setting of full paths to .finalize() of this config
+            #        class when it is implemented.
+            full_path = sdoc_source_config_entry_.setdefault(
+                "full_path",
+                os.path.join(
+                    self.source_root_path, sdoc_source_config_entry_["path"]
+                ),
+            )
+            if path_to_file.startswith(full_path):
+                return True
+        return False
+
 
 class ProjectConfigLoader:
     @staticmethod

--- a/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/description.sdoc
+++ b/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/description.sdoc
@@ -1,0 +1,39 @@
+[DOCUMENT]
+MID: c2d4542d5f1741c88dfcb4f68ad7dcbd
+TITLE: Test specification
+UID: TEST_DOC
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: TEST_SPEC
+  PROPERTIES:
+    VIEW_STYLE: Narrative
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  - TITLE: INTENTION
+    TYPE: String
+    REQUIRED: False
+  - TITLE: INPUT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: EXPECTED_RESULTS
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File

--- a/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/input.sdoc
+++ b/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/input.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ-1
+TITLE: Requirement Title
+STATEMENT: Requirement Statement
+
+[REQUIREMENT]
+UID: REQ-2
+TITLE: Requirement Title #2
+STATEMENT: Requirement Statement #2

--- a/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/strictdoc.toml
+++ b/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/strictdoc.toml
@@ -1,0 +1,12 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+  "SOURCE_FILE_LANGUAGE_PARSERS",
+]
+
+source_nodes = [
+  # Parsing of source nodes is disabled because there the provided path does not
+  # exist/have files with valid source comments containing SDoc node descriptions.
+  { "tests_another_path/" = { uid = "TEST_DOC", node_type = "TEST_SPEC" } }
+]

--- a/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/test.itest
+++ b/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/test.itest
@@ -1,0 +1,10 @@
+REQUIRES: PYTHON_39_OR_HIGHER
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
+
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%T/html/_source_files/tests/file.c.html"
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/description.html | filecheck %s --check-prefix CHECK-SPEC
+CHECK-SPEC: The document is empty.

--- a/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/tests/file.c
+++ b/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/tests/file.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-1, scope=function)
+ *
+ * INTENTION: Intention...
+ *
+ * INPUT: This
+ *        is
+ *        a statement
+ *        \n\n
+ *        And this is the same statement's another paragraph.
+ *
+ * EXPECTED_RESULTS: This is a comment.
+ */
+void test_case_1(void) {
+    print("hello world\n");
+}
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-2, scope=function)
+ *
+ * INTENTION: Intention...
+ *
+ * INPUT: This
+ *        is
+ *        a statement
+ *        \n\n
+ *        And this is the same statement's another paragraph.
+ *
+ * EXPECTED_RESULTS: This is a comment.
+ */
+void test_case_2(void) {
+    print("hello world\n");
+}

--- a/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/tests/file2.c
+++ b/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/tests/file2.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-1, scope=function)
+ *
+ * INTENTION: Intention...
+ *
+ * INPUT: This
+ *        is
+ *        a statement
+ *        \n\n
+ *        And this is the same statement's another paragraph.
+ *
+ * EXPECTED_RESULTS: This is a comment.
+ */
+void test_case_1(void) {
+    print("hello world\n");
+}
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-2, scope=function)
+ *
+ * INTENTION: Intention...
+ *
+ * INPUT: This
+ *        is
+ *        a statement
+ *        \n\n
+ *        And this is the same statement's another paragraph.
+ *
+ * EXPECTED_RESULTS: This is a comment.
+ */
+void test_case_2(void) {
+    print("hello world\n");
+}

--- a/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/tests/subfolder/file3.c
+++ b/tests/integration/features/file_traceability/_source_nodes/01_feature_disabled/tests/subfolder/file3.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-1, scope=function)
+ *
+ * INTENTION: Intention...
+ *
+ * INPUT: This
+ *        is
+ *        a statement
+ *        \n\n
+ *        And this is the same statement's another paragraph.
+ *
+ * EXPECTED_RESULTS: This is a comment.
+ */
+void test_case_1(void) {
+    print("hello world\n");
+}
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-2, scope=function)
+ *
+ * INTENTION: Intention...
+ *
+ * INPUT: This
+ *        is
+ *        a statement
+ *        \n\n
+ *        And this is the same statement's another paragraph.
+ *
+ * EXPECTED_RESULTS: This is a comment.
+ */
+void test_case_2(void) {
+    print("hello world\n");
+}

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_c.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_c.py
@@ -19,7 +19,7 @@ def test_00_empty_file():
 
     reader = SourceFileTraceabilityReader_C()
 
-    info = reader.read(input_string)
+    info = reader.read(input_string, file_path="NOT_RELEVANT")
 
     assert isinstance(info, SourceFileTraceabilityInfo)
     assert len(info.markers) == 0
@@ -32,7 +32,7 @@ def test_01_single_string():
 
     reader = SourceFileTraceabilityReader_C()
 
-    info = reader.read(input_string)
+    info = reader.read(input_string, file_path="NOT_RELEVANT")
 
     assert isinstance(info, SourceFileTraceabilityInfo)
     assert len(info.functions) == 0

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_cpp.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_cpp.py
@@ -32,7 +32,7 @@ class Foo
 
     reader = SourceFileTraceabilityReader_C()
 
-    info = reader.read(input_string)
+    info = reader.read(input_string, file_path="NOT_RELEVANT")
 
     assert isinstance(info, SourceFileTraceabilityInfo)
     assert len(info.functions) == 1
@@ -64,7 +64,7 @@ class Bar {
 
     reader = SourceFileTraceabilityReader_C()
 
-    info = reader.read(input_string)
+    info = reader.read(input_string, file_path="NOT_RELEVANT")
 
     assert isinstance(info, SourceFileTraceabilityInfo)
     assert len(info.functions) == 1
@@ -93,7 +93,7 @@ bool Foo::Bar::CanSend(const CanFrame &frame) {
 
     reader = SourceFileTraceabilityReader_C()
 
-    info = reader.read(input_string)
+    info = reader.read(input_string, file_path="NOT_RELEVANT")
 
     assert isinstance(info, SourceFileTraceabilityInfo)
     assert len(info.functions) == 1
@@ -127,7 +127,7 @@ class TrkVertex
 
     reader = SourceFileTraceabilityReader_C()
 
-    info = reader.read(input_string)
+    info = reader.read(input_string, file_path="NOT_RELEVANT")
 
     assert isinstance(info, SourceFileTraceabilityInfo)
     assert len(info.functions) == 1
@@ -168,7 +168,7 @@ class TrkVertex
 
     reader = SourceFileTraceabilityReader_C()
 
-    info = reader.read(input_string)
+    info = reader.read(input_string, file_path="NOT_RELEVANT")
 
     assert isinstance(info, SourceFileTraceabilityInfo)
     assert len(info.functions) == 3
@@ -229,7 +229,7 @@ class TrkVertex
 
     reader = SourceFileTraceabilityReader_C()
 
-    info = reader.read(input_string)
+    info = reader.read(input_string, file_path="NOT_RELEVANT")
 
     assert isinstance(info, SourceFileTraceabilityInfo)
     assert len(info.functions) == 3
@@ -292,7 +292,7 @@ Foo& Foo::operator+(const Foo& c) { return *this; }
 
     reader = SourceFileTraceabilityReader_C()
 
-    info = reader.read(input_string)
+    info = reader.read(input_string, file_path="NOT_RELEVANT")
 
     assert isinstance(info, SourceFileTraceabilityInfo)
     assert len(info.functions) == 4

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_lexer.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_lexer.py
@@ -174,7 +174,7 @@ STATEMENT: When 1, The system 2 shall do 3
 FOOBAR
 """
 
-    tree = MarkerLexer.parse(input_string)
+    tree = MarkerLexer.parse(input_string, parse_nodes=True)
     assert tree.data == "start"
 
     assert len(tree.children) == 5
@@ -239,7 +239,7 @@ def test_31_single_node_field():
         STATEMENT: This can likely replace _weak below with no problem.
     """
 
-    tree = MarkerLexer.parse(input_string)
+    tree = MarkerLexer.parse(input_string, parse_nodes=True)
     assert tree.data == "start"
 
     assert len(tree.children) == 1
@@ -274,7 +274,7 @@ def test_31B_single_node_field():
   
     """  # noqa: W293
 
-    tree = MarkerLexer.parse(input_string)
+    tree = MarkerLexer.parse(input_string, parse_nodes=True)
     assert tree.data == "start"
 
     assert len(tree.children) == 1
@@ -309,7 +309,7 @@ void hello_world(void) {
 }
 """  # noqa: W293
 
-    tree = MarkerLexer.parse(input_string)
+    tree = MarkerLexer.parse(input_string, parse_nodes=True)
     assert tree.data == "start"
 
     assert len(tree.children) == 2
@@ -334,7 +334,7 @@ def test_32_two_single_line_fields():
         STATEMENT: This can likely replace _weak below with no problem.
     """
 
-    tree = MarkerLexer.parse(input_string)
+    tree = MarkerLexer.parse(input_string, parse_nodes=True)
     assert tree.data == "start"
 
     assert len(tree.children) == 2
@@ -358,7 +358,7 @@ def test_32B_two_single_line_fields_consecutive():
         STATEMENTT: This can likely replace _weak below with no problem.
     """
 
-    tree = MarkerLexer.parse(input_string)
+    tree = MarkerLexer.parse(input_string, parse_nodes=True)
 
     assert tree.data == "start"
 
@@ -386,7 +386,7 @@ STATEMENT: This
 FOOBAR
 """
 
-    tree = MarkerLexer.parse(input_string)
+    tree = MarkerLexer.parse(input_string, parse_nodes=True)
     assert tree.data == "start"
 
     assert len(tree.children) == 1


### PR DESCRIPTION
This is a more permanent and proper solution for a use case where a user does not want the SDoc nodes to be parsed out of the source code comments. Parsing of SDoc nodes will from now on be only activated if the `source_nodes` config is provided in the `strictdoc.toml` config file.

Related to: #2342