### PR TITLE
export/html: extend an outdated assert to support composite nodes

### DIFF
--- a/strictdoc/__init__.py
+++ b/strictdoc/__init__.py
@@ -1,6 +1,6 @@
 from strictdoc.core.environment import SDocRuntimeEnvironment
 
-__version__ = "0.9.3"
+__version__ = "0.9.4a1"
 
 
 environment = SDocRuntimeEnvironment(__file__)

--- a/strictdoc/export/html/templates/screens/source_file_view/requirement.jinja
+++ b/strictdoc/export/html/templates/screens/source_file_view/requirement.jinja
@@ -1,5 +1,5 @@
 {%- assert
-    requirement.__class__.__name__ == "SDocNode",
+    requirement.__class__.__name__ in ("SDocNode", "SDocCompositeNode"),
     "Expected requirement"
 -%}
 {%- assert

--- a/tests/integration/features/file_traceability/70_link_from_section_to_file/file.py
+++ b/tests/integration/features/file_traceability/70_link_from_section_to_file/file.py
@@ -1,0 +1,6 @@
+"""
+@relation(SECT-1, scope=file)
+"""
+
+def hello_world():
+    print("hello world")  # noqa: T201

--- a/tests/integration/features/file_traceability/70_link_from_section_to_file/input.sdoc
+++ b/tests/integration/features/file_traceability/70_link_from_section_to_file/input.sdoc
@@ -1,0 +1,39 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  RELATIONS:
+  - TYPE: File
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+
+[[SECTION]]
+UID: SECT-1
+TITLE: Sample section
+
+[REQUIREMENT]
+UID: REQ-001
+TITLE: Requirement Title
+STATEMENT: Requirement Statement
+
+[[/SECTION]]

--- a/tests/integration/features/file_traceability/70_link_from_section_to_file/strictdoc.toml
+++ b/tests/integration/features/file_traceability/70_link_from_section_to_file/strictdoc.toml
@@ -1,0 +1,10 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+  "SOURCE_FILE_LANGUAGE_PARSERS",
+]
+
+exclude_source_paths = [
+  "test.itest",
+]

--- a/tests/integration/features/file_traceability/70_link_from_section_to_file/test.itest
+++ b/tests/integration/features/file_traceability/70_link_from_section_to_file/test.itest
@@ -1,0 +1,21 @@
+# This test verifies that a source file can be linked to a [[SECTION]] element.
+# @relation(SDOC-SRS-33, scope=file)
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%T/html/_source_files/file.py.html"
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#SECT-1#1#6">
+
+RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+
+# Left/aside panel: The requirement cell has a link that correctly points to the document file.
+CHECK-SOURCE-FILE: href="../70_link_from_section_to_file/input.html#SECT-1"
+CHECK-SOURCE-FILE: ../_source_files/file.py.html#SECT-1#1#6
+
+# Central panel.
+CHECK-SOURCE-FILE: "../_source_files/file.py.html##1#6"
+CHECK-SOURCE-FILE: 1 - 6 | entire file
+CHECK-SOURCE-FILE: hello world{{.*}}# noqa: T201


### PR DESCRIPTION
A user wants to link a source file to a section which we support but haven't encountered and tested before explicitly. This updates the assert and adds an integration test to exercise linking files to sections.