### PR TITLE
UI: fix math equation numbering

### DIFF
--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -42,17 +42,48 @@
   {%- endif -%}
 
   {%- if view_object.project_config.is_activated_mathjax() -%}
-  <script id="MathJax-script" async src="{{ view_object.render_static_url('mathjax/tex-mml-chtml.js') }}"></script>
   <script>
-  // This EventListener is needed to re-typeset the MathJax expressions (after saving)...
-  document.addEventListener("turbo:before-stream-render", (event) => {
-    if (window.MathJax?.typesetPromise) {
-      requestAnimationFrame(() => {
-        MathJax.typesetPromise().catch(console.error);
+  // configure mathjax to show equation numbers
+  window.MathJax = {
+    tex: {
+      tags: 'ams',
+    },   
+  };
+  </script>
+  <script id="MathJax-script" async src="{{ view_object.render_static_url('mathjax/tex-mml-chtml.js') }}"></script>
+  {%- if view_object.is_running_on_server -%}
+  <script>
+    // edits can break equation numbering, requiring a full MathJax re-typeset().
+    // To allow MathJax to reparse, the server stores the original math in an extra
+    // 'original-math' attribute on each affected div/span. This function then restores
+    // the original DOM state, for reprocessing.
+    function restoreOriginalMathElements(root = document)
+    {
+      // Select all div or span elements with class 'math' and an 'original-math' attribute
+      const mathElements = root.querySelectorAll('div.math[original-math], span.math[original-math]');
+
+      mathElements.forEach(el => {
+        const original = el.getAttribute('original-math');
+        if (original !== null) {
+            // Restore the original content
+            el.innerHTML = original;
+        }
       });
     }
-  });
+
+    // This EventListener will hook to node updates and re-typeset the MathJax expressions (i.e. after saving)...
+    document.addEventListener("turbo:before-stream-render", (event) => {
+      if (window.MathJax?.typesetPromise) {
+        requestAnimationFrame(() => {
+          restoreOriginalMathElements();                 // restore all math divs and spans in the DOM
+          MathJax.texReset();                            // reset all previous tex input state (eq numbering...) 
+          MathJax.typesetClear();                        // remove all previous output state (typesetting, elements...)
+          MathJax.typesetPromise().catch(console.error); // typeset again, this re-creates the equation numbers
+        });
+      }
+    });  
   </script>
+  {%- endif -%}
   {%- endif -%}
   {%- if view_object.project_config.is_activated_rapidoc() -%}
   <script src="{{ view_object.render_static_url('rapidoc/rapidoc-min.js') }}"></script>

--- a/strictdoc/export/rst/directives/sphinx_style_math.py
+++ b/strictdoc/export/rst/directives/sphinx_style_math.py
@@ -7,28 +7,41 @@ from docutils.parsers.rst.states import Inliner
 
 def eq_role(
     _role: str,
-    rawtext: str,
+    _rawtext: str,
     text: str,
-    lineno: int,
-    inliner: Inliner,
+    _lineno: int,
+    _inliner: Inliner,
     _options: Optional[Dict[str, Any]] = None,
     _content: Optional[List[str]] = None,
 ) -> Tuple[List[nodes.Node], List[nodes.system_message]]:
     """Handle rst :eq: role, producing a link to an equation."""
-    doc = inliner.document
+    eqref = f"\\( \\eqref{{{text}}} \\)"
+    node = nodes.raw(
+        "",
+        f'<span class="math notranslate nohighlight">{eqref}</span>',
+        format="html",
+    )
+    return [node], []
 
-    if (
-        not hasattr(doc, "math_equation_labels")
-        or text not in doc.math_equation_labels
-    ):
-        msg = inliner.reporter.error(
-            f"Unknown equation label: {text}", line=lineno
-        )
-        return [inliner.problematic(rawtext, rawtext, msg)], [msg]
 
-    eq_number = doc.math_equation_labels[text]
-    ref = nodes.raw("", f'<a href="#{text}">({eq_number})</a>', format="html")
-    return [ref], []
+def eq_role_for_server(
+    _role: str,
+    _rawtext: str,
+    text: str,
+    _lineno: int,
+    _inliner: Inliner,
+    _options: Optional[Dict[str, Any]] = None,
+    _content: Optional[List[str]] = None,
+) -> Tuple[List[nodes.Node], List[nodes.system_message]]:
+    """Handle rst :eq: role, producing a link to an equation. (server edition)."""
+    eqref = f"\\( \\eqref{{{text}}} \\)"
+
+    node = nodes.raw(
+        "",
+        f'<span class="math notranslate nohighlight" original-math="{eqref}">{eqref}</span>',
+        format="html",
+    )
+    return [node], []
 
 
 def math_role(
@@ -46,9 +59,36 @@ def math_role(
     else:
         extracted = text
 
+    extracted = f"\\( {extracted} \\)"
+
     node = nodes.raw(
         "",
-        f'<span class="math notranslate nohighlight">\\( {extracted} \\)</span>',
+        f'<span class="math notranslate nohighlight">{extracted}</span>',
+        format="html",
+    )
+    return [node], []
+
+
+def math_role_for_server(
+    _role: str,
+    rawtext: str,
+    text: str,
+    _lineno: int,
+    _inliner: Inliner,
+    _options: Optional[Dict[str, Any]] = None,
+    _content: Optional[List[str]] = None,
+) -> Tuple[List[nodes.Node], List[nodes.system_message]]:
+    """Handle rst :math: role, rendering a formula inline with text. (server edition)."""
+    if rawtext.startswith(":math:`") and rawtext.endswith("`"):
+        extracted = rawtext[len(":math:`") : -1]
+    else:
+        extracted = text
+
+    extracted = f"\\( {extracted} \\)"
+
+    node = nodes.raw(
+        "",
+        f'<span class="math notranslate nohighlight" original-math="{extracted}">{extracted}</span>',
         format="html",
     )
     return [node], []
@@ -57,43 +97,33 @@ def math_role(
 class MathDirective(Directive):  # type: ignore[misc]
     """Docutils directive emulating Sphinx-style math syntax."""
 
+    is_running_in_server: bool = False
     has_content = True
     optional_arguments = 0
     final_argument_whitespace = False
     option_spec = {
         "nowrap": directives.flag,
+        "no-wrap": directives.flag,
         "label": directives.unchanged,
         "number": directives.flag,
     }
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Constuct a MathDirective."""
+        self.is_running_in_server = False
+        super().__init__(*args, **kwargs)
+
     def run(self) -> List[nodes.Node]:
         """Handle ..math :: directive, rendering a formula centered, optionally with eq number."""
-        doc = self.state.document
-        if not hasattr(doc, "math_equation_counter"):
-            doc.math_equation_counter = 0
-            doc.math_equation_labels = {}
 
-        nowrap = "nowrap" in self.options
+        nowrap = "no-wrap" in self.options or "nowrap" in self.options
         label = self.options.get("label")
-        numbered = "number" in self.options or label is not None
 
         math_content = "\n".join(self.content).strip()
         html_parts = []
 
-        if numbered:
-            doc.math_equation_counter += 1
-            eq_number = doc.math_equation_counter
-            if label:
-                doc.math_equation_labels[label] = eq_number
-            number_html = f'<span class="eqno">({eq_number})</span>'
-        else:
-            number_html = ""
-
         if nowrap:
-            html_parts.append('<div class="math notranslate nohighlight">')
-            html_parts.append(math_content)
-            html_parts.append(number_html)
-            html_parts.append("</div>")
+            mathjax_content = math_content
         else:
             parts = [p.strip() for p in math_content.split("\n\n") if p.strip()]
             if len(parts) > 1:
@@ -103,21 +133,47 @@ class MathDirective(Directive):  # type: ignore[misc]
                         wrapped.append(r"\begin{split}" + part + r"\end{split}")
                     else:
                         wrapped.append(part)
-                mathjax_content = (
-                    r"\begin{align}\begin{aligned}"
-                    + r" \\ ".join(wrapped)
-                    + r"\end{aligned}\end{align}"
-                )
+
+                if label:
+                    mathjax_content = (
+                        f"\\begin{{equation}}\\label{{{label}}}"
+                        r"\begin{aligned}"
+                        + r" \\ ".join(wrapped)
+                        + r"\end{aligned}\end{equation}"
+                    )
+                else:
+                    mathjax_content = (
+                        r"\begin{align*}\begin{aligned}"
+                        + r" \\ ".join(wrapped)
+                        + r"\end{aligned}\end{align*}"
+                    )
             else:
-                mathjax_content = math_content
+                if label:
+                    mathjax_content = f"\\begin{{equation}}\\label{{{label}}}\\begin{{aligned}} {math_content} \\end{{aligned}}\\end{{equation}}"
+                else:
+                    mathjax_content = (
+                        f" \\begin{{align*}}  {math_content} \\end{{align*}}"
+                    )
 
+        mathjax_content = f"\\[ {mathjax_content} \\]"
+
+        if self.is_running_in_server:
+            html_parts.append(
+                f'<div class="math notranslate nohighlight" original-math="{mathjax_content}">'
+            )
+        else:
             html_parts.append('<div class="math notranslate nohighlight">')
-            html_parts.append(number_html)
-            html_parts.append(f"\\[{mathjax_content}\\]")
-            html_parts.append("</div>")
-
-        if label:
-            html_parts.insert(0, f'<a id="{label}"></a>')
+        html_parts.append(mathjax_content)
+        html_parts.append("</div>")
 
         html = "".join(html_parts)
         return [nodes.raw("", html, format="html")]
+
+
+class MathDirectiveForServer(MathDirective):
+    """Docutils directive emulating Sphinx-style math syntax. (server edition)"""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Constuct a MathDirective, and set flag for running in server-mode."""
+        super().__init__(*args, **kwargs)
+        self.is_running_in_server = True

--- a/strictdoc/export/rst/rst_to_html_fragment_writer.py
+++ b/strictdoc/export/rst/rst_to_html_fragment_writer.py
@@ -16,8 +16,11 @@ from strictdoc.core.project_config import ProjectConfig, ProjectFeature
 from strictdoc.export.rst.directives.raw_html_role import raw_html_role
 from strictdoc.export.rst.directives.sphinx_style_math import (
     MathDirective,
+    MathDirectiveForServer,
     eq_role,
+    eq_role_for_server,
     math_role,
+    math_role_for_server,
 )
 from strictdoc.export.rst.directives.wildcard_enhanced_image import (
     WildcardEnhancedImage,
@@ -70,9 +73,14 @@ class RstToHtmlFragmentWriter:
         self.context_document: Optional[SDocDocument] = context_document
 
         if project_config.is_feature_activated(ProjectFeature.MATHJAX):
-            directives.register_directive("math", MathDirective)
-            roles.register_canonical_role("math", math_role)
-            roles.register_canonical_role("eq", eq_role)
+            if project_config.is_running_on_server:
+                roles.register_canonical_role("eq", eq_role_for_server)
+                roles.register_canonical_role("math", math_role_for_server)
+                directives.register_directive("math", MathDirectiveForServer)
+            else:
+                roles.register_canonical_role("eq", eq_role)
+                roles.register_canonical_role("math", math_role)
+                directives.register_directive("math", MathDirective)
 
     def write(self, rst_fragment: str, use_cache: bool = True) -> Markup:
         assert isinstance(rst_fragment, str), rst_fragment

--- a/tests/integration/features/mathjax/03_mathjax_enabled_math_block/input.sdoc
+++ b/tests/integration/features/mathjax/03_mathjax_enabled_math_block/input.sdoc
@@ -3,13 +3,22 @@ TITLE: Hello math!
 
 [TEXT]
 STATEMENT: >>>
-When the ``MATHJAX`` feature is enabled, we support the role for inline math.
-Use like this:
+When the ``MATHJAX`` feature is enabled, we support the sphinx math syntax. 
+<<<
+
+[[SECTION]]
+TITLE: Expressing Math (Sphinx-Style)
+
+[TEXT]
+STATEMENT: >>>
+The input language for mathematics is LaTeX markup. This is the de-facto standard for plain-text math notation.
+StricDoc supports the Sphinx-style math extensions to wrap LaTex markup in rST.
+
+The ``:math:`` role can be used for inline math, like this:
 
 .. code-block ::
 
     Since Pythagoras, we know that :math:`a^2 + b^2 = c^2`.
-
 
 Since Pythagoras, we know that :math:`a^2 + b^2 = c^2`.
 
@@ -17,8 +26,8 @@ Since Pythagoras, we know that :math:`a^2 + b^2 = c^2`.
 
 [TEXT]
 STATEMENT: >>>
-When the ``MATHJAX`` feature is enabled, we support also the math directive. 
-Use like this:
+StrictDoc also supports the ``.. math::`` directive, which renders the equation(s) as a new, centered paragrahs. 
+The directive supports multiple equations, which should be separated by a blank line. For example:
 
 .. code-block ::
 
@@ -33,13 +42,37 @@ Use like this:
    (a + b)^2 = a^2 + 2ab + b^2
 
    (a - b)^2 = a^2 - 2ab + b^2
+
+In addition, each single equation is set within a split environment, which means that you can have multiple aligned lines in an equation, aligned at ``&`` and separated by ``\\\\``:
+
+.. code-block ::
+
+  .. math::
+
+     (a + b)^2  &=  (a + b)(a + b) \\
+                &=  a^2 + 2ab + b^2
+
+.. math::
+
+   (a + b)^2  &=  (a + b)(a + b) \\
+              &=  a^2 + 2ab + b^2
+
+
+When the math is only one line of text, it can also be given as a directive argument:
+
+.. code-block ::
+
+  .. math:: (a + b)^2 = a^2 + 2ab + b^2
+
+.. math:: (a + b)^2 = a^2 + 2ab + b^2
 <<<
+
+[[SECTION]]
+TITLE: Referencing Equations
 
 [TEXT]
 STATEMENT: >>>
-Normally, equations are not numbered. If you want your equation to get a number, use 
-the label option. When given, it selects a label for the equation, by which it can be 
-cross-referenced, and causes an equation number to be issued. 
+Normally, equations are not numbered. To issue an equation number, add a label: 
 
 .. code-block ::
   
@@ -47,12 +80,10 @@ cross-referenced, and causes an equation number to be issued.
      :label: euler
   
 
-
-
 .. math:: e^{i\pi} + 1 = 0
    :label: euler
 
-When you want to cross-reference, use this syntax:
+To cross-reference an equation from the text, use the ``:eq:`` role, and specify the desired label.
 
 .. code-block ::
 
@@ -63,13 +94,70 @@ When you want to cross-reference, use this syntax:
 Euler's identity, equation :eq:`euler`, was elected one of the most
 beautiful mathematical formulas.
 
+The directive supports only a single label per block, so you need to split multiple equations into multiple blocks to reference them:
+
+.. code-block :: 
+
+  .. math::
+     :label: binominal-plus
+
+     (a + b)^2 = a^2 + 2ab + b^2
+
+  .. math::
+     :label: binominal-minus
+
+     (a - b)^2 = a^2 - 2ab + b^2
+
+.. math::
+   :label: binominal-plus
+
+   (a + b)^2 = a^2 + 2ab + b^2
+
+.. math::
+   :label: binominal-minus
+
+   (a - b)^2 = a^2 - 2ab + b^2
+
+
+If you want the two formulas to share a single equation number (and reference), you can put them into a single aligned block:
+
+.. code-block :: 
+
+   .. math::
+     :label: binominal
+
+     (a + b)^2 &= a^2 + 2ab + b^2  \\
+     (a - b)^2 &= a^2 - 2ab + b^2
+
+.. math::
+   :label: binominal
+
+   (a + b)^2 &= a^2 + 2ab + b^2  \\
+   (a - b)^2 &= a^2 - 2ab + b^2
+
 <<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: More Control over the Math Environment
 
 [TEXT]
 STATEMENT: >>>
-There is also an option ``nowrap`` that prevents any wrapping of the given math 
-in a math environment. When you give this option, you must make sure yourself 
-that the math is properly set up. For example:
+There is also an option ``no-wrap`` that prevents any automatic wrapping of the given equations in a math environment.
+This option gives you full control, but you are also now responsible that the math environemnt is properly set up. 
+
+If you want equation numbering, use an environment without asterisk ``*``:
+
+.. code-block ::
+
+  .. math::
+     :no-wrap:
+
+     \begin{eqnarray}
+        y    & = & ax^2 + bx + c \\
+        f(x) & = & x^2 + 2xy + y^2
+     \end{eqnarray}
 
 .. math::
    :nowrap:
@@ -78,4 +166,119 @@ that the math is properly set up. For example:
       y    & = & ax^2 + bx + c \\
       f(x) & = & x^2 + 2xy + y^2
    \end{eqnarray}
+
+To suppress the equation numbering for the entire block, add an
+asterisk ``*`` to the end of the environment name.
+For example:
+
+.. code-block ::
+
+  .. math::
+     :nowrap:
+
+     \begin{eqnarray*}
+        y    & = & ax^2 + bx + c \\
+        f(x) & = & x^2 + 2xy + y^2
+     \end{eqnarray*}
+
+.. math::
+   :nowrap:
+
+   \begin{eqnarray*}
+      y    & = & ax^2 + bx + c \\
+      f(x) & = & x^2 + 2xy + y^2
+   \end{eqnarray*}
+
+It is also possible to suppress the equation numbering for an individual equation using ``\notag``.
+
+.. code-block ::
+
+  .. math::
+     :nowrap:
+
+     \begin{eqnarray}
+        y    & = & ax^2 + bx + c  \notag \\
+        f(x) & = & x^2 + 2xy + y^2
+     \end{eqnarray}
+
+.. math::
+   :nowrap:
+
+   \begin{eqnarray}
+      y    & = & ax^2 + bx + c \notag \\
+      f(x) & = & x^2 + 2xy + y^2
+   \end{eqnarray}
+
+.. note ::
+   
+   Note that recent versions of Sphinx use ``no-wrap``, but in older versions of Sphinx, the option was called ``nowrap`` without the dash. StricDoc supports both variants for compatibility reasons, but
+   for new content, we recommend to use the more recent version ``no-wrap``.
+
 <<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Referencing Equations in other Nodes
+
+[TEXT]
+STATEMENT: >>>
+
+Referencing equations only works within the same .sdoc document, but equations from any node in the current document can be referenced, and it does not matter wether the equation is defined before the reference, or after.
+
+For example, these are Maxwell's equations:
+
+.. math::
+   :label: maxwell
+
+   \nabla \cdot \mathbf{E} &= \frac{\rho}{\varepsilon_0} \\
+   \nabla \cdot \mathbf{B} &= 0 \\
+   \nabla \times \mathbf{E} &= -\frac{\partial \mathbf{B}}{\partial t} \\
+   \nabla \times \mathbf{B} &= \mu_0 \mathbf{J} + \mu_0 \varepsilon_0 \frac{\partial \mathbf{E}}{\partial t}
+
+And, here we check that we can correctly refer to:
+
+* an equation that is located earlier in the same node: :eq:`maxwell`   
+* an equation that is located later in the same node: :eq:`einstein`
+* an equation that is located in a different, earlier node: :eq:`euler`
+* an equation that is located in a later node :eq:`navier-stokes`
+
+And here is Einsteins well-known equation:
+
+.. math:: E = mc^2 
+   :label: einstein
+
+.. note::
+  
+  To ensure that this feature works correctly also in the webeditor, converting labels to equation numbers needs to be performed by MathJax (at render time in the browser).
+  StricDoc therefore transparently passes the equation lables to the generated HTML code.  
+<<<
+
+[REQUIREMENT]
+STATEMENT: >>>
+This requirement shows the navier stokes equations:
+
+.. math::
+   :label: navier-stokes
+
+   \rho \left( \frac{\partial \mathbf{u}}{\partial t} + \mathbf{u} \cdot \nabla \mathbf{u} \right)
+   &= - \nabla p + \mu \nabla^2 \mathbf{u} + \mathbf{f} \\
+
+   \nabla \cdot \mathbf{u} &= 0 
+<<<
+
+[TEXT]
+STATEMENT: >>>
+Here is some more filler text to make the scrolling in the brower more obvious:
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vel mattis enim. Nam pellentesque mattis 
+augue volutpat interdum. Nam suscipit turpis malesuada sem commodo placerat. Suspendisse venenatis arcu vitae 
+ipsum lobortis, in iaculis tellus placerat. In tincidunt ante odio, id mollis dolor vestibulum quis. 
+Quisque id ligula libero. Aenean interdum ac urna accumsan pellentesque. Sed pulvinar ac lorem eu malesuada. 
+Morbi hendrerit eleifend venenatis. Donec quis viverra metus. Etiam sagittis, nisl vel ultrices egestas, urna dui 
+euismod enim, ut convallis ante nulla et ex.
+<<<
+
+[[/SECTION]]
+
+[[/SECTION]]

--- a/tests/integration/features/mathjax/03_mathjax_enabled_math_block/test.itest
+++ b/tests/integration/features/mathjax/03_mathjax_enabled_math_block/test.itest
@@ -7,7 +7,15 @@ RUN: %check_exists --file "%T/html/_static/mathjax/output/chtml/fonts/tex.js"
 RUN: %cat %T/html/03_mathjax_enabled_math_block/input.html | filecheck %s --check-prefix CHECK-HTML
 
 CHECK-HTML: <span class="math notranslate nohighlight">\( a^2 + b^2 = c^2 \)</span>
-CHECK-HTML: <div class="math notranslate nohighlight">\[\begin{align}\begin{aligned}(a + b)^2 = a^2 + 2ab + b^2 \\ (a - b)^2 = a^2 - 2ab + b^2\end{aligned}\end{align}\]</div></div>
-CHECK-HTML: <a id="euler"></a><div class="math notranslate nohighlight"><span class="eqno">(1)</span>\[e^{i\pi} + 1 = 0\]</div>
-CHECK-HTML: <a href="#euler">(1)</a>
-CHECK-HTML: <div class="math notranslate nohighlight">\begin{eqnarray}
+CHECK-HTML: <div class="math notranslate nohighlight">\[ \begin{align*}\begin{aligned}(a + b)^2 = a^2 + 2ab + b^2 \\ (a - b)^2 = a^2 - 2ab + b^2\end{aligned}\end{align*} \]</div>
+CHECK-HTML: <div class="math notranslate nohighlight">\[ \begin{equation}\label{euler}\begin{aligned} e^{i\pi} + 1 = 0 \end{aligned}\end{equation} \]</div>
+CHECK-HTML: <p>Euler's identity, equation <span class="math notranslate nohighlight">\( \eqref{euler} \)</span>, was elected one of the most
+CHECK-HTML: <div class="math notranslate nohighlight">\[ \begin{eqnarray}
+CHECK-HTML:    y    & = & ax^2 + bx + c \\
+CHECK-HTML:    f(x) & = & x^2 + 2xy + y^2
+CHECK-HTML: \end{eqnarray} \]</div>
+CHECK-HTML: <span class="math notranslate nohighlight">\( \eqref{maxwell} \)</span>
+CHECK-HTML: <span class="math notranslate nohighlight">\( \eqref{einstein} \)</span>
+CHECK-HTML: <span class="math notranslate nohighlight">\( \eqref{euler} \)</span>
+CHECK-HTML: <span class="math notranslate nohighlight">\( \eqref{navier-stokes} \)</span>
+


### PR DESCRIPTION
This PR addresses an issue where wrong equation numbers were shown when editing documents.

- The PR use the 'ams' equation numbering mechanism of MathJax (which happens at render-time in the browser)
- On every document update, the original DOM is first restored from the new 'original-math' attribute
- Then MathJax is asked to reparse/re-typeset the document. 
- As a result, the eq numbers are updated after the edit.

Tested with Chrome / Firefox on Windows