### PR TITLE
fix(helpers/path_filter): add space character to the regex mask

### DIFF
--- a/strictdoc/helpers/path_filter.py
+++ b/strictdoc/helpers/path_filter.py
@@ -1,7 +1,7 @@
 import re
 from typing import List
 
-REGEX_NAME_PART = r"[A-Za-z0-9-_\.]+"
+REGEX_NAME_PART = r"[A-Za-z0-9-_\. ]+"
 REGEX_FILENAME = rf"{REGEX_NAME_PART}"
 REGEX_FOLDER = rf"{REGEX_NAME_PART}"
 

--- a/tests/unit/strictdoc/core/test_file_tree.py
+++ b/tests/unit/strictdoc/core/test_file_tree.py
@@ -135,3 +135,46 @@ def test_53_both_include_and_exclude_paths():
         found_file2 = folder.files[1]
         assert isinstance(found_file2, File)
         assert found_file2.full_path == path_to_file2
+
+
+def test_54_exclude_paths():
+    """
+    Verify that spaces in filenames have no effect on the exclusion/inclusion
+    of files.
+
+    This test ensures a proper fix for the issue reported in:
+    https://github.com/strictdoc-project/strictdoc/issues/2594
+    """
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        path_to_file1 = os.path.join(tmp_dir, "file1.py")
+        path_to_file2 = os.path.join(tmp_dir, "file2.py")
+        path_to_file3 = os.path.join(tmp_dir, "dev/file 3.log")
+
+        Path(path_to_file3).parent.mkdir(parents=True, exist_ok=True)
+
+        Path(path_to_file1).touch()
+        Path(path_to_file2).touch()
+        Path(path_to_file3).touch()
+
+        file_tree = FileFinder.find_files_with_extensions(
+            root_path=tmp_dir,
+            ignored_dirs=[],
+            extensions=[".py", ".log"],
+            include_paths=[],
+            exclude_paths=["**/*.log"],
+        )
+
+        assert isinstance(file_tree, FileTree)
+        assert isinstance(file_tree.root_folder_or_file, Folder)
+
+        folder: Folder = file_tree.root_folder_or_file
+        assert folder.full_path == tmp_dir
+        assert len(folder.files) == 2
+
+        # Verify that the .log file is not found.
+        assert len(folder.subfolder_trees) == 1, folder.subfolder_trees
+        subfolder = folder.subfolder_trees[0]
+        assert subfolder.full_path == os.path.join(tmp_dir, "dev")
+        assert len(subfolder.files) == 0
+        assert len(subfolder.subfolder_trees) == 0


### PR DESCRIPTION
WHAT:

Add the space character to the path filter regex mask. This change allows the include/exclude filters to correctly handle file names that contain spaces.

WHY:

This fixes a bug reported by a user: https://github.com/strictdoc-project/strictdoc/issues/2594
