### PR TITLE
fix(FileFinder): ignore Linux pipe files

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -46,6 +46,18 @@ This document maintains a record of all changes to StrictDoc since November 2023
 <<<
 
 [[SECTION]]
+MID: c2ee8e32a2324963a90e7ba81f95ee0d
+TITLE: Unreleased
+
+[TEXT]
+MID: 12345f3b28ea4bfe9ca8afe6b21826a8
+STATEMENT: >>>
+An edge case has been fixed where StrictDoc's FileFinder was detecting Linux pipe files that could not be processed meaningfully by StrictDoc's source file generator. With this release, such files will be ignored.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
 MID: 403c9f0ad6c34b50b25133f1d9357335
 TITLE: 0.14.0 (2025-10-05)
 

--- a/strictdoc/__init__.py
+++ b/strictdoc/__init__.py
@@ -1,6 +1,6 @@
 from strictdoc.core.environment import SDocRuntimeEnvironment
 
-__version__ = "0.14.0"
+__version__ = "0.14.1a1"
 
 
 environment = SDocRuntimeEnvironment(__file__)

--- a/strictdoc/core/file_tree.py
+++ b/strictdoc/core/file_tree.py
@@ -166,6 +166,14 @@ class FileFinder:
                     continue
 
                 full_file_path = os.path.join(current_root_path, file)
+
+                # A known edge case: A file is found by os.walk(), but it is a
+                # Linux pipe file which fails an os.path.isfile() check.
+                # It seems to be safe to ignore this and possibly other cases
+                # here without writing any test for this case.
+                if not os.path.isfile(full_file_path):  # pragma: no cover
+                    continue
+
                 rel_file_path = os.path.join(current_root_relative_path, file)
 
                 if path_filter_excludes.match(rel_file_path):


### PR DESCRIPTION
This is an edge case where a source code repository can have Linux pipe files stored in non-build and non-cache folders. There is nothing we can do with these files, so we simply ignore them.