### PR TITLE
Static export: fix script paths and handle missing elements

### DIFF
--- a/strictdoc/export/html/_static/project_tree.js
+++ b/strictdoc/export/html/_static/project_tree.js
@@ -180,7 +180,9 @@ class ProjectTree {
 
     this._initStateAndStorage();
 
-    console.assert(this.controlTarget, `controlTarget not found on the page`);
+    // * this.controlTarget may not be present on the page, for example, in the case of static export.
+    // console.assert(this.controlTarget, `controlTarget not found on the page`);
+
     this._createControl();
     this._addControl();
 
@@ -315,7 +317,8 @@ class ProjectTree {
   }
 
   _addControl() {
-    this.controlTarget.append(this.controlElement);
+    // * this.controlTarget may not be present on the page, for example, in the case of static export.
+    this.controlTarget && this.controlTarget.append(this.controlElement);
   }
 
   _removeControl() {
@@ -348,10 +351,12 @@ class ProjectTree {
 window.addEventListener("DOMContentLoaded", function(){
 
   const controlTarget = document.querySelector(SWITCH_SELECTOR);
-  if (!controlTarget) {
-    console.error(`Selector "${SWITCH_SELECTOR}" not found on the page`);
-    return;
-  }
+  // * This element may not be present on the page, for example, in the case of static export.
+  // if (!controlTarget) {
+  //   console.error(`Selector "${SWITCH_SELECTOR}" not found on the page`);
+  //   return;
+  // }
+
   const mutatingFrame = document.querySelector(FRAME_SELECTOR);
   if (!mutatingFrame) {
     console.error(`Selector "${FRAME_SELECTOR}" not found on the page`);

--- a/strictdoc/export/html/templates/screens/git/index.jinja
+++ b/strictdoc/export/html/templates/screens/git/index.jinja
@@ -9,7 +9,7 @@
 {% block head_scripts %}
   {{ super() }}
 
-  <script src="{{ view_object.render_static_url_with_prefix('stimulus_umd.min.js') }}"></script>
+  <script src="{{ view_object.render_static_url('stimulus_umd.min.js') }}"></script>
   <script>
     Stimulus.application = Stimulus.Application.start();
   </script>

--- a/strictdoc/export/html/templates/screens/project_index/index.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/index.jinja
@@ -8,7 +8,7 @@
 {% endblock head_css %}
 
 {% block head_scripts %}
-  <script src="{{ view_object.render_static_url_with_prefix('stimulus_umd.min.js') }}"></script>
+  <script src="{{ view_object.render_static_url('stimulus_umd.min.js') }}"></script>
   <script>
     Stimulus.application = Stimulus.Application.start();
   </script>

--- a/strictdoc/export/html/templates/screens/search/index.jinja
+++ b/strictdoc/export/html/templates/screens/search/index.jinja
@@ -8,7 +8,7 @@
 {% block head_scripts %}
   {{ super() }}
 
-  <script src="{{ view_object.render_static_url_with_prefix('stimulus_umd.min.js') }}"></script>
+  <script src="{{ view_object.render_static_url('stimulus_umd.min.js') }}"></script>
   <script>
     Stimulus.application = Stimulus.Application.start();
   </script>


### PR DESCRIPTION


- Project Index: fixed static export error by removing incorrect usage of render_static_url_with_prefix() in non-module <script>.
- Search and Git pages: same cleanup, although not included in static export.
- Project tree: replaced hard asserts for the "included documents" switch container with safe checks, since this element is absent in static export.