### PR TITLE
fix(pyproject.toml): update html2pdf4doc_python to a version without a regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ dependencies = [
     "WebSockets",
 
     # HTML2PDF dependencies
-    "html2pdf4doc >= 0.0.20",
+    "html2pdf4doc >= 0.0.21",
 
     # Robot Framework dependencies
     "robotframework >= 4.0.0",


### PR DESCRIPTION
Related to: https://github.com/strictdoc-project/html2pdf4doc_python/issues/46