### PR TITLE
feat(backend/sdoc_source_code): tighten lark grammar for custom source nodes

### DIFF
--- a/strictdoc/backend/sdoc_source_code/marker_parser.py
+++ b/strictdoc/backend/sdoc_source_code/marker_parser.py
@@ -32,7 +32,7 @@ class MarkerParser:
         comment_line_start: int,
         entity_name: Optional[str] = None,
         col_offset: int = 0,
-        parse_nodes: bool = False,
+        custom_tags: Optional[list[str]] = None,
     ) -> SourceNode:
         """
         Parse relation markers from source file comments.
@@ -54,7 +54,7 @@ class MarkerParser:
         input_string = preprocess_source_code_comment(input_string)
 
         tree: ParseTree = MarkerLexer.parse(
-            input_string, parse_nodes=parse_nodes
+            input_string, custom_tags=custom_tags
         )
 
         for element_ in tree.children:

--- a/strictdoc/backend/sdoc_source_code/reader_c.py
+++ b/strictdoc/backend/sdoc_source_code/reader_c.py
@@ -40,8 +40,8 @@ from strictdoc.helpers.file_system import file_open_read_bytes
 
 
 class SourceFileTraceabilityReader_C:
-    def __init__(self, parse_nodes: bool = False) -> None:
-        self.parse_nodes: bool = parse_nodes
+    def __init__(self, custom_tags: Optional[list[str]] = None) -> None:
+        self.custom_tags: Optional[list[str]] = custom_tags
 
     def read(
         self,
@@ -93,7 +93,7 @@ class SourceFileTraceabilityReader_C:
                             if input_buffer[-1] == 10
                             else node_.end_point[0] + 1,
                             node_.start_point[0] + 1,
-                            parse_nodes=self.parse_nodes,
+                            custom_tags=self.custom_tags,
                         )
                         for marker_ in source_node.markers:
                             if not isinstance(marker_, FunctionRangeMarker):
@@ -192,7 +192,7 @@ class SourceFileTraceabilityReader_C:
                         function_last_line,
                         function_comment_node.start_point[0] + 1,
                         entity_name=function_display_name,
-                        parse_nodes=self.parse_nodes,
+                        custom_tags=self.custom_tags,
                     )
                     for marker_ in source_node.markers:
                         if isinstance(marker_, FunctionRangeMarker) and (
@@ -300,7 +300,7 @@ class SourceFileTraceabilityReader_C:
                         function_last_line,
                         function_comment_node.start_point[0] + 1,
                         entity_name=function_display_name,
-                        parse_nodes=self.parse_nodes,
+                        custom_tags=self.custom_tags,
                     )
                     traceability_info.source_nodes.append(source_node)
                     for marker_ in source_node.markers:
@@ -356,7 +356,7 @@ class SourceFileTraceabilityReader_C:
                     node_.start_point[0] + 1,
                     node_.end_point[0] + 1,
                     node_.start_point[0] + 1,
-                    parse_nodes=False,
+                    custom_tags=None,
                 )
 
                 for marker_ in source_node.markers:

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -458,6 +458,26 @@ class ProjectConfig:
 
         return False
 
+    def parse_nodes_type(self, path_to_file: str) -> Optional[tuple[str, str]]:
+        if self.source_root_path is None:
+            return None
+
+        for sdoc_source_config_entry_ in self.source_nodes:
+            # FIXME: Move the setting of full paths to .finalize() of this config
+            #        class when it is implemented.
+            full_path = sdoc_source_config_entry_.setdefault(
+                "full_path",
+                os.path.join(
+                    self.source_root_path, sdoc_source_config_entry_["path"]
+                ),
+            )
+            if path_to_file.startswith(full_path):
+                return sdoc_source_config_entry_[
+                    "uid"
+                ], sdoc_source_config_entry_["node_type"]
+
+        return None
+
 
 class ProjectConfigLoader:
     @staticmethod

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_lexer.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_lexer.py
@@ -191,7 +191,7 @@ STATEMENT: When 1, The system 2 shall do 3
 FOOBAR
 """
 
-    tree = MarkerLexer.parse(input_string, parse_nodes=True)
+    tree = MarkerLexer.parse(input_string, custom_tags=["STATEMENT"])
     assert tree.data == "start"
 
     assert len(tree.children) == 5
@@ -256,7 +256,7 @@ def test_31_single_node_field():
         STATEMENT: This can likely replace _weak below with no problem.
     """
 
-    tree = MarkerLexer.parse(input_string, parse_nodes=True)
+    tree = MarkerLexer.parse(input_string, custom_tags=["STATEMENT"])
     assert tree.data == "start"
 
     assert len(tree.children) == 1
@@ -291,7 +291,7 @@ def test_31B_single_node_field():
   
     """  # noqa: W293
 
-    tree = MarkerLexer.parse(input_string, parse_nodes=True)
+    tree = MarkerLexer.parse(input_string, custom_tags=["INTENTION"])
     assert tree.data == "start"
 
     assert len(tree.children) == 1
@@ -326,7 +326,7 @@ void hello_world(void) {
 }
 """  # noqa: W293
 
-    tree = MarkerLexer.parse(input_string, parse_nodes=True)
+    tree = MarkerLexer.parse(input_string, custom_tags=["INTENTION"])
     assert tree.data == "start"
 
     assert len(tree.children) == 2
@@ -351,7 +351,7 @@ def test_32_two_single_line_fields():
         STATEMENT: This can likely replace _weak below with no problem.
     """
 
-    tree = MarkerLexer.parse(input_string, parse_nodes=True)
+    tree = MarkerLexer.parse(input_string, custom_tags=["STATEMENT"])
     assert tree.data == "start"
 
     assert len(tree.children) == 2
@@ -375,7 +375,9 @@ def test_32B_two_single_line_fields_consecutive():
         STATEMENTT: This can likely replace _weak below with no problem.
     """
 
-    tree = MarkerLexer.parse(input_string, parse_nodes=True)
+    tree = MarkerLexer.parse(
+        input_string, custom_tags=["STATEMENT", "STATEMENTT"]
+    )
 
     assert tree.data == "start"
 
@@ -403,7 +405,7 @@ STATEMENT: This
 FOOBAR
 """
 
-    tree = MarkerLexer.parse(input_string, parse_nodes=True)
+    tree = MarkerLexer.parse(input_string, custom_tags=["STATEMENT"])
     assert tree.data == "start"
 
     assert len(tree.children) == 1
@@ -434,6 +436,38 @@ def test_60_exclude_reserved_keywords():
     assert len(tree.children) == 0
 
 
+def test_70_exclude_similar_but_not_in_grammar():
+    input_string = """
+        Note: This is ordinary comment text.
+
+        STATEMENT: This can likely replace _weak below with no problem.
+        FYI: More ordinary comment text.
+
+        TEST: This can likely replace _weak below with no problem.
+
+        Hint: Again, ordinary comment text.
+    """
+
+    tree = MarkerLexer.parse(input_string, custom_tags=["STATEMENT", "TEST"])
+    assert tree.data == "start"
+    assert len(tree.children) == 2
+    assert tree.children[0].data == "node_field"
+    assert tree.children[0].children[0].data == "node_name"
+    assert tree.children[0].children[0].children[0].value == "STATEMENT"
+    assert (
+        tree.children[0].children[1].children[0].value
+        == "This can likely replace _weak below with no problem."
+    )
+    assert tree.children[0].children[1].data == "node_multiline_value"
+    assert tree.children[1].children[0].data == "node_name"
+    assert tree.children[1].children[0].children[0].value == "TEST"
+    assert (
+        tree.children[1].children[1].children[0].value
+        == "This can likely replace _weak below with no problem."
+    )
+    assert tree.children[1].children[1].data == "node_multiline_value"
+
+
 def test_80_linux_spdx_like_identifiers():
     input_string = """\
 SPDX-ID: REQ-1
@@ -445,7 +479,7 @@ SPDX-Text: This
            And this is the same statement's another paragraph.
 """
 
-    tree = MarkerLexer.parse(input_string, parse_nodes=True)
+    tree = MarkerLexer.parse(input_string, custom_tags=["SPDX-ID", "SPDX-Text"])
     assert tree.data == "start"
 
     assert len(tree.children) == 2


### PR DESCRIPTION
With source node parsing enabled, the comment parser considered **any word** followed by ":" as StrictDoc relevant custom tag. This is overly greedy.

We know right on startup which tag values are allowed and now narrow the search to exactly the allowed values. This prevents parsing errors or unexpected results where comments have "someword:" by chance instead of as intentional SDoc annotation.

@stanislaw: This is just a quick patch to ask whether you would like the idea. If so, I can write tests and think about better design (in particular, passing TraceabilityIndex as a whole to SourceFileTraceabilityCachingReader is a bit too much).