### PR TITLE
Add sanity checks for source_nodes configuration

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -2987,6 +2987,14 @@ To enable SDoc node parsing, the corresponding source file must be registered in
 
 .. code-block::
 
+    features = [
+      "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+      "SOURCE_FILE_LANGUAGE_PARSERS",
+    ]
+
+    # if custom include_source_paths are set, it must include the corresponding source file
+    include_source_paths = ["tests/**"]
+
     source_nodes = [
         { "tests/" = { uid = "TEST_DOC", node_type = "TEST_SPEC" } }
     ]

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -749,6 +749,14 @@ class ProjectConfigLoader:
 
             if "source_nodes" in project_content:
                 source_nodes_config = project_content["source_nodes"]
+                if len(source_nodes_config) > 0 and not {
+                    ProjectFeature.REQUIREMENT_TO_SOURCE_TRACEABILITY,
+                    ProjectFeature.SOURCE_FILE_LANGUAGE_PARSERS,
+                }.issubset(project_features):
+                    print(  # noqa: T201
+                        "warning: defining source_nodes without enabling REQUIREMENT_TO_SOURCE_TRACEABILITY and "
+                        "SOURCE_FILE_LANGUAGE_PARSERS has no effect"
+                    )
                 assert isinstance(source_nodes_config, list)
                 for item_ in source_nodes_config:
                     source_node_path = next(iter(item_))

--- a/tests/integration/features/source_code_traceability/_source_nodes/_validation/01_cfg_required_features_not_enabled/input.sdoc
+++ b/tests/integration/features/source_code_traceability/_source_nodes/_validation/01_cfg_required_features_not_enabled/input.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ-1
+TITLE: Requirement Title
+STATEMENT: Requirement Statement
+
+[REQUIREMENT]
+UID: REQ-2
+TITLE: Requirement Title #2
+STATEMENT: Requirement Statement #2

--- a/tests/integration/features/source_code_traceability/_source_nodes/_validation/01_cfg_required_features_not_enabled/src/file.c
+++ b/tests/integration/features/source_code_traceability/_source_nodes/_validation/01_cfg_required_features_not_enabled/src/file.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-1, scope=function)
+ *
+ * INTENTION: Ensure alls steps are taken to make foo ready.
+ */
+void setup_foo(void) {
+    print("please setup foo manually\n");
+}

--- a/tests/integration/features/source_code_traceability/_source_nodes/_validation/01_cfg_required_features_not_enabled/src_code.sdoc
+++ b/tests/integration/features/source_code_traceability/_source_nodes/_validation/01_cfg_required_features_not_enabled/src_code.sdoc
@@ -1,0 +1,33 @@
+[DOCUMENT]
+MID: c2d4542d5f1741c88dfcb4f68ad7dcbd
+TITLE: Source Code
+UID: SRC_DOC
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: SRC_SPEC
+  PROPERTIES:
+    VIEW_STYLE: Narrative
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  - TITLE: INTENTION
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File

--- a/tests/integration/features/source_code_traceability/_source_nodes/_validation/01_cfg_required_features_not_enabled/strictdoc.toml
+++ b/tests/integration/features/source_code_traceability/_source_nodes/_validation/01_cfg_required_features_not_enabled/strictdoc.toml
@@ -1,0 +1,11 @@
+[project]
+
+features = []
+
+source_nodes = [
+  { "src/" = { uid = "SRC_DOC", node_type = "SRC_SPEC" } }
+]
+
+exclude_source_paths = [
+    "src.itest"
+]

--- a/tests/integration/features/source_code_traceability/_source_nodes/_validation/01_cfg_required_features_not_enabled/test.itest
+++ b/tests/integration/features/source_code_traceability/_source_nodes/_validation/01_cfg_required_features_not_enabled/test.itest
@@ -1,0 +1,9 @@
+#
+# @relation(SDOC-SRS-141, scope=file)
+#
+# Using source_nodes depends on having REQUIREMENT_TO_SOURCE_TRACEABILITY
+# and SOURCE_FILE_LANGUAGE_PARSERS enabled. Warn if not enabled by configuration.
+#
+
+RUN: %expect_exit 0 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: warning: defining source_nodes without enabling REQUIREMENT_TO_SOURCE_TRACEABILITY and SOURCE_FILE_LANGUAGE_PARSERS has no effect

--- a/tests/integration/features/source_code_traceability/_source_nodes/_validation/02_cfg_no_source_nodes_matched/input.sdoc
+++ b/tests/integration/features/source_code_traceability/_source_nodes/_validation/02_cfg_no_source_nodes_matched/input.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ-1
+TITLE: Requirement Title
+STATEMENT: Requirement Statement
+
+[REQUIREMENT]
+UID: REQ-2
+TITLE: Requirement Title #2
+STATEMENT: Requirement Statement #2

--- a/tests/integration/features/source_code_traceability/_source_nodes/_validation/02_cfg_no_source_nodes_matched/src/file.c
+++ b/tests/integration/features/source_code_traceability/_source_nodes/_validation/02_cfg_no_source_nodes_matched/src/file.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+/**
+ * Some text.
+ *
+ * @relation(REQ-1, scope=function)
+ *
+ * INTENTION: Ensure alls steps are taken to make foo ready.
+ */
+void setup_foo(void) {
+    print("please setup foo manually\n");
+}

--- a/tests/integration/features/source_code_traceability/_source_nodes/_validation/02_cfg_no_source_nodes_matched/src_code.sdoc
+++ b/tests/integration/features/source_code_traceability/_source_nodes/_validation/02_cfg_no_source_nodes_matched/src_code.sdoc
@@ -1,0 +1,33 @@
+[DOCUMENT]
+MID: c2d4542d5f1741c88dfcb4f68ad7dcbd
+TITLE: Source Code
+UID: SRC_DOC
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: SRC_SPEC
+  PROPERTIES:
+    VIEW_STYLE: Narrative
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  - TITLE: INTENTION
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File

--- a/tests/integration/features/source_code_traceability/_source_nodes/_validation/02_cfg_no_source_nodes_matched/strictdoc.toml
+++ b/tests/integration/features/source_code_traceability/_source_nodes/_validation/02_cfg_no_source_nodes_matched/strictdoc.toml
@@ -1,0 +1,18 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+  "SOURCE_FILE_LANGUAGE_PARSERS",
+]
+
+include_source_paths = [
+    "other_src/*.c"
+]
+
+source_nodes = [
+  { "src/" = { uid = "SRC_DOC", node_type = "SRC_SPEC" } }
+]
+
+exclude_source_paths = [
+    "src.itest"
+]

--- a/tests/integration/features/source_code_traceability/_source_nodes/_validation/02_cfg_no_source_nodes_matched/test.itest
+++ b/tests/integration/features/source_code_traceability/_source_nodes/_validation/02_cfg_no_source_nodes_matched/test.itest
@@ -1,0 +1,9 @@
+#
+# @relation(SDOC-SRS-141, scope=file)
+#
+# Listing a source directory in source_nodes is not enough to enable the feature.
+# Source files must still be matched by include_source_paths / exclude_source_paths.
+#
+
+RUN: %expect_exit 0 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: warning: source_node path src/ doesn't match any source file. Hint: Check include_source_paths.


### PR DESCRIPTION
Please check if following assumptions are correct.

Using source_nodes depends on having `REQUIREMENT_TO_SOURCE_TRACEABILITY` and `SOURCE_FILE_LANGUAGE_PARSERS` enabled. Further, if custom `include_source_paths` are used, they must include the directories listed in `source_nodes`. Listing directories in in source_nodes is not enough. Warn if one of the above preconditions are not met, and enhance documentation accordingly.