### PR TITLE
Disable backgrounds of problematic split sections (workaround for html2pdf4doc bug)

### DIFF
--- a/strictdoc/export/html/_static/node_content.css
+++ b/strictdoc/export/html/_static/node_content.css
@@ -40,6 +40,19 @@ sdoc-node-content {
    */
 }
 
+/* Workaround for html2pdf4doc print bug:
+  (https://github.com/strictdoc-project/strictdoc/issues/2450#issuecomment-3299134769)
+   Disable background for elements that trigger header/footer overlap.
+   This hides the background of problematic split (not sliced) sections
+   to prevent them from covering header/footer areas during printing.
+   Real fix will be applied in html2pdf4doc in a future release. */
+@media print {
+  sdoc-node-content {
+    background: none;
+    background-color: transparent;
+  }
+}
+
 sdoc-node-title {
   display: block;
 


### PR DESCRIPTION
Workaround for html2pdf4doc print bug.
Disable backgrounds of split sections to prevent header/footer overlap (workaround for html2pdf4doc).

See strictdoc-project/strictdoc#2450 – this only mitigates the header/footer overlap for Strictdoc exports.
The root issue in html2pdf4doc is still open and will be fixed upstream.