### PR TITLE
chore(.github): switch the macOS tests to macos-latest

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-13
+    runs-on: macos-latest
 
     strategy:
       matrix:

--- a/.github/workflows/end2end-tests.yml
+++ b/.github/workflows/end2end-tests.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   tests_end2end_macos:
     name: E2E - macOS
-    runs-on: macos-13
+    runs-on: macos-latest
 
     strategy:
       matrix:

--- a/tests/end2end/__init__.py
+++ b/tests/end2end/__init__.py
@@ -1,1 +1,1 @@
-# Dummy comment.
+# Dummy comment


### PR DESCRIPTION
It looks like the previously used macos-13 machines are not available anymore. Let's try to live with the macos-latest for now.