### PR TITLE
/backend/sdoc: remove the TITLE-STATEMENT-DESCRIPTION-CONTENT validation

### DIFF
--- a/strictdoc/backend/sdoc/models/grammar_element.py
+++ b/strictdoc/backend/sdoc/models/grammar_element.py
@@ -10,7 +10,6 @@ from strictdoc.backend.sdoc.models.model import (
     RequirementFieldName,
 )
 from strictdoc.helpers.auto_described import auto_described
-from strictdoc.helpers.exception import StrictDocException
 from strictdoc.helpers.mid import MID
 
 
@@ -278,14 +277,7 @@ class GrammarElement:
             multiline_field_index = self.get_field_titles().index("TITLE") + 1
         except ValueError:
             multiline_field_index = self.content_field[1]
-            if multiline_field_index == -1:
-                raise StrictDocException(
-                    (
-                        f"The grammar element {self.tag} must have at least one of the "
-                        f"following fields: TITLE, STATEMENT, DESCRIPTION, CONTENT."
-                    ),
-                ) from None
-        self.multiline_field_index: int = multiline_field_index
+        self._multiline_field_index: int = multiline_field_index
 
         self.mid: MID = MID.create()
         self.ng_line_start: Optional[int] = None
@@ -341,16 +333,12 @@ class GrammarElement:
 
     def is_field_multiline(self, field_name: str) -> bool:
         field_index = self.field_titles.index(field_name)
-        try:
-            title_field_index = self.field_titles.index("TITLE")
-            if field_index <= title_field_index:
-                return False
-        except ValueError:
-            pass
-        return field_index >= self.content_field[1]
+        return self.is_field_idx_multiline(field_index)
 
-    def get_multiline_field_index(self) -> int:
-        return self.multiline_field_index
+    def is_field_idx_multiline(self, field_idx: int) -> bool:
+        # If there is none of TITLE-STATEMENT-DESCRIPTION-CONTENT present, i.e.,
+        # multiline_field_index is -1, every field will be treated as multiline.
+        return self._multiline_field_index <= field_idx
 
     def get_view_style(self) -> Optional[str]:
         if self.property_view_style_lower is not None:

--- a/strictdoc/backend/sdoc/models/node.py
+++ b/strictdoc/backend/sdoc/models/node.py
@@ -482,21 +482,14 @@ class SDocNode(SDocNodeIF):
         element: GrammarElement = document_grammar.elements_by_type[
             self.node_type
         ]
-        grammar_field_titles = list(map(lambda f: f.title, element.fields))
-
-        reference_field_index: int = element.get_multiline_field_index()
 
         for field in self.enumerate_fields():
             if field.field_name in RESERVED_NON_META_FIELDS:
                 continue
-            field_index = grammar_field_titles.index(field.field_name)
 
-            # A field is considered singleline if it goes before the STATEMENT
-            # field and vice versa.
-            if field_index >= reference_field_index:
-                is_single_line_field = False
-            else:
-                is_single_line_field = True
+            is_single_line_field = not element.is_field_multiline(
+                field.field_name
+            )
 
             if is_single_line_field and skip_single_lines:
                 continue
@@ -654,10 +647,10 @@ class SDocNode(SDocNodeIF):
             document.grammar, DocumentGrammar
         )
         element: GrammarElement = grammar.elements_by_type[self.node_type]
-        grammar_field_titles = list(map(lambda f: f.title, element.fields))
-        field_index = grammar_field_titles.index(field_name)
 
-        multiline = field_index >= element.get_multiline_field_index()
+        field_index = element.field_titles.index(field_name)
+
+        multiline = element.is_field_multiline(field_name)
         if multiline and isinstance(value, str):
             value = ensure_newline(value)
 
@@ -688,7 +681,7 @@ class SDocNode(SDocNodeIF):
             return
 
         new_ordered_fields_lookup = OrderedDict()
-        for field_title in grammar_field_titles[:field_index]:
+        for field_title in element.field_titles[:field_index]:
             if field_title in self.ordered_fields_lookup:
                 new_ordered_fields_lookup[field_title] = (
                     self.ordered_fields_lookup[field_title]
@@ -704,7 +697,7 @@ class SDocNode(SDocNodeIF):
             else value
         ]
         after_field_index = field_index + 1
-        for field_title in grammar_field_titles[after_field_index:]:
+        for field_title in element.field_titles[after_field_index:]:
             if field_title in self.ordered_fields_lookup:
                 new_ordered_fields_lookup[field_title] = (
                     self.ordered_fields_lookup[field_title]

--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -299,11 +299,9 @@ class RequirementFormObject(ErrorObject):
         element: GrammarElement = grammar.elements_by_type[element_type]
         form_fields: List[RequirementFormField] = []
 
-        fields_names = list(element.fields_map.keys())
-        content_field_idx = element.get_multiline_field_index()
+        for field_idx, field_name in enumerate(element.field_titles):
+            multiline = element.is_field_idx_multiline(field_idx)
 
-        for field_idx, field_name in enumerate(fields_names):
-            multiline = field_idx >= content_field_idx
             field = element.fields_map[field_name]
 
             if field_name not in requirement_fields:
@@ -358,16 +356,14 @@ class RequirementFormObject(ErrorObject):
         element: GrammarElement = grammar.elements_by_type[element_type]
 
         form_fields: List[RequirementFormField] = []
-        fields_names = list(element.fields_map.keys())
 
-        content_field_idx = element.get_multiline_field_index()
-
-        for field_idx, field_name in enumerate(fields_names):
+        for field_idx, field_name in enumerate(element.field_titles):
             field = element.fields_map[field_name]
+            multiline = element.is_field_idx_multiline(field_idx)
             form_field: RequirementFormField = (
                 RequirementFormField.create_from_grammar_field(
                     grammar_field=field,
-                    multiline=field_idx >= content_field_idx,
+                    multiline=multiline,
                     value="",
                 )
             )
@@ -411,11 +407,8 @@ class RequirementFormObject(ErrorObject):
         form_fields: List[RequirementFormField] = []
         form_refs_fields: List[RequirementReferenceFormField] = []
 
-        fields_names = list(element.fields_map.keys())
-        content_field_idx = element.get_multiline_field_index()
-
-        for field_idx, field_name in enumerate(fields_names):
-            multiline = field_idx >= content_field_idx
+        for field_idx, field_name in enumerate(element.field_titles):
+            multiline = element.is_field_idx_multiline(field_idx)
 
             # Handle all other fields in a general way.
             field = element.fields_map[field_name]

--- a/tests/integration/features/sdoc/document_grammar/_grammar_from_file/_validations/03_must_check_element_has_either_title_or_reserved_statement/grammar.sgra
+++ b/tests/integration/features/sdoc/document_grammar/_grammar_from_file/_validations/03_must_check_element_has_either_title_or_reserved_statement/grammar.sgra
@@ -1,7 +1,0 @@
-[GRAMMAR]
-ELEMENTS:
-- TAG: REQUIREMENT
-  FIELDS:
-  - TITLE: FOO
-    TYPE: String
-    REQUIRED: True

--- a/tests/integration/features/sdoc/document_grammar/_grammar_from_file/_validations/03_must_check_element_has_either_title_or_reserved_statement/input.sdoc
+++ b/tests/integration/features/sdoc/document_grammar/_grammar_from_file/_validations/03_must_check_element_has_either_title_or_reserved_statement/input.sdoc
@@ -1,8 +1,0 @@
-[DOCUMENT]
-TITLE: Test document
-
-[GRAMMAR]
-IMPORT_FROM_FILE: grammar.sgra
-
-[REQUIREMENT]
-UID: ABC-123

--- a/tests/integration/features/sdoc/document_grammar/_grammar_from_file/_validations/03_must_check_element_has_either_title_or_reserved_statement/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/_grammar_from_file/_validations/03_must_check_element_has_either_title_or_reserved_statement/test.itest
@@ -1,3 +1,0 @@
-RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
-
-CHECK: StrictDocException: The grammar element REQUIREMENT must have at least one of the following fields: TITLE, STATEMENT, DESCRIPTION, CONTENT.

--- a/tests/unit/strictdoc/backend/sdoc/models/test_requirement.py
+++ b/tests/unit/strictdoc/backend/sdoc/models/test_requirement.py
@@ -78,8 +78,11 @@ def test_04_meta_multilines_not_nones():
         required="False",
     )
     requirement_grammar_element = grammar.elements_by_type["REQUIREMENT"]
+    # FIXME: All these methods could be well encapsulated in the Grammar Element.
     requirement_grammar_element.fields.append(meta_test_field)
     requirement_grammar_element.fields_map["META_TEST_FIELD"] = meta_test_field
+    requirement_grammar_element.field_titles.append("META_TEST_FIELD")
+
     document.grammar = grammar
 
     requirement = SDocObjectFactory.create_requirement(

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_grammar.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_grammar.py
@@ -1,12 +1,9 @@
-import pytest
-
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.node import SDocNode
 from strictdoc.backend.sdoc.reader import SDReader
 from strictdoc.backend.sdoc.validations.sdoc_validator import SDocValidator
 from strictdoc.backend.sdoc.writer import SDWriter
 from strictdoc.helpers.cast import assert_cast
-from strictdoc.helpers.exception import StrictDocException
 from tests.unit.helpers.fake_document_meta import create_fake_document_meta
 
 
@@ -455,29 +452,3 @@ the foo must bar
     writer = SDWriter(default_project_config)
     output = writer.write(document)
     assert input_sdoc == output
-
-
-def test_500_validation_grammar_without_TITLE_or_STATEMENT():
-    input_sdoc = """
-[DOCUMENT]
-TITLE: Test Doc
-
-[GRAMMAR]
-ELEMENTS:
-- TAG: TEXT
-  FIELDS:
-  - TITLE: FOO
-    TYPE: String
-    REQUIRED: True
-""".lstrip()
-
-    reader = SDReader()
-
-    with pytest.raises(Exception) as exc_info:
-        _ = reader.read(input_sdoc)
-
-    assert exc_info.type is StrictDocException
-    assert exc_info.value.args[0] == (
-        "The grammar element TEXT must have at least one of the following fields: "
-        "TITLE, STATEMENT, DESCRIPTION, CONTENT."
-    )


### PR DESCRIPTION
There are cases where we want to allow none of the standard SDoc reserved fields to be present on a node, even though this means that no SDoc naming conventions are followed.

In particular, some ReqIF files contain fields that follow neither ReqIF nor SDoc naming conventions.

Currently, the fields TITLE, STATEMENT, DESCRIPTION, or CONTENT are used to determine whether a field should be treated as single-line or multiline. Under the new behavior, if none of these fields are present, all fields will be treated as multiline by default.

In the future, we may introduce a separate field for the GrammarElement field declarations, for example, to explicitly specify whether a field should be interpreted as Title, Meta, Content, etc.