### PR TITLE
refactor(backend/sdoc_source_code): add test helpers for marker_lexer tests, add a MarkerParser-level Linux/SPDX test

### DIFF
--- a/strictdoc/backend/sdoc_source_code/comment_parser/marker_lexer.py
+++ b/strictdoc/backend/sdoc_source_code/comment_parser/marker_lexer.py
@@ -25,7 +25,7 @@ node_name: /##CUSTOM_TAGS/
 node_multiline_value: (_WS_INLINE | _NL) (NODE_FIRST_STRING_VALUE _NL) (NODE_STRING_VALUE _NL)*
 
 NODE_FIRST_STRING_VALUE.2: /\\s*[^\n\r]+/x
-NODE_STRING_VALUE.2: /(?![ ]*##RELATION_MARKER_START)(?!\\s*[A-Z_]+: )[^\n\r]+/x
+NODE_STRING_VALUE.2: /(?![ ]*##RELATION_MARKER_START)(?!\\s*(##CUSTOM_TAGS): )[^\n\r]+/x
 
 _NORMAL_STRING_NO_MARKER_NO_NODE: /(?!\\s*##RELATION_MARKER_START)((?!\\s*(##CUSTOM_TAGS): )|(##RESERVED_KEYWORDS)).+/
 """)

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
@@ -257,3 +257,48 @@ def test_24_parses_multiline_marker():
     assert function_range.reqs_objs[2].uid == "REQ-3"
     assert function_range.reqs_objs[2].ng_source_line == 7
     assert function_range.reqs_objs[2].ng_source_column == 8
+
+
+def test_80_linux_spdx_example():
+    input_string = """\
+/**
+ * Some text.
+ *
+ * @relation(REQ-1, scope=function)
+ *
+ * SPDX-Req-ID: SRC-1
+ *
+ * SPDX-Req-HKey: TBD
+ *
+ * SPDX-Text: This
+ *            is
+ *            a statement
+ *            \\n\\n
+ *            And this is the same statement's another paragraph.
+ */
+"""
+
+    source_node = MarkerParser.parse(
+        input_string=input_string,
+        line_start=1,
+        line_end=11,
+        comment_line_start=1,
+        custom_tags={"SPDX-Req-ID", "SPDX-Req-HKey", "SPDX-Text"},
+    )
+
+    assert list(source_node.fields.keys()) == [
+        "SPDX-Req-ID",
+        "SPDX-Req-HKey",
+        "SPDX-Text",
+    ]
+
+    assert (
+        source_node.fields["SPDX-Text"]
+        == """\
+This
+is
+a statement
+
+And this is the same statement's another paragraph.\
+"""
+    )


### PR DESCRIPTION
This change is one more fragment from a larger https://github.com/strictdoc-project/strictdoc/pull/2555 extracted for an easier review.

The custom assertion helpers are introduced to the test_marker_lexer which reduces the test boilerplate.

The marker parser-level test_80_linux_spdx_example is introduced to verify that the comments are parsed correctly. Previously this test only existed at the marker lexer level.