### PR TITLE
refactor(backend/sdoc_source_code): de-duplicate line_marker_processor

### DIFF
--- a/strictdoc/backend/sdoc_source_code/marker_parser.py
+++ b/strictdoc/backend/sdoc_source_code/marker_parser.py
@@ -189,7 +189,7 @@ class MarkerParser:
                 element_.meta.column + col_offset
             )
             line_marker.ng_range_line_begin = line_start
-            line_marker.ng_range_line_end = line_end
+            line_marker.ng_range_line_end = line_end + 1
             markers.append(line_marker)
         else:
             raise NotImplementedError

--- a/strictdoc/export/html/templates/screens/source_file_view/requirement.jinja
+++ b/strictdoc/export/html/templates/screens/source_file_view/requirement.jinja
@@ -75,7 +75,7 @@
             {%- endif -%}
             </span>
             {% elif range.is_line_marker() %}
-            <b>[ {{ range.ng_range_line_begin }} ]</b>
+            <b>[ {{ range.ng_range_line_begin }}-{{ range.ng_range_line_end }} ]</b>
             <span class="source__range-pointer_description">{{ link }}, line</span>
             {% endif %}
           </a>

--- a/tests/integration/features/source_code_traceability/_file_roles/01_relations_with_role/file.py
+++ b/tests/integration/features/source_code_traceability/_file_roles/01_relations_with_role/file.py
@@ -21,4 +21,5 @@ def bar2():
 
 
 if __name__ == "__main__":
-    pass  # @relation(REQ-001, scope=line, role=Implementation)
+    # @relation(REQ-001, scope=line, role=Implementation)
+    pass

--- a/tests/integration/features/source_code_traceability/_file_roles/01_relations_with_role/test.itest
+++ b/tests/integration/features/source_code_traceability/_file_roles/01_relations_with_role/test.itest
@@ -17,8 +17,8 @@ CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#4#6">
 CHECK-HTML: file.c, <i>lines: 4-6</i>, function extfoo
 CHECK-HTML: <span{{.*}}">(Implementation)</span>
 
-CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#11#11">
-CHECK-HTML: file.c, <i>lines: 11-11</i>, line
+CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#11#12">
+CHECK-HTML: file.c, <i>lines: 11-12</i>, line
 CHECK-HTML: <span{{.*}}">(Implementation)</span>
 
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-001#15#16">
@@ -41,8 +41,8 @@ CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#13#20">
 CHECK-HTML: file.py, <i>lines: 13-20</i>, range
 CHECK-HTML: <span{{.*}}">(Implementation)</span>
 
-CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#24#24">
-CHECK-HTML: file.py, <i>lines: 24-24</i>, line
+CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-001#24#25">
+CHECK-HTML: file.py, <i>lines: 24-25</i>, line
 CHECK-HTML: <span{{.*}}">(Implementation)</span>
 
 CHECK-HTML: <a{{.*}}href="../_source_files/file.txt.html#REQ-001#1#2">

--- a/tests/integration/features/source_code_traceability/_general_parser_backward/50_line_marker/file.py
+++ b/tests/integration/features/source_code_traceability/_general_parser_backward/50_line_marker/file.py
@@ -1,7 +1,7 @@
 def hello_world():
-    """
-    @sdoc(REQ-001)
-    """
+    # @relation(REQ-001, scope=line)
+    print("Line marker")  # noqa: T201
+
     # @sdoc[REQ-001]
     print("ignored hello world")  # noqa: T201
     print("ignored hello world")  # noqa: T201

--- a/tests/integration/features/source_code_traceability/_general_parser_backward/50_line_marker/test.itest
+++ b/tests/integration/features/source_code_traceability/_general_parser_backward/50_line_marker/test.itest
@@ -6,5 +6,5 @@ CHECK: Published: Hello world doc
 RUN: %check_exists --file "%T/html/_source_files/file.py.html"
 
 RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
-CHECK-SOURCE-FILE: [ 3 ]
+CHECK-SOURCE-FILE: [ 2-3 ]
 CHECK-SOURCE-FILE: [ 5-8 ]

--- a/tests/integration/features/source_code_traceability/_language_parsers/c/20_c_backward_and_forward_functions/test.itest
+++ b/tests/integration/features/source_code_traceability/_language_parsers/c/20_c_backward_and_forward_functions/test.itest
@@ -11,7 +11,7 @@ RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHE
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#1#55">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#1#55">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#3#10">
-CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#32#32">
+CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#32#33">
 CHECK-HTML: <a{{.*}}href="../_source_files/file2.c.html#REQ-1#1#8">
 
 RUN: %cat %T/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
@@ -19,7 +19,7 @@ CHECK-SOURCE-FILE: 1 - 55 | entire file
 CHECK-SOURCE-FILE: 3 - 10 | function foo()
 CHECK-SOURCE-FILE: 12 - 16 | range
 CHECK-SOURCE-FILE: 22 - 55 | function longFunctionName()
-CHECK-SOURCE-FILE: 32 - 32 | line
+CHECK-SOURCE-FILE: 32 - 33 | line
 
 RUN: %cat %T/html/source_coverage.html | filecheck %s --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 100.0

--- a/tests/integration/features/source_code_traceability/_language_parsers/python/03_python_forward_function/test.itest
+++ b/tests/integration/features/source_code_traceability/_language_parsers/python/03_python_forward_function/test.itest
@@ -11,12 +11,12 @@ RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail 
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#1#10">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#1#10">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#5#10">
-CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#7#7">
+CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#7#8">
 
 RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: 1 - 10 | function hello_world()
 CHECK-SOURCE-FILE: 5 - 10 | range
-CHECK-SOURCE-FILE: 7 - 7 | line
+CHECK-SOURCE-FILE: 7 - 8 | line
 
 RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
 CHECK-SOURCE-COVERAGE: 83.3

--- a/tests/integration/features/source_code_traceability/_language_parsers/python/04_python_forward_function_in_class/test.itest
+++ b/tests/integration/features/source_code_traceability/_language_parsers/python/04_python_forward_function_in_class/test.itest
@@ -11,7 +11,7 @@ RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail 
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#7#16">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#7#16">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#11#16">
-CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#13#13">
+CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-1#13#14">
 CHECK-HTML: <a{{.*}}href="../_source_files/file.py.html#REQ-2#4#5">
 
 RUN: %cat %T/html/_source_files/file.py.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
@@ -25,7 +25,7 @@ CHECK-SOURCE-FILE: file.py, function Foo.hello_world
 CHECK-SOURCE-FILE: <b>[ 11-16 ]</b>
 CHECK-SOURCE-FILE: file.py, range
 
-CHECK-SOURCE-FILE: <b>[ 13 ]</b>
+CHECK-SOURCE-FILE: <b>[ 13-14 ]</b>
 CHECK-SOURCE-FILE: file.py, line
 
 CHECK-SOURCE-FILE: <b>[ 4-5 ]</b>

--- a/tests/integration/features/source_code_traceability/_language_parsers/robot/02_robot_line/test.itest
+++ b/tests/integration/features/source_code_traceability/_language_parsers/robot/02_robot_line/test.itest
@@ -6,13 +6,13 @@ CHECK: Published: Hello world doc
 RUN: %check_exists --file "%T/html/_source_files/file.robot.html"
 
 RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
-CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-1#5#5">
-CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-1#11#11">
+CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-1#5#6">
+CHECK-HTML: <a{{.*}}href="../_source_files/file.robot.html#REQ-1#11#12">
 
 RUN: %cat %T/html/_source_files/file.robot.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
 CHECK-SOURCE-FILE: href="../{{.*}}/input.html#REQ-1"
-CHECK-SOURCE-FILE: href="../_source_files/file.robot.html##5#5"
-CHECK-SOURCE-FILE: href="../_source_files/file.robot.html##11#11"
+CHECK-SOURCE-FILE: href="../_source_files/file.robot.html##5#6"
+CHECK-SOURCE-FILE: href="../_source_files/file.robot.html##11#12"
 
 RUN: %cat %T/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
-CHECK-SOURCE-COVERAGE: 16.7
+CHECK-SOURCE-COVERAGE: 33.3

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_python.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_python.py
@@ -407,15 +407,15 @@ CONTENT 3
     assert markers[0].reqs == ["REQ-001"]
     assert markers[0].ng_source_line_begin == 1
     assert markers[0].ng_range_line_begin == 1
-    assert markers[0].ng_range_line_end == 1
+    assert markers[0].ng_range_line_end == 2
     assert markers[1].reqs == ["REQ-002"]
     assert markers[1].ng_source_line_begin == 3
     assert markers[1].ng_range_line_begin == 3
-    assert markers[1].ng_range_line_end == 3
+    assert markers[1].ng_range_line_end == 4
     assert markers[2].reqs == ["REQ-003"]
     assert markers[2].ng_source_line_begin == 5
     assert markers[2].ng_range_line_begin == 5
-    assert markers[2].ng_range_line_end == 5
+    assert markers[2].ng_range_line_end == 6
 
 
 def test_070_function_marker():


### PR DESCRIPTION
This is a small follow-up to: https://github.com/strictdoc-project/strictdoc/pull/2458.

