### PR TITLE
Code climate: backend/sdoc: relocate Reference, merge type_system into models

### DIFF
--- a/strictdoc/backend/sdoc/models/constants.py
+++ b/strictdoc/backend/sdoc/models/constants.py
@@ -1,3 +1,7 @@
+"""
+@relation(SDOC-SRS-18, scope=file)
+"""
+
 from strictdoc.backend.sdoc.models.anchor import Anchor
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_config import (
@@ -22,13 +26,13 @@ from strictdoc.backend.sdoc.models.node import (
 )
 from strictdoc.backend.sdoc.models.reference import (
     ChildReqReference,
+    FileEntry,
     FileReference,
     ParentReqReference,
     Reference,
 )
 from strictdoc.backend.sdoc.models.section import SDocSection
 from strictdoc.backend.sdoc.models.type_system import (
-    FileEntry,
     GrammarElementFieldMultipleChoice,
     GrammarElementFieldSingleChoice,
     GrammarElementFieldString,

--- a/strictdoc/backend/sdoc/models/document.py
+++ b/strictdoc/backend/sdoc/models/document.py
@@ -1,5 +1,5 @@
 """
-@relation(SDOC-SRS-109, scope=file)
+@relation(SDOC-SRS-98, SDOC-SRS-109, scope=file)
 """
 
 from typing import Generator, List, Optional

--- a/strictdoc/backend/sdoc/models/document_config.py
+++ b/strictdoc/backend/sdoc/models/document_config.py
@@ -1,3 +1,7 @@
+"""
+@relation(SDOC-SRS-110, scope=file)
+"""
+
 from typing import List, Optional, Tuple
 
 from strictdoc.helpers.auto_described import auto_described

--- a/strictdoc/backend/sdoc/models/document_grammar.py
+++ b/strictdoc/backend/sdoc/models/document_grammar.py
@@ -2,9 +2,13 @@
 from collections import OrderedDict
 from typing import Dict, Generator, List, Optional, Set, Tuple, Union
 
-from strictdoc.backend.sdoc.models.model import SDocDocumentIF, SDocGrammarIF
-from strictdoc.backend.sdoc.models.type_system import (
+from strictdoc.backend.sdoc.models.model import (
     RESERVED_NON_META_FIELDS,
+    RequirementFieldName,
+    SDocDocumentIF,
+    SDocGrammarIF,
+)
+from strictdoc.backend.sdoc.models.type_system import (
     GrammarElementField,
     GrammarElementFieldMultipleChoice,
     GrammarElementFieldSingleChoice,
@@ -12,7 +16,6 @@ from strictdoc.backend.sdoc.models.type_system import (
     GrammarElementRelationChild,
     GrammarElementRelationFile,
     GrammarElementRelationParent,
-    RequirementFieldName,
 )
 from strictdoc.helpers.auto_described import auto_described
 from strictdoc.helpers.exception import StrictDocException

--- a/strictdoc/backend/sdoc/models/model.py
+++ b/strictdoc/backend/sdoc/models/model.py
@@ -5,9 +5,41 @@
 from abc import ABC, abstractmethod
 from typing import Generator, List, Optional, Union
 
-from strictdoc.backend.sdoc.models.document_config import DocumentConfig
+from strictdoc.backend.sdoc.models.document_config import (
+    DocumentConfig,
+)
 from strictdoc.core.document_meta import DocumentMeta
 from strictdoc.helpers.mid import MID
+
+
+class RequirementFieldName:
+    MID = "MID"
+    UID = "UID"
+    PREFIX = "PREFIX"
+    LEVEL = "LEVEL"
+    STATUS = "STATUS"
+    TAGS = "TAGS"
+    TITLE = "TITLE"
+
+    # {STATEMENT, DESCRIPTION, CONTENT} are aliases.
+    # It is assumed that either field is provided for each node.
+    STATEMENT = "STATEMENT"
+    DESCRIPTION = "DESCRIPTION"
+    CONTENT = "CONTENT"
+
+    RATIONALE = "RATIONALE"
+    COMMENT = "COMMENT"
+
+
+RESERVED_NON_META_FIELDS = [
+    RequirementFieldName.TITLE,
+    RequirementFieldName.STATEMENT,
+    RequirementFieldName.DESCRIPTION,
+    RequirementFieldName.CONTENT,
+    RequirementFieldName.COMMENT,
+    RequirementFieldName.RATIONALE,
+    RequirementFieldName.LEVEL,
+]
 
 
 class SDocNodeFieldIF(ABC):

--- a/strictdoc/backend/sdoc/models/node.py
+++ b/strictdoc/backend/sdoc/models/node.py
@@ -13,6 +13,8 @@ from strictdoc.backend.sdoc.models.document_grammar import (
 )
 from strictdoc.backend.sdoc.models.inline_link import InlineLink
 from strictdoc.backend.sdoc.models.model import (
+    RESERVED_NON_META_FIELDS,
+    RequirementFieldName,
     SDocDocumentIF,
     SDocElementIF,
     SDocNodeIF,
@@ -24,9 +26,7 @@ from strictdoc.backend.sdoc.models.reference import (
     Reference,
 )
 from strictdoc.backend.sdoc.models.type_system import (
-    RESERVED_NON_META_FIELDS,
     ReferenceType,
-    RequirementFieldName,
 )
 from strictdoc.helpers.auto_described import auto_described
 from strictdoc.helpers.cast import assert_cast

--- a/strictdoc/backend/sdoc/models/object_factory.py
+++ b/strictdoc/backend/sdoc/models/object_factory.py
@@ -3,8 +3,8 @@ from typing import List, Optional
 
 from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.models.document import SDocDocument
+from strictdoc.backend.sdoc.models.model import RequirementFieldName
 from strictdoc.backend.sdoc.models.node import SDocNode, SDocNodeField
-from strictdoc.backend.sdoc.models.type_system import RequirementFieldName
 
 
 class SDocObjectFactory:

--- a/strictdoc/backend/sdoc/models/reference.py
+++ b/strictdoc/backend/sdoc/models/reference.py
@@ -3,14 +3,67 @@
 """
 
 # mypy: disable-error-code="no-untyped-call,no-untyped-def"
-from typing import Optional
+from typing import Optional, Tuple
 
 from strictdoc.backend.sdoc.models.type_system import (
-    FileEntry,
     ReferenceType,
 )
 from strictdoc.helpers.auto_described import auto_described
 from strictdoc.helpers.mid import MID
+
+
+@auto_described
+class FileEntry:
+    def __init__(
+        self,
+        parent,
+        g_file_format: Optional[str],
+        g_file_path: str,
+        g_line_range: Optional[str],
+        function: Optional[str],
+        clazz: Optional[str],
+    ):
+        self.parent = parent
+
+        # Default: FileEntryFormat.SOURCECODE  # noqa: ERA001
+        self.g_file_format: Optional[str] = g_file_format
+
+        # TODO: Might be worth to prohibit the use of Windows paths altogether.
+        self.g_file_path: str = g_file_path
+        file_path_posix = g_file_path.replace("\\", "/")
+        self.file_path_posix = file_path_posix
+
+        # The textX parser passes an empty string even if there is no LINE_RANGE
+        # provided in the SDoc source.
+        g_line_range = (
+            g_line_range
+            if g_line_range is not None and len(g_line_range) > 0
+            else None
+        )
+
+        self.g_line_range: Optional[str] = g_line_range
+        self.line_range: Optional[Tuple[int, int]] = None
+        if g_line_range is not None:
+            range_components_str = g_line_range.split(", ")
+            assert len(range_components_str) == 2, range_components_str
+            self.line_range = (
+                int(range_components_str[0]),
+                int(range_components_str[1]),
+            )
+
+        # The textX parser parses an optional element as an empty string. We
+        # make it to None ourselves.
+        self.function: Optional[str] = (
+            function if function is not None and len(function) > 0 else None
+        )
+        self.clazz: Optional[str] = (
+            clazz if clazz is not None and len(clazz) > 0 else None
+        )
+
+
+class FileEntryFormat:
+    SOURCECODE = "Sourcecode"
+    PYTHON = "Python"
 
 
 @auto_described

--- a/strictdoc/backend/sdoc/models/type_system.py
+++ b/strictdoc/backend/sdoc/models/type_system.py
@@ -1,38 +1,8 @@
 # mypy: disable-error-code="no-untyped-call,no-untyped-def"
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from strictdoc.helpers.auto_described import auto_described
 from strictdoc.helpers.mid import MID
-
-
-class RequirementFieldName:
-    MID = "MID"
-    UID = "UID"
-    PREFIX = "PREFIX"
-    LEVEL = "LEVEL"
-    STATUS = "STATUS"
-    TAGS = "TAGS"
-    TITLE = "TITLE"
-
-    # {STATEMENT, DESCRIPTION, CONTENT} are aliases.
-    # It is assumed that either field is provided for each node.
-    STATEMENT = "STATEMENT"
-    DESCRIPTION = "DESCRIPTION"
-    CONTENT = "CONTENT"
-
-    RATIONALE = "RATIONALE"
-    COMMENT = "COMMENT"
-
-
-RESERVED_NON_META_FIELDS = [
-    RequirementFieldName.TITLE,
-    RequirementFieldName.STATEMENT,
-    RequirementFieldName.DESCRIPTION,
-    RequirementFieldName.CONTENT,
-    RequirementFieldName.COMMENT,
-    RequirementFieldName.RATIONALE,
-    RequirementFieldName.LEVEL,
-]
 
 
 class RequirementFieldType:
@@ -47,60 +17,6 @@ class GrammarReferenceType:
     PARENT_REQ_REFERENCE = "ParentReqReference"
     CHILD_REQ_REFERENCE = "ChildReqReference"
     FILE_REFERENCE = "FileReference"
-
-
-@auto_described
-class FileEntry:
-    def __init__(
-        self,
-        parent,
-        g_file_format: Optional[str],
-        g_file_path: str,
-        g_line_range: Optional[str],
-        function: Optional[str],
-        clazz: Optional[str],
-    ):
-        self.parent = parent
-
-        # Default: FileEntryFormat.SOURCECODE  # noqa: ERA001
-        self.g_file_format: Optional[str] = g_file_format
-
-        # TODO: Might be worth to prohibit the use of Windows paths altogether.
-        self.g_file_path: str = g_file_path
-        file_path_posix = g_file_path.replace("\\", "/")
-        self.file_path_posix = file_path_posix
-
-        # The textX parser passes an empty string even if there is no LINE_RANGE
-        # provided in the SDoc source.
-        g_line_range = (
-            g_line_range
-            if g_line_range is not None and len(g_line_range) > 0
-            else None
-        )
-
-        self.g_line_range: Optional[str] = g_line_range
-        self.line_range: Optional[Tuple[int, int]] = None
-        if g_line_range is not None:
-            range_components_str = g_line_range.split(", ")
-            assert len(range_components_str) == 2, range_components_str
-            self.line_range = (
-                int(range_components_str[0]),
-                int(range_components_str[1]),
-            )
-
-        # The textX parser parses an optional element as an empty string. We
-        # make it to None ourselves.
-        self.function: Optional[str] = (
-            function if function is not None and len(function) > 0 else None
-        )
-        self.clazz: Optional[str] = (
-            clazz if clazz is not None and len(clazz) > 0 else None
-        )
-
-
-class FileEntryFormat:
-    SOURCECODE = "Sourcecode"
-    PYTHON = "Python"
 
 
 class ReferenceType:

--- a/strictdoc/backend/sdoc/validations/sdoc_validator.py
+++ b/strictdoc/backend/sdoc/validations/sdoc_validator.py
@@ -10,13 +10,13 @@ from strictdoc.backend.sdoc.models.document_grammar import (
     GrammarElement,
 )
 from strictdoc.backend.sdoc.models.document_view import DocumentView
+from strictdoc.backend.sdoc.models.model import RequirementFieldName
 from strictdoc.backend.sdoc.models.node import SDocNode, SDocNodeField
 from strictdoc.backend.sdoc.models.type_system import (
     GrammarElementField,
     GrammarElementFieldMultipleChoice,
     GrammarElementFieldSingleChoice,
     GrammarElementFieldTag,
-    RequirementFieldName,
 )
 from strictdoc.helpers.cast import assert_optional_cast
 

--- a/strictdoc/backend/sdoc_source_code/coverage_reports/gcov.py
+++ b/strictdoc/backend/sdoc_source_code/coverage_reports/gcov.py
@@ -11,9 +11,12 @@ from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_grammar import DocumentGrammar
 from strictdoc.backend.sdoc.models.node import SDocNode, SDocNodeField
-from strictdoc.backend.sdoc.models.reference import FileReference
+from strictdoc.backend.sdoc.models.reference import (
+    FileEntry,
+    FileEntryFormat,
+    FileReference,
+)
 from strictdoc.backend.sdoc.models.section import SDocSection
-from strictdoc.backend.sdoc.models.type_system import FileEntry, FileEntryFormat
 from strictdoc.core.file_tree import File
 from strictdoc.core.project_config import ProjectConfig
 

--- a/strictdoc/backend/sdoc_source_code/test_reports/junit_xml_reader.py
+++ b/strictdoc/backend/sdoc_source_code/test_reports/junit_xml_reader.py
@@ -13,9 +13,12 @@ from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_grammar import DocumentGrammar
 from strictdoc.backend.sdoc.models.node import SDocNode, SDocNodeField
-from strictdoc.backend.sdoc.models.reference import FileReference
+from strictdoc.backend.sdoc.models.reference import (
+    FileEntry,
+    FileEntryFormat,
+    FileReference,
+)
 from strictdoc.backend.sdoc.models.section import SDocSection
-from strictdoc.backend.sdoc.models.type_system import FileEntry, FileEntryFormat
 from strictdoc.core.file_tree import File
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.helpers.cast import assert_cast, assert_optional_cast

--- a/strictdoc/backend/sdoc_source_code/test_reports/robot_xml_reader.py
+++ b/strictdoc/backend/sdoc_source_code/test_reports/robot_xml_reader.py
@@ -11,9 +11,12 @@ from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_grammar import DocumentGrammar
 from strictdoc.backend.sdoc.models.node import SDocNode, SDocNodeField
-from strictdoc.backend.sdoc.models.reference import FileReference
+from strictdoc.backend.sdoc.models.reference import (
+    FileEntry,
+    FileEntryFormat,
+    FileReference,
+)
 from strictdoc.backend.sdoc.models.section import SDocSection
-from strictdoc.backend.sdoc.models.type_system import FileEntry, FileEntryFormat
 from strictdoc.core.file_tree import File
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.helpers.paths import path_to_posix_path

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -11,8 +11,7 @@ from strictdoc.backend.sdoc.error_handling import StrictDocSemanticError
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.model import SDocDocumentIF, SDocNodeIF
 from strictdoc.backend.sdoc.models.node import SDocNode
-from strictdoc.backend.sdoc.models.reference import FileReference
-from strictdoc.backend.sdoc.models.type_system import FileEntry
+from strictdoc.backend.sdoc.models.reference import FileReference, FileEntry
 from strictdoc.backend.sdoc_source_code.models.function import Function
 from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
     ForwardFunctionRangeMarker,

--- a/strictdoc/export/html/form_objects/grammar_element_form_object.py
+++ b/strictdoc/export/html/form_objects/grammar_element_form_object.py
@@ -10,13 +10,13 @@ from strictdoc.backend.sdoc.models.document_grammar import (
     DocumentGrammar,
     GrammarElement,
 )
+from strictdoc.backend.sdoc.models.model import RequirementFieldName
 from strictdoc.backend.sdoc.models.type_system import (
     GrammarElementField,
     GrammarElementFieldString,
     GrammarElementRelationChild,
     GrammarElementRelationFile,
     GrammarElementRelationParent,
-    RequirementFieldName,
 )
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.export.html.form_objects.form_object import (

--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -14,13 +14,13 @@ from strictdoc.backend.sdoc.models.inline_link import InlineLink
 from strictdoc.backend.sdoc.models.node import SDocNode, SDocNodeField
 from strictdoc.backend.sdoc.models.reference import (
     ChildReqReference,
+    FileEntry,
+    FileEntryFormat,
     FileReference,
     ParentReqReference,
     Reference,
 )
 from strictdoc.backend.sdoc.models.type_system import (
-    FileEntry,
-    FileEntryFormat,
     GrammarElementField,
     GrammarElementFieldMultipleChoice,
     GrammarElementFieldSingleChoice,

--- a/strictdoc/export/html/renderers/markup_renderer.py
+++ b/strictdoc/export/html/renderers/markup_renderer.py
@@ -5,8 +5,8 @@ from markupsafe import Markup
 from strictdoc.backend.sdoc.models.anchor import Anchor
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.inline_link import InlineLink
+from strictdoc.backend.sdoc.models.model import RequirementFieldName
 from strictdoc.backend.sdoc.models.node import SDocNode, SDocNodeField
-from strictdoc.backend.sdoc.models.type_system import RequirementFieldName
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.core.traceability_index import TraceabilityIndex
 from strictdoc.export.html.document_type import DocumentType

--- a/strictdoc/export/spdx/spdx_to_sdoc_converter.py
+++ b/strictdoc/export/spdx/spdx_to_sdoc_converter.py
@@ -23,12 +23,12 @@ from strictdoc.backend.sdoc.models.node import (
 )
 from strictdoc.backend.sdoc.models.reference import (
     ChildReqReference,
+    FileEntry,
     FileReference,
     ParentReqReference,
 )
 from strictdoc.backend.sdoc.models.section import SDocSection
 from strictdoc.backend.sdoc.models.type_system import (
-    FileEntry,
     GrammarElementFieldString,
     GrammarElementRelationChild,
     GrammarElementRelationFile,

--- a/tests/unit/strictdoc/backend/sdoc/test_requirement_from_dict.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_requirement_from_dict.py
@@ -1,6 +1,6 @@
 from strictdoc.backend.sdoc.models.document_grammar import DocumentGrammar
+from strictdoc.backend.sdoc.models.model import RequirementFieldName
 from strictdoc.backend.sdoc.models.object_factory import SDocObjectFactory
-from strictdoc.backend.sdoc.models.type_system import RequirementFieldName
 
 
 def test_010_full_dict():


### PR DESCRIPTION


This simplifies tracing the L2 requirement of SDoc model.