### PR TITLE
fix(css): include svg selector for sdoc-autogen media

### DIFF
--- a/strictdoc/export/html/_static/autogen.css
+++ b/strictdoc/export/html/_static/autogen.css
@@ -136,10 +136,11 @@ sdoc-autogen dt ol {
 /* object */
 
 sdoc-autogen img,
+sdoc-autogen svg,
 sdoc-autogen object {
   max-width: 100%;
   height: auto;
-  padding: 1em;
+  padding: 1em 0;
   background: var(--color-bg-contrast);
 }
 


### PR DESCRIPTION
- include svg selector for sdoc-autogen media
- adjust padding so that the side borders are aligned with the main content

Closes  #2586
