### PR TITLE
fix(link_renderer): fix links between two included documents

### DIFF
--- a/strictdoc/export/html/renderers/link_renderer.py
+++ b/strictdoc/export/html/renderers/link_renderer.py
@@ -108,7 +108,10 @@ class LinkRenderer:
             return f"#{local_link}"
 
         including_document = node.get_including_document()
-        if including_document is not None:
+        if (
+            including_document is not None
+            and including_document == context_document
+        ):
             return f"#{local_link}"
 
         if allow_local and context_document is not None:

--- a/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/00_sys/_index.sdoc
+++ b/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/00_sys/_index.sdoc
@@ -1,0 +1,26 @@
+[DOCUMENT]
+TITLE: System Requirements
+VERSION: 0.0.1
+PREFIX: SYS-
+ROOT: True
+
+[GRAMMAR]
+IMPORT_FROM_FILE: _sys_grammar.sgra
+
+[[SECTION]]
+TITLE: System Requirements
+
+[[SECTION]]
+TITLE: General Requirements
+
+[[SECTION]]
+TITLE: Dummy
+
+[DOCUMENT_FROM_FILE]
+FILE: dummy.sdoc
+
+[[/SECTION]]
+
+[[/SECTION]]
+
+[[/SECTION]]

--- a/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/00_sys/_sys_grammar.sgra
+++ b/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/00_sys/_sys_grammar.sgra
@@ -1,0 +1,37 @@
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: True
+  - TITLE: STATUS
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TYPE
+    TYPE: SingleChoice(Functional, Non-Functional)
+    REQUIRED: True
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True

--- a/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/00_sys/dummy.sdoc
+++ b/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/00_sys/dummy.sdoc
@@ -1,0 +1,13 @@
+[DOCUMENT]
+TITLE: Dummy Document
+REQ_PREFIX: SYS-Dummy-
+
+[GRAMMAR]
+IMPORT_FROM_FILE: _sys_grammar.sgra
+
+[REQUIREMENT]
+UID: SYS-Some-Requirement
+TYPE: Functional
+STATEMENT: >>>
+System Requirement Text
+<<<

--- a/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/01_srs/_index.sdoc
+++ b/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/01_srs/_index.sdoc
@@ -1,0 +1,16 @@
+[DOCUMENT]
+TITLE: Software Requirements Specification.
+VERSION: 0.0.1
+PREFIX: SRS-
+ROOT: False
+
+[GRAMMAR]
+IMPORT_FROM_FILE: _srs_grammar.sgra
+
+[[SECTION]]
+TITLE: Software Requirements
+
+[DOCUMENT_FROM_FILE]
+FILE: dummy.sdoc
+
+[[/SECTION]]

--- a/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/01_srs/_srs_grammar.sgra
+++ b/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/01_srs/_srs_grammar.sgra
@@ -1,0 +1,46 @@
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: True
+  - TITLE: KEYWORDS
+    TYPE: Tag
+    REQUIRED: False
+  - TITLE: STATUS
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TYPE
+    TYPE: SingleChoice(Functional, Non-Functional)
+    REQUIRED: True
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+  - TITLE: NOTE
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+    ROLE: DECOMPOSED_FROM

--- a/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/01_srs/dummy.sdoc
+++ b/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/01_srs/dummy.sdoc
@@ -1,0 +1,30 @@
+[DOCUMENT]
+TITLE: Dummy Software Requirements
+REQ_PREFIX: SRS-Dummy-
+
+[GRAMMAR]
+IMPORT_FROM_FILE: _srs_grammar.sgra
+
+[TEXT]
+STATEMENT: >>>
+Just some normal text.
+<<<
+
+[REQUIREMENT]
+UID: SRS-Dummy-Requirement_1
+TYPE: Functional
+STATEMENT: >>>
+Software Requirement Text.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SYS-Some-Requirement
+  ROLE: DECOMPOSED_FROM
+
+[REQUIREMENT]
+UID: SRS-Dummy-Requirement_2
+KEYWORDS: Derived
+TYPE: Functional
+STATEMENT: >>>
+Derived Software Requirement Text.
+<<<

--- a/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/pyproject.toml
+++ b/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/pyproject.toml
@@ -1,0 +1,25 @@
+
+[project]
+name = "Documentation"
+version = "0.1.0"
+description = "Product Life-Cycle Documentation based on strict-doc"
+dependencies = [
+    "strictdoc==0.15.2",
+    "html2pdf4doc==0.0.23", # doesn't work on ARM
+    "selenium>=4.39.0",
+]
+readme = "readme.md"
+requires-python = ">= 3.11"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"] # dummy/unused
+
+[tool.uv]
+managed = true

--- a/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/strictdoc.toml
+++ b/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/strictdoc.toml
@@ -1,0 +1,22 @@
+[project]
+title = "Documentation"
+# html_assets_strictdoc_dir = "assets"
+
+features = [
+#    # Stable features that should be enabled by default.
+#    "TABLE_SCREEN",
+#    "TRACEABILITY_SCREEN",
+#    "DEEP_TRACEABILITY_SCREEN",
+#
+#    # Stable features that are disabled by default.
+#    "MATHJAX",
+#    "SEARCH",
+
+    # Experimental features are disabled by default.
+    # "REQIF",
+    # "HTML2PDF", # this would require chromium to be installed, which doesn't exist on ARM
+    # "PROJECT_STATISTICS_SCREEN",
+    # "STANDALONE_DOCUMENT_SCREEN",
+    # "TRACEABILITY_MATRIX_SCREEN",
+    # "REQUIREMENT_TO_SOURCE_TRACEABILITY"
+]

--- a/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/test.itest
+++ b/tests/integration/features/document_fragments/60_relations_between_nodes_in_included_documents/test.itest
@@ -1,0 +1,8 @@
+RUN: %strictdoc --debug export %S --output-dir %T | filecheck %s
+CHECK: Published: System Requirements
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/00_sys/_index.html | filecheck %s --check-prefix CHECK-SYS
+CHECK-SYS: href="../../60_relations_between_nodes_in_included_documents/01_srs/_index.html#SRS-Dummy-Requirement_1">
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/01_srs/_index.html | filecheck %s --check-prefix CHECK-SRS
+CHECK-SRS: href="../../60_relations_between_nodes_in_included_documents/00_sys/_index.html#SYS-Some-Requirement">


### PR DESCRIPTION
WHAT:

This change fixes a regression introduced by this commit: https://github.com/strictdoc-project/strictdoc/commit/ec4d95c6b52fbf38fc4550432fbe2e3658490489.

WHY:

A bug report by a user who discovered the regression: #2595.

HOW:

With this fix, the case of one included document node linking to another included document node is now handled by not letting the code to enter the local-only path with `return f"#{local_link}"`. If the link renderer now sees this case, it will not return early but generate a proper full relative path to the target document node.

Closes #2595