### PR TITLE
chore(tests/end2end): remove checking of 404 errors

### DIFF
--- a/tests/end2end/helpers/screens/project_index/screen_project_index.py
+++ b/tests/end2end/helpers/screens/project_index/screen_project_index.py
@@ -35,10 +35,9 @@ class Screen_ProjectIndex:  # pylint: disable=invalid-name
             by=By.XPATH,
         )
         self.test_case.wait_for_ready_state_complete()
-        self.assert_no_js_and_404_errors()
+        self.assert_no_js_errors()
 
-    def assert_no_js_and_404_errors(self) -> None:
-        self.test_case.assert_no_404_errors()
+    def assert_no_js_errors(self) -> None:
         self.test_case.assert_no_js_errors()
 
     def assert_header_project_name(self, project_title: str) -> None:

--- a/tests/end2end/helpers/screens/project_statistics/project_statistics.py
+++ b/tests/end2end/helpers/screens/project_statistics/project_statistics.py
@@ -21,8 +21,7 @@ class Screen_ProjectStatistics:  # pylint: disable=invalid-name
             by=By.XPATH,
         )
         self.test_case.wait_for_ready_state_complete()
-        self.assert_no_js_and_404_errors()
+        self.assert_no_js_errors()
 
-    def assert_no_js_and_404_errors(self) -> None:
-        self.test_case.assert_no_404_errors()
+    def assert_no_js_errors(self) -> None:
         self.test_case.assert_no_js_errors()

--- a/tests/end2end/helpers/screens/screen.py
+++ b/tests/end2end/helpers/screens/screen.py
@@ -15,8 +15,7 @@ class Screen:  # pylint: disable=invalid-name, too-many-public-methods
         assert isinstance(test_case, BaseCase)
         self.test_case: BaseCase = test_case
 
-    def assert_no_js_and_404_errors(self) -> None:
-        self.test_case.assert_no_404_errors()
+    def assert_no_js_errors(self) -> None:
         self.test_case.assert_no_js_errors()
 
     def assert_text(self, text: str) -> None:

--- a/tests/end2end/helpers/screens/source_coverage/screen_source_coverage.py
+++ b/tests/end2end/helpers/screens/source_coverage/screen_source_coverage.py
@@ -17,7 +17,7 @@ class Screen_SourceCoverage:
             by=By.XPATH,
         )
         self.test_case.wait_for_ready_state_complete()
-        self.assert_no_js_and_404_errors()
+        self.assert_no_js_errors()
 
     def assert_contains_text(self, text) -> None:
         self.test_case.assert_element(
@@ -25,8 +25,7 @@ class Screen_SourceCoverage:
             by=By.XPATH,
         )
 
-    def assert_no_js_and_404_errors(self) -> None:
-        self.test_case.assert_no_404_errors()
+    def assert_no_js_errors(self) -> None:
         self.test_case.assert_no_js_errors()
 
     def do_click_on_file(self, file: str) -> Screen_SourceFileCoverage:

--- a/tests/end2end/helpers/screens/source_file_coverage/screen_source_file_coverage.py
+++ b/tests/end2end/helpers/screens/source_file_coverage/screen_source_file_coverage.py
@@ -13,7 +13,7 @@ class Screen_SourceFileCoverage:
             by=By.XPATH,
         )
         self.test_case.wait_for_ready_state_complete()
-        self.assert_no_js_and_404_errors()
+        self.assert_no_js_errors()
 
     def assert_contains_text(self, text) -> None:
         self.test_case.assert_element(
@@ -21,6 +21,5 @@ class Screen_SourceFileCoverage:
             by=By.XPATH,
         )
 
-    def assert_no_js_and_404_errors(self) -> None:
-        self.test_case.assert_no_404_errors()
+    def assert_no_js_errors(self) -> None:
         self.test_case.assert_no_js_errors()

--- a/tests/end2end/helpers/screens/traceability_matrix/screen_requirements_coverage.py
+++ b/tests/end2end/helpers/screens/traceability_matrix/screen_requirements_coverage.py
@@ -13,8 +13,7 @@ class Screen_RequirementsCoverage:
             by=By.XPATH,
         )
         self.test_case.wait_for_ready_state_complete()
-        self.assert_no_js_and_404_errors()
+        self.assert_no_js_errors()
 
-    def assert_no_js_and_404_errors(self) -> None:
-        self.test_case.assert_no_404_errors()
+    def assert_no_js_errors(self) -> None:
         self.test_case.assert_no_js_errors()

--- a/tests/end2end/helpers/screens/tree_map/tree_map.py
+++ b/tests/end2end/helpers/screens/tree_map/tree_map.py
@@ -13,7 +13,7 @@ class Screen_TreeMap:
             by=By.XPATH,
         )
         self.test_case.wait_for_ready_state_complete()
-        self.assert_no_js_and_404_errors()
+        self.assert_no_js_errors()
 
     def assert_contains_text(self, text) -> None:
         self.test_case.assert_element(
@@ -21,6 +21,5 @@ class Screen_TreeMap:
             by=By.XPATH,
         )
 
-    def assert_no_js_and_404_errors(self) -> None:
-        self.test_case.assert_no_404_errors()
+    def assert_no_js_errors(self) -> None:
         self.test_case.assert_no_js_errors()

--- a/tests/end2end/project_options/features/01_features_option_specified/test_case.py
+++ b/tests/end2end/project_options/features/01_features_option_specified/test_case.py
@@ -24,4 +24,4 @@ class Test(E2ECase):
             screen_project_index.assert_link_to_requirements_coverage_present()
             screen_project_index.assert_link_to_source_coverage_present()
 
-            screen_project_index.assert_no_js_and_404_errors()
+            screen_project_index.assert_no_js_errors()

--- a/tests/end2end/project_options/html_assets_strictdoc_dir/01_option_specified_project_index/test_01_option_specified.py
+++ b/tests/end2end/project_options/html_assets_strictdoc_dir/01_option_specified_project_index/test_01_option_specified.py
@@ -20,4 +20,4 @@ class Test_ProjectOptions_HTMLAssetsStrictDocDir_01_OptionSpecified_ProjectIndex
 
             screen_project_index = Screen_ProjectIndex(self)
             screen_project_index.assert_on_screen()
-            screen_project_index.assert_no_js_and_404_errors()
+            screen_project_index.assert_no_js_errors()

--- a/tests/end2end/project_options/html_assets_strictdoc_dir/02_option_specified_document/test_02_option_specified_document.py
+++ b/tests/end2end/project_options/html_assets_strictdoc_dir/02_option_specified_document/test_02_option_specified_document.py
@@ -25,4 +25,4 @@ class Test_ProjectOptions_HTMLAssetsStrictDocDir_02_OptionSpecified_Document(
 
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
-            screen_document.assert_no_js_and_404_errors()
+            screen_document.assert_no_js_errors()

--- a/tests/end2end/project_options/html_assets_strictdoc_dir/03_option_specified_requirements_coverage/test_03_option_specified_requirements_coverage.py
+++ b/tests/end2end/project_options/html_assets_strictdoc_dir/03_option_specified_requirements_coverage/test_03_option_specified_requirements_coverage.py
@@ -30,4 +30,4 @@ class Test_ProjectOptions_HTMLAssetsStrictDocDir_03_OptionSpecified_Requirements
                 screen_project_index.do_click_on_requirements_coverage_link()
             )
             screen_requirements_coverage.assert_on_screen()
-            screen_requirements_coverage.assert_no_js_and_404_errors()
+            screen_requirements_coverage.assert_no_js_errors()

--- a/tests/end2end/screens/deep_traceability/view_document/view_document_statement_with_inline_csv_table/test_case.py
+++ b/tests/end2end/screens/deep_traceability/view_document/view_document_statement_with_inline_csv_table/test_case.py
@@ -37,7 +37,7 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
             screen_document.assert_not_empty_document()
 
-            screen_document.assert_no_js_and_404_errors()
+            screen_document.assert_no_js_errors()
 
             viewtype_selector = ViewType_Selector(self)
             screen_deep_traceability = (

--- a/tests/end2end/screens/document/create_requirement/create_requirement_with_rst_image/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/create_requirement_with_rst_image/test_case.py
@@ -45,6 +45,6 @@ class Test_UC03_T09_CreateSectionWithRSTImage(E2ECase):
             )
             form_edit_requirement.do_form_submit()
 
-            screen_document.assert_no_js_and_404_errors()
+            screen_document.assert_no_js_errors()
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/create_requirement/create_requirement_with_rst_wildcard_image/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/create_requirement_with_rst_wildcard_image/test_case.py
@@ -45,6 +45,6 @@ class Test_UC03_T09_CreateSectionWithRSTImage(E2ECase):
             )
             form_edit_requirement.do_form_submit()
 
-            screen_document.assert_no_js_and_404_errors()
+            screen_document.assert_no_js_errors()
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/view_document/view_document_display_png_image/test_case.py
+++ b/tests/end2end/screens/document/view_document/view_document_display_png_image/test_case.py
@@ -31,4 +31,4 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
             screen_document.assert_not_empty_document()
 
-            screen_document.assert_no_js_and_404_errors()
+            screen_document.assert_no_js_errors()

--- a/tests/end2end/screens/document/view_document/view_document_display_rst_directive_wildcard_image/test_case.py
+++ b/tests/end2end/screens/document/view_document/view_document_display_rst_directive_wildcard_image/test_case.py
@@ -31,4 +31,4 @@ class Test_UC01_T05_DisplayRSTDirectiveWildcardImage(E2ECase):
             screen_document.assert_header_document_title("Document 1")
             screen_document.assert_not_empty_document()
 
-            screen_document.assert_no_js_and_404_errors()
+            screen_document.assert_no_js_errors()

--- a/tests/end2end/screens/document/view_document/view_document_display_rst_directive_wildcard_image_nested_dir/test_case.py
+++ b/tests/end2end/screens/document/view_document/view_document_display_rst_directive_wildcard_image_nested_dir/test_case.py
@@ -31,4 +31,4 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
             screen_document.assert_not_empty_document()
 
-            screen_document.assert_no_js_and_404_errors()
+            screen_document.assert_no_js_errors()

--- a/tests/end2end/screens/document/view_document/view_document_display_svg_image/test_case.py
+++ b/tests/end2end/screens/document/view_document/view_document_display_svg_image/test_case.py
@@ -31,4 +31,4 @@ class Test(E2ECase):
             screen_document.assert_header_document_title("Document 1")
             screen_document.assert_not_empty_document()
 
-            screen_document.assert_no_js_and_404_errors()
+            screen_document.assert_no_js_errors()

--- a/tests/end2end/screens/standalone_document/view_standalone_document/view_standalone_document_basic/test_case.py
+++ b/tests/end2end/screens/standalone_document/view_standalone_document/view_standalone_document_basic/test_case.py
@@ -34,4 +34,4 @@ class Test(E2ECase):
             )
             screen_standalone_document.assert_on_standalone_screen_document()
             screen_standalone_document.assert_not_empty_document()
-            screen_standalone_document.assert_no_js_and_404_errors()
+            screen_standalone_document.assert_no_js_errors()


### PR DESCRIPTION
WHAT: This removes the checking for 404 errors in the end2end tests.

WHY: This causes too many false positives when GitHub responds 404 for properly existing StrictDoc release links.

HOW: N/A