### PR TITLE
fix(html2pdf): Update narrative rules

### DIFF
--- a/strictdoc/export/html/templates/components/node/readonly.jinja
+++ b/strictdoc/export/html/templates/components/node/readonly.jinja
@@ -2,6 +2,22 @@
 
 {% set node_type_string = sdoc_entity.get_node_type_string() %}
 
+{#
+  dev tag: #narrative_meta_hanging
+
+  Html2pdf4doc rules for `Narrative` requirement style:
+  * If no multi-line content:
+    the node is not split at all (with or without a title)
+    -> add .html2pdf4doc-no-break to node.
+  * PROBLEM:
+    We assume that the number of single-line strings is no greater than the height of the page
+
+  FIXME: Review this rules after upgrading html2pdf4doc to 0.2.4+
+#}
+{% set _user_requirement_style = sdoc_entity.get_requirement_style_mode() %}
+{% set _has_multiline_fields = sdoc_entity.has_multiline_fields() %}
+{% set _narrative_has_no_multiline_fields = not _has_multiline_fields and _user_requirement_style == 'narrative' %}
+
   <sdoc-node
     node-style="readonly"
     node-role="{{ sdoc_entity.get_type_string() }}"
@@ -9,8 +25,11 @@
       show-node-type-name="{{ node_type_string }}"
     {%- endif %}
     {% if sdoc_entity.is_requirement %}
-      node-view="{{ sdoc_entity.get_requirement_style_mode() }}"
+      node-view="{{ _user_requirement_style }}"
     {%- endif -%}
+    {%- if _narrative_has_no_multiline_fields %}
+      class="html2pdf4doc-no-break"
+    {%- endif %}
     data-testid="node-{{ sdoc_entity.get_type_string() }}"
   >
 

--- a/strictdoc/export/html/templates/components/node_content/index.jinja
+++ b/strictdoc/export/html/templates/components/node_content/index.jinja
@@ -17,11 +17,34 @@
 #}
 {% set user_requirement_style = sdoc_entity.get_requirement_style_mode() %}
 
+{#
+  dev tag: #narrative_meta_hanging
+
+  Html2pdf4doc rules for `Narrative` requirement style:
+  * If no title:
+    “meta” does not hang
+    -> add .html2pdf4doc-no-hanging to .node_fields_group-secondary.
+  * If no multi-line content:
+    the node is not split at all (with or without a title)
+    -> add .html2pdf4doc-no-break to node.
+  * PROBLEM:
+    We assume that the number of single-line strings is no greater than the height of the page
+
+  FIXME: Review this rules after upgrading html2pdf4doc to 0.2.4+
+#}
+{% set _no_title = not sdoc_entity.reserved_title %}
+{% set _has_multiline_fields = sdoc_entity.has_multiline_fields() %}
+{% set _narrative_has_multiline_fields = _has_multiline_fields and user_requirement_style == 'narrative' %}
+{% set _narrative_has_no_multiline_fields = not _has_multiline_fields and user_requirement_style == 'narrative' %}
+
 <sdoc-node-content
   node-view="{{ requirement_style|d(sdoc_entity.get_requirement_style_mode()) }}"
   data-level="{{ sdoc_entity.context.title_number_string }}"
   {%- if sdoc_entity.reserved_status %}
     data-status='{{ sdoc_entity.reserved_status.lower() }}'
+  {%- endif %}
+  {%- if _narrative_has_no_multiline_fields %}
+    class="html2pdf4doc-no-break"
   {%- endif %}
   show-node-type-name="{{ sdoc_entity.get_node_type_string() }}"
   data-testid="requirement-style-{{ requirement_style|d(sdoc_entity.get_requirement_style_mode()) }}"
@@ -37,12 +60,12 @@
   #}
 
   {% if user_requirement_style == 'narrative' %}
-    <sdoc-scope class="node_fields_group-secondary html2pdf4doc-no-hanging">
+    <sdoc-scope class="node_fields_group-secondary{% if _no_title %} html2pdf4doc-no-hanging{% endif %}">
       {% include "components/node_field/meta/index.jinja" %}
       {% include "components/node_field/links/index.jinja" %}
       {% include "components/node_field/files/index.jinja" %}
     </sdoc-scope>
-    {% if sdoc_entity.has_multiline_fields() %}
+    {% if _narrative_has_multiline_fields %}
     <sdoc-scope class="node_fields_group-primary">
       {% include "components/node_field/statement/index.jinja" %}
       {% include "components/node_field/rationale/index.jinja" %}


### PR DESCRIPTION
Added narrative rules: 

1. Disable **hanging meta** when there is no title.
2. Prevent **node breaks** when there are no multiline fields.
   _The 2nd is potentially dangerous if the structure consists only of single-column fields and there are a lot of them (more than 20)._

This is a temporary fix and may still fail in edge cases. A full solution requires upgrading html2pdf to the 0.2.4+ version (currently in development and not yet released), which resolves conflicts between multiple page-break rules. In complex documents with deep nesting or long nodes, multiple active rules can overload the algorithm, resulting in empty pages or page breaks in undesirable places.

Attached is the most layout-intensive document we have so far — its rendering now looks acceptable.
[User Guide - PDF.pdf](https://github.com/user-attachments/files/22405579/User.Guide.-.PDF.pdf)