### PR TITLE
feat(pyproject.toml): update html2pdf4doc to latest version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dependencies = [
     "WebSockets",
 
     # HTML2PDF dependencies
-    "html2pdf4doc == 0.0.25",
+    "html2pdf4doc == 0.0.28",
 
     # Robot Framework dependencies
     "robotframework >= 4.0.0",

--- a/strictdoc/export/html/templates/screens/document/pdf/main.jinja
+++ b/strictdoc/export/html/templates/screens/document/pdf/main.jinja
@@ -5,7 +5,7 @@
   class="main"
 >
       <div
-        html2pdf
+        html2pdf4doc
         class="content"
       >
         {#-

--- a/strictdoc/export/html/templates/screens/document/pdf/template/footer.jinja
+++ b/strictdoc/export/html/templates/screens/document/pdf/template/footer.jinja
@@ -24,10 +24,10 @@ html2pdf-footer {
   text-indent: -10000px;
 }
 </style>
-<template html2pdf-footer>
-  {#- uncomment html2pdf-page-number to print page numbers: -#}
-  <div html2pdf-page-number>
-    <span html2pdf-page-number-current></span>/<span html2pdf-page-number-total></span>
+<template html2pdf4doc-footer>
+  {#- uncomment html2pdf4doc-page-number to print page numbers: -#}
+  <div html2pdf4doc-page-number>
+    <span html2pdf4doc-page-number-current></span>/<span html2pdf4doc-page-number-total></span>
   </div>
   {# TODO: improve page number system #}
 

--- a/strictdoc/export/html/templates/screens/document/pdf/template/frontpage.jinja
+++ b/strictdoc/export/html/templates/screens/document/pdf/template/frontpage.jinja
@@ -15,7 +15,7 @@
   align-items: flex-end;
 }
 </style>
-<template html2pdf-frontpage>
+<template html2pdf4doc-frontpage>
   {#- add here frontpage html -#}
   <div class="html2pdf-frontpage-grid">
   <div class="html2pdf-frontpage-grid-top"></div>

--- a/strictdoc/export/html/templates/screens/document/pdf/template/header.jinja
+++ b/strictdoc/export/html/templates/screens/document/pdf/template/header.jinja
@@ -22,10 +22,10 @@ html2pdf-header {
   font-weight: bold;
 }
 </style>
-<template html2pdf-header>
-  {#- uncomment html2pdf-page-number to print page numbers: -#}
-  {#- <div html2pdf-page-number>
-    <span html2pdf-page-number-current></span>/<span html2pdf-page-number-total></span>
+<template html2pdf4doc-header>
+  {#- uncomment html2pdf4doc-page-number to print page numbers: -#}
+  {#- <div html2pdf4doc-page-number>
+    <span html2pdf4doc-page-number-current></span>/<span html2pdf4doc-page-number-total></span>
   </div> -#}
 
   {#- add here header html: -#}

--- a/tests/end2end/screens/pdf/view_pdf_document_custom_template/html2pdf_template/index.jinja
+++ b/tests/end2end/screens/pdf/view_pdf_document_custom_template/html2pdf_template/index.jinja
@@ -34,7 +34,7 @@ Notes:
   align-items: flex-end;
 }
 </style>
-<template html2pdf-frontpage>
+<template html2pdf4doc-frontpage>
   {#- add here frontpage html -#}
   <div class="html2pdf-frontpage-grid">
   <div class="html2pdf-frontpage-grid-top">  </div>
@@ -146,10 +146,10 @@ html2pdf-header {
   font-weight: bold;
 }
 </style>
-<template html2pdf-header>
-  {#- uncomment html2pdf-page-number to print page numbers: -#}
-  {#- <div html2pdf-page-number>
-    <span html2pdf-page-number-current></span>/<span html2pdf-page-number-total></span>
+<template html2pdf4doc-header>
+  {#- uncomment html2pdf4doc-page-number to print page numbers: -#}
+  {#- <div html2pdf4doc-page-number>
+    <span html2pdf4doc-page-number-current></span>/<span html2pdf4doc-page-number-total></span>
   </div> -#}
 
   {#- add here header html: -#}
@@ -192,10 +192,10 @@ html2pdf-footer {
   text-indent: -10000px;
 }
 </style>
-<template html2pdf-footer>
-  {#- uncomment html2pdf-page-number to print page numbers: -#}
-  <div html2pdf-page-number>
-    <span html2pdf-page-number-current></span>/<span html2pdf-page-number-total></span>
+<template html2pdf4doc-footer>
+  {#- uncomment html2pdf4doc-page-number to print page numbers: -#}
+  <div html2pdf4doc-page-number>
+    <span html2pdf4doc-page-number-current></span>/<span html2pdf4doc-page-number-total></span>
   </div>  
   {#- add here footer html -#}
   <div class="html2pdf-footer">


### PR DESCRIPTION
WHAT:

This brings in:

- https://github.com/strictdoc-project/html2pdf4doc_python/releases/tag/0.0.26
- https://github.com/strictdoc-project/html2pdf4doc_python/releases/tag/0.0.28

and contains a minor change: the printable area is now specified with `html2pdf4doc`, not `html2pdf`.

WHY:

This fixes:

- The image scaling issue.
- The page breaks issues discussed in https://github.com/strictdoc-project/strictdoc/discussions/2593.

HOW:

N/A