### PR TITLE
rst: support for sphinx-style math syntax

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -2339,7 +2339,7 @@ StrictDoc can include the `MathJax <https://www.mathjax.org/>`_ Javascript libra
       "MATHJAX"
     ]
 
-Example of using MathJax:
+Examples of using MathJax:
 
 .. code-block:: text
 
@@ -2354,6 +2354,22 @@ Example of using MathJax:
         \mathbf{\underline{j}}_{\text{a}}
         $$
     <<<
+
+Sphinx-style syntax is also supported:
+
+.. code-block:: text
+
+    [TEXT]
+    STATEMENT: >>>
+    The following formula :math:`a^2 + b^2 = c^2` is rendered inline with the text.
+  
+    When using the math directive, the enclosing $$ are not required.
+
+    .. math::
+        \mathbf{\underline{k}}_{\text{a}} =
+        \mathbf{\underline{i}}_{\text{a}} \times
+        \mathbf{\underline{j}}_{\text{a}}
+    >>>
 
 See [LINK: SDOC_UG_CONFIG_FEATURES] for the description of other features.
 <<<

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -11,7 +11,7 @@ from strictdoc.backend.sdoc.error_handling import StrictDocSemanticError
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.model import SDocDocumentIF, SDocNodeIF
 from strictdoc.backend.sdoc.models.node import SDocNode
-from strictdoc.backend.sdoc.models.reference import FileReference, FileEntry
+from strictdoc.backend.sdoc.models.reference import FileEntry, FileReference
 from strictdoc.backend.sdoc_source_code.models.function import Function
 from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
     ForwardFunctionRangeMarker,

--- a/strictdoc/export/html/_static/node.css
+++ b/strictdoc/export/html/_static/node.css
@@ -228,3 +228,19 @@ sdoc-node-controls[data-direction~="row"] sdoc-menu,
 sdoc-node-controls[data-direction~="row"] sdoc-menu-handler {
   flex-direction: row;
 }
+
+/* math equation numbering support */
+div.math {
+  position: relative;
+  text-align: center;
+  padding-right: 3em;  /* reserve space for eqno */
+  overflow: hidden;    /* prevents scrollbars */
+}
+
+.math .eqno {
+  position: absolute;
+  right: 0;
+  top: 0;
+  font-size: 90%;
+  white-space: nowrap;
+}

--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -43,6 +43,16 @@
 
   {%- if view_object.project_config.is_activated_mathjax() -%}
   <script id="MathJax-script" async src="{{ view_object.render_static_url('mathjax/tex-mml-chtml.js') }}"></script>
+  <script>
+  // This EventListener is needed to re-typeset the MathJax expressions (after saving)...
+  document.addEventListener("turbo:before-stream-render", (event) => {
+    if (window.MathJax?.typesetPromise) {
+      requestAnimationFrame(() => {
+        MathJax.typesetPromise().catch(console.error);
+      });
+    }
+  });
+  </script>
   {%- endif -%}
   {%- if view_object.project_config.is_activated_rapidoc() -%}
   <script src="{{ view_object.render_static_url('rapidoc/rapidoc-min.js') }}"></script>

--- a/strictdoc/export/rst/directives/sphinx_style_math.py
+++ b/strictdoc/export/rst/directives/sphinx_style_math.py
@@ -1,0 +1,123 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+from docutils.parsers.rst.states import Inliner
+
+
+def eq_role(
+    _role: str,
+    rawtext: str,
+    text: str,
+    lineno: int,
+    inliner: Inliner,
+    _options: Optional[Dict[str, Any]] = None,
+    _content: Optional[List[str]] = None,
+) -> Tuple[List[nodes.Node], List[nodes.system_message]]:
+    """Handle rst :eq: role, producing a link to an equation."""
+    doc = inliner.document
+
+    if (
+        not hasattr(doc, "math_equation_labels")
+        or text not in doc.math_equation_labels
+    ):
+        msg = inliner.reporter.error(
+            f"Unknown equation label: {text}", line=lineno
+        )
+        return [inliner.problematic(rawtext, rawtext, msg)], [msg]
+
+    eq_number = doc.math_equation_labels[text]
+    ref = nodes.raw("", f'<a href="#{text}">({eq_number})</a>', format="html")
+    return [ref], []
+
+
+def math_role(
+    _role: str,
+    rawtext: str,
+    text: str,
+    _lineno: int,
+    _inliner: Inliner,
+    _options: Optional[Dict[str, Any]] = None,
+    _content: Optional[List[str]] = None,
+) -> Tuple[List[nodes.Node], List[nodes.system_message]]:
+    """Handle rst :math: role, rendering a formula inline with text."""
+    if rawtext.startswith(":math:`") and rawtext.endswith("`"):
+        extracted = rawtext[len(":math:`") : -1]
+    else:
+        extracted = text
+
+    node = nodes.raw(
+        "",
+        f'<span class="math notranslate nohighlight">\\( {extracted} \\)</span>',
+        format="html",
+    )
+    return [node], []
+
+
+class MathDirective(Directive):
+    """Docutils directive emulating Sphinx-style math syntax."""
+
+    has_content = True
+    optional_arguments = 0
+    final_argument_whitespace = False
+    option_spec = {
+        "nowrap": directives.flag,
+        "label": directives.unchanged,
+        "number": directives.flag,
+    }
+
+    def run(self) -> List[nodes.Node]:
+        """Handle ..math :: directive, rendering a formula centered, optionally with eq number."""
+        doc = self.state.document
+        if not hasattr(doc, "math_equation_counter"):
+            doc.math_equation_counter = 0
+            doc.math_equation_labels = {}
+
+        nowrap = "nowrap" in self.options
+        label = self.options.get("label")
+        numbered = "number" in self.options or label is not None
+
+        math_content = "\n".join(self.content).strip()
+        html_parts = []
+
+        if numbered:
+            doc.math_equation_counter += 1
+            eq_number = doc.math_equation_counter
+            if label:
+                doc.math_equation_labels[label] = eq_number
+            number_html = f'<span class="eqno">({eq_number})</span>'
+        else:
+            number_html = ""
+
+        if nowrap:
+            html_parts.append('<div class="math notranslate nohighlight">')
+            html_parts.append(math_content)
+            html_parts.append(number_html)
+            html_parts.append("</div>")
+        else:
+            parts = [p.strip() for p in math_content.split("\n\n") if p.strip()]
+            if len(parts) > 1:
+                wrapped = []
+                for part in parts:
+                    if r"\\" in part:
+                        wrapped.append(r"\begin{split}" + part + r"\end{split}")
+                    else:
+                        wrapped.append(part)
+                mathjax_content = (
+                    r"\begin{align}\begin{aligned}"
+                    + r" \\ ".join(wrapped)
+                    + r"\end{aligned}\end{align}"
+                )
+            else:
+                mathjax_content = math_content
+
+            html_parts.append('<div class="math notranslate nohighlight">')
+            html_parts.append(number_html)
+            html_parts.append(f"\\[{mathjax_content}\\]")
+            html_parts.append("</div>")
+
+        if label:
+            html_parts.insert(0, f'<a id="{label}"></a>')
+
+        html = "".join(html_parts)
+        return [nodes.raw("", html, format="html")]

--- a/strictdoc/export/rst/rst_to_html_fragment_writer.py
+++ b/strictdoc/export/rst/rst_to_html_fragment_writer.py
@@ -13,8 +13,13 @@ from docutils.utils import SystemMessage
 from markupsafe import Markup
 
 from strictdoc.backend.sdoc.models.document import SDocDocument
-from strictdoc.core.project_config import ProjectConfig
+from strictdoc.core.project_config import ProjectConfig, ProjectFeature
 from strictdoc.export.rst.directives.raw_html_role import raw_html_role
+from strictdoc.export.rst.directives.sphinx_style_math import (
+    MathDirective,
+    eq_role,
+    math_role,
+)
 from strictdoc.export.rst.directives.wildcard_enhanced_image import (
     WildcardEnhancedImage,
 )
@@ -63,6 +68,11 @@ class RstToHtmlFragmentWriter:
         else:
             self.source_path = "<string>"
         self.context_document: Optional[SDocDocument] = context_document
+
+        if project_config.is_feature_activated(ProjectFeature.MATHJAX):
+            directives.register_directive("math", MathDirective)
+            roles.register_canonical_role("math", math_role)
+            roles.register_canonical_role("eq", eq_role)
 
     def write(self, rst_fragment: str, use_cache: bool = True) -> Markup:
         assert isinstance(rst_fragment, str), rst_fragment

--- a/tests/integration/features/mathjax/03_mathjax_enabled_math_block/input.sdoc
+++ b/tests/integration/features/mathjax/03_mathjax_enabled_math_block/input.sdoc
@@ -1,0 +1,81 @@
+[DOCUMENT]
+TITLE: Hello math! 
+
+[TEXT]
+STATEMENT: >>>
+When the ``MATHJAX`` feature is enabled, we support the role for inline math.
+Use like this:
+
+.. code-block ::
+
+    Since Pythagoras, we know that :math:`a^2 + b^2 = c^2`.
+
+
+Since Pythagoras, we know that :math:`a^2 + b^2 = c^2`.
+
+<<<
+
+[TEXT]
+STATEMENT: >>>
+When the ``MATHJAX`` feature is enabled, we support also the math directive. 
+Use like this:
+
+.. code-block ::
+
+  .. math::
+
+     (a + b)^2 = a^2 + 2ab + b^2
+
+     (a - b)^2 = a^2 - 2ab + b^2
+
+.. math::
+
+   (a + b)^2 = a^2 + 2ab + b^2
+
+   (a - b)^2 = a^2 - 2ab + b^2
+<<<
+
+[TEXT]
+STATEMENT: >>>
+Normally, equations are not numbered. If you want your equation to get a number, use 
+the label option. When given, it selects a label for the equation, by which it can be 
+cross-referenced, and causes an equation number to be issued. 
+
+.. code-block ::
+  
+  .. math:: e^{i\pi} + 1 = 0
+     :label: euler
+  
+
+
+
+.. math:: e^{i\pi} + 1 = 0
+   :label: euler
+
+When you want to cross-reference, use this syntax:
+
+.. code-block ::
+
+  Euler's identity, equation :eq:`euler`, was elected one of the most
+  beautiful mathematical formulas.
+
+
+Euler's identity, equation :eq:`euler`, was elected one of the most
+beautiful mathematical formulas.
+
+<<<
+
+[TEXT]
+STATEMENT: >>>
+There is also an option ``nowrap`` that prevents any wrapping of the given math 
+in a math environment. When you give this option, you must make sure yourself 
+that the math is properly set up. For example:
+
+.. math::
+   :nowrap:
+
+   \begin{eqnarray}
+      y    & = & ax^2 + bx + c \\
+      f(x) & = & x^2 + 2xy + y^2
+   \end{eqnarray}
+<<<

--- a/tests/integration/features/mathjax/03_mathjax_enabled_math_block/test.itest
+++ b/tests/integration/features/mathjax/03_mathjax_enabled_math_block/test.itest
@@ -1,0 +1,13 @@
+RUN: %strictdoc export %S --enable-mathjax --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Hello math!
+
+RUN: %check_exists --file "%T/html/_static/mathjax/tex-mml-chtml.js"
+RUN: %check_exists --file "%T/html/_static/mathjax/output/chtml/fonts/tex.js"
+
+RUN: %cat %T/html/03_mathjax_enabled_math_block/input.html | filecheck %s --check-prefix CHECK-HTML
+
+CHECK-HTML: <span class="math notranslate nohighlight">\( a^2 + b^2 = c^2 \)</span>
+CHECK-HTML: <div class="math notranslate nohighlight">\[\begin{align}\begin{aligned}(a + b)^2 = a^2 + 2ab + b^2 \\ (a - b)^2 = a^2 - 2ab + b^2\end{aligned}\end{align}\]</div></div>
+CHECK-HTML: <a id="euler"></a><div class="math notranslate nohighlight"><span class="eqno">(1)</span>\[e^{i\pi} + 1 = 0\]</div>
+CHECK-HTML: <a href="#euler">(1)</a>
+CHECK-HTML: <div class="math notranslate nohighlight">\begin{eqnarray}

--- a/tests/integration/features/mathjax/04_mathjax_disabled_math_block/input.sdoc
+++ b/tests/integration/features/mathjax/04_mathjax_disabled_math_block/input.sdoc
@@ -1,0 +1,34 @@
+[DOCUMENT]
+TITLE: Hello math! 
+
+[TEXT]
+STATEMENT: >>>
+When the ``MATHJAX`` feature is disabled, the inline math role uses the docutils fallback renderer.
+
+.. code-block ::
+
+    Since Pythagoras, we know that :math:`a^2 + b^2 = c^2`.
+
+
+Since Pythagoras, we know that :math:`a^2 + b^2 = c^2`.
+
+<<<
+
+[TEXT]
+STATEMENT: >>>
+When the ``MATHJAX`` feature is disabled, the math directive uses the docutils fallback renderer. 
+
+.. code-block ::
+
+  .. math::
+
+     (a + b)^2 = a^2 + 2ab + b^2
+
+     (a - b)^2 = a^2 - 2ab + b^2
+
+.. math::
+
+   (a + b)^2 = a^2 + 2ab + b^2
+
+   (a - b)^2 = a^2 - 2ab + b^2
+<<<

--- a/tests/integration/features/mathjax/04_mathjax_disabled_math_block/test.itest
+++ b/tests/integration/features/mathjax/04_mathjax_disabled_math_block/test.itest
@@ -1,0 +1,10 @@
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Hello math!
+
+RUN: %check_exists --invert --file "%T/html/_static/mathjax/tex-mml-chtml.js"
+RUN: %check_exists --invert --file "%T/html/_static/mathjax/output/chtml/fonts/tex.js"
+
+RUN: %cat %T/html/04_mathjax_disabled_math_block/input.html | filecheck %s --check-prefix CHECK-HTML
+
+CHECK-HTML: <span class="formula"><i>a</i><sup>2</sup> + <i>b</i><sup>2</sup> = <i>c</i><sup>2</sup></span>.</p>
+CHECK-HTML: (<i>a</i> + <i>b</i>)<sup>2</sup> = <i>a</i><sup>2</sup> + 2<i>ab</i> + <i>b</i><sup>2</sup>


### PR DESCRIPTION
This PR emulates the Sphinx-style `` .. math :: `` syntax and the `:math:` role for inline formulas in Strictdoc.

The intention is to make it simply work for users that might already be familiar the Sphinx syntax from other tools they use.
This is only enabled if the MATHJAX feature is enabled. Otherwise, math blocks will be rendered by the docutils fallback mechanism, as before.

There is an honest attempt to also support the equation numbering feature via `:eq:` and `:label` as well, although that is not documented, and only works for the current document.
