### PR TITLE
feat(backend/sdoc): support SingleChoice values with parentheses

### DIFF
--- a/strictdoc/backend/sdoc/grammar/type_system.py
+++ b/strictdoc/backend/sdoc/grammar/type_system.py
@@ -4,7 +4,7 @@ BooleanChoice[noskipws]:
 ;
 
 ChoiceOption[noskipws]:
-  /[\w\/|-]+( *[\w\/|-]+)*/
+  /(["])[^,]+\1|[^,()"]+/
 ;
 
 ChoiceOptionXs[noskipws]:

--- a/strictdoc/backend/sdoc/models/grammar_element.py
+++ b/strictdoc/backend/sdoc/models/grammar_element.py
@@ -83,9 +83,23 @@ class GrammarElementFieldSingleChoice(GrammarElementField):
         self.title: str = title
         self.human_title: Optional[str] = human_title
         self.gef_type = RequirementFieldType.SINGLE_CHOICE
-        self.options: List[str] = options
+
+        processed_options = []
+        for option_ in options:
+            processed_options.append(option_.strip('"'))
+        self.options: List[str] = processed_options
+
         self.required: bool = required == "True"
         self.mid: MID = MID.create()
+
+    def get_unprocessed_options(self) -> List[str]:
+        unprocessed_options = []
+        for option_ in self.options:
+            if any(char_ in option_ for char_ in ["(", ")"]):
+                unprocessed_options.append('"' + option_ + '"')
+            else:
+                unprocessed_options.append(option_)
+        return unprocessed_options
 
 
 @auto_described

--- a/strictdoc/backend/sdoc/writer.py
+++ b/strictdoc/backend/sdoc/writer.py
@@ -458,7 +458,7 @@ class SDWriter:
         elif isinstance(grammar_field, GrammarElementFieldSingleChoice):
             output += RequirementFieldType.SINGLE_CHOICE
             output += "("
-            output += ", ".join(grammar_field.options)
+            output += ", ".join(grammar_field.get_unprocessed_options())
             output += ")"
         elif isinstance(grammar_field, GrammarElementFieldMultipleChoice):
             output += RequirementFieldType.MULTIPLE_CHOICE

--- a/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/31_custom_grammar_single_choice_type/sample.sdoc
+++ b/tests/integration/features/reqif/profiles/p01_sdoc/end_to_end/31_custom_grammar_single_choice_type/sample.sdoc
@@ -8,9 +8,13 @@ ELEMENTS:
   - TITLE: CHOICE_FIELD
     TYPE: SingleChoice(A, B, C, D)
     REQUIRED: False
+  - TITLE: CHOICE_FIELD_2
+    TYPE: SingleChoice("A(B)", "B(C)", "C(D)")
+    REQUIRED: False
   - TITLE: STATEMENT
     TYPE: String
     REQUIRED: False
 
 [REQUIREMENT]
 CHOICE_FIELD: A
+CHOICE_FIELD_2: A(B)


### PR DESCRIPTION
Based on feedback from a user who generates `SingleChoice` values through ReqIF from Polarion, the reported examples are: `A(B)`, `B(C)`, `C(D)`, etc.