### PR TITLE
feat(html2pdf): bring in latest html2pdf with API backwards-compatibility fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dependencies = [
     "WebSockets",
 
     # HTML2PDF dependencies
-    "html2pdf4doc == 0.0.28",
+    "html2pdf4doc == 0.0.30",
 
     # Robot Framework dependencies
     "robotframework >= 4.0.0",

--- a/tests/integration/features/html2pdf/02_three_top_level_requirements/test_pdf.py
+++ b/tests/integration/features/html2pdf/02_three_top_level_requirements/test_pdf.py
@@ -8,5 +8,71 @@ reader = PdfReader("Output/html2pdf/pdf/input.pdf")
 
 assert len(reader.pages) == 3, reader.pages
 
-page2_text = reader.pages[1].extract_text()
-assert "Table of contents" in page2_text
+page1_text_normalized = (
+    reader.pages[0].extract_text()
+)
+assert (
+        page1_text_normalized
+        == """\
+Dummy Software Requirements
+Speciﬁcation #1
+Untitled Project Dummy Software Requirements Speciﬁcation #1
+2025-12-23 1/3\
+"""
+), page1_text_normalized
+
+
+page2_text_normalized = (
+    reader.pages[1].extract_text()
+)
+assert (
+        page2_text_normalized
+        == """\
+Table of contents
+1 3
+2 3
+3 3
+Dummy high-level requirement #1
+Dummy high-level requirement #2
+Dummy high-level requirement #3
+Untitled Project Dummy Software Requirements Speciﬁcation #1
+2025-12-23 2/3\
+"""
+), page2_text_normalized
+
+
+page3_text_normalized = (
+    reader.pages[2].extract_text()
+    .replace("R E Q-", "R E Q -")
+)
+assert (
+        page3_text_normalized
+        == """\
+REQUIREMENT
+1. Dummy high-level requirement #1
+M I D :
+c 1 6 5 c c 5 2 a f2 0 4 1 7 e 9 1 9 9 e 3 0 a 4 e 1 7 f1 3 8
+U I D :
+R E Q - 1
+S T A T E M E N T :
+System ABC shall do 1.
+REQUIREMENT
+2. Dummy high-level requirement #2
+M I D :
+7 4 d d d c 4 c 5 5 a c 4 4 a e 8 3 d c 0 f7 3 e f8 e d 2 a a
+U I D :
+R E Q - 2
+S T A T E M E N T :
+System ABC shall do 2.
+REQUIREMENT
+3. Dummy high-level requirement #3
+M I D :
+fc b c e 0 c 4 8 6 a c 4 d 3 1 8 9 a 7 a a 1 d d 6 4 6 3 9 9 e
+U I D :
+R E Q - 3
+S T A T E M E N T :
+System ABC shall do 3.
+Untitled Project Dummy Software Requirements Speciﬁcation #1
+2025-12-23 3/3\
+"""
+), page3_text_normalized


### PR DESCRIPTION
WHAT:

This brings in the API backwards- compatibility fixes from the upstream html2pdf4doc:

https://github.com/strictdoc-project/html2pdf4doc_python/releases/tag/0.0.30 https://github.com/strictdoc-project/html2pdf4doc_python/releases/tag/0.0.28

As part of this change, one integration test updated to do more precise matching of resulting PDF text to better catch API regressions in the future.

WHY:

We want to preserve the backward compatibility with the older html2pdf4doc API where the main "print this area" attribute was "html2pdf" not "html2pdf4doc".

HOW: -