### PR TITLE
fix(pyproject.toml): pin the html2pdf4doc dependency to the latest version

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -61,6 +61,8 @@ This release contains the following enhancements and fixes:
 3) The Link Renderer class was fixed to resolve the links between two including documents. This behavior had been implemented correctly but was broken due to the recent HTML2PDF-related adjustments, and there were no tests to catch the regression. Thanks to @lmapii for reporting this.
 
 4) The document metadata has been extended to recognize reserved macros such as ``@GIT_VERSION`` and ``@GIT_BRANCH``. Previously, these macros were recognized only when added as part of the document's ``VERSION`` and ``DATE`` fields. Now it is possible to use them with any user-defined metadata field. Thanks to @xw-mk for contributing the patch with this improvement.
+
+5) The html2pdf4doc dependency was changed to be exact-pinned with == instead of >=. A user reported that they are using an older version of StrictDoc that relies on the older html2pdf4doc API. There is a reason why they cannot migrate to the latest version of StrictDoc, so to support their use case, StrictDoc should have an exact version pinning to avoid html2pdf4doc running away from what the older StrictDoc versions can support.
 <<<
 
 [[/SECTION]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dependencies = [
     "WebSockets",
 
     # HTML2PDF dependencies
-    "html2pdf4doc >= 0.0.24",
+    "html2pdf4doc == 0.0.25",
 
     # Robot Framework dependencies
     "robotframework >= 4.0.0",


### PR DESCRIPTION


WHAT:

This change stops using >= for html2pdf4doc and switches to the exact version pinning with ==.

WHY:

A user reported that they are using an older version of StrictDoc that relies on the older html2pdf4doc API. There is a reason why they cannot migrate to the latest version of StrictDoc, so to support their use case, StrictDoc should have an exact version pinning to avoid html2pdf4doc running away from what the older StrictDoc versions can support.

HOW: -