### PR TITLE
TOC highlighting refactor and robustness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ __pycache__
 /*.local.toml
 /__*.sdoc
 /__*.sgra
+/docs/test/
 
 ### webdriver_manager: cache with downloaded Chrome Driver binaries ###
 /strictdoc/export/html2pdf/.wdm

--- a/strictdoc/export/html/_static/toc_highlighting.js
+++ b/strictdoc/export/html/_static/toc_highlighting.js
@@ -100,9 +100,17 @@ function handleHashChange() {
     targetItem(link, false)
   });
   // * If there's a fragment and a mapped pair, highlight its link.
-  fragment
-    && tocHighlightingState.data[fragment]
-    && targetItem(tocHighlightingState.data[fragment].link)
+  if (fragment) {
+    const pair = tocHighlightingState.data[fragment];
+    if (pair && pair.link) {
+      targetItem(pair.link);
+    } else {
+      // No mapping found — keep URL as-is and move on silently
+      // TOC_HIGHLIGHT_DEBUG &&
+      console.warn('handleHashChange(): no mapping for fragment', fragment);
+      return;
+    }
+  }
 }
 
 function processLinkList(tocFrame) {
@@ -234,7 +242,11 @@ function handleIntersect(entries, observer) {
       if (tocHighlightingState.closerForFolder[anchor]) {
         tocHighlightingState.closerForFolder[anchor].forEach(id => {
           TOC_HIGHLIGHT_DEBUG && console.log(`🔴`, id, `(from ${anchor})`);
-          fireFolder(tocHighlightingState.data[id].link)
+          const pair2 = tocHighlightingState.data[id];
+          console.assert(pair2 && pair2.link, 'handleIntersect(): missing folder link for', id);
+          if (pair2 && pair2.link) {
+            fireFolder(pair2.link);
+          }
         })
       }
       TOC_HIGHLIGHT_DEBUG && console.groupEnd();
@@ -273,7 +285,11 @@ function handleIntersect(entries, observer) {
         // ** remove highlights from closer`s parent folder in the TOC
         tocHighlightingState.closerForFolder[anchor].forEach(id => {
           TOC_HIGHLIGHT_DEBUG && console.log(`⚫ ⬆️`, id,);
-          fireFolder(tocHighlightingState.data[id].link, false)
+          const pair3 = tocHighlightingState.data[id];
+          console.assert(pair3 && pair3.link, 'handleIntersect(): missing folder link for', id);
+          if (pair3 && pair3.link) {
+            fireFolder(pair3.link, false);
+          }
         });
       }
 
@@ -303,9 +319,12 @@ function findDeepestLastChild(element) {
 }
 
 function targetItem(element, on = true) {
-  if (!element) { return } // Guard against race conditions:
-  // hashchange or intersection events may fire
-  // before the TOC is fully built, resulting in undefined link elements.
+  // * Toggle "targeted" attribute for direct hash navigation.
+
+  //// hashchange or intersection events may fire
+  //// before the TOC is fully built, resulting in undefined link elements.
+
+  console.assert(element, 'targetItem(): expected a valid element');
   if(on) {
     element.setAttribute('targeted', '');
   } else {
@@ -314,7 +333,12 @@ function targetItem(element, on = true) {
 }
 
 function fireItem(element, on = true) {
-  if (!element) { return } // Guard against race conditions
+  // * Toggle "intersected" attribute for visible anchors.
+
+  //// Guard: events may fire before TOC is fully built.
+  ////// Guard against race conditions
+
+  console.assert(element, 'fireItem(): expected a valid element');
   if(on) {
     element.setAttribute('intersected', '');
   } else {
@@ -323,7 +347,11 @@ function fireItem(element, on = true) {
 }
 
 function fireFolder(element, on = true) {
-  if (!element) { return } // Guard against race conditions
+  // * Toggle "parented" attribute for section folders.
+
+  //// Guard against race conditions
+
+  console.assert(element, 'fireFolder(): expected a valid element');
   if(on) {
     element.setAttribute('parented', '');
   } else {

--- a/strictdoc/export/html/_static/toc_highlighting.js
+++ b/strictdoc/export/html/_static/toc_highlighting.js
@@ -86,8 +86,7 @@ function highlightTOC(tocFrame, contentFrame, anchorObserver) {
 
 function handleHashChange() {
   const hash = window.location.hash;
-  const match = hash.match(/#(.*)/);
-  const fragment = match ? match[1] : null;
+  const fragment = hash ? decodeURIComponent(hash.slice(1)) : null;
 
   if (!tocHighlightingState.links || tocHighlightingState.links.length === 0) {
     return;

--- a/strictdoc/export/html/_static/toc_highlighting.js
+++ b/strictdoc/export/html/_static/toc_highlighting.js
@@ -218,15 +218,15 @@ function handleIntersect(entries, observer) {
 
       if(
         // * If the node goes up ⬆️ off the screen
-        entry.boundingClientRect.y < tocHighlightingState.contentFrameTop
+        entry.boundingClientRect.top <= entry.rootBounds.top
         // * and this is the last child of the section
         && tocHighlightingState.closerForFolder[anchor]
       ) {
         // * When the LAST CHILD of the section disappears
-        // * over the upper boundary ( < tocHighlightingState.contentFrameTop),
+        // * over the upper boundary (<= entry.rootBounds.top),
         // * strictly speaking, this occurs when the lower bound disappears:
         // * entry.boundingClientRect.bottom.
-        // * But we will use the upper bound, entry.boundingClientRect.y
+        // * But we will use the upper bound, entry.boundingClientRect.top
         // * which will be less than or equal to the lower bound.
 
         // ** remove highlights from closer`s parent folder in the TOC

--- a/strictdoc/export/html/_static/toc_highlighting.js
+++ b/strictdoc/export/html/_static/toc_highlighting.js
@@ -9,6 +9,13 @@ const TOC_ELEMENT_SELECTOR = 'a';
 const CONTENT_FRAME_SELECTOR = 'turbo-frame#frame_document_content'; // action="replace" => parentNode is needed
 const CONTENT_ELEMENT_SELECTOR = 'sdoc-anchor';
 
+// Virtual viewport for TOC section highlighting.
+// We do not use the raw screen edges (0..innerHeight): we shrink the effective
+// area to [top+offset, bottom-offset]. This keeps the active range aligned with
+// what users perceive as "currently visible content" (header space, early closing of the previous node).
+const VIEWPORT_TOP_OFFSET_PX = 64;
+const VIEWPORT_BOTTOM_OFFSET_PX = 32;
+
 // * Runtime state;
 // * anchorsCount/anchorsSig skip unnecessary re-observe on TOC mutations.
 let tocHighlightingState = {
@@ -18,6 +25,7 @@ let tocHighlightingState = {
   anchorsCount: -1,
   anchorsSig: 0,
   contentFrameTop: undefined,
+  contentFrameEl: null,
   closerForFolder: {},
   folderSet: new Set(),
 };
@@ -27,6 +35,7 @@ function resetState() {
   tocHighlightingState.data = {};
   tocHighlightingState.links = null;
   tocHighlightingState.anchors = null;
+  tocHighlightingState.contentFrameEl = null;
   tocHighlightingState.closerForFolder = {};
   tocHighlightingState.folderSet = new Set();
 }
@@ -164,6 +173,7 @@ function processAnchorList(contentFrame, anchorObserver) {
 
   // * Collects all anchors in the document
   const newAnchors = contentFrame.querySelectorAll(CONTENT_ELEMENT_SELECTOR);
+  tocHighlightingState.contentFrameEl = contentFrame;
 
   // * Build order-sensitive signature to detect renames/reorders without full re-subscribe.
   let sig = 0;
@@ -218,13 +228,18 @@ function processAnchorList(contentFrame, anchorObserver) {
 }
 
 function handleIntersect(entries, observer) {
+  // IntersectionObserver drives events, but the actual "which sections are
+  // visible" decision is done by range geometry in updateVisibleSectionItems().
+  let topBound = VIEWPORT_TOP_OFFSET_PX;
+  let bottomBound = window.innerHeight - VIEWPORT_BOTTOM_OFFSET_PX;
+  if (entries.length > 0 && entries[0].rootBounds) {
+    topBound = entries[0].rootBounds.top + VIEWPORT_TOP_OFFSET_PX;
+    bottomBound = entries[0].rootBounds.bottom - VIEWPORT_BOTTOM_OFFSET_PX;
+  }
 
   entries.forEach((entry) => {
 
     const anchor = entry.target.id;
-    // * Fallback: rootBounds can be null right after IO init; use viewport bounds in that case.
-    const topBound = entry.rootBounds ? entry.rootBounds.top : 0;
-    const bottomBound = entry.rootBounds ? entry.rootBounds.bottom : window.innerHeight;
 
     // * IO may fire between resets; mapping may be missing — skip safely.
     const link = tocHighlightingState.data[anchor]?.link;
@@ -238,8 +253,6 @@ function handleIntersect(entries, observer) {
     if (entry.isIntersecting) { //! entry.intersectionRatio > 0 -- it happens to be equal to zero at the intersection!
 
       TOC_HIGHLIGHT_DEBUG && console.group('🔶', entry.isIntersecting, entry.intersectionRatio, anchor, entry.intersectionRect.height);
-      // * and highlights them in the TOC,
-      fireItem(link)
 
       // * semi-highlights folder in the TOC,
       if (tocHighlightingState.folderSet.has(anchor)) {
@@ -262,10 +275,7 @@ function handleIntersect(entries, observer) {
 
     // ** Not visible. Remove item highlight and conditionally de-highlight folders.
     } else {
-
       TOC_HIGHLIGHT_DEBUG && console.group('🔹', entry.isIntersecting, entry.intersectionRatio, anchor);
-      // * or cancels highlighting for the rest of the links.
-      fireItem(link, false);
 
       if(
         // * If the node goes down ⬇️ off the screen
@@ -306,6 +316,55 @@ function handleIntersect(entries, observer) {
     }
   });
 
+  updateVisibleSectionItems(topBound, bottomBound);
+}
+
+function updateVisibleSectionItems(topBound, bottomBound) {
+  // Section visibility is computed by intervals between anchors:
+  // section_i := [anchor_i.top, anchor_{i+1}.top), and for the last section:
+  // [anchor_last.top, contentFrame.bottom).
+  // If this interval overlaps the virtual viewport [topBound, bottomBound],
+  // the corresponding TOC item is marked as intersected.
+  if (!tocHighlightingState.anchors || tocHighlightingState.anchors.length === 0) {
+    return;
+  }
+
+  const linkedAnchors = [];
+  tocHighlightingState.anchors.forEach(anchor => {
+    const id = anchor.id;
+    const pair = tocHighlightingState.data[id];
+    if (!pair || !pair.anchor || !pair.link) {
+      return;
+    }
+    linkedAnchors.push({ id, anchor: pair.anchor, link: pair.link });
+  });
+
+  if (linkedAnchors.length === 0) {
+    return;
+  }
+
+  const visibleIds = new Set();
+  for (let i = 0; i < linkedAnchors.length; i++) {
+    const current = linkedAnchors[i];
+    const next = linkedAnchors[i + 1];
+
+    // Section i is the interval [anchor_i, anchor_{i+1}).
+    const sectionTop = current.anchor.getBoundingClientRect().top;
+    const sectionBottom = next
+      ? next.anchor.getBoundingClientRect().top
+      : (tocHighlightingState.contentFrameEl?.getBoundingClientRect().bottom ?? bottomBound);
+
+    const sectionOverlapsViewport =
+      sectionBottom > topBound && sectionTop < bottomBound;
+
+    if (sectionOverlapsViewport) {
+      visibleIds.add(current.id);
+    }
+  }
+
+  linkedAnchors.forEach(item => {
+    fireItem(item.link, visibleIds.has(item.id));
+  });
 }
 
 function findDeepestLastChild(element) {

--- a/strictdoc/export/html/_static/toc_highlighting.js
+++ b/strictdoc/export/html/_static/toc_highlighting.js
@@ -329,10 +329,6 @@ function findDeepestLastChild(element) {
 
 function targetItem(element, on = true) {
   // * Toggle "targeted" attribute for direct hash navigation.
-
-  //// hashchange or intersection events may fire
-  //// before the TOC is fully built, resulting in undefined link elements.
-
   console.assert(element, 'targetItem(): expected a valid element');
   if(on) {
     element.setAttribute('targeted', '');
@@ -343,10 +339,6 @@ function targetItem(element, on = true) {
 
 function fireItem(element, on = true) {
   // * Toggle "intersected" attribute for visible anchors.
-
-  //// Guard: events may fire before TOC is fully built.
-  ////// Guard against race conditions
-
   console.assert(element, 'fireItem(): expected a valid element');
   if(on) {
     element.setAttribute('intersected', '');
@@ -357,9 +349,6 @@ function fireItem(element, on = true) {
 
 function fireFolder(element, on = true) {
   // * Toggle "parented" attribute for section folders.
-
-  //// Guard against race conditions
-
   console.assert(element, 'fireFolder(): expected a valid element');
   if(on) {
     element.setAttribute('parented', '');

--- a/strictdoc/export/html/_static/toc_highlighting.js
+++ b/strictdoc/export/html/_static/toc_highlighting.js
@@ -310,21 +310,27 @@ function handleIntersect(entries, observer) {
 
 function findDeepestLastChild(element) {
   // * Walk down the last-child chain to find the last <a> inside a nested list
-  // * (depends on TOC markup):
 
   // ! depends on TOC markup
   // ul > li > div + a + ul > ...
   // ul > li > a
   //    > li > a <---------------***
+
+  // Return the last <a> in the subtree or null if none exists.
+  // This avoids returning container elements (UL/LI/DIV) that lack the 'anchor' attribute.
+  if (!element) return null;
   if (element.nodeName === 'A') {
     return element;
   }
   const children = element.children;
   if (children && children.length > 0) {
-    return findDeepestLastChild([...children].at(-1))
-  } else {
-    return element;
+    // Walk from the end toward the start; return the first <a> found in the deepest/rightmost branch.
+    for (let i = children.length - 1; i >= 0; i--) {
+      const found = findDeepestLastChild(children[i]);
+      if (found) return found;
+    }
   }
+  return null;
 }
 
 function targetItem(element, on = true) {

--- a/strictdoc/export/html/_static/toc_highlighting.js
+++ b/strictdoc/export/html/_static/toc_highlighting.js
@@ -227,7 +227,7 @@ function handleIntersect(entries, observer) {
     const bottomBound = entry.rootBounds ? entry.rootBounds.bottom : window.innerHeight;
 
     // * IO may fire between resets; mapping may be missing — skip safely.
-    const link = tocHighlightingState.data[anchor].link;
+    const link = tocHighlightingState.data[anchor]?.link;
 
     // * if there is no menu item for the section in the TOC
     if(!link) {

--- a/tests/end2end/helpers/components/toc.py
+++ b/tests/end2end/helpers/components/toc.py
@@ -78,3 +78,17 @@ class TOC:  # pylint: disable=invalid-name
         self.test_case.click_xpath(
             f"//*[@data-testid='toc-list']//a[@href='#{anchor}']"
         )
+
+    def assert_toc_link_has_attribute(self, anchor, attribute) -> None:
+        # toc link has attribute
+        self.test_case.assert_element(
+            f"//*[@data-testid='toc-list']//a[@href='#{anchor}'][@{attribute}]",
+            by=By.XPATH,
+        )
+
+    def assert_toc_link_has_not_attribute(self, anchor, attribute) -> None:
+        # toc link has not attribute
+        self.test_case.assert_element(
+            f"//*[@data-testid='toc-list']//a[@href='#{anchor}'][not(@{attribute})]",
+            by=By.XPATH,
+        )

--- a/tests/end2end/navigation/toc/toc_highlighting/expected_output/document.sdoc
+++ b/tests/end2end/navigation/toc/toc_highlighting/expected_output/document.sdoc
@@ -1,0 +1,290 @@
+[DOCUMENT]
+MID: c2d4542d5f1741c88dfcb4f68ad7dcbd
+TITLE: User Guide
+UID: SDOC_UG
+VERSION: Git commit: @GIT_VERSION, Git branch: @GIT_BRANCH
+DATE: @GIT_COMMIT_DATETIME
+OPTIONS:
+  ENABLE_MID: True
+  VIEW_STYLE: Inline
+  NODE_IN_TOC: True
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+    PREFIX: None
+    VIEW_STYLE: Narrative
+  FIELDS:
+  - TITLE: MID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: TEXT
+  PROPERTIES:
+    VIEW_STYLE: Narrative
+  FIELDS:
+  - TITLE: MID
+    TYPE: String
+    REQUIRED: True
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File
+
+[[SECTION]]
+MID: bcd0cf7c13cf4cf2ab176455aedc0c90
+UID: SECTION_1
+TITLE: Section 1
+
+[TEXT]
+MID: 3ae6491057674be1abf057b7e0d9bf21
+STATEMENT: >>>
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+<<<
+
+[[SECTION]]
+MID: 8e4ede8cdc70402b91a59026d31a7020
+UID: SECTION_2
+TITLE: Section 2
+
+[TEXT]
+MID: c46def916b6f4df692c95f47414feebb
+STATEMENT: >>>
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+<<<
+
+[[/SECTION]]
+
+[[/SECTION]]
+
+[[SECTION]]
+MID: e0a00ca3085f444187050ce9576aa31b
+UID: SECTION_BEFORE_LONG_NODE
+TITLE: Examples
+
+[TEXT]
+MID: e000000000000000007050ce9576aa31b
+STATEMENT: >>>
+[LINK: ANCHOR-EXAMPLE]
+<<<
+
+[[SECTION]]
+MID: 2122186075e8455181178b01331101fa
+UID: THE_LONG_NODE_ID
+TITLE: Hello World
+
+[TEXT]
+MID: ffbdb80fb21d48adbaeffb782d7994a2
+STATEMENT: >>>
+"Hello World" example of the SDoc text language:
+
+.. code:: strictdoc
+
+    [DOCUMENT]
+    TITLE: StrictDoc
+
+    [REQUIREMENT]
+    UID: SDOC-HIGH-REQS-MANAGEMENT
+    TITLE: Requirements management
+    STATEMENT: StrictDoc shall enable requirements management.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+[ANCHOR: ANCHOR-EXAMPLE, Anchor ABC]
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+.. code:: text
+
+    cd <your user home directory>/workspace/hello_world
+
+Run StrictDoc as follows:
+
+.. code:: text
+
+    strictdoc export .
+
+The expected output:
+
+.. code:: text
+
+    $ strictdoc export hello.sdoc
+    Parallelization: Enabled
+    Step 'Collect traceability information' start
+    Step 'Find and read SDoc files' start
+    Reading SDOC: hello.sdoc .................................... 0.08s
+    Step 'Find and read SDoc files' took: 0.09 sec
+    Step 'Collect traceability information' start
+    Step 'Collect traceability information' took: 0.01 sec
+    Step 'Collect traceability information' took: 0.11 sec
+    Published: StrictDoc ........................................ 0.24s
+    ...
+    Export completed. Documentation tree can be found at:
+    .../output/html
+
+The HTML output produced so far has been generated statically. Now, start a StrictDoc server from the same directory:
+
+.. code:: text
+
+    strictdoc server .
+
+The expected output should contain the following line:
+
+.. code:: text
+
+    INFO:     Uvicorn running on http://127.0.0.1:5111 (Press CTRL+C to quit)
+
+Open the URL in the browser and explore the contents of the example.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+MID: 83369fc77d584407b530b179a449479b
+UID: SECTION_AFTER_LONG_NODE
+TITLE: StrictDoc Examples repository
+
+[TEXT]
+MID: d6bde8e4055b42138d216b48692c8f26
+STATEMENT: >>>
+Test line.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+MID: 0a736f05ab154b2599988b63201d4f10
+TITLE: Other examples
+
+[TEXT]
+MID: 47c2088447d7452ba28962ee220ba63a
+STATEMENT: >>>
+Test line.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+MID: 2b2e39c48cc740e5b8452d76881f667d
+TITLE: Other examples
+
+[TEXT]
+MID: 2eaa8bfe5a354fcbb704ea7fd94f3a0a
+STATEMENT: >>>
+Test line.
+Test line.
+Test line.
+Test line.
+Test line.
+Test line.
+<<<
+
+[[/SECTION]]
+
+[[/SECTION]]

--- a/tests/end2end/navigation/toc/toc_highlighting/expected_output/strictdoc.toml
+++ b/tests/end2end/navigation/toc/toc_highlighting/expected_output/strictdoc.toml
@@ -1,0 +1,3 @@
+[project]
+
+section_behavior = "[[SECTION]]"

--- a/tests/end2end/navigation/toc/toc_highlighting/input/document.sdoc
+++ b/tests/end2end/navigation/toc/toc_highlighting/input/document.sdoc
@@ -1,0 +1,290 @@
+[DOCUMENT]
+MID: c2d4542d5f1741c88dfcb4f68ad7dcbd
+TITLE: User Guide
+UID: SDOC_UG
+VERSION: Git commit: @GIT_VERSION, Git branch: @GIT_BRANCH
+DATE: @GIT_COMMIT_DATETIME
+OPTIONS:
+  ENABLE_MID: True
+  VIEW_STYLE: Inline
+  NODE_IN_TOC: True
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+    PREFIX: None
+    VIEW_STYLE: Narrative
+  FIELDS:
+  - TITLE: MID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: TEXT
+  PROPERTIES:
+    VIEW_STYLE: Narrative
+  FIELDS:
+  - TITLE: MID
+    TYPE: String
+    REQUIRED: True
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File
+
+[[SECTION]]
+MID: bcd0cf7c13cf4cf2ab176455aedc0c90
+UID: SECTION_1
+TITLE: Section 1
+
+[TEXT]
+MID: 3ae6491057674be1abf057b7e0d9bf21
+STATEMENT: >>>
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+<<<
+
+[[SECTION]]
+MID: 8e4ede8cdc70402b91a59026d31a7020
+UID: SECTION_2
+TITLE: Section 2
+
+[TEXT]
+MID: c46def916b6f4df692c95f47414feebb
+STATEMENT: >>>
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+<<<
+
+[[/SECTION]]
+
+[[/SECTION]]
+
+[[SECTION]]
+MID: e0a00ca3085f444187050ce9576aa31b
+UID: SECTION_BEFORE_LONG_NODE
+TITLE: Examples
+
+[TEXT]
+MID: e000000000000000007050ce9576aa31b
+STATEMENT: >>>
+[LINK: ANCHOR-EXAMPLE]
+<<<
+
+[[SECTION]]
+MID: 2122186075e8455181178b01331101fa
+UID: THE_LONG_NODE_ID
+TITLE: Hello World
+
+[TEXT]
+MID: ffbdb80fb21d48adbaeffb782d7994a2
+STATEMENT: >>>
+"Hello World" example of the SDoc text language:
+
+.. code:: strictdoc
+
+    [DOCUMENT]
+    TITLE: StrictDoc
+
+    [REQUIREMENT]
+    UID: SDOC-HIGH-REQS-MANAGEMENT
+    TITLE: Requirements management
+    STATEMENT: StrictDoc shall enable requirements management.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+[ANCHOR: ANCHOR-EXAMPLE, Anchor ABC]
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+Test line.
+
+.. code:: text
+
+    cd <your user home directory>/workspace/hello_world
+
+Run StrictDoc as follows:
+
+.. code:: text
+
+    strictdoc export .
+
+The expected output:
+
+.. code:: text
+
+    $ strictdoc export hello.sdoc
+    Parallelization: Enabled
+    Step 'Collect traceability information' start
+    Step 'Find and read SDoc files' start
+    Reading SDOC: hello.sdoc .................................... 0.08s
+    Step 'Find and read SDoc files' took: 0.09 sec
+    Step 'Collect traceability information' start
+    Step 'Collect traceability information' took: 0.01 sec
+    Step 'Collect traceability information' took: 0.11 sec
+    Published: StrictDoc ........................................ 0.24s
+    ...
+    Export completed. Documentation tree can be found at:
+    .../output/html
+
+The HTML output produced so far has been generated statically. Now, start a StrictDoc server from the same directory:
+
+.. code:: text
+
+    strictdoc server .
+
+The expected output should contain the following line:
+
+.. code:: text
+
+    INFO:     Uvicorn running on http://127.0.0.1:5111 (Press CTRL+C to quit)
+
+Open the URL in the browser and explore the contents of the example.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+MID: 83369fc77d584407b530b179a449479b
+UID: SECTION_AFTER_LONG_NODE
+TITLE: StrictDoc Examples repository
+
+[TEXT]
+MID: d6bde8e4055b42138d216b48692c8f26
+STATEMENT: >>>
+Test line.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+MID: 0a736f05ab154b2599988b63201d4f10
+TITLE: Other examples
+
+[TEXT]
+MID: 47c2088447d7452ba28962ee220ba63a
+STATEMENT: >>>
+Test line.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+MID: 2b2e39c48cc740e5b8452d76881f667d
+TITLE: Other examples
+
+[TEXT]
+MID: 2eaa8bfe5a354fcbb704ea7fd94f3a0a
+STATEMENT: >>>
+Test line.
+Test line.
+Test line.
+Test line.
+Test line.
+Test line.
+<<<
+
+[[/SECTION]]
+
+[[/SECTION]]

--- a/tests/end2end/navigation/toc/toc_highlighting/input/strictdoc.toml
+++ b/tests/end2end/navigation/toc/toc_highlighting/input/strictdoc.toml
@@ -1,0 +1,3 @@
+[project]
+
+section_behavior = "[[SECTION]]"

--- a/tests/end2end/navigation/toc/toc_highlighting/test_case.py
+++ b/tests/end2end/navigation/toc/toc_highlighting/test_case.py
@@ -1,0 +1,54 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.toc import TOC
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            # start: on the document tree
+            screen_project_index.assert_on_screen()
+
+            # go to document
+            screen_document = screen_project_index.do_click_on_first_document()
+            screen_toc: TOC = screen_document.get_toc()
+
+            # Click on the link in the TOC.
+            # It is highlighted and gets the expected attributes.
+            screen_toc.do_toc_go_to_anchor("SECTION_BEFORE_LONG_NODE")
+            screen_toc.assert_toc_link_has_attribute(
+                "SECTION_BEFORE_LONG_NODE", "parented"
+            )
+            screen_toc.assert_toc_link_has_attribute(
+                "SECTION_BEFORE_LONG_NODE", "targeted"
+            )
+            screen_toc.assert_toc_link_has_attribute(
+                "SECTION_BEFORE_LONG_NODE", "intersected"
+            )
+
+            # Click on the inline link to the anchor in the middle of long node.
+            # Its beginning and end are both outside the screen.
+            # It is the only one highlighted.
+            # The nodes before and after it are not highlighted.
+            self.click_xpath('(//*[@href="#ANCHOR-EXAMPLE"])[1]')
+            screen_toc.assert_toc_link_has_attribute(
+                "THE_LONG_NODE_ID", "intersected"
+            )
+            screen_toc.assert_toc_link_has_not_attribute(
+                "SECTION_BEFORE_LONG_NODE", "intersected"
+            )
+            screen_toc.assert_toc_link_has_not_attribute(
+                "SECTION_AFTER_LONG_NODE", "intersected"
+            )

--- a/tests/end2end/navigation/toc/toc_navigation/test_case.py
+++ b/tests/end2end/navigation/toc/toc_navigation/test_case.py
@@ -41,17 +41,6 @@ class Test(E2ECase):
             )
             requirement_with_title.assert_requirement_uid_contains("REQ_02")
 
-            # # FIXME after:
-            # # TODO: https://github.com/strictdoc-project/strictdoc/issues/1382
-
-            # Anchor generation formats
-            # * in section:
-            # f"{unique_prefix}-{self._string_to_link(node.title)}" # noqa: ERA001
-            # * in requirement:
-            # f"{unique_prefix}-{self._string_to_link(node.reserved_uid)}" # noqa: ERA001
-            # f"{unique_prefix}-{self._string_to_link(node.reserved_title)}" # noqa: ERA001
-            # *** where unique_prefix = context.get_title_number_string()
-
             toc_section_without_uid_anchor = "1-Section-without-UID"
             toc_section_with_uid_anchor = "SECTION_01"
             toc_requirement_with_title_anchor = "REQ_02"


### PR DESCRIPTION
- Simplified and cleaned guards: removed redundant checks, unified coordinate comparisons in IntersectionObserver, simplified hash extraction.
- Robustness improvements: added viewport fallback for rootBounds=null, replaced silent guards with console.assert and moved checks to call sites.
- Efficient re-scan: introduced anchorsCount/anchorsSig to detect TOC mutations and skip unnecessary re-observe, while keeping mapping valid after resetState().
- Removed legacy code: dropped unused contentFrameTop metric and clarified inline comments.
- Hash remapping: implemented resolveMovedFragment() to transparently remap outdated hashes when TOC entries are reordered and renumbered.