### PR TITLE
chore(rst_to_html_fragment_writer): fix a deprecation warning by updating to new API

### DIFF
--- a/strictdoc/export/rst/rst_to_html_fragment_writer.py
+++ b/strictdoc/export/rst/rst_to_html_fragment_writer.py
@@ -128,7 +128,7 @@ class RstToHtmlFragmentWriter:
 
         output = publish_parts(
             rst_fragment,
-            writer_name="html",
+            writer="html",
             settings_overrides=settings,
             source_path=self.source_path,
         )
@@ -175,7 +175,7 @@ class RstToHtmlFragmentWriter:
 
         try:
             output = publish_parts(
-                rst_fragment, writer_name="html", settings_overrides=settings
+                rst_fragment, writer="html", settings_overrides=settings
             )
             warnings = (
                 warning_stream.getvalue().rstrip("\n")


### PR DESCRIPTION


This fixes a deprecation warning.

```
...strictdoc/strictdoc/export/rst/rst_to_html_fragment_writer.py:177: PendingDeprecationWarning: Argument "writer_name" will be removed in Docutils 2.0.  Specify writer name in the "writer" argument.
```

Closes #2459