### PR TITLE
fix(html2pdf_generator): resolve the document output path correctly

### DIFF
--- a/strictdoc/__init__.py
+++ b/strictdoc/__init__.py
@@ -1,6 +1,6 @@
 from strictdoc.core.environment import SDocRuntimeEnvironment
 
-__version__ = "0.14.1a2"
+__version__ = "0.14.1a3"
 
 
 environment = SDocRuntimeEnvironment(__file__)

--- a/strictdoc/export/html2pdf/html2pdf_generator.py
+++ b/strictdoc/export/html2pdf/html2pdf_generator.py
@@ -91,7 +91,7 @@ class HTML2PDFGenerator:
 
             path_to_output_html_doc = os.path.join(
                 path_to_output_html_doc_dir,
-                document_.meta.document_filename_base + ".html",
+                document_.meta.document_filename_base + "-PDF.html",
             )
 
             with open(

--- a/tests/integration/features/html2pdf/01_empty_document/test.itest
+++ b/tests/integration/features/html2pdf/01_empty_document/test.itest
@@ -6,6 +6,6 @@ CHECK: html2pdf4doc: JS logs from the print session
 
 RUN: %check_exists --file %T/html2pdf/pdf/input.pdf
 
-RUN: %check_exists --file %T/html2pdf/html/01_empty_document/input.html
+RUN: %check_exists --file %T/html2pdf/html/01_empty_document/input-PDF.html
 
 RUN: python %S/test_pdf.py

--- a/tests/integration/features/html2pdf/02_three_top_level_requirements/test.itest
+++ b/tests/integration/features/html2pdf/02_three_top_level_requirements/test.itest
@@ -7,8 +7,8 @@ RUN: %check_exists --file %T/html2pdf/pdf/input.pdf
 RUN: %check_exists --file %T/html2pdf/pdf/nested/input2.pdf
 RUN: %check_exists --file %T/html2pdf/pdf/nested/subnested/input3.pdf
 
-RUN: %check_exists --file %T/html2pdf/html/02_three_top_level_requirements/input.html
-RUN: %check_exists --file %T/html2pdf/html/02_three_top_level_requirements/nested/input2.html
-RUN: %check_exists --file %T/html2pdf/html/02_three_top_level_requirements/nested/subnested/input3.html
+RUN: %check_exists --file %T/html2pdf/html/02_three_top_level_requirements/input-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/02_three_top_level_requirements/nested/input2-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/02_three_top_level_requirements/nested/subnested/input3-PDF.html
 
 RUN: python %S/test_pdf.py

--- a/tests/integration/features/html2pdf/03_three_documents_with_assets/test.itest
+++ b/tests/integration/features/html2pdf/03_three_documents_with_assets/test.itest
@@ -3,15 +3,15 @@ REQUIRES: TEST_HTML2PDF
 RUN: %strictdoc export %S --formats=html2pdf --output-dir %T | filecheck %s --dump-input=fail
 CHECK: html2pdf4doc: JS logs from the print session
 
-RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/input.html
-RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/nested/input2.html
-RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/nested/subnested/input3.html
+RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/input-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/nested/input2-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/nested/subnested/input3-PDF.html
 
 RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/_assets/file.svg
 RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/nested/_assets/file.svg
 RUN: %check_exists --file %T/html2pdf/html/03_three_documents_with_assets/nested/subnested/_assets/file.svg
 
-RUN: %cat %T/html2pdf/html/03_three_documents_with_assets/nested/subnested/input3.html | filecheck %s --check-prefix CHECK-DOC-HTML
+RUN: %cat %T/html2pdf/html/03_three_documents_with_assets/nested/subnested/input3-PDF.html | filecheck %s --check-prefix CHECK-DOC-HTML
 CHECK-DOC-HTML:data="_assets/file.svg"
 
 RUN: python %S/test_pdf.py

--- a/tests/integration/features/html2pdf/04_composable_document_with_assets/test.itest
+++ b/tests/integration/features/html2pdf/04_composable_document_with_assets/test.itest
@@ -3,9 +3,9 @@ REQUIRES: TEST_HTML2PDF
 RUN: %strictdoc export %S --formats=html2pdf --included-documents --output-dir %T | filecheck %s --dump-input=fail
 CHECK: html2pdf4doc: JS logs from the print session
 
-RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/input.html
-RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/nested/input2.html
-RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/nested/subnested/input3.html
+RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/input-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/nested/input2-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/nested/subnested/input3-PDF.html
 
 RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/_assets/file.svg
 RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/nested/_assets/file.svg
@@ -14,7 +14,7 @@ RUN: %check_exists --file %T/html2pdf/html/04_composable_document_with_assets/ne
 # By default, a bundle document is not generated.
 RUN: %check_exists --file --invert %T/html2pdf/pdf/bundle.pdf
 
-RUN: %cat %T/html2pdf/html/04_composable_document_with_assets/nested/subnested/input3.html | filecheck %s --check-prefix CHECK-DOC-HTML
+RUN: %cat %T/html2pdf/html/04_composable_document_with_assets/nested/subnested/input3-PDF.html | filecheck %s --check-prefix CHECK-DOC-HTML
 CHECK-DOC-HTML:data="_assets/file.svg"
 
 RUN: python %S/test_pdf.py

--- a/tests/integration/features/html2pdf/05_generate_bundle_document/test.itest
+++ b/tests/integration/features/html2pdf/05_generate_bundle_document/test.itest
@@ -3,12 +3,12 @@ REQUIRES: TEST_HTML2PDF
 RUN: %strictdoc export %S --formats=html2pdf --generate-bundle-document --output-dir %T | filecheck %s --dump-input=fail
 CHECK: html2pdf4doc: JS logs from the print session
 
-RUN: %check_exists --file %T/html2pdf/html/bundle.html
-RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/input.html
-RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/input2.html
-RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/subnested/input3.html
+RUN: %check_exists --file %T/html2pdf/html/bundle-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/input-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/input2-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/subnested/input3-PDF.html
 
-RUN: %cat %T/html2pdf/html/bundle.html | filecheck %s --check-prefix CHECK-DOC-HTML
+RUN: %cat %T/html2pdf/html/bundle-PDF.html | filecheck %s --check-prefix CHECK-DOC-HTML
 # This ensures that the link is resolved correctly.
 CHECK-DOC-HTML:<a href="#SEC-1">🔗&nbsp;1.1. Section #1</a>
 

--- a/tests/integration/features/html2pdf/06_system_chromedriver/test.itest
+++ b/tests/integration/features/html2pdf/06_system_chromedriver/test.itest
@@ -9,6 +9,6 @@ CHECK-NOT: html2pdf4doc: ChromeDriver available at path: {{.*}}strictdoc_cache{{
 
 RUN: %check_exists --file %T/html2pdf/pdf/input.pdf
 
-RUN: %check_exists --file %T/html2pdf/html/06_system_chromedriver/input.html
+RUN: %check_exists --file %T/html2pdf/html/06_system_chromedriver/input-PDF.html
 
 RUN: python %S/test_pdf.py

--- a/tests/integration/features/html2pdf/07_composable_document_with_relations/input.sdoc
+++ b/tests/integration/features/html2pdf/07_composable_document_with_relations/input.sdoc
@@ -1,0 +1,22 @@
+[DOCUMENT]
+TITLE: Project Risk Management
+
+[TEXT]
+STATEMENT: Main file
+
+[DOCUMENT_FROM_FILE]
+FILE: nested/included.sdoc
+
+[REQUIREMENT]
+UID: REQ-003
+TITLE: Third one
+STATEMENT: >>>
+Third statement links to fourth: [LINK: REQ-004]
+<<<
+
+[REQUIREMENT]
+UID: REQ-004
+TITLE: fourth one
+STATEMENT: >>>
+The fourth statement
+<<<

--- a/tests/integration/features/html2pdf/07_composable_document_with_relations/nested/included.sdoc
+++ b/tests/integration/features/html2pdf/07_composable_document_with_relations/nested/included.sdoc
@@ -1,0 +1,16 @@
+[DOCUMENT]
+TITLE: Included doc
+
+[REQUIREMENT]
+UID: REQ-001
+TITLE: First one
+STATEMENT: >>>
+First statement links to second: [LINK: REQ-002]
+<<<
+
+[REQUIREMENT]
+UID: REQ-002
+TITLE: second one
+STATEMENT: >>>
+The second statement
+<<<

--- a/tests/integration/features/html2pdf/07_composable_document_with_relations/strictdoc.toml
+++ b/tests/integration/features/html2pdf/07_composable_document_with_relations/strictdoc.toml
@@ -1,0 +1,7 @@
+[project]
+
+cache_dir = "./Output/cache"
+
+features = [
+  "HTML2PDF",
+]

--- a/tests/integration/features/html2pdf/07_composable_document_with_relations/test.itest
+++ b/tests/integration/features/html2pdf/07_composable_document_with_relations/test.itest
@@ -1,0 +1,18 @@
+REQUIRES: TEST_HTML2PDF
+
+RUN: %strictdoc export %S --formats=html2pdf --included-documents --output-dir %T | filecheck %s --dump-input=fail
+CHECK: html2pdf4doc: JS logs from the print session
+
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/input-PDF.html
+RUN: %check_exists --file %T/html2pdf/pdf/input.pdf
+
+RUN: %cat %T/html2pdf/html/%THIS_TEST_FOLDER/input-PDF.html | filecheck %s --dump-input=fail --check-prefix CHECK-INPUT-PDF
+CHECK-INPUT-PDF: <p>First statement links to second: <a href="../07_composable_document_with_relations/input-PDF.html#REQ-002">🔗&nbsp;1.2. second one</a></p>
+
+RUN: %strictdoc export %S --formats=html2pdf --included-documents --generate-bundle-document --output-dir %T | filecheck %s --dump-input=fail
+# With --generate-bundle-document, a bundle document is generated.
+RUN: %check_exists --file %T/html2pdf/html/bundle-PDF.html
+RUN: %check_exists --file %T/html2pdf/pdf/bundle.pdf
+
+FIXME: CHECK-INPUT-PDF-BUNDLE: Resolve the links correctly.
+


### PR DESCRIPTION
This fixes an issue reported in #2503, where an included document did not have its LINKs correctly resolved when the including document was printed to PDF.