### PR TITLE
feat(backend/sdoc): writer: implement writing FUNCTION back to SDoc

### DIFF
--- a/strictdoc/backend/sdoc/writer.py
+++ b/strictdoc/backend/sdoc/writer.py
@@ -496,6 +496,10 @@ class SDWriter:
                     output += ", "
                     output += str(ref.g_file_entry.line_range[1])
                     output += "\n"
+                elif ref.g_file_entry.function is not None:
+                    output += "  FUNCTION: "
+                    output += str(ref.g_file_entry.function)
+                    output += "\n"
 
             elif isinstance(reference, ParentReqReference):
                 parent_reference: ParentReqReference = reference

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_relations.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_relations.py
@@ -87,3 +87,50 @@ RELATIONS:
     output = writer.write(document)
 
     assert input_sdoc == output
+
+
+def test_003_file_relations(default_project_config):
+    input_sdoc = """
+[DOCUMENT]
+TITLE: Test Doc
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+  RELATIONS:
+  - TYPE: Parent
+    ROLE: Refines
+
+[REQUIREMENT]
+STATEMENT: >>>
+This is a statement.
+<<<
+RELATIONS:
+- TYPE: File
+  VALUE: tools/testing/selftests/devmem/tests.c
+- TYPE: File
+  VALUE: tools/testing/selftests/devmem/devmem.c
+  LINE_RANGE: 27, 32
+- TYPE: File
+  VALUE: tools/testing/selftests/devmem/devmem.c
+  FUNCTION: test_function
+""".lstrip()
+
+    reader = SDReader()
+
+    document = reader.read(input_sdoc)
+    assert isinstance(document, SDocDocument)
+
+    writer = SDWriter(default_project_config)
+    output = writer.write(document)
+
+    assert input_sdoc == output


### PR DESCRIPTION
Context: This addresses a code review comment given on another ticket: https://github.com/strictdoc-project/strictdoc/pull/2566#issuecomment-3562885922.

Problem: The SDWriter class didn't implement the writing of File relations with the `FUNCTION:` field indicated.

Solution: Implement writing back the `FUNCTION:` field.

Verification: Unit test.