### PR TITLE
fix(docs): fix a link to a strictdoc config example

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -4544,7 +4544,7 @@ Instead of using ``strictdoc.toml``, the new approach includes ``strictdoc_confi
 
 All TOML configuration options specified in StrictDoc’s documentation are still valid but must be migrated to their Python equivalents.
 
-See `StrictDoc's own config file <https://github.com/strictdoc-project/strictdoc/blob/main/strictdoc/core/project_config.py>`_ for a realistic example.
+See `StrictDoc's own config file <https://github.com/strictdoc-project/strictdoc/blob/main/strictdoc_config.py>`_ for a realistic example.
 
 Refer to the `ProjectConfig <https://github.com/strictdoc-project/strictdoc/blob/main/strictdoc/core/project_config.py>`_ class for a complete overview of all available options.
 <<<


### PR DESCRIPTION
At the very bottom of the User Guide, both the links to the project's Python config file and the link to the Python class for that config file are linked to the same file--the core config processing code. Changed the former to link to the proper file.