### PR TITLE
refactor(export/html): get html2pdf classes from view object, not Jinja

### DIFF
--- a/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
@@ -415,3 +415,27 @@ class DocumentScreenViewObject:
         if node.reserved_mid is not None and node.mid_permanent:
             return base_url + "#" + node.reserved_mid
         return base_url
+
+    def get_html2pdf_classes(self, node: SDocNode) -> str:
+        """
+        Get CSS classes for html2pdf4doc for a given node.
+
+        html2pdf4doc rules for `Narrative` requirement style:
+        * If no multi-line content:
+            the node is not split at all (with or without a title)
+            -> add .html2pdf4doc-no-break to node.
+         * ASSUMPTION:
+            We assume that the number of single-line strings is no greater
+            than the height of the page
+
+        FIXME: Review this rules after upgrading html2pdf4doc to 0.2.4+
+        """
+
+        assert isinstance(node, SDocNode), node
+
+        user_requirement_style = node.get_requirement_style_mode()
+        if user_requirement_style == "narrative":
+            has_multiline_fields = node.has_multiline_fields()
+            if not has_multiline_fields:
+                return "html2pdf4doc-no-break"
+        return ""

--- a/strictdoc/export/html/generators/view_objects/source_file_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/source_file_view_object.py
@@ -229,3 +229,13 @@ class SourceFileViewObject:
         total = len(self.trace_info.functions)
         percentage = (covered / total * 100) if total > 0 else 0
         return f"{covered} / {total} ({percentage:.1f}%)"
+
+    def get_html2pdf_classes(self, node: SDocNode) -> str:  # noqa: ARG002
+        """
+        This view object class is coupled with the HTML2PDF-related template
+        logic.
+
+        The Source File View is not printed with HTML2PDF, so we keep its classes
+        to noop.
+        """
+        return ""

--- a/strictdoc/export/html/templates/components/node/readonly.jinja
+++ b/strictdoc/export/html/templates/components/node/readonly.jinja
@@ -2,34 +2,17 @@
 
 {% set node_type_string = sdoc_entity.get_node_type_string() %}
 
-{#
-  dev tag: #narrative_meta_hanging
-
-  Html2pdf4doc rules for `Narrative` requirement style:
-  * If no multi-line content:
-    the node is not split at all (with or without a title)
-    -> add .html2pdf4doc-no-break to node.
-  * PROBLEM:
-    We assume that the number of single-line strings is no greater than the height of the page
-
-  FIXME: Review this rules after upgrading html2pdf4doc to 0.2.4+
-#}
-{% set _user_requirement_style = sdoc_entity.get_requirement_style_mode() %}
-{% set _has_multiline_fields = sdoc_entity.has_multiline_fields() %}
-{% set _narrative_has_no_multiline_fields = not _has_multiline_fields and _user_requirement_style == 'narrative' %}
-
   <sdoc-node
     node-style="readonly"
     node-role="{{ sdoc_entity.get_type_string() }}"
     {%- if node_type_string is not none %}
       show-node-type-name="{{ node_type_string }}"
     {%- endif %}
-    {% if sdoc_entity.is_requirement %}
-      node-view="{{ _user_requirement_style }}"
+    {# FIXME: Is this template always called on SDocNode? Can this check be removed? #}
+    {% if sdoc_entity.is_requirement() %}
+      node-view="{{ sdoc_entity.get_requirement_style_mode() }}"
     {%- endif -%}
-    {%- if _narrative_has_no_multiline_fields %}
-      class="html2pdf4doc-no-break"
-    {%- endif %}
+    class="{{ view_object.get_html2pdf_classes(sdoc_entity) }}"
     data-testid="node-{{ sdoc_entity.get_type_string() }}"
   >
 

--- a/strictdoc/export/html/templates/components/node_content/index.jinja
+++ b/strictdoc/export/html/templates/components/node_content/index.jinja
@@ -15,27 +15,9 @@
     can be overridden when calling a template,
     e.g. cards only use a 'simple' node-view.
 #}
+
 {% set user_requirement_style = sdoc_entity.get_requirement_style_mode() %}
-
-{#
-  dev tag: #narrative_meta_hanging
-
-  Html2pdf4doc rules for `Narrative` requirement style:
-  * If no title:
-    “meta” does not hang
-    -> add .html2pdf4doc-no-hanging to .node_fields_group-secondary.
-  * If no multi-line content:
-    the node is not split at all (with or without a title)
-    -> add .html2pdf4doc-no-break to node.
-  * PROBLEM:
-    We assume that the number of single-line strings is no greater than the height of the page
-
-  FIXME: Review this rules after upgrading html2pdf4doc to 0.2.4+
-#}
-{% set _no_title = not sdoc_entity.reserved_title %}
-{% set _has_multiline_fields = sdoc_entity.has_multiline_fields() %}
-{% set _narrative_has_multiline_fields = _has_multiline_fields and user_requirement_style == 'narrative' %}
-{% set _narrative_has_no_multiline_fields = not _has_multiline_fields and user_requirement_style == 'narrative' %}
+{% set _narrative_has_multiline_fields = sdoc_entity.has_multiline_fields() and user_requirement_style == 'narrative' %}
 
 {{ view_object.render_issues(node) }}
 
@@ -45,9 +27,6 @@
   {%- if sdoc_entity.reserved_status %}
     data-status='{{ sdoc_entity.reserved_status.lower() }}'
   {%- endif %}
-  {%- if _narrative_has_no_multiline_fields %}
-    class="html2pdf4doc-no-break"
-  {%- endif %}
   show-node-type-name="{{ sdoc_entity.get_node_type_string() }}"
   data-testid="requirement-style-{{ requirement_style|d(sdoc_entity.get_requirement_style_mode()) }}"
 >
@@ -56,7 +35,11 @@
   {% include "components/node_field/title/index.jinja" %}
 
   {% if user_requirement_style == 'narrative' %}
-    <sdoc-scope class="node_fields_group-secondary{% if _no_title %} html2pdf4doc-no-hanging{% endif %}">
+    {#
+      If no title, "meta" must not hang, therefore:
+          add .html2pdf4doc-no-hanging to .node_fields_group-secondary.
+    #}
+    <sdoc-scope class="node_fields_group-secondary{% if not sdoc_entity.reserved_title %} html2pdf4doc-no-hanging{% endif %}">
       {% include "components/node_field/meta/index.jinja" %}
       {% include "components/node_field/links/index.jinja" %}
       {% include "components/node_field/files/index.jinja" %}


### PR DESCRIPTION
WHAT:

This extracts the logic for building html2pdf4doc classes into DocumentViewObject.

Also, we found an opportunity to remove the setting of html2pdf4doc classes in the template: `components/node_content/index.jinja` because that logic is not needed anymore.

WHY:

We want to avoid programming logic and control flow in Jinja. Python does this much better.

We are planning to add more logic for customizing the html2pdf4doc control classes, and doing this in Python will be much easier.

HOW:

- All Jinja logic has been moved to Python.