### PR TITLE
screens/search: fix an incorrectly escaped search example

### DIFF
--- a/strictdoc/export/html/generators/view_objects/search_screen_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/search_screen_view_object.py
@@ -2,6 +2,8 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
+from markupsafe import Markup
+
 from strictdoc import __version__
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_view import DocumentView
@@ -79,8 +81,8 @@ class SearchScreenViewObject:
     def iterator_files_first(self):
         yield from self.document_tree_iterator.iterator_files_first()
 
-    def render_url(self, url: str):
-        return self.link_renderer.render_url(url)
+    def render_url(self, url: str) -> Markup:
+        return Markup(self.link_renderer.render_url(url))
 
     def render_static_url_with_prefix(self, url: str) -> str:
         return self.link_renderer.render_static_url_with_prefix(url)

--- a/strictdoc/export/html/templates/screens/search/legend.jinja
+++ b/strictdoc/export/html/templates/screens/search/legend.jinja
@@ -32,7 +32,14 @@
         <code>node.is_section</code>
       </a>
       <div class="sdoc-table_key_value-value">Find all sections.</div>
-      <a class="sdoc-table_key_value-key" href="{{ view_object.render_url('search?q=(node.is_requirement and "System" in node["TITLE"])') }}"><code>(node.is_requirement and "System" in node["TITLE"])</code></a>
+      <a
+        class="sdoc-table_key_value-key"
+        href="{{ view_object.render_url('search?q=(node.is_requirement and "System" in node["TITLE"])') }}"
+        data-testid="node_is_title_system"
+      >
+        <code>
+        (node.is_requirement and "System" in node["TITLE"])</code>
+      </a>
       <div class="sdoc-table_key_value-value">Find all requirements with a TITLE that equals to "System".</div>
       <a class="sdoc-table_key_value-key" href="{{ view_object.render_url('search?q=(node.is_requirement and node.is_root)') }}"><code>(node.is_requirement and node.is_root)</code></a>
       <div class="sdoc-table_key_value-value">Find all root requirements.</div>

--- a/tests/end2end/helpers/screens/search/search.py
+++ b/tests/end2end/helpers/screens/search/search.py
@@ -39,6 +39,12 @@ class Screen_Search(Screen):  # pylint: disable=invalid-name
         )
         return Screen_SearchResults(self.test_case)
 
+    def do_click_on_search_node_with_system_title(self) -> Screen_SearchResults:
+        self.test_case.click_xpath(
+            '//a[@data-testid="node_is_title_system"]',
+        )
+        return Screen_SearchResults(self.test_case)
+
     def do_search(self, query) -> Screen_SearchResults:
         textBox = self.test_case.driver.find_element(
             By.XPATH, "//input[@id='q']"

--- a/tests/end2end/screens/search/view_search_screen/test_case.py
+++ b/tests/end2end/screens/search/view_search_screen/test_case.py
@@ -14,7 +14,7 @@ path_to_this_test_file_folder = os.path.dirname(os.path.abspath(__file__))
 
 
 class Test(E2ECase):
-    def test_search_links(self):
+    def test_01_search_links(self):
         with SDocTestServer(
             input_path=path_to_this_test_file_folder
         ) as test_server:
@@ -32,13 +32,19 @@ class Test(E2ECase):
                 screen_search.do_click_on_search_requirements()
             )
             screen_search_results.assert_text("Requirement statement.")
-
             self.go_back()
 
             screen_search_results = screen_search.do_click_on_search_sections()
             screen_search_results.assert_text("Section title")
+            self.go_back()
 
-    def test_empty_search(self):
+            screen_search_results = (
+                screen_search.do_click_on_search_node_with_system_title()
+            )
+            screen_search_results.assert_nr_results(0)
+            self.go_back()
+
+    def test_02_empty_search(self):
         with SDocTestServer(
             input_path=path_to_this_test_file_folder
         ) as test_server:
@@ -51,12 +57,12 @@ class Test(E2ECase):
                 screen_project_index.do_click_on_search_screen_link()
             )
             screen_search_results = screen_search.do_search(
-                """(node.is_requirement and node["STATEMENT"] == "NONE")"""
+                """(node.is_requirement and node["STATEMENT"] == "BOGUS_STATEMENT")"""
             )
 
             screen_search_results.assert_nr_results(0)
 
-    def test_invalid_search(self):
+    def test_03_invalid_search(self):
         with SDocTestServer(
             input_path=path_to_this_test_file_folder
         ) as test_server:


### PR DESCRIPTION
After the 2024-Q4 changes related to escaping of Jinja templates, escaping URLs by LinkRenderer is not needed anymore and can cause over-escaping. This only affected the example query found in the legend, and this commit fixes the issue. An e2e test is added to prove that the URL is rendered correctly.