### PR TITLE
chore(.gitattributes): remove the LF normalization for test files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-tests/** text=auto eol=lf

--- a/strictdoc/commands/manage_autouid_command.py
+++ b/strictdoc/commands/manage_autouid_command.py
@@ -176,6 +176,7 @@ class ManageAutoUIDCommand:
             ]
 
             # This is important for Windows. Otherwise, the hash key will be calculated incorrectly.
+            instance_bytes = instance_bytes.replace(b"\r\n", b"\n")
             code = code.replace(b"\r\n", b"\n")
 
             hash_spdx_id = bytes(get_random_sha256(), encoding="utf8")

--- a/tests/end2end/__init__.py
+++ b/tests/end2end/__init__.py
@@ -1,1 +1,1 @@
-# Dummy comment
+# Dummy comment.


### PR DESCRIPTION
This reverts https://github.com/strictdoc-project/strictdoc/pull/2565. It should be possible because we found the underlying issue in the lark grammar which broke the integration test on Windows. See https://github.com/strictdoc-project/strictdoc/pull/2575.