### PR TITLE
fix(export/html): Consider MARKUP = Text option in source file view

### DIFF
--- a/strictdoc/export/html/generators/source_file_view_generator.py
+++ b/strictdoc/export/html/generators/source_file_view_generator.py
@@ -20,6 +20,7 @@ from pygments.lexers.special import TextLexer
 from pygments.lexers.templates import HtmlDjangoLexer
 from pygments.util import ClassNotFound
 
+from strictdoc.backend.sdoc.constants import SDocMarkup
 from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
     ForwardFunctionRangeMarker,
     FunctionRangeMarker,
@@ -114,7 +115,15 @@ class SourceFileViewHTMLGenerator:
             static_path=project_config.dir_for_sdoc_assets,
         )
         markup_renderer = MarkupRenderer.create(
-            "RST",
+            SDocMarkup.RST,
+            traceability_index,
+            link_renderer,
+            html_templates,
+            project_config,
+            None,
+        )
+        text_renderer = MarkupRenderer.create(
+            SDocMarkup.TEXT,
             traceability_index,
             link_renderer,
             html_templates,
@@ -127,6 +136,7 @@ class SourceFileViewHTMLGenerator:
             project_config=project_config,
             link_renderer=link_renderer,
             markup_renderer=markup_renderer,
+            text_renderer=text_renderer,
             source_file=source_file,
             pygments_styles=pygments_styles,
             pygmented_source_file_lines=pygmented_source_file_lines,

--- a/tests/integration/features/options/options_per_document/MARKUP/02_options_markup_is_text/input.sdoc
+++ b/tests/integration/features/options/options_per_document/MARKUP/02_options_markup_is_text/input.sdoc
@@ -8,3 +8,9 @@ STATEMENT: >>>
 **This text will not be converted to strong tag**
 <a href="url">link</a>
 <<<
+
+[REQUIREMENT]
+UID: REQ-1
+TITLE: This Requirement Is Rendered in Document View *and* Source Code View
+STATEMENT: Writing about '*name' in statement shall not cause an RST parser error.
+RATIONALE: Writing about '*name' in rationale shall not cause an RST parser error.

--- a/tests/integration/features/options/options_per_document/MARKUP/02_options_markup_is_text/src/file.c
+++ b/tests/integration/features/options/options_per_document/MARKUP/02_options_markup_is_text/src/file.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+// @relation(REQ-1, scope=line)
+void examle_1(char *name) {
+    print("hello %s\n", name);
+}

--- a/tests/integration/features/options/options_per_document/MARKUP/02_options_markup_is_text/strictdoc.toml
+++ b/tests/integration/features/options/options_per_document/MARKUP/02_options_markup_is_text/strictdoc.toml
@@ -1,0 +1,5 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+]

--- a/tests/integration/features/options/options_per_document/MARKUP/02_options_markup_is_text/test.itest
+++ b/tests/integration/features/options/options_per_document/MARKUP/02_options_markup_is_text/test.itest
@@ -4,3 +4,8 @@ CHECK: Published: Hello world doc
 RUN: %cat %T/html/02_options_markup_is_text/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 CHECK-HTML: **This text will not be converted to strong tag**
 CHECK-HTML: &lt;a href=&#34;url&#34;&gt;link&lt;/a&gt;
+
+RUN: %cat %T/html/_source_files/src/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+CHECK-SOURCE-FILE: This Requirement Is Rendered in Document View *and* Source Code View
+CHECK-SOURCE-FILE: Writing about &#39;*name&#39; in statement shall not cause an RST parser error.
+CHECK-SOURCE-FILE: Writing about &#39;*name&#39; in rationale shall not cause an RST parser error.


### PR DESCRIPTION
Previously, `RST` was hard-coded.

Fix it by checking on a per-node basis if `RST` or `Text` rendering shall be used. It's not possible to do this on a per-source-file basis, since requirements for one source file may come from multiple documents and the MARKUP option is attached to that documents, not to the source file.

Fixes #2544.