### PR TITLE
docs: update the hello world example with a more realistic command

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -161,7 +161,7 @@ Run StrictDoc as follows:
 
 .. code-block:: text
 
-    strictdoc export hello.sdoc
+    strictdoc export .
 
 The expected output:
 

--- a/strictdoc/core/traceability_index_builder.py
+++ b/strictdoc/core/traceability_index_builder.py
@@ -337,7 +337,12 @@ class TraceabilityIndexBuilder:
                         "TraceabilityIndex: "
                         f'the document "{document.reserved_title}" '
                         "imports a grammar from a file that does not exist: "
-                        f'"{document.grammar.import_from_file}".'
+                        f'"{document.grammar.import_from_file}". One known '
+                        f"source of this error is when only a single document "
+                        f"file is provided as input to the export or server "
+                        f"command, rather than the containing folder. To locate "
+                        f"the grammar file, StrictDoc needs to be able to "
+                        f"resolve it relative to the input path."
                     )
                 document.grammar.update_with_elements(document_grammar.elements)
 


### PR DESCRIPTION
This will hopefully help the users to not stumble upon the edge cases like the one encountered by a user in the issue closed by this commit, see https://github.com/strictdoc-project/strictdoc/issues/2394#issuecomment-3110576718.

In that case, the user was running the "Hello, World!" example by providing a single file as input, rather than the containing folder. With this setup, StrictDoc could not discover the .sgra file located in the same folder as the document, because it was only processing the specified file and not considering the full contents of the folder.

Closes #2394