### PR TITLE
fix(RST): do not exit(1) but raise RuntimeError

### DIFF
--- a/strictdoc/export/rst/rst_to_html_fragment_writer.py
+++ b/strictdoc/export/rst/rst_to_html_fragment_writer.py
@@ -2,7 +2,6 @@ import hashlib
 import io
 import os
 import re
-import sys
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -151,13 +150,13 @@ class RstToHtmlFragmentWriter:
                 )
             else:
                 error_message = f"RST markup syntax error: {warnings}"
-            print(  # noqa: T201
-                f"error: problems when converting RST to HTML:\n{error_message}"
+            final_message = (
+                f"problems when converting RST to HTML: {error_message}\n"
+                "RST fragment: >>>\n"
+                f"{rst_fragment}"
+                "<<<"
             )
-            print("RST fragment: >>>")  # noqa: T201
-            print(rst_fragment)  # noqa: T201
-            print("<<<")  # noqa: T201
-            sys.exit(1)
+            raise RuntimeError(final_message)
 
         html: str = output["html_body"]
 

--- a/tests/integration/features/html/rst_markup_to_html/_validations/03_rst_to_html_conversion_warnings/test.itest
+++ b/tests/integration/features/html/rst_markup_to_html/_validations/03_rst_to_html_conversion_warnings/test.itest
@@ -1,6 +1,5 @@
 RUN: %expect_exit 1 %strictdoc export %S | filecheck %s --dump-input=fail
-CHECK: error: problems when converting RST to HTML:
-CHECK: RST markup syntax error on line 2: Bullet list ends without a blank line; unexpected unindent.
+CHECK: error: problems when converting RST to HTML: RST markup syntax error on line 2: Bullet list ends without a blank line; unexpected unindent.
 CHECK: RST fragment: >>>
 CHECK: - item 1
 CHECK: adsfasdfasdf


### PR DESCRIPTION
This improves the error reporting when StrictDoc hits a malformed RST.