### PR TITLE
feat(pyproject.toml): html2pdf4doc: bring in the SDoc RST admonitions fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dependencies = [
     "WebSockets",
 
     # HTML2PDF dependencies
-    "html2pdf4doc == 0.0.30",
+    "html2pdf4doc == 0.0.31",
 
     # Robot Framework dependencies
     "robotframework >= 4.0.0",


### PR DESCRIPTION

WHAT:

Brings in: https://github.com/strictdoc-project/html2pdf4doc_python/pull/84.

The most important change is a fix for StrictDoc admonition styles that were not fully covered by the page-to-page mask.

WHY:

Solves a StrictDoc issue with RST admonitions. This is the last but one known issue before we could fully enable the strict2 mode in StrictDoc's tests.