### PR TITLE
perf(HTML static search): reduce the size of the search index by 4x

### DIFF
--- a/strictdoc/backend/sdoc/models/document.py
+++ b/strictdoc/backend/sdoc/models/document.py
@@ -32,7 +32,6 @@ from strictdoc.helpers.cast import assert_cast
 from strictdoc.helpers.mid import MID
 from strictdoc.helpers.ordered_set import OrderedSet
 from strictdoc.helpers.string import tokenize
-from strictdoc.helpers.timing import measure_performance
 
 
 @auto_described

--- a/strictdoc/export/html/_static/static_html_search.js
+++ b/strictdoc/export/html/_static/static_html_search.js
@@ -119,12 +119,12 @@ class SearchResultsView {
                 suggestions.appendChild(entry);
             }
 
-            const node = window.SDOC_MAP_MID_TO_NODES[flatResult];
+            const node = window.SDOC_MAP_MID_TO_NODES[parseInt(flatResult, 10)];
             console.assert(!!node, "node must be defined for result: " + flatResult);
 
             let node_key_values = "";
             Object.entries(node).forEach(([key, value]) => {
-                if (value === "") {
+                if (value === "" || key === "_LINK") {
                     return;
                 }
 
@@ -323,7 +323,7 @@ function handleInputEvent_input() {
             highlightElements = [andQuery];
 
             for (const result of results) {
-                const node = window.SDOC_MAP_MID_TO_NODES[result];
+                const node = window.SDOC_MAP_MID_TO_NODES[parseInt(result, 10)];
                 console.assert(!!node, "node must be defined for result: " + result);
 
 

--- a/strictdoc/export/html/templates/base.jinja.html
+++ b/strictdoc/export/html/templates/base.jinja.html
@@ -105,5 +105,11 @@
   <div id="modal"></div>
   <div id="confirm"></div>
   {% block scripts %}{% endblock scripts %}
+
+  {% if not view_object.project_config.is_running_on_server %}
+    <script src="{{ view_object.render_static_url('static_html_search_index.js') }}" defer></script>
+    <script src="{{ view_object.render_static_url('static_html_search.js') }}" defer></script>
+  {% endif %}
+
 </body>
 </html>

--- a/strictdoc/export/html/templates/components/static_search/index.jinja
+++ b/strictdoc/export/html/templates/components/static_search/index.jinja
@@ -17,6 +17,3 @@
     <div id="suggestions" class="search-suggestions"></div>
   </div>
 </div>
-
-<script src="{{ view_object.render_static_url('static_html_search_index.js') }}"></script>
-<script src="{{ view_object.render_static_url('static_html_search.js') }}"></script>


### PR DESCRIPTION
Also, do not display internal _LINK fields.