### PR TITLE
chore(backend/sdoc_source_code): MarkerParser class: require explicit arguments for better readability

### DIFF
--- a/strictdoc/backend/sdoc_source_code/marker_parser.py
+++ b/strictdoc/backend/sdoc_source_code/marker_parser.py
@@ -26,6 +26,7 @@ from strictdoc.backend.sdoc_source_code.models.source_node import SourceNode
 class MarkerParser:
     @staticmethod
     def parse(
+        *,
         input_string: str,
         line_start: int,
         line_end: int,

--- a/strictdoc/backend/sdoc_source_code/reader_c.py
+++ b/strictdoc/backend/sdoc_source_code/reader_c.py
@@ -85,14 +85,14 @@ class SourceFileTraceabilityReader_C:
                     if comment_node.text is not None:
                         comment_text = comment_node.text.decode("utf-8")
                         source_node = MarkerParser.parse(
-                            comment_text,
-                            node_.start_point[0] + 1,
+                            input_string=comment_text,
+                            line_start=node_.start_point[0] + 1,
                             # It is important that +1 is not present here because
                             # currently StrictDoc does not display the last empty line (\n is 10).
-                            node_.end_point[0]
+                            line_end=node_.end_point[0]
                             if input_buffer[-1] == 10
                             else node_.end_point[0] + 1,
-                            node_.start_point[0] + 1,
+                            comment_line_start=node_.start_point[0] + 1,
                             custom_tags=self.custom_tags,
                         )
                         for marker_ in source_node.markers:
@@ -187,10 +187,11 @@ class SourceFileTraceabilityReader_C:
                     function_last_line = node_.end_point[0] + 1
 
                     source_node = MarkerParser.parse(
-                        function_comment_text,
-                        function_comment_node.start_point[0] + 1,
-                        function_last_line,
-                        function_comment_node.start_point[0] + 1,
+                        input_string=function_comment_text,
+                        line_start=function_comment_node.start_point[0] + 1,
+                        line_end=function_last_line,
+                        comment_line_start=function_comment_node.start_point[0]
+                        + 1,
                         entity_name=function_display_name,
                         custom_tags=self.custom_tags,
                     )
@@ -295,10 +296,11 @@ class SourceFileTraceabilityReader_C:
                     function_last_line = node_.end_point[0] + 1
 
                     source_node = MarkerParser.parse(
-                        function_comment_text,
-                        function_comment_node.start_point[0] + 1,
-                        function_last_line,
-                        function_comment_node.start_point[0] + 1,
+                        input_string=function_comment_text,
+                        line_start=function_comment_node.start_point[0] + 1,
+                        line_end=function_last_line,
+                        comment_line_start=function_comment_node.start_point[0]
+                        + 1,
                         entity_name=function_display_name,
                         custom_tags=self.custom_tags,
                     )
@@ -352,10 +354,10 @@ class SourceFileTraceabilityReader_C:
                 node_text_string = node_.text.decode("utf8")
 
                 source_node = MarkerParser.parse(
-                    node_text_string,
-                    node_.start_point[0] + 1,
-                    node_.end_point[0] + 1,
-                    node_.start_point[0] + 1,
+                    input_string=node_text_string,
+                    line_start=node_.start_point[0] + 1,
+                    line_end=node_.end_point[0] + 1,
+                    comment_line_start=node_.start_point[0] + 1,
                     custom_tags=None,
                 )
 

--- a/strictdoc/backend/sdoc_source_code/reader_python.py
+++ b/strictdoc/backend/sdoc_source_code/reader_python.py
@@ -102,14 +102,15 @@ class SourceFileTraceabilityReader_Python:
 
                         block_comment_text = string_content.text.decode("utf-8")
                         source_node = MarkerParser.parse(
-                            block_comment_text,
-                            node_.start_point[0] + 1,
+                            input_string=block_comment_text,
+                            line_start=node_.start_point[0] + 1,
                             # It is important that +1 is not present here because
                             # currently StrictDoc does not display the last empty line (\n is 10).
-                            node_.end_point[0]
+                            line_end=node_.end_point[0]
                             if input_buffer[-1] == 10
                             else node_.end_point[0] + 1,
-                            string_content.start_point[0] + 1,
+                            comment_line_start=string_content.start_point[0]
+                            + 1,
                         )
                         for marker_ in source_node.markers:
                             if isinstance(marker_, FunctionRangeMarker) and (
@@ -164,11 +165,12 @@ class SourceFileTraceabilityReader_Python:
                                 "utf-8"
                             )
                             source_node = MarkerParser.parse(
-                                block_comment_text,
-                                node_.start_point[0] + 1,
-                                node_.end_point[0] + 1,
-                                string_content.start_point[0] + 1,
-                                function_name,
+                                input_string=block_comment_text,
+                                line_start=node_.start_point[0] + 1,
+                                line_end=node_.end_point[0] + 1,
+                                comment_line_start=string_content.start_point[0]
+                                + 1,
+                                entity_name=function_name,
                             )
                             for marker_ in source_node.markers:
                                 if isinstance(marker_, FunctionRangeMarker):
@@ -241,11 +243,11 @@ class SourceFileTraceabilityReader_Python:
                 last_comment = node_.parent.children[last_idx - 1]
 
                 source_node = MarkerParser.parse(
-                    merged_comments,
-                    node_.start_point[0] + 1,
-                    last_comment.end_point[0] + 1,
-                    node_.start_point[0] + 1,
-                    None,
+                    input_string=merged_comments,
+                    line_start=node_.start_point[0] + 1,
+                    line_end=last_comment.end_point[0] + 1,
+                    comment_line_start=node_.start_point[0] + 1,
+                    entity_name=None,
                 )
                 for marker_ in source_node.markers:
                     if isinstance(marker_, RangeMarker) and (

--- a/strictdoc/backend/sdoc_source_code/reader_robot.py
+++ b/strictdoc/backend/sdoc_source_code/reader_robot.py
@@ -95,12 +95,12 @@ class SdocRelationVisitor(ModelVisitor):  # type: ignore[misc]
             if isinstance(stmt, (Comment, Tags, Documentation)):
                 for token in filter(self._token_filter, stmt.tokens):
                     source_node = MarkerParser.parse(
-                        token.value,
-                        token.lineno,
-                        token.lineno,
-                        token.lineno,
-                        node.name,
-                        token.col_offset,
+                        input_string=token.value,
+                        line_start=token.lineno,
+                        line_end=token.lineno,
+                        comment_line_start=token.lineno,
+                        entity_name=node.name,
+                        col_offset=token.col_offset,
                     )
                     tc_markers.extend(source_node.markers)
 
@@ -136,12 +136,12 @@ class SdocRelationVisitor(ModelVisitor):  # type: ignore[misc]
     ) -> None:
         for token in filter(self._token_filter, node.tokens):
             source_node = MarkerParser.parse(
-                token.value,
-                node.lineno,
-                node.lineno,
-                node.lineno,
-                None,
-                token.col_offset,
+                input_string=token.value,
+                line_start=node.lineno,
+                line_end=node.lineno,
+                comment_line_start=node.lineno,
+                entity_name=None,
+                col_offset=token.col_offset,
             )
             for marker_ in source_node.markers:
                 if (

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
@@ -26,7 +26,12 @@ def test_01_basic_nominal():
     ]
 
     for input_string_ in input_strings:
-        source_node = MarkerParser.parse(input_string_, 1, 1, 1)
+        source_node = MarkerParser.parse(
+            input_string=input_string_,
+            line_start=1,
+            line_end=1,
+            comment_line_start=1,
+        )
         function_range = source_node.markers[0]
         assert isinstance(function_range, FunctionRangeMarker)
         assert function_range.ng_source_line_begin == 1
@@ -43,7 +48,12 @@ def test_10_parses_with_leading_newlines():
 @relation(REQ-1, scope=function)
 """
 
-    source_node = MarkerParser.parse(input_string, 1, 5, 1)
+    source_node = MarkerParser.parse(
+        input_string=input_string,
+        line_start=1,
+        line_end=5,
+        comment_line_start=1,
+    )
     function_range = source_node.markers[0]
 
     assert isinstance(function_range, FunctionRangeMarker)
@@ -61,7 +71,12 @@ def test_11_parses_with_leading_whitespace():
     @relation(REQ-1, scope=function)
 """
 
-    source_node = MarkerParser.parse(input_string, 1, 3, 1)
+    source_node = MarkerParser.parse(
+        input_string=input_string,
+        line_start=1,
+        line_end=3,
+        comment_line_start=1,
+    )
     function_range = source_node.markers[0]
 
     assert isinstance(function_range, FunctionRangeMarker)
@@ -81,7 +96,12 @@ def test_20_parses_within_doxygen_comment():
  */
 """
 
-    source_node = MarkerParser.parse(input_string, 1, 5, 1)
+    source_node = MarkerParser.parse(
+        input_string=input_string,
+        line_start=1,
+        line_end=5,
+        comment_line_start=1,
+    )
     function_range = source_node.markers[0]
 
     assert isinstance(function_range, FunctionRangeMarker)
@@ -102,7 +122,12 @@ def test_21_parses_within_doxygen_comment_two_markers():
  */
 """
 
-    source_node = MarkerParser.parse(input_string, 1, 6, 1)
+    source_node = MarkerParser.parse(
+        input_string=input_string,
+        line_start=1,
+        line_end=6,
+        comment_line_start=1,
+    )
     function_range = source_node.markers[0]
 
     assert isinstance(function_range, FunctionRangeMarker)
@@ -122,7 +147,12 @@ def test_22_parses_within_doxygen_comment_curly_braces():
  */
 """
 
-    source_node = MarkerParser.parse(input_string, 1, 5, 1)
+    source_node = MarkerParser.parse(
+        input_string=input_string,
+        line_start=1,
+        line_end=5,
+        comment_line_start=1,
+    )
     function_range = source_node.markers[0]
 
     assert isinstance(function_range, FunctionRangeMarker)
@@ -153,7 +183,12 @@ def test_23_parses_within_doxygen_comment():
  */
 """
 
-    source_node = MarkerParser.parse(input_string, 1, 16, 1)
+    source_node = MarkerParser.parse(
+        input_string=input_string,
+        line_start=1,
+        line_end=16,
+        comment_line_start=1,
+    )
 
     function_range = source_node.markers[0]
     assert isinstance(function_range, FunctionRangeMarker)
@@ -201,7 +236,12 @@ def test_24_parses_multiline_marker():
  */
 """
 
-    source_node = MarkerParser.parse(input_string, 1, 11, 1)
+    source_node = MarkerParser.parse(
+        input_string=input_string,
+        line_start=1,
+        line_end=11,
+        comment_line_start=1,
+    )
 
     function_range = source_node.markers[0]
     assert isinstance(function_range, LineMarker)


### PR DESCRIPTION

The upcoming PR https://github.com/strictdoc-project/strictdoc/pull/2555 adds some more variables to this class, and it feels like it is time to enforce the explicit argument names every time this class's constructor is called. This should help with avoiding the issues when a wrong position argument can be set in place of the right one.