### PR TITLE
feat(backend/sdoc_source_code): Allow empty lines in source node fields 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/** text=auto eol=lf

--- a/strictdoc/backend/sdoc_source_code/comment_parser/marker_lexer.py
+++ b/strictdoc/backend/sdoc_source_code/comment_parser/marker_lexer.py
@@ -22,9 +22,8 @@ RELATION_MARKER_START = r"@relation[\(\{]"
 NODE_GRAMMAR_EXTENSION = GrammarTemplate("""
 node_field: node_name ":" node_multiline_value
 node_name: /##CUSTOM_TAGS/
-node_multiline_value: (_WS_INLINE | _NL) (NODE_FIRST_STRING_VALUE NEWLINE) (NODE_STRING_VALUE NEWLINE)*
+node_multiline_value: (_WS_INLINE? | (_WS_INLINE NODE_STRING_VALUE)) NEWLINE (NODE_STRING_VALUE NEWLINE)*
 
-NODE_FIRST_STRING_VALUE.2: /\\s*[^\n\r]+/x
 NODE_STRING_VALUE.2: /(?![ ]*##RELATION_MARKER_START)(?!\\s*(##CUSTOM_TAGS):\\s)(?!\\s*##NODE_FIELD_END_MARKER)[^\n\r]+/x
 
 _NORMAL_STRING_NO_MARKER_NO_NODE: /(?!\\s*##RELATION_MARKER_START)((?!\\s*(##CUSTOM_TAGS):\\s)|(##RESERVED_KEYWORDS)).+/

--- a/strictdoc/backend/sdoc_source_code/comment_parser/marker_lexer.py
+++ b/strictdoc/backend/sdoc_source_code/comment_parser/marker_lexer.py
@@ -22,12 +22,12 @@ RELATION_MARKER_START = r"@relation[\(\{]"
 NODE_GRAMMAR_EXTENSION = GrammarTemplate("""
 node_field: node_name ":" node_multiline_value
 node_name: /##CUSTOM_TAGS/
-node_multiline_value: (_WS_INLINE | _NL) (NODE_FIRST_STRING_VALUE _NL) (NODE_STRING_VALUE _NL)*
+node_multiline_value: (_WS_INLINE | _NL) (NODE_FIRST_STRING_VALUE NEWLINE) (NODE_STRING_VALUE NEWLINE)*
 
 NODE_FIRST_STRING_VALUE.2: /\\s*[^\n\r]+/x
-NODE_STRING_VALUE.2: /(?![ ]*##RELATION_MARKER_START)(?!\\s*(##CUSTOM_TAGS): )[^\n\r]+/x
+NODE_STRING_VALUE.2: /(?![ ]*##RELATION_MARKER_START)(?!\\s*(##CUSTOM_TAGS):\\s)(?!\\s*##NODE_FIELD_END_MARKER)[^\n\r]+/x
 
-_NORMAL_STRING_NO_MARKER_NO_NODE: /(?!\\s*##RELATION_MARKER_START)((?!\\s*(##CUSTOM_TAGS): )|(##RESERVED_KEYWORDS)).+/
+_NORMAL_STRING_NO_MARKER_NO_NODE: /(?!\\s*##RELATION_MARKER_START)((?!\\s*(##CUSTOM_TAGS):\\s)|(##RESERVED_KEYWORDS)).+/
 """)
 
 GRAMMAR = GrammarTemplate("""
@@ -74,6 +74,7 @@ class MarkerLexer:
                 CUSTOM_TAGS="|".join(f"{tag}(?=:)" for tag in custom_tags),
                 RESERVED_KEYWORDS=RESERVED_KEYWORDS,
                 RELATION_MARKER_START=RELATION_MARKER_START,
+                NODE_FIELD_END_MARKER="SPDX-Req-End",
             )
             start = "(relation_marker | node_field | _NORMAL_STRING_NO_MARKER_NO_NODE | _WS)*"
         else:

--- a/strictdoc/backend/sdoc_source_code/marker_parser.py
+++ b/strictdoc/backend/sdoc_source_code/marker_parser.py
@@ -227,17 +227,21 @@ class MarkerParser:
         assert isinstance(node_value_node, Tree)
         assert node_value_node.data == "node_multiline_value"
 
-        processed_node_values = []
-        for node_value_component_ in node_value_node.children:
+        # let the first non-empty line after a field determine the dedent
+        dedent = None
+        node_value = ""
+        for i, node_value_component_ in enumerate(node_value_node.children):
             assert isinstance(node_value_component_, Token)
-            processed_node_value = node_value_component_.value.strip()
-            if "\\n\\n" in processed_node_value:
-                processed_node_value = processed_node_value.replace(
-                    "\\n\\n", ""
-                )
+            line_value = node_value_component_.value
+            if dedent is None:
+                if i > 0 and line_value != "\n":
+                    dedent = len(line_value) - len(line_value.lstrip(" "))
+                    line_value = line_value[dedent:]
+            else:
+                leading_spaces = len(line_value) - len(line_value.lstrip(" "))
+                line_value = line_value[min(leading_spaces, dedent) :]
+            node_value += line_value
 
-            processed_node_values.append(processed_node_value)
-
-        node_value = "\n".join(processed_node_values)
+        node_value = node_value.rstrip()
 
         return node_name, node_value

--- a/tests/integration/features/source_code_traceability/_source_nodes/_auto_uuid/10_linux_spdx_req_id_autogen/src/example/example.c
+++ b/tests/integration/features/source_code_traceability/_source_nodes/_auto_uuid/10_linux_spdx_req_id_autogen/src/example/example.c
@@ -12,7 +12,7 @@
  * SPDX-Text: This
  *            is
  *            a statement
- *            \n\n
+ *
  *            And this is the same statement's another paragraph.
  */
 void example_1(void) {

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_lexer.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_lexer.py
@@ -44,7 +44,8 @@ def assert_node_field(
 
     values = list(
         node_value.scan_values(
-            lambda t: t.type in ("NODE_FIRST_STRING_VALUE", "NODE_STRING_VALUE")
+            lambda t: t.type
+            in ("NODE_FIRST_STRING_VALUE", "NODE_STRING_VALUE", "NEWLINE")
         )
     )
     for idx in range(len(expected_field_value)):
@@ -232,7 +233,7 @@ STATEMENT: When 1, The system 2 shall do 3
 
 STATEMENT: When 1, The system 2 shall do 3
 
-FOOBAR
+Additionally, the system 3 shall do 4.
 """
 
     tree = MarkerLexer.parse(input_string, custom_tags={"STATEMENT"})
@@ -252,13 +253,13 @@ FOOBAR
     assert_node_field(
         node_fields[0],
         "STATEMENT",
-        ["When C,", "           The system A shall do B"],
+        ["When C,", "\n", "           The system A shall do B"],
     )
 
     assert_node_field(
         node_fields[1],
         "STATEMENT",
-        ["When Z,", "           The system X shall do Y"],
+        ["When Z,", "\n", "           The system X shall do Y"],
     )
 
     assert_node_field(
@@ -270,7 +271,11 @@ FOOBAR
     assert_node_field(
         node_fields[3],
         "STATEMENT",
-        ["When 1, The system 2 shall do 3"],
+        [
+            "When 1, The system 2 shall do 3",
+            "\n\n",
+            "Additionally, the system 3 shall do 4.",
+        ],
     )
 
 
@@ -433,12 +438,10 @@ def test_33_multiline_and_multiparagraph_fields() -> None:
 FOOBAR
 
 STATEMENT: This
-           \\n\\n
-           is
-           \\n\\n
-           how we do paragraphs.
 
-FOOBAR
+           is
+
+           how we do paragraphs.
 """
 
     tree = MarkerLexer.parse(input_string, custom_tags={"STATEMENT"})
@@ -451,9 +454,9 @@ FOOBAR
         "STATEMENT",
         [
             "This",
-            "           \\n\\n",
+            "\n\n",
             "           is",
-            "           \\n\\n",
+            "\n\n",
             "           how we do paragraphs.",
         ],
     )
@@ -510,7 +513,7 @@ SPDX-ID: REQ-1
 SPDX-Text: This
            is
            a statement
-           \\n\\n
+
            And this is the same statement's another paragraph.
 """
 
@@ -530,9 +533,11 @@ SPDX-Text: This
         "SPDX-Text",
         [
             "This",
+            "\n",
             "           is",
+            "\n",
             "           a statement",
-            "           \\n\\n",
+            "\n\n",
             "           And this is the same statement's another paragraph.",
         ],
     )

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_lexer.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_lexer.py
@@ -462,6 +462,33 @@ STATEMENT: This
     )
 
 
+def test_34_node_text_starting_below() -> None:
+    """
+    Ensure that first text can start somewhere in the next lines after a field,
+    and that the result keeps starting newlines as separate NEWLINE-symbol.
+    """
+    input_string = """\
+FIELD1:
+
+   Text starting far off from tag.
+"""
+    tree = MarkerLexer.parse(input_string, custom_tags={"FIELD1"})
+    assert tree.data == "start"
+
+    node_fields = list(tree.find_data("node_field"))
+    assert len(node_fields) == 1
+
+    assert_node_field(
+        node_fields[0],
+        "FIELD1",
+        [
+            "\n\n",
+            "   Text starting far off from tag.",
+            "\n",
+        ],
+    )
+
+
 def test_60_exclude_reserved_keywords() -> None:
     input_string = """
         FIXME: This can likely replace _weak below with no problem.

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
@@ -267,6 +267,36 @@ def test_24_parses_multiline_marker():
     assert function_range.reqs_objs[2].ng_source_column == 8
 
 
+def test_30_parser_dedents_field_lines():
+    input_string = """\
+    /**
+     * FIELD1: Nothing to dedent here.
+     *
+     * FIELD2: Nothing to
+     * dedent here.
+     *
+     * FIELD3: Dedent
+     *         this statement:
+     *           but keep
+     *             inner indent
+     */"""
+
+    source_node = MarkerParser.parse(
+        input_string=input_string,
+        line_start=1,
+        line_end=7,
+        comment_line_start=1,
+        comment_byte_range=None,
+        custom_tags=["FIELD1", "FIELD2", "FIELD3"],
+    )
+    assert source_node.fields["FIELD1"] == "Nothing to dedent here."
+    assert source_node.fields["FIELD2"] == "Nothing to\ndedent here."
+    assert (
+        source_node.fields["FIELD3"]
+        == "Dedent\nthis statement:\n  but keep\n    inner indent"
+    )
+
+
 def test_80_linux_spdx_example():
     input_string = """\
 /**
@@ -281,7 +311,7 @@ def test_80_linux_spdx_example():
  * SPDX-Text: This
  *            is
  *            a statement
- *            \\n\\n
+ *
  *            And this is the same statement's another paragraph.
  */
 """

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
@@ -268,6 +268,10 @@ def test_24_parses_multiline_marker():
 
 
 def test_30_parser_dedents_field_lines():
+    """
+    Since source code fields will likely opt for text rendering (instead of RST),
+    ensure that ASCII formating is preserved reasonably.
+    """
     input_string = """\
     /**
      * FIELD1: Nothing to dedent here.
@@ -276,9 +280,15 @@ def test_30_parser_dedents_field_lines():
      * dedent here.
      *
      * FIELD3: Dedent
-     *         this statement:
-     *           but keep
-     *             inner indent
+     *         - this list
+     *           - but keep
+     *             - inner indent
+     *
+     * FIELD4:
+     *        ASCII art
+     *    ___           ___
+     *  ( foo ) <---> ( bar )
+     *    ‾‾‾           ‾‾‾
      */"""
 
     source_node = MarkerParser.parse(
@@ -287,13 +297,19 @@ def test_30_parser_dedents_field_lines():
         line_end=7,
         comment_line_start=1,
         comment_byte_range=None,
-        custom_tags=["FIELD1", "FIELD2", "FIELD3"],
+        custom_tags=["FIELD1", "FIELD2", "FIELD3", "FIELD4"],
     )
     assert source_node.fields["FIELD1"] == "Nothing to dedent here."
     assert source_node.fields["FIELD2"] == "Nothing to\ndedent here."
-    assert (
-        source_node.fields["FIELD3"]
-        == "Dedent\nthis statement:\n  but keep\n    inner indent"
+    assert source_node.fields["FIELD3"] == (
+        "Dedent\n- this list\n  - but keep\n    - inner indent"
+    )
+    assert source_node.fields["FIELD4"] == (
+        "\n"
+        "      ASCII art\n"
+        "  ___           ___\n"
+        "( foo ) <---> ( bar )\n"
+        "  ‾‾‾           ‾‾‾"
     )
 
 


### PR DESCRIPTION
Previously, a source node field was terminated at the first empty line. A workaround existed where adding literal `\n\n` was translated to new line.

This change removes the workaround and introduces a more user friendly rule where empty lines are kept as part of a field. To terminate the field we can either simply start the next field, or insert a reserved termination word that ends the field preliminary.

Comment grammar didn't change much. Most notably
- newlines that belong to field text are now preserved and part of the parse tree
- auto-dedent: the first non-empty line after the field line determines how much indent is automatically removed from each line

Note: The termination symbol is fixed to "SPDX-Req-End", this should be made configurable in an upcoming PR.