### PR TITLE
chore(pyinstaller): fix regression by installing jaraco.text manually for now

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,12 +77,22 @@ commands =
     python developer/pip_install_strictdoc_deps.py
     {posargs}
 
+# FIXME: jaraco.text is needed because without it there is a regression (started on 2025-11-23):
+# $ /tmp/strictdoc/strictdoc/strictdoc
+# Traceback (most recent call last):
+# File "pyi_rth_pkgres.py", line 177, in <module>
+# File "pyi_rth_pkgres.py", line 44, in _pyi_rthook
+# File "pyimod02_importers.py", line 457, in exec_module
+# File "pkg_resources/__init__.py", line 90, in <module>
+# ModuleNotFoundError: No module named 'jaraco'
+# [PYI-21537:ERROR] Failed to execute script 'pyi_rth_pkgres' due to unhandled exception!
 [testenv:{py38,py39,py310,py311,py312,py313}-pyinstaller]
 package = "skip"
 skip_install = true
 deps =
     -rrequirements.bootstrap.txt
     pyinstaller
+    jaraco.text
 commands =
     python developer/pip_install_strictdoc_deps.py
     {posargs}


### PR DESCRIPTION
This unblocks the failing CI tests: https://github.com/strictdoc-project/strictdoc/pull/2570.