### PR TITLE
feat(html2pdf): provide a config parameter for specifying bundle document UID

### DIFF
--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -123,6 +123,7 @@ class ProjectConfig:
         html2pdf_strict: bool = False,
         html2pdf_template: Optional[str] = None,
         html2pdf_forced_page_break_nodes: Optional[List[str]] = None,
+        bundle_document_uid: Optional[str] = None,
         bundle_document_version: Optional[
             str
         ] = ProjectConfigDefault.DEFAULT_BUNDLE_DOCUMENT_VERSION,
@@ -239,6 +240,7 @@ class ProjectConfig:
             html2pdf_forced_page_break_nodes or []
         )
 
+        self.bundle_document_uid: Optional[str] = bundle_document_uid
         self.bundle_document_version: Optional[str] = bundle_document_version
         self.bundle_document_date: Optional[str] = bundle_document_date
 

--- a/strictdoc/core/traceability_index.py
+++ b/strictdoc/core/traceability_index.py
@@ -1086,6 +1086,12 @@ class TraceabilityIndex:
         bundle_document.config = DocumentConfig.default_config(bundle_document)
 
         if (
+            project_config.bundle_document_uid is not None
+            and len(project_config.bundle_document_uid) > 0
+        ):
+            bundle_document.config.uid = project_config.bundle_document_uid
+
+        if (
             project_config.bundle_document_version is not None
             and len(project_config.bundle_document_version) > 0
         ):

--- a/tests/integration/features/html2pdf/05_generate_bundle_document/strictdoc.toml
+++ b/tests/integration/features/html2pdf/05_generate_bundle_document/strictdoc.toml
@@ -1,7 +1,0 @@
-[project]
-
-cache_dir = "./Output/cache"
-
-features = [
-  "HTML2PDF",
-]

--- a/tests/integration/features/html2pdf/05_generate_bundle_document/strictdoc_config.py
+++ b/tests/integration/features/html2pdf/05_generate_bundle_document/strictdoc_config.py
@@ -1,0 +1,10 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=[
+            "HTML2PDF",
+        ],
+    )
+    return config

--- a/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/_assets/file.svg
+++ b/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/_assets/file.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-40 -40 80 80">
+  <circle r="39"/>
+  <path fill="#fff" d="M0,38a38,38 0 0 1 0,-76a19,19 0 0 1 0,38a19,19 0 0 0 0,38"/>
+  <circle r="5" cy="19" fill="#fff"/>
+  <circle r="5" cy="-19"/>
+</svg>

--- a/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/input.sdoc
+++ b/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/input.sdoc
@@ -1,0 +1,18 @@
+[DOCUMENT]
+TITLE: Dummy Software Requirements Specification #1
+VERSION: @GIT_VERSION, @GIT_BRANCH
+DATE: @GIT_COMMIT_DATETIME
+
+[[SECTION]]
+UID: SEC-1
+TITLE: Section #1
+
+[TEXT]
+STATEMENT: >>>
+.. image:: _assets/file.svg
+   :alt: Test image
+   :class: image
+   :width: 100%
+<<<
+
+[[/SECTION]]

--- a/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/nested/_assets/file.svg
+++ b/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/nested/_assets/file.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-40 -40 80 80">
+  <circle r="39"/>
+  <path fill="#fff" d="M0,38a38,38 0 0 1 0,-76a19,19 0 0 1 0,38a19,19 0 0 0 0,38"/>
+  <circle r="5" cy="19" fill="#fff"/>
+  <circle r="5" cy="-19"/>
+</svg>

--- a/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/nested/input2.sdoc
+++ b/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/nested/input2.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: Dummy Software Requirements Specification #2
+
+[TEXT]
+STATEMENT: >>>
+.. image:: _assets/file.svg
+   :alt: Test image
+   :class: image
+   :width: 100%
+<<<

--- a/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/nested/subnested/_assets/file.svg
+++ b/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/nested/subnested/_assets/file.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-40 -40 80 80">
+  <circle r="39"/>
+  <path fill="#fff" d="M0,38a38,38 0 0 1 0,-76a19,19 0 0 1 0,38a19,19 0 0 0 0,38"/>
+  <circle r="5" cy="19" fill="#fff"/>
+  <circle r="5" cy="-19"/>
+</svg>

--- a/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/nested/subnested/input3.sdoc
+++ b/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/nested/subnested/input3.sdoc
@@ -1,0 +1,15 @@
+[DOCUMENT]
+TITLE: Dummy Software Requirements Specification #3
+
+[TEXT]
+STATEMENT: >>>
+.. image:: _assets/file.svg
+   :alt: Test image
+   :class: image
+   :width: 100%
+<<<
+
+[TEXT]
+STATEMENT: >>>
+[LINK: SEC-1]
+<<<

--- a/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/strictdoc_config.py
+++ b/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/strictdoc_config.py
@@ -1,0 +1,13 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=[
+            "HTML2PDF",
+        ],
+        bundle_document_uid="MY_BUNDLE_DOC_UID",
+        bundle_document_version="v1.2.3",
+        bundle_document_date="2026-01-01"
+    )
+    return config

--- a/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/test.itest
+++ b/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/test.itest
@@ -1,0 +1,22 @@
+# @relation(SDOC-SRS-51, scope=file)
+
+REQUIRES: TEST_HTML2PDF
+
+RUN: %strictdoc export %S --formats=html2pdf --generate-bundle-document --output-dir %T | filecheck %s --dump-input=fail
+CHECK: html2pdf4doc: JS logs from the print session
+
+RUN: %check_exists --file %T/html2pdf/html/bundle-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/input-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/input2-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/subnested/input3-PDF.html
+
+RUN: %cat %T/html2pdf/html/bundle-PDF.html | filecheck %s --check-prefix CHECK-DOC-HTML
+# This ensures that the link is resolved correctly.
+CHECK-DOC-HTML:<a href="#SEC-1">🔗&nbsp;1.1. Section #1</a>
+
+# Git meta information.
+CHECK-DOC-HTML: MY_BUNDLE_DOC_UID
+CHECK-DOC-HTML: v1.2.3
+CHECK-DOC-HTML: 2026-01-01
+
+RUN: python %S/test_pdf.py

--- a/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/test_pdf.py
+++ b/tests/integration/features/html2pdf/05b_generate_bundle_document_meta_via_config/test_pdf.py
@@ -1,0 +1,9 @@
+"""
+@relation(SDOC-SRS-51, scope=file)
+"""
+
+from pypdf import PdfReader
+
+reader = PdfReader("Output/html2pdf/pdf/bundle.pdf")
+
+assert len(reader.pages) == 5, reader.pages


### PR DESCRIPTION


WHAT:

Add the `bundle_document_uid` parameter to StrictDoc's ProjectConfig class. This allows a user to specify a UID that the bundle document will be generated with.

WHY:

The bundle document is a synthetic document. It does not exist in SDoc files, so its meta information has to come from somewhere. The best place for keeping it is `strictdoc_config.py` config file.

Closes #2592

HOW:

This change seemly extends the ProjectConfig to support the UID parameter. The other two parameters had been implemented already some time ago. Now the config parameters look like this:

```py
        self.bundle_document_uid: Optional[str] = bundle_document_uid
        self.bundle_document_version: Optional[str] = bundle_document_version
        self.bundle_document_date: Optional[str] = bundle_document_date
```