### PR TITLE
trace: add missing traces between L2, source code and tests

### DIFF
--- a/.github/workflows/ci-linux-ubuntu-latest.yml
+++ b/.github/workflows/ci-linux-ubuntu-latest.yml
@@ -1,3 +1,7 @@
+#
+# @relation(SDOC-SRS-9, scope=file)
+#
+
 name: "StrictDoc on Linux"
 
 on:

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -1,3 +1,7 @@
+#
+# @relation(SDOC-SRS-10, scope=file)
+#
+
 name: "StrictDoc on macOS"
 
 on:

--- a/.github/workflows/ci-windows-powershell.yml
+++ b/.github/workflows/ci-windows-powershell.yml
@@ -1,3 +1,7 @@
+#
+# @relation(SDOC-SRS-11, scope=file)
+#
+
 name: "StrictDoc on Windows (Powershell)"
 
 on:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -1,3 +1,7 @@
+#
+# @relation(SDOC-SRS-11, scope=file)
+#
+
 name: "StrictDoc on Windows"
 
 on:

--- a/.github/workflows/periodic-integration-test.yml
+++ b/.github/workflows/periodic-integration-test.yml
@@ -1,3 +1,7 @@
+#
+# @relation(SDOC-SRS-9, SDOC-SRS-10, scope=file)
+#
+
 ---
 name: StrictDoc - Periodic integration test
 on:

--- a/.github/workflows/periodic-release-test.yml
+++ b/.github/workflows/periodic-release-test.yml
@@ -1,3 +1,7 @@
+#
+# @relation(SDOC-SRS-9, scope=file)
+#
+
 ---
 name: StrictDoc - Periodic release test
 on:

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2020-2024 Stanislav Pankevich, Maryna Balioura
+Copyright 2020-2025 Stanislav Pankevich, Maryna Balioura
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/strictdoc_21_L2_StrictDoc_Requirements.sdoc
+++ b/docs/strictdoc_21_L2_StrictDoc_Requirements.sdoc
@@ -1372,8 +1372,6 @@ STATUS: Active
 TITLE: File marker
 STATEMENT: >>>
 StrictDoc's shall support file markers that can be attached to entire source files.
-
-NOTE: A single-line marker points to a single line in a source file.
 <<<
 RATIONALE: >>>
 There are cases when a requirement can be attached to an entire file.
@@ -2329,5 +2327,9 @@ All StrictDoc software shall be licensed under the Apache 2 license.
 RELATIONS:
 - TYPE: Parent
   VALUE: SDOC-SSS-40
+- TYPE: File
+  VALUE: LICENSE
+- TYPE: File
+  VALUE: NOTICE
 
 [[/SECTION]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+#
+# @relation(SDOC-SRS-8, scope=file)
+#
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -77,6 +81,7 @@ dependencies = [
     "openpyxl >= 3.1.0",
 
     # ReqIF
+    # @relation(SDOC-SRS-73, scope=line)
     "reqif >= 0.0.39, == 0.*",
 
     # SPDX

--- a/strictdoc/backend/sdoc/grammar/grammar.py
+++ b/strictdoc/backend/sdoc/grammar/grammar.py
@@ -1,7 +1,9 @@
 """
-@relation(SDOC-SRS-20, scope=file)
+@relation(SDOC-SRS-19, SDOC-SRS-127, SDOC-SRS-20, SDOC-SRS-23, SDOC-SRS-145, scope=file)
 """
 
+# FIXME: Extract this to a file with a shared set of global constants.
+# @relation(SDOC-SRS-22, scope=line)
 REGEX_UID = r"([\w]+[\w()\-\/.: ]*)"
 
 NEGATIVE_MULTILINE_STRING_START = "(?!>>>\n)"

--- a/strictdoc/backend/sdoc/models/document_grammar.py
+++ b/strictdoc/backend/sdoc/models/document_grammar.py
@@ -43,6 +43,10 @@ class DocumentGrammar(SDocGrammarIF):
         parent: Optional[SDocDocumentIF],
         enable_mid: bool = False,
     ) -> "DocumentGrammar":
+        """
+        @relation(SDOC-SRS-93, scope=function)
+        """
+
         text_element: GrammarElement = (
             DocumentGrammar.create_default_text_element(enable_mid=enable_mid)
         )

--- a/strictdoc/backend/sdoc/models/node.py
+++ b/strictdoc/backend/sdoc/models/node.py
@@ -100,6 +100,10 @@ class SDocNodeField:
 
 @auto_described
 class SDocNode(SDocNodeIF):
+    """
+    @relation(SDOC-SRS-135, SDOC-SRS-100, scope=class)
+    """
+
     def __init__(
         self,
         parent: Union[SDocDocumentIF, SDocNodeIF],
@@ -770,6 +774,10 @@ class SDocNode(SDocNodeIF):
 
 @auto_described
 class SDocCompositeNode(SDocNode):
+    """
+    @relation(SDOC-SRS-99, scope=class)
+    """
+
     def __init__(
         self,
         parent: Union[SDocDocumentIF, SDocNodeIF],

--- a/strictdoc/backend/sdoc/models/reference.py
+++ b/strictdoc/backend/sdoc/models/reference.py
@@ -73,6 +73,10 @@ class Reference:
 
 @auto_described
 class FileReference(Reference):
+    """
+    @relation(SDOC-SRS-145, scope=function)
+    """
+
     def __init__(
         self, parent: Any, g_file_entry: FileEntry, role: Optional[str] = None
     ):

--- a/strictdoc/backend/sdoc/reader.py
+++ b/strictdoc/backend/sdoc/reader.py
@@ -1,3 +1,7 @@
+"""
+@relation(SDOC-SRS-105, scope=file)
+"""
+
 from copy import copy
 from typing import Optional, Tuple
 

--- a/strictdoc/backend/sdoc_source_code/models/function_range_marker.py
+++ b/strictdoc/backend/sdoc_source_code/models/function_range_marker.py
@@ -1,5 +1,5 @@
 """
-@relation(SDOC-SRS-137, SDOC-SRS-140, scope=file)
+@relation(SDOC-SRS-137, SDOC-SRS-139, SDOC-SRS-140, scope=file)
 """
 
 from copy import copy

--- a/strictdoc/backend/sdoc_source_code/models/source_file_info.py
+++ b/strictdoc/backend/sdoc_source_code/models/source_file_info.py
@@ -69,6 +69,9 @@ class SourceFileTraceabilityInfo:
 
         self.markers: List[RelationMarkerType] = []
 
+    def is_document(self) -> bool:
+        return False
+
     # FIXME: is_requirement() will go away.
     def is_requirement(self) -> bool:
         return False

--- a/strictdoc/backend/sdoc_source_code/reader_c.py
+++ b/strictdoc/backend/sdoc_source_code/reader_c.py
@@ -1,5 +1,5 @@
 """
-@relation(SDOC-SRS-142, scope=file)
+@relation(SDOC-SRS-142, SDOC-SRS-146, scope=file)
 """
 
 from typing import List, Optional, Sequence

--- a/strictdoc/backend/sdoc_source_code/reader_python.py
+++ b/strictdoc/backend/sdoc_source_code/reader_python.py
@@ -1,5 +1,5 @@
 """
-@relation(SDOC-SRS-142, scope=file)
+@relation(SDOC-SRS-142, SDOC-SRS-147, scope=file)
 """
 
 from itertools import islice

--- a/strictdoc/backend/sdoc_source_code/reader_robot.py
+++ b/strictdoc/backend/sdoc_source_code/reader_robot.py
@@ -1,5 +1,5 @@
 """
-@relation(SDOC-SRS-142, scope=file)
+@relation(SDOC-SRS-142, SDOC-SRS-148, scope=file)
 """
 
 from typing import Optional, Union

--- a/strictdoc/commands/manage_autouid_command.py
+++ b/strictdoc/commands/manage_autouid_command.py
@@ -21,6 +21,10 @@ class ManageAutoUIDCommand:
     def execute(
         *, project_config: ProjectConfig, parallelizer: Parallelizer
     ) -> None:
+        """
+        @relation(SDOC-SRS-85, scope=function)
+        """
+
         # FIXME: Traceability Index is coupled with HTML output.
         project_config.export_output_html_root = "NOT_RELEVANT"
 

--- a/strictdoc/core/document_finder.py
+++ b/strictdoc/core/document_finder.py
@@ -78,12 +78,16 @@ class DocumentFinder:
             f"Reading SDOC: {os.path.basename(doc_full_path)}"
         ):
             document_or_grammar: Union[SDocDocument, DocumentGrammar]
+
+            # @relation(SDOC-SRS-104, scope=range_start)
             if doc_full_path.endswith(".sdoc"):
                 sdoc_reader: SDReader = SDReader()
                 document_or_grammar = sdoc_reader.read_from_file(
                     doc_full_path, project_config
                 )
                 assert isinstance(document_or_grammar, SDocDocument)
+            # @relation(SDOC-SRS-104, scope=range_end)
+
             elif doc_full_path.endswith(".sgra"):
                 sgra_reader = SDocGrammarReader()
                 document_or_grammar = sgra_reader.read_from_file(
@@ -125,6 +129,10 @@ class DocumentFinder:
         project_config: ProjectConfig,
         parallelizer: Parallelizer,
     ) -> DocumentTree:
+        """
+        @relation(SDOC-SRS-48, scope=function)
+        """
+
         assert isinstance(file_trees, list)
 
         output_root_html = project_config.export_output_html_root

--- a/strictdoc/core/document_meta.py
+++ b/strictdoc/core/document_meta.py
@@ -15,6 +15,8 @@ DocumentMeta(
     output_document_dir_full_path = "/tmp/doc_project/output/html/doc_project",
     output_document_dir_rel_path = "doc_project"
 )
+
+@relation(SDOC-SRS-48, scope=file)
 """
 
 import os

--- a/strictdoc/core/file_tree.py
+++ b/strictdoc/core/file_tree.py
@@ -139,11 +139,7 @@ class FileFinder:
                 dirs[:] = []
                 continue
 
-            dirs[:] = [
-                d
-                for d in dirs
-                if (not d.startswith(".") and d not in ("output", "Output"))
-            ]
+            dirs[:] = [d for d in dirs if d not in ("output", "Output")]
             dirs.sort(key=alphanumeric_sort)
 
             current_root_path_level: int = (
@@ -270,8 +266,7 @@ class PathFinder:
             dirs[:] = [
                 d
                 for d in dirs
-                if not d.startswith(".")
-                and not d.startswith("__")
+                if not d.startswith("__")
                 and d not in ("build", "output", "Output", "tests")
             ]
 

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -1,3 +1,7 @@
+"""
+@relation(SDOC-SRS-39, scope=file)
+"""
+
 import datetime
 import os
 import re
@@ -86,6 +90,10 @@ class ProjectConfigDefault:
 
 @auto_described
 class ProjectConfig:
+    """
+    @relation(SDOC-SRS-119, scope=class)
+    """
+
     def __init__(
         self,
         project_title: str = ProjectConfigDefault.DEFAULT_PROJECT_TITLE,

--- a/strictdoc/core/traceability_index_builder.py
+++ b/strictdoc/core/traceability_index_builder.py
@@ -218,6 +218,10 @@ class TraceabilityIndexBuilder:
         document_tree: DocumentTree,
         project_config: ProjectConfig,
     ) -> TraceabilityIndex:
+        """
+        @relation(SDOC-SRS-32, SDOC-SRS-102, scope=function)
+        """
+
         # FIXME: Too many things going on below. Would be great to simplify this
         # workflow.
         d_01_document_iterators: Dict[

--- a/strictdoc/export/html/templates/screens/search/main.jinja
+++ b/strictdoc/export/html/templates/screens/search/main.jinja
@@ -19,7 +19,15 @@
       {% elif node.is_source_file() %}
         <sdoc-node node-style="card" node-role="requirement" data-testid="node-source-file">
           <sdoc-node-field>
+          {#
+           # The source files are not generated when there are no nodes linking to them.
+           # Adding hyperlinks only if the files actually exist.
+           #}
+          {% if node.ng_map_reqs_to_markers.keys() | length > 0 %}
           <a href="{{ view_object.render_source_file_link_from_root_2(node.source_file) }}">{{ node.source_file.in_doctree_source_file_rel_path }}</a>
+          {% else %}
+          {{ node.source_file.in_doctree_source_file_rel_path }}
+          {% endif %}
           </sdoc-node-field>
           <sdoc-node-field>
           Lines: {{ node.file_stats.lines_total }}

--- a/strictdoc/export/rst/rst_to_html_fragment_writer.py
+++ b/strictdoc/export/rst/rst_to_html_fragment_writer.py
@@ -1,3 +1,7 @@
+"""
+@relation(SDOC-SRS-3, scope=file)
+"""
+
 import hashlib
 import io
 import os

--- a/strictdoc/helpers/path_filter.py
+++ b/strictdoc/helpers/path_filter.py
@@ -13,16 +13,16 @@ REGEX_DOUBLE_WILDCARD = (
 
 REGEX_MASK_VALIDATION = rf"[^(\\|\/)]{REGEX_DOUBLE_WILDCARD}"
 
-MOST_COMMON_CHARACTERS = ("[", "]", "(", ")", "{", "}", "?", "+", "!")
+MOST_COMMON_CHARACTERS = ("..", "[", "]", "(", ")", "{", "}", "?", "+", "!")
 
 
 def validate_mask(mask: str) -> None:
     if mask == "":
         raise SyntaxError("Path mask must not be empty.")
 
-    if not mask[0].isalnum() and mask[0] != "*":
+    if not mask[0].isalnum() and mask[0] not in ("*", "."):
         raise SyntaxError(
-            "Path mask must start with an alphanumeric character or "
+            "Path mask must start with an alphanumeric character, a dot, or "
             "a wildcard symbol '*'."
         )
 

--- a/strictdoc/server/app.py
+++ b/strictdoc/server/app.py
@@ -1,3 +1,7 @@
+"""
+@relation(SDOC-SRS-126, scope=file)
+"""
+
 import os
 import sys
 import time

--- a/strictdoc/server/config.py
+++ b/strictdoc/server/config.py
@@ -1,2 +1,7 @@
+"""
+@relation(SDOC-SRS-126, scope=file)
+"""
+
+
 class SDocServerEnvVariable:
     PATH_TO_CONFIG = "PATH_TO_CONFIG"

--- a/strictdoc/server/reload_config.py
+++ b/strictdoc/server/reload_config.py
@@ -1,3 +1,7 @@
+"""
+@relation(SDOC-SRS-126, scope=file)
+"""
+
 import os
 from dataclasses import dataclass
 from typing import List, Optional

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -532,6 +532,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
     def get_edit_requirement(
         node_id: str, context_document_mid: str
     ) -> Response:
+        """
+        @relation(SDOC-SRS-106, scope=function)
+        """
+
         requirement: SDocNode = (
             export_action.traceability_index.get_node_by_mid(MID(node_id))
         )
@@ -630,6 +634,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
 
     @router.post("/actions/document/update_requirement")
     async def document__update_requirement(request: Request) -> Response:
+        """
+        @relation(SDOC-SRS-106, scope=function)
+        """
+
         request_form_data: FormData = await request.form()
         request_dict = dict(request_form_data)
         requirement_mid = request_dict["requirement_mid"]
@@ -791,6 +799,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
         "/actions/document/cancel_edit_requirement", response_class=Response
     )
     def cancel_edit_requirement(requirement_mid: str) -> Response:
+        """
+        @relation(SDOC-SRS-106, scope=function)
+        """
+
         assert isinstance(requirement_mid, str) and len(requirement_mid) > 0, (
             f"{requirement_mid}"
         )
@@ -1048,6 +1060,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
 
     @router.get("/actions/project_index/new_document", response_class=Response)
     def get_new_document() -> Response:
+        """
+        @relation(SDOC-SRS-107, scope=function)
+        """
+
         output = env().render_template_as_markup(
             "actions/project_index/stream_new_document.jinja.html",
             error_object=ErrorObject(),
@@ -1068,6 +1084,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
         document_title: str = Form(""),
         document_path: str = Form(""),
     ) -> Response:
+        """
+        @relation(SDOC-SRS-107, scope=function)
+        """
+
         error_object = ErrorObject()
         if document_title is None or len(document_title) == 0:
             error_object.add_error(
@@ -1306,6 +1326,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
 
     @router.get("/actions/document/edit_config", response_class=Response)
     def document__edit_config(document_mid: str) -> Response:
+        """
+        @relation(SDOC-SRS-57, scope=function)
+        """
+
         document: SDocDocument = (
             export_action.traceability_index.get_node_by_mid(MID(document_mid))
         )
@@ -1386,6 +1410,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
 
     @router.post("/actions/document/save_config", response_class=Response)
     async def document__save_edit_config(request: Request) -> Response:
+        """
+        @relation(SDOC-SRS-57, scope=function)
+        """
+
         request_form_data: FormData = await request.form()
         request_dict: Dict[str, str] = dict(request_form_data)
         document_mid: str = request_dict["document_mid"]
@@ -1554,6 +1582,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
 
     @router.get("/actions/document/cancel_edit_config", response_class=Response)
     def document__cancel_edit_config(document_mid: str) -> Response:
+        """
+        @relation(SDOC-SRS-57, scope=function)
+        """
+
         document: SDocDocument = (
             export_action.traceability_index.get_node_by_mid(MID(document_mid))
         )
@@ -1643,6 +1675,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
 
     @router.get("/actions/document/edit_grammar", response_class=Response)
     def document__edit_grammar(document_mid: str) -> Response:
+        """
+        @relation(SDOC-SRS-56, scope=function)
+        """
+
         document: SDocDocument = (
             export_action.traceability_index.get_node_by_mid(MID(document_mid))
         )
@@ -1661,6 +1697,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
 
     @router.post("/actions/document/save_grammar", response_class=Response)
     async def document__save_grammar(request: Request) -> Response:
+        """
+        @relation(SDOC-SRS-56, scope=function)
+        """
+
         request_form_data: FormData = await request.form()
         request_dict: Dict[str, str] = dict(request_form_data)
         document_mid: str = request_dict["document_mid"]
@@ -1745,6 +1785,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
         "/actions/document/add_grammar_element", response_class=Response
     )
     def document__add_grammar_element(document_mid: str) -> Response:
+        """
+        @relation(SDOC-SRS-56, scope=function)
+        """
+
         form_object: GrammarFormObject = GrammarFormObject(
             document_mid=document_mid,
             fields=[],  # Not used in this limited partial template.
@@ -1766,6 +1810,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
     def document__edit_grammar_element(
         document_mid: str, element_mid: str
     ) -> Response:
+        """
+        @relation(SDOC-SRS-56, scope=function)
+        """
+
         document: SDocDocument = (
             export_action.traceability_index.get_node_by_mid(MID(document_mid))
         )
@@ -1790,6 +1838,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
         "/actions/document/save_grammar_element", response_class=Response
     )
     async def document__save_grammar_element(request: Request) -> Response:
+        """
+        @relation(SDOC-SRS-56, scope=function)
+        """
+
         request_form_data: FormData = await request.form()
         request_dict: Dict[str, str] = dict(request_form_data)
         document_mid: str = request_dict["document_mid"]
@@ -1875,6 +1927,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
 
     @router.get("/actions/document/add_grammar_field", response_class=Response)
     def document__add_grammar_field(document_mid: str) -> Response:
+        """
+        @relation(SDOC-SRS-56, scope=function)
+        """
+
         form_object: GrammarElementFormObject = GrammarElementFormObject(
             document_mid=document_mid,
             element_mid="NOT_RELEVANT",
@@ -1899,6 +1955,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
         "/actions/document/add_grammar_relation", response_class=Response
     )
     def document__add_grammar_relation(document_mid: str) -> Response:
+        """
+        @relation(SDOC-SRS-56, scope=function)
+        """
+
         form_object = GrammarElementFormObject(
             document_mid=document_mid,
             element_mid="NOT_RELEVANT",
@@ -2426,6 +2486,10 @@ def create_main_router(project_config: ProjectConfig) -> APIRouter:
             return get_asset(request, full_path)
 
     def get_document(request: Request, url_to_document: str) -> Response:
+        """
+        @relation(SDOC-SRS-4, scope=function)
+        """
+
         document_relative_path: SDocRelativePath = SDocRelativePath.from_url(
             url_to_document
         )

--- a/strictdoc/server/server.py
+++ b/strictdoc/server/server.py
@@ -1,3 +1,7 @@
+"""
+@relation(SDOC-SRS-126, scope=file)
+"""
+
 import os
 import tempfile
 from contextlib import ExitStack

--- a/strictdoc_config.py
+++ b/strictdoc_config.py
@@ -37,6 +37,9 @@ def create_config() -> ProjectConfig:
             "tests/**",
         ],
         include_source_paths=[
+            "LICENSE",
+            "NOTICE",
+            ".github/workflows/**",
             "strictdoc/**.py",
             "strictdoc/**.js",
             "strictdoc/**.jinja.rst",
@@ -50,6 +53,7 @@ def create_config() -> ProjectConfig:
         exclude_source_paths=[
             # StrictDoc (almost never) uses __init__ files.
             # The used files will be whitelisted include_source_paths.
+            "**__pycache__**",
             "**__init__.py",
             "**.test.py",
             "build/**",

--- a/tasks.py
+++ b/tasks.py
@@ -233,6 +233,10 @@ def test_end2end(
     test_path=None,
     coverage: bool = False,
 ):
+    """
+    @relation(SDOC-SRS-46, scope=function)
+    """
+
     environment = {}
 
     coverage_command_or_none = ""
@@ -318,6 +322,10 @@ def test_end2end(
 
 @task(aliases=["tu"])
 def test_unit(context, focus=None, output=False):
+    """
+    @relation(SDOC-SRS-44, scope=function)
+    """
+
     Path(TEST_REPORTS_DIR).mkdir(parents=True, exist_ok=True)
 
     focus_argument = f"-k {focus}" if focus is not None else ""
@@ -385,6 +393,10 @@ def test_integration(
     shard=None,
     environment=ToxEnvironment.CHECK,
 ):
+    """
+    @relation(SDOC-SRS-45, scope=function)
+    """
+
     cwd = os.getcwd()
 
     if strictdoc is None:
@@ -547,6 +559,10 @@ def coverage_combine(context):
 
 @task
 def lint_ruff_format(context):
+    """
+    @relation(SDOC-SRS-42, scope=function)
+    """
+
     result: invoke.runners.Result = run_invoke_with_tox(
         context,
         ToxEnvironment.CHECK,
@@ -572,6 +588,10 @@ def lint_ruff_format(context):
 
 @task(aliases=["lr"])
 def lint_ruff(context):
+    """
+    @relation(SDOC-SRS-42, scope=function)
+    """
+
     run_invoke_with_tox(
         context,
         ToxEnvironment.CHECK,
@@ -581,9 +601,12 @@ def lint_ruff(context):
     )
 
 
-# @sdoc[SDOC-SRS-43]
 @task(aliases=["lm"])
 def lint_mypy(context):
+    """
+    @relation(SDOC-SRS-41, SDOC-SRS-43, scope=function)
+    """
+
     # These checks do not seem to be useful:
     # - import
     # --disallow-any-expr
@@ -624,9 +647,6 @@ def lint_mypy(context):
                 --python-version=3.9
         """,
     )
-
-
-# # @sdoc[/SDOC-SRS-43]
 
 
 @task

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -1,3 +1,7 @@
+"""
+@relation(SDOC-SRS-46, scope=file)
+"""
+
 # ruff: noqa: ARG001
 import os
 import sys

--- a/tests/end2end/e2e_case.py
+++ b/tests/end2end/e2e_case.py
@@ -1,3 +1,7 @@
+"""
+@relation(SDOC-SRS-46, scope=file)
+"""
+
 from time import sleep
 
 from selenium.common import WebDriverException

--- a/tests/end2end/end2end_test_setup.py
+++ b/tests/end2end/end2end_test_setup.py
@@ -1,3 +1,7 @@
+"""
+@relation(SDOC-SRS-46, scope=file)
+"""
+
 import difflib
 import filecmp
 import os.path

--- a/tests/end2end/exporter.py
+++ b/tests/end2end/exporter.py
@@ -1,3 +1,7 @@
+"""
+@relation(SDOC-SRS-46, scope=file)
+"""
+
 import os
 import shutil
 import subprocess

--- a/tests/end2end/sdoc_test_environment.py
+++ b/tests/end2end/sdoc_test_environment.py
@@ -1,3 +1,7 @@
+"""
+@relation(SDOC-SRS-46, scope=file)
+"""
+
 WAIT_TIMEOUT = 10
 POLL_TIMEOUT = 0.1
 WARMUP_INTERVAL = 0

--- a/tests/end2end/server.py
+++ b/tests/end2end/server.py
@@ -4,6 +4,8 @@ A non-blocking read on a subprocess.PIPE in Python,
 https://stackoverflow.com/a/4896288/598057
 TODO: Consider switching from subprocess to asyncio for starting a server...
 https://stackoverflow.com/a/68564737/598057
+
+@relation(SDOC-SRS-46, scope=file)
 """
 
 import datetime

--- a/tests/integration/features/options/options_per_project/include_doc_paths/02_invalid_option/test.itest
+++ b/tests/integration/features/options/options_per_project/include_doc_paths/02_invalid_option/test.itest
@@ -1,3 +1,3 @@
 RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
-CHECK: error: strictdoc.toml: 'include_doc_paths': Path mask must start with an alphanumeric character or a wildcard symbol '*'. Provided string: ' '.
+CHECK: error: strictdoc.toml: 'include_doc_paths': Path mask must start with an alphanumeric character, a dot, or a wildcard symbol '*'. Provided string: ' '.

--- a/tests/unit/strictdoc/helpers/test_path_filter.py
+++ b/tests/unit/strictdoc/helpers/test_path_filter.py
@@ -134,6 +134,15 @@ def test_case_10_dot_slash_in_the_beginning():
     assert path_filter.match("./filename.part.sdoc")
 
 
+def test_case_11_mask_starts_with_dot():
+    path_filter = PathFilter(
+        [".github/workflows/**"], positive_or_negative=True
+    )
+
+    # POSITIVE
+    assert path_filter.match(".github/workflows/release.yml")
+
+
 def test_case_50_negative_empty_mask():
     path_filter = PathFilter([], positive_or_negative=False)
 

--- a/tests/unit/strictdoc/helpers/test_path_filter_mask_validation.py
+++ b/tests/unit/strictdoc/helpers/test_path_filter_mask_validation.py
@@ -13,9 +13,9 @@ def test_case_01_empty_mask_allows_everything():
     assert "Path mask must not be empty." in exc_info.value.args[0]
 
     with pytest.raises(SyntaxError) as exc_info:
-        validate_mask(".")
+        validate_mask(" ")
     assert (
-        "Path mask must start with an alphanumeric character or "
+        "Path mask must start with an alphanumeric character, a dot, or "
         "a wildcard symbol '*'."
     ) in exc_info.value.args[0]
 
@@ -39,5 +39,5 @@ def test_case_01_empty_mask_allows_everything():
         validate_mask("a[")
     assert (
         "Path mask must not contain any of the special characters: "
-        "('[', ']', '(', ')', '{', '}', '?', '+', '!')."
+        "('..', '[', ']', '(', ')', '{', '}', '?', '+', '!')."
     ) in exc_info.value.args[0]


### PR DESCRIPTION
Also, find source files starting with '.'. This has been a no longer needed limitation which can now be removed.