### PR TITLE
chore(.gitattributes): normalize endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+tests/** text=auto eol=lf
+


### PR DESCRIPTION
This should avoid any differences between how the source files are stored on Linux and Windows developer machines.