### PR TITLE
fix(html2pdf_generator): support printing RST as well as other markups

### DIFF
--- a/strictdoc/backend/sdoc/models/document_config.py
+++ b/strictdoc/backend/sdoc/models/document_config.py
@@ -4,6 +4,7 @@
 
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
+from strictdoc.backend.sdoc.constants import SDocMarkup
 from strictdoc.helpers.auto_described import auto_described
 
 if TYPE_CHECKING:
@@ -128,7 +129,7 @@ class DocumentConfig:
 
     def get_markup(self) -> str:
         if self.markup is None:
-            return "RST"
+            return SDocMarkup.RST
         return self.markup
 
     def get_requirement_style_mode(self) -> str:

--- a/strictdoc/export/html/renderers/markup_renderer.py
+++ b/strictdoc/export/html/renderers/markup_renderer.py
@@ -2,6 +2,7 @@ from typing import Dict, Optional, Tuple, Union
 
 from markupsafe import Markup
 
+from strictdoc.backend.sdoc.constants import SDocMarkup
 from strictdoc.backend.sdoc.models.anchor import Anchor
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.inline_link import InlineLink
@@ -38,7 +39,7 @@ class MarkupRenderer:
             HTMLFragmentWriter,
             TextToHtmlWriter,
         ]
-        if not markup or markup == "RST":
+        if not markup or markup == SDocMarkup.RST:
             html_fragment_writer = RstToHtmlFragmentWriter(
                 project_config=config,
                 context_document=context_document,

--- a/strictdoc/export/html2pdf/html2pdf_generator.py
+++ b/strictdoc/export/html2pdf/html2pdf_generator.py
@@ -62,7 +62,7 @@ class HTML2PDFGenerator:
                 static_path=project_config.dir_for_sdoc_assets,
             )
             markup_renderer = MarkupRenderer.create(
-                "RST",
+                document_.config.get_markup(),
                 traceability_index,
                 link_renderer,
                 html_templates,

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -2616,7 +2616,7 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
             root_path=root_path, static_path=project_config.dir_for_sdoc_assets
         )
         markup_renderer = MarkupRenderer.create(
-            "RST",
+            document.config.get_markup(),
             export_action.traceability_index,
             link_renderer,
             html_templates,


### PR DESCRIPTION
This is triggered by printing ECSS standards that do not use RST markup.