### PR TITLE
chore(backend/sdoc_source_code): Function class: require explicit arguments for better readability

### DIFF
--- a/strictdoc/backend/sdoc_source_code/models/function.py
+++ b/strictdoc/backend/sdoc_source_code/models/function.py
@@ -15,6 +15,7 @@ from strictdoc.helpers.auto_described import auto_described
 class Function:
     def __init__(
         self,
+        *,
         parent: Any,
         name: str,
         display_name: str,


### PR DESCRIPTION
The upcoming PR https://github.com/strictdoc-project/strictdoc/pull/2555 adds some more variables to this class, and it feels like it is time to enforce the explicit argument names every time this class's constructor is called. This should help with avoiding the issues when a wrong position argument can be set in place of the right one.