### PR TITLE
project_statistics: support user-provided custom statistics generators

### DIFF
--- a/strictdoc.toml
+++ b/strictdoc.toml
@@ -28,6 +28,8 @@ features = [
   "NESTOR",
 ]
 
+statistics_generator = "docs.sdoc_project_statistics.SDocStatisticsGenerator"
+
 include_doc_paths = [
   "docs/**",
   "docs_extra/**",

--- a/strictdoc/backend/sdoc/models/model.py
+++ b/strictdoc/backend/sdoc/models/model.py
@@ -8,6 +8,9 @@ from typing import Generator, List, Optional, Union
 from strictdoc.backend.sdoc.models.document_config import (
     DocumentConfig,
 )
+from strictdoc.backend.sdoc_source_code.models.source_file_info import (
+    SourceFileTraceabilityInfo,
+)
 from strictdoc.core.document_meta import DocumentMeta
 from strictdoc.helpers.mid import MID
 
@@ -171,4 +174,10 @@ SDocElementIF = Union[
     SDocSectionIF,
     SDocDocumentIF,
     SDocDocumentFromFileIF,
+]
+
+
+SDocExtendedElementIF = Union[
+    SDocElementIF,
+    SourceFileTraceabilityInfo,
 ]

--- a/strictdoc/backend/sdoc_source_code/models/source_file_info.py
+++ b/strictdoc/backend/sdoc_source_code/models/source_file_info.py
@@ -69,6 +69,18 @@ class SourceFileTraceabilityInfo:
 
         self.markers: List[RelationMarkerType] = []
 
+    # FIXME: is_requirement() will go away.
+    def is_requirement(self) -> bool:
+        return False
+
+    # FIXME: is_section() will go away.
+    def is_section(self) -> bool:
+        return False
+
+    # FIXME: is_section() will go away.
+    def is_source_file(self) -> bool:
+        return True
+
     def get_coverage(self) -> float:
         return self._coverage
 

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -111,6 +111,7 @@ class ProjectConfig:
         config_last_update: Optional[datetime.datetime],
         chromedriver: Optional[str],
         section_behavior: Optional[str],
+        statistics_generator: Optional[str],
     ) -> None:
         assert isinstance(environment, SDocRuntimeEnvironment)
         if source_root_path is not None:
@@ -206,6 +207,8 @@ class ProjectConfig:
         self.chromedriver: Optional[str] = chromedriver
         self.section_behavior: Optional[str] = section_behavior
 
+        self.statistics_generator: Optional[str] = statistics_generator
+
     @staticmethod
     def default_config(environment: SDocRuntimeEnvironment) -> "ProjectConfig":
         assert isinstance(environment, SDocRuntimeEnvironment)
@@ -235,6 +238,7 @@ class ProjectConfig:
             config_last_update=None,
             chromedriver=None,
             section_behavior=ProjectConfig.DEFAULT_SECTION_BEHAVIOR,
+            statistics_generator=None,
         )
 
     # Some server command settings can override the project config settings.
@@ -508,6 +512,7 @@ class ProjectConfigLoader:
         chromedriver: Optional[str] = None
 
         section_behavior: str = ProjectConfig.DEFAULT_SECTION_BEHAVIOR
+        statistics_generator: Optional[str] = None
 
         if "project" in config_dict:
             project_content = config_dict["project"]
@@ -536,6 +541,10 @@ class ProjectConfigLoader:
                     sys.exit(1)
             if ProjectFeature.ALL_FEATURES in project_features:
                 project_features = ProjectFeature.all()
+
+            statistics_generator = project_content.get(
+                "statistics_generator", statistics_generator
+            )
 
             include_doc_paths = project_content.get(
                 "include_doc_paths", include_doc_paths
@@ -752,4 +761,5 @@ class ProjectConfigLoader:
             config_last_update=config_last_update,
             chromedriver=chromedriver,
             section_behavior=section_behavior,
+            statistics_generator=statistics_generator,
         )

--- a/strictdoc/core/query_engine/grammar.py
+++ b/strictdoc/core/query_engine/grammar.py
@@ -45,6 +45,14 @@ BooleanExpression:
   |
   NodeIsSectionExpression
   |
+  NodeIsSourceFileExpression
+  |
+  NodeIsSourceFileWithCompleteCoverageExpression
+  |
+  NodeIsSourceFileWithPartialCoverageExpression
+  |
+  NodeIsSourceFileWithNoCoverageExpression
+  |
   NodeIsRootExpression
   |
   EqualExpression
@@ -81,7 +89,7 @@ NodeHasChildRequirementsExpression:
 ;
 
 NodeIsRequirementExpression:
-  _ = 'node.is_requirement'
+  _ = 'node.is_requirement' '()'?
 ;
 
 NodeIsRootExpression:
@@ -89,7 +97,23 @@ NodeIsRootExpression:
 ;
 
 NodeIsSectionExpression:
-  _ = 'node.is_section'
+  _ = 'node.is_section' '()'?
+;
+
+NodeIsSourceFileExpression:
+  _ = 'node.is_source_file()'
+;
+
+NodeIsSourceFileWithCompleteCoverageExpression:
+  _ = 'node.is_source_file_with_complete_coverage()'
+;
+
+NodeIsSourceFileWithPartialCoverageExpression:
+  _ = 'node.is_source_file_with_partial_coverage()'
+;
+
+NodeIsSourceFileWithNoCoverageExpression:
+  _ = 'node.is_source_file_with_no_coverage()'
 ;
 
 EqualExpression:

--- a/strictdoc/core/query_engine/query_reader.py
+++ b/strictdoc/core/query_engine/query_reader.py
@@ -1,4 +1,3 @@
-# mypy: disable-error-code="no-untyped-call"
 from typing import Callable, Dict, Optional, Tuple
 
 from textx import metamodel_from_str
@@ -16,6 +15,10 @@ from strictdoc.core.query_engine.query_object import (
     NodeIsRequirementExpression,
     NodeIsRootExpression,
     NodeIsSectionExpression,
+    NodeIsSourceFileExpression,
+    NodeIsSourceFileWithCompleteCoverageExpression,
+    NodeIsSourceFileWithNoCoverageExpression,
+    NodeIsSourceFileWithPartialCoverageExpression,
     NoneExpression,
     NotEqualExpression,
     NotExpression,
@@ -37,6 +40,10 @@ QUERY_MODELS = [
     NodeIsRequirementExpression,
     NodeIsRootExpression,
     NodeIsSectionExpression,
+    NodeIsSourceFileExpression,
+    NodeIsSourceFileWithCompleteCoverageExpression,
+    NodeIsSourceFileWithPartialCoverageExpression,
+    NodeIsSourceFileWithNoCoverageExpression,
     NoneExpression,
     NotEqualExpression,
     NotExpression,
@@ -52,7 +59,7 @@ class QueryParseContext:
 
 
 class QueryParsingProcessor:
-    def __init__(self, parse_context: QueryParseContext):
+    def __init__(self, parse_context: QueryParseContext) -> None:
         self.parse_context: QueryParseContext = parse_context
 
     def get_default_processors(self) -> Dict[str, Callable[..., None]]:
@@ -60,7 +67,7 @@ class QueryParsingProcessor:
 
 
 class QueryReader:
-    def __init__(self, path_to_output_root: str = "NOT_RELEVANT"):
+    def __init__(self, path_to_output_root: str = "NOT_RELEVANT") -> None:
         self.path_to_output_root = path_to_output_root
 
     @staticmethod

--- a/strictdoc/core/statistics/metric.py
+++ b/strictdoc/core/statistics/metric.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class Metric:
+    name: str
+    value: str
+    link: Optional[str] = None
+
+
+@dataclass
+class MetricSection:
+    name: str
+    metrics: List[Metric]

--- a/strictdoc/export/html/generators/view_objects/project_statistics_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/project_statistics_view_object.py
@@ -1,6 +1,5 @@
-# mypy: disable-error-code="no-untyped-call"
 from dataclasses import dataclass
-from datetime import datetime
+from typing import List, Union
 
 from markupsafe import Markup
 
@@ -8,10 +7,8 @@ from strictdoc import __version__
 from strictdoc.core.document_tree import DocumentTree
 from strictdoc.core.document_tree_iterator import DocumentTreeIterator
 from strictdoc.core.project_config import ProjectConfig
+from strictdoc.core.statistics.metric import Metric, MetricSection
 from strictdoc.core.traceability_index import TraceabilityIndex
-from strictdoc.export.html.generators.view_objects.project_tree_stats import (
-    DocumentTreeStats,
-)
 from strictdoc.export.html.html_templates import JinjaEnvironment
 from strictdoc.export.html.renderers.link_renderer import LinkRenderer
 from strictdoc.helpers.cast import assert_cast
@@ -25,12 +22,13 @@ class ProjectStatisticsViewObject:
         traceability_index: TraceabilityIndex,
         project_config: ProjectConfig,
         link_renderer: LinkRenderer,
-        document_tree_stats: DocumentTreeStats,
-    ):
+        metrics: List[Union[Metric, MetricSection]],
+    ) -> None:
         self.traceability_index: TraceabilityIndex = traceability_index
         self.project_config: ProjectConfig = project_config
         self.link_renderer: LinkRenderer = link_renderer
-        self.document_tree_stats: DocumentTreeStats = document_tree_stats
+        self.metrics: List[Union[Metric, MetricSection]] = metrics
+
         self.document_tree_iterator: DocumentTreeIterator = (
             DocumentTreeIterator(
                 assert_cast(traceability_index.document_tree, DocumentTree)
@@ -50,10 +48,3 @@ class ProjectStatisticsViewObject:
 
     def render_url(self, url: str) -> Markup:
         return Markup(self.link_renderer.render_url(url))
-
-    def get_datetime(self) -> str:
-        return datetime.today().strftime("%Y-%m-%d %H:%M:%S")
-
-    def document_status_have_status(self) -> bool:
-        statuses = self.document_tree_stats.requirements_status_breakdown.keys()
-        return any(key is not None for key in statuses)

--- a/strictdoc/export/html/generators/view_objects/project_tree_stats.py
+++ b/strictdoc/export/html/generators/view_objects/project_tree_stats.py
@@ -16,8 +16,14 @@ class DocumentTreeStats:
     total_documents: int = 0
     total_requirements: int = 0
     total_sections: int = 0
+    total_source_files: int = 0
+    total_source_files_complete_coverage: int = 0
+    total_source_files_partial_coverage: int = 0
+    total_source_files_no_coverage: int = 0
+
     total_tbd: int = 0
     total_tbc: int = 0
+
     git_commit_hash: Optional[str] = None
 
     # Section.

--- a/strictdoc/export/html/generators/view_objects/search_screen_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/search_screen_view_object.py
@@ -8,13 +8,14 @@ from strictdoc import __version__
 from strictdoc.backend.sdoc.models.anchor import Anchor
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_view import DocumentView
-from strictdoc.backend.sdoc.models.model import SDocElementIF
+from strictdoc.backend.sdoc.models.model import SDocExtendedElementIF
 from strictdoc.backend.sdoc.models.node import SDocNode
 from strictdoc.backend.sdoc.models.section import SDocSection
 from strictdoc.core.document_tree import DocumentTree
 from strictdoc.core.document_tree_iterator import DocumentTreeIterator
 from strictdoc.core.file_tree import FileOrFolderEntry
 from strictdoc.core.project_config import ProjectConfig
+from strictdoc.core.source_tree import SourceFile
 from strictdoc.core.traceability_index import TraceabilityIndex
 from strictdoc.export.html.document_type import DocumentType
 from strictdoc.export.html.html_templates import HTMLTemplates, JinjaEnvironment
@@ -31,14 +32,14 @@ class SearchScreenViewObject:
         traceability_index: TraceabilityIndex,
         project_config: ProjectConfig,
         templates: HTMLTemplates,
-        search_results: List[SDocElementIF],
+        search_results: List[SDocExtendedElementIF],
         search_value: str,
         error: Optional[str],
     ) -> None:
         self.traceability_index: TraceabilityIndex = traceability_index
         self.project_config: ProjectConfig = project_config
         self.templates: HTMLTemplates = templates
-        self.search_results: List[SDocElementIF] = search_results
+        self.search_results: List[SDocExtendedElementIF] = search_results
         self.search_value: str = search_value
         self.error: Optional[str] = error
 
@@ -100,6 +101,13 @@ class SearchScreenViewObject:
 
     def render_static_url(self, url: str) -> str:
         return self.link_renderer.render_static_url(url)
+
+    def render_source_file_link_from_root_2(
+        self, source_file: SourceFile
+    ) -> str:
+        return Markup(
+            self.link_renderer.render_source_file_link_from_root_2(source_file)
+        )
 
     def render_local_anchor(
         self, node: Union[Anchor, SDocNode, SDocSection, SDocDocument]

--- a/strictdoc/export/html/templates/components/table_key_value/index.jinja
+++ b/strictdoc/export/html/templates/components/table_key_value/index.jinja
@@ -3,7 +3,7 @@
 {% if key_value_pair["Section"] is defined %}
   <div class="sdoc-table_key_value-section">{{ key_value_pair["Section"] }}</div>
 {% else %}
-  {% if view_object.project_config.is_activated_search() and key_value_pair["Link"] is defined %}
+  {% if view_object.project_config.is_activated_search() and key_value_pair["Link"] is defined and key_value_pair["Link"] is not none %}
     <a
       class="sdoc-table_key_value-key"
       data-testid="search-{{ key_value_pair["Key"].lower().replace(" ", "-") }}"

--- a/strictdoc/export/html/templates/screens/project_statistics/main.jinja
+++ b/strictdoc/export/html/templates/screens/project_statistics/main.jinja
@@ -2,193 +2,38 @@
 
 <div class="sdoc-table_key_value">
 
-{% with key_value_pair =
-  {
-  "Section": "General information"
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
+{% for metric_or_section_ in view_object.metrics %}
+  {% if metric_or_section_.__class__.__name__ == "MetricSection" %}
+    {% with key_value_pair =
+      {
+      "Section": metric_or_section_.name
+      }
+    %}
+      {% include "components/table_key_value/index.jinja" %}
+    {% endwith %}
 
-{% with key_value_pair =
-  {
-    "Key":"Project name",
-    "Value": view_object.project_config.project_title,
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {
-    "Key":"Statistics generation date",
-    "Value": view_object.get_datetime(),
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {
-    "Key":"Last modification of project data",
-    "Value": view_object.traceability_index.strictdoc_last_update.strftime("%Y-%m-%d %H:%M:%S"),
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {
-    "Key":"Git commit/release",
-    "Value": view_object.document_tree_stats.git_commit_hash,
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {
-    "Key":"Total documents",
-    "Value": view_object.document_tree_stats.total_documents,
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {"Section":"Sections"}
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {
-    "Key":"Total sections",
-    "Link": view_object.render_url('search?q=node.is_section'),
-    "Value": view_object.document_tree_stats.total_sections,
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {
-    "Key":"Sections without any text",
-    "Link": view_object.render_url('search?q=(node.is_section and not node.contains_any_text)'),
-    "Value": view_object.document_tree_stats.sections_without_text_nodes,
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {"Section":"Requirements"}
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {
-    "Key":"Total requirements",
-    "Link": view_object.render_url('search?q=node.is_requirement'),
-    "Value": view_object.document_tree_stats.total_requirements,
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {
-    "Key":"Requirements with no UID",
-    "Link": view_object.render_url('search?q=(node.is_requirement and node["UID"] == None)'),
-    "Value": view_object.document_tree_stats.requirements_no_uid,
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {
-    "Key":"Root-level requirements not connected to by any requirement",
-    "Link": view_object.render_url('search?q=(node.is_requirement and node.is_root and node["STATUS"] != "Backlog" and not node.has_child_requirements)'),
-    "Value": view_object.document_tree_stats.requirements_root_no_links,
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {
-    "Key":"Non-root-level requirements not connected to any parent requirement",
-    "Link": view_object.render_url('search?q=(node.is_requirement and not node.is_root and node["STATUS"] != "Backlog" and not node.has_parent_requirements)'),
-    "Value": view_object.document_tree_stats.requirements_no_links,
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {
-    "Key":"Requirements with no RATIONALE",
-    "Link": view_object.render_url('search?q=(node.is_requirement and node["RATIONALE"] == None)'),
-    "Value": view_object.document_tree_stats.requirements_no_rationale,
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% if view_object.document_status_have_status() %}
-
-{% with key_value_pair =
-  {"Section": "Requirements status breakdown"}
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% for status_, status_count_ in view_object.document_tree_stats.requirements_status_breakdown.items() %}
-  {#
-   # Careful with quotes. The status None is without quotes, all other statuses with.
-   #}
-  {% set status_query_value = '"'~status_~'"' if status_ is not none else "None" %}
-
-  {% with key_value_pair =
-    {
-      "Key":"Requirements with status "~status_,
-      "Link": view_object.render_url('search?q=(node.is_requirement and node["STATUS"] == ' + status_query_value + ')'),
-      "Value": status_count_,
-    }
-  %}
-    {% include "components/table_key_value/index.jinja" %}
-  {% endwith %}
+    {% for metric_ in metric_or_section_.metrics %}
+      {% with key_value_pair =
+        {
+          "Key": metric_.name,
+          "Value": metric_.value,
+          "Link": view_object.render_url(metric_.link) if metric_.link is not none else none,
+        }
+      %}
+        {% include "components/table_key_value/index.jinja" %}
+      {% endwith %}
+    {% endfor %}
+  {% else %}
+    {% with key_value_pair =
+      {
+        "Key": metric_or_section_.name,
+        "Value": metric_or_section_.value,
+      }
+    %}
+      {% include "components/table_key_value/index.jinja" %}
+    {% endwith %}
+  {% endif %}
 {% endfor %}
-
-{% endif %}
-
-{% with key_value_pair =
-  {"Section":"TBD/TBC"}
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {
-    "Key":"Total TBD",
-    "Link": view_object.render_url('search?q=node.contains("TBD")'),
-    "Value": view_object.document_tree_stats.total_tbd,
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
-
-{% with key_value_pair =
-  {
-    "Key":"Total TBC",
-    "Link": view_object.render_url('search?q=node.contains("TBC")'),
-    "Value": view_object.document_tree_stats.total_tbc,
-  }
-%}
-  {% include "components/table_key_value/index.jinja" %}
-{% endwith %}
 
 </div>{# / .sdoc-table_key_value #}
 

--- a/strictdoc/export/html/templates/screens/search/main.jinja
+++ b/strictdoc/export/html/templates/screens/search/main.jinja
@@ -16,6 +16,21 @@
         {% with section=node, document=node.document, node_controls=True %}
           {%- include "components/section/tiny_extends_card.jinja" -%}
         {% endwith %}
+      {% elif node.is_source_file() %}
+        <sdoc-node node-style="card" node-role="requirement" data-testid="node-source-file">
+          <sdoc-node-field>
+          <a href="{{ view_object.render_source_file_link_from_root_2(node.source_file) }}">{{ node.source_file.in_doctree_source_file_rel_path }}</a>
+          </sdoc-node-field>
+          <sdoc-node-field>
+          Lines: {{ node.file_stats.lines_total }}
+          </sdoc-node-field>
+          <sdoc-node-field>
+          Connected requirements: {{ node.ng_map_reqs_to_markers.keys() | length }}
+          </sdoc-node-field>
+          <sdoc-node-field>
+          Coverage: {{ node.get_coverage() }}%
+          </sdoc-node-field>
+        </sdoc-node>
       {% endif %}
     {% endfor %}
     </div>

--- a/tests/integration/features/project_statistics/90_user_provided_statistics/input.sdoc
+++ b/tests/integration/features/project_statistics/90_user_provided_statistics/input.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ001
+TITLE: Hello
+STATEMENT: The System shall do 1.
+
+[REQUIREMENT]
+UID: REQ002
+TITLE: Hello
+STATEMENT: The System shall do 1.
+
+[REQUIREMENT]
+UID: REQ003
+TITLE: Hello
+STATEMENT: The System shall do 1.

--- a/tests/integration/features/project_statistics/90_user_provided_statistics/statistics_generator.py
+++ b/tests/integration/features/project_statistics/90_user_provided_statistics/statistics_generator.py
@@ -1,0 +1,47 @@
+from typing import List, Union
+
+from markupsafe import Markup
+
+from strictdoc.core.project_config import ProjectConfig
+from strictdoc.core.statistics.metric import Metric, MetricSection
+from strictdoc.core.traceability_index import TraceabilityIndex
+from strictdoc.export.html.generators.view_objects.project_statistics_view_object import (
+    ProjectStatisticsViewObject,
+)
+from strictdoc.export.html.html_templates import HTMLTemplates
+from strictdoc.export.html.renderers.link_renderer import LinkRenderer
+
+
+class CustomStatisticsGenerator:
+    @staticmethod
+    def export(
+        project_config: ProjectConfig,
+        traceability_index: TraceabilityIndex,
+        link_renderer: LinkRenderer,
+        html_templates: HTMLTemplates,
+    ) -> Markup:
+
+        #
+        # Create all metrics.
+        #
+
+        metrics: List[Union[Metric, MetricSection]] = []
+
+        section = MetricSection(name="Custom section", metrics=[])
+        metrics.append(section)
+
+        section.metrics.append(
+            Metric(name="Custom metric", value="Custom value")
+        )
+
+        #
+        # Return the final view object.
+        #
+
+        view_object = ProjectStatisticsViewObject(
+            traceability_index=traceability_index,
+            project_config=project_config,
+            link_renderer=link_renderer,
+            metrics=metrics,
+        )
+        return view_object.render_screen(html_templates.jinja_environment())

--- a/tests/integration/features/project_statistics/90_user_provided_statistics/strictdoc.toml
+++ b/tests/integration/features/project_statistics/90_user_provided_statistics/strictdoc.toml
@@ -1,0 +1,8 @@
+[project]
+title = "Test project"
+
+features = [
+  "PROJECT_STATISTICS_SCREEN",
+]
+
+statistics_generator = "statistics_generator.CustomStatisticsGenerator"

--- a/tests/integration/features/project_statistics/90_user_provided_statistics/test.itest
+++ b/tests/integration/features/project_statistics/90_user_provided_statistics/test.itest
@@ -1,0 +1,10 @@
+RUN: cd %S/
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%T/html/project_statistics.html"
+
+RUN: %cat "%T/html/project_statistics.html" | filecheck %s --check-prefix CHECK-HTML
+CHECK-HTML: Custom section
+CHECK-HTML: Custom metric
+CHECK-HTML: Custom value

--- a/tests/integration/features/project_statistics/91_user_provided_statistics_wrong_module/input.sdoc
+++ b/tests/integration/features/project_statistics/91_user_provided_statistics_wrong_module/input.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ001
+TITLE: Hello
+STATEMENT: The System shall do 1.
+
+[REQUIREMENT]
+UID: REQ002
+TITLE: Hello
+STATEMENT: The System shall do 1.
+
+[REQUIREMENT]
+UID: REQ003
+TITLE: Hello
+STATEMENT: The System shall do 1.

--- a/tests/integration/features/project_statistics/91_user_provided_statistics_wrong_module/strictdoc.toml
+++ b/tests/integration/features/project_statistics/91_user_provided_statistics_wrong_module/strictdoc.toml
@@ -1,0 +1,8 @@
+[project]
+title = "Test project"
+
+features = [
+  "PROJECT_STATISTICS_SCREEN",
+]
+
+statistics_generator = "statistics_generator.CustomStatisticsGenerator"

--- a/tests/integration/features/project_statistics/91_user_provided_statistics_wrong_module/test.itest
+++ b/tests/integration/features/project_statistics/91_user_provided_statistics_wrong_module/test.itest
@@ -1,0 +1,3 @@
+RUN: cd %S/
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s
+CHECK: error: Could not import a user-provided statistics generator: No module named 'statistics_generator'.


### PR DESCRIPTION
- Rework how metrics are collected, stored and rendered. Metric and MetricSection classes are introduced to encapsulate which metrics have to be rendered on the Statistics screen.
- A hook into config file is added where a user can provide their own Statistics generator. If provided, the custom generator will be used instead of the default one.
- Four new metrics were added: Total source files: total, complete coverage, partial coverage, no coverage.
- StrictDoc has its own statistics generator that will be customized for its own documentation over time.