### PR TITLE
fix(_static/node_content.css): do not capitalize field names with CSS

### DIFF
--- a/strictdoc/export/html/_static/node_content.css
+++ b/strictdoc/export/html/_static/node_content.css
@@ -115,10 +115,9 @@ sdoc-node-field-label {
   font-family: var(--code-font-family);
   font-weight: 500;
   line-height: 1;
-  text-transform: uppercase;
   color: var(--requirement-label-color);
 
-  /* @mettta and @stanislaw are commenting this out because the REQUIREMENT's field names
+  /* @mettta and @stanislaw are commenting this out because REQUIREMENT's field names
      were split apart, even though there was enough screen width
     word-break: break-word;
   */

--- a/tests/end2end/screens/document/edit_document_grammar_element/edit_grammar_add_human_title/test_case.py
+++ b/tests/end2end/screens/document/edit_document_grammar_element/edit_grammar_add_human_title/test_case.py
@@ -57,6 +57,6 @@ class Test(E2ECase):
 
             form_edit_grammar_element.do_form_submit()
 
-            screen_document.assert_text("CUSTOM FIELD")
+            screen_document.assert_text("Custom Field")
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/edit_document_grammar_element/edit_grammar_rename_field_human_title/test_case.py
+++ b/tests/end2end/screens/document/edit_document_grammar_element/edit_grammar_rename_field_human_title/test_case.py
@@ -57,6 +57,6 @@ class Test(E2ECase):
 
             form_edit_grammar_element.do_form_submit()
 
-            screen_document.assert_text("CUSTOM FIELD 2")
+            screen_document.assert_text("Custom Field 2")
 
         assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
This is not needed. The normal SDoc fields are capitalized anyway but the HUMAN_TITLE field can contain non-capital characters.