### PR TITLE
Add ability to render git information in metadata fields for html2pdf

### DIFF
--- a/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
@@ -224,6 +224,23 @@ class DocumentScreenViewObject:
 
         return interpolate_at_pattern_lazy(self.document.config.date, resolver)
 
+    def render_metadata_value(self, metada_value:Optional[str]) -> Optional[str]:
+        if metada_value is None:
+            return ""
+
+        def resolver(variable_name: str) -> str:
+            if variable_name == "GIT_VERSION":
+                return self.git_client.get_commit_hash()
+            elif variable_name == "GIT_BRANCH":
+                return self.git_client.get_branch()
+            elif variable_name == "GIT_COMMIT_DATE":
+                return self.git_client.get_commit_date()
+            elif variable_name == "GIT_COMMIT_DATETIME":
+                return self.git_client.get_commit_datetime()
+            return variable_name
+
+        return interpolate_at_pattern_lazy(metada_value, resolver)
+
     def is_empty_tree(self) -> bool:
         return self.document_tree_iterator.is_empty_tree()
 

--- a/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
@@ -224,7 +224,9 @@ class DocumentScreenViewObject:
 
         return interpolate_at_pattern_lazy(self.document.config.date, resolver)
 
-    def render_metadata_value(self, metada_value:Optional[str]) -> Optional[str]:
+    def render_metadata_value(
+        self, metada_value: Optional[str]
+    ) -> Optional[str]:
         if metada_value is None:
             return ""
 


### PR DESCRIPTION
It would be useful for us to be able to include git info (commit, data, branch etc.) in document metadata when converting to pdf.

After digging around in the docs and source code it looks like this funcionality already existed in some capacity so I have repurposed that.

Let me know if anything needs changing!

This is a snippet from .jinja file used to test 

```
    {% if document_config.has_custom_metadata %}
    {% for key, value in document_config.get_custom_metadata() %}
    <sdoc-meta-label data-testid="document-config-metadata-label">{{key}}:</sdoc-meta-label>
    <sdoc-meta-field data-testid="document-config-metadata-field" style="min-height: 60px;">
      <sdoc-autogen>{{ value }}</sdoc-autogen>
    </sdoc-meta-field>
    {%- endif -%}
    
    {% endfor %}
```