### PR TITLE
feat(server, html2pdf): implement better error reporting when Chrome is not found

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dependencies = [
     "WebSockets",
 
     # HTML2PDF dependencies
-    "html2pdf4doc >= 0.0.23",
+    "html2pdf4doc >= 0.0.24",
 
     # Robot Framework dependencies
     "robotframework >= 4.0.0",


### PR DESCRIPTION


**WHAT:**

This change improves the error message when the StrictDoc web server cannot find a Chrome installation on the system it is running on.

**WHY:**

Before this change, the error message was a simple Internal Server Error without an explicit indication that the Chrome could not be found. A user would have to dig through the server logs to understand the issue.

**HOW:**

This integrates the upstream html2pdf4doc work where the error reporting was improved in the main.py driver program.

In particular, the driver now exits with a specific exit code `COULD_NOT_FIND_CHROME = 5` that we can rely on in StrictDoc to identify the missing Chrome issue.

https://github.com/strictdoc-project/html2pdf4doc_python/issues/58 https://github.com/strictdoc-project/html2pdf4doc_python/pull/70