### PR TITLE
chore(tasks): add lint-commit task to validate Conventional Commits

### DIFF
--- a/.github/workflows/ci-linux-ubuntu-latest.yml
+++ b/.github/workflows/ci-linux-ubuntu-latest.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 5
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -27,6 +27,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 5
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/ci-windows-powershell.yml
+++ b/.github/workflows/ci-windows-powershell.yml
@@ -26,6 +26,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 5
 
     - name: "Print Debug info"
       run: |
@@ -53,6 +55,10 @@ jobs:
     - name: "Windows specific: Install Check dependencies (everything for lint + test)"
       run: |
         pip install -r requirements.check.txt
+
+    - name: Run Lint tasks
+      run: |
+        invoke lint
 
     - name: " Windows specific: Install Tidy via Chocolatey, and add it to $PATH"
       shell: pwsh

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -26,6 +26,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 5
 
     - name: "Print Debug info"
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 5
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -28,6 +30,10 @@ jobs:
     - name: Install minimal Python packages
       run: |
         pip install -r requirements.bootstrap.txt
+
+    - name: Run Lint tasks
+      run: |
+        invoke lint
 
     - name: Build Docker image with PR branch
       run: |

--- a/.github/workflows/end2end-tests.yml
+++ b/.github/workflows/end2end-tests.yml
@@ -33,6 +33,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 5
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v6
@@ -46,6 +48,10 @@ jobs:
     - name: Install minimal Python packages
       run: |
         pip install -r requirements.bootstrap.txt
+
+    - name: Run Lint tasks
+      run: |
+        invoke lint
 
     - name: Run end-to-end tasks
       run: |
@@ -61,6 +67,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 5
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -74,6 +82,10 @@ jobs:
     - name: Install minimal Python packages
       run: |
         pip install -r requirements.bootstrap.txt
+
+    - name: Run Lint tasks
+      run: |
+        invoke lint
 
     - name: Run end-to-end tasks
       run: |
@@ -92,6 +104,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 5
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v6
@@ -113,6 +127,10 @@ jobs:
     - name: "Windows specific: Install Check dependencies (everything for test)"
       run: |
         pip install -r requirements.check.txt
+
+    - name: Run Lint tasks
+      run: |
+        invoke lint
 
     - name: Run end-to-end tasks
       run: |

--- a/.github/workflows/periodic-integration-test.yml
+++ b/.github/workflows/periodic-integration-test.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 5
 
       - name: Set up Python 3.
         uses: actions/setup-python@v6
@@ -33,6 +35,10 @@ jobs:
       - name: Install minimal Python packages
         run: |
           pip install -r requirements.bootstrap.txt
+
+      - name: Run Lint tasks
+        run: |
+          invoke lint
 
       - name: Build and test locally
         run: |
@@ -43,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 5
 
       - name: Set up Python 3.
         uses: actions/setup-python@v6
@@ -56,6 +64,10 @@ jobs:
       - name: Install minimal Python packages
         run: |
           pip install -r requirements.bootstrap.txt
+
+      - name: Run Lint tasks
+        run: |
+          invoke lint
 
       - name: Build and test using PyInstaller
         run: |
@@ -74,6 +86,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 5
 
       - name: Set up Python 3.
         uses: actions/setup-python@v6
@@ -87,6 +101,10 @@ jobs:
       - name: Install minimal Python packages
         run: |
           pip install -r requirements.bootstrap.txt
+
+      - name: Run Lint tasks
+        run: |
+          invoke lint
 
       - name: Build and test locally
         run: |
@@ -97,6 +115,8 @@ jobs:
     runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 5
 
       - name: Set up Python 3.
         uses: actions/setup-python@v6
@@ -110,6 +130,10 @@ jobs:
       - name: Install minimal Python packages
         run: |
           pip install -r requirements.bootstrap.txt
+
+      - name: Run Lint tasks
+        run: |
+          invoke lint
 
       - name: Build using PyInstaller
         run: |

--- a/developer/git/commit_validator.py
+++ b/developer/git/commit_validator.py
@@ -1,0 +1,134 @@
+import os
+import re
+import subprocess
+from typing import List
+
+ALLOWED_TYPES = [
+    "chore",
+    "ci",
+    "docs",
+    "feat",
+    "fix",
+    "refactor",
+    "release",
+    "test",
+]
+
+
+def is_github_ci() -> bool:
+    return os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+def get_last_10_non_merge_commits():
+    result = subprocess.run(
+        [
+            "git",
+            "log",
+            # Skip merge commits.
+            "--no-merges",
+            # Last 10 commits
+            "-n",
+            "10",
+            # Full commit message + ASCII record separator.
+            "--pretty=%B%x1e",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Split by the record separator and remove any empty strings.
+    commit_messages = []
+    for msg_ in result.stdout.split("\x1e"):
+        msg = msg_.strip()
+        if len(msg) == 0:
+            continue
+        # Merge commits still show up on GitHub CI because it does shallow checkouts.
+        if "Merge" in msg:
+            continue
+        commit_messages.append(msg)
+    return commit_messages
+
+
+def validate_commits_locally_or_ci() -> None:
+    commit_messages = get_last_10_non_merge_commits()
+    if len(commit_messages) == 0:
+        return
+    validate_commits(commit_messages)
+
+
+def validate_commits(commit_messages: List[str]):
+    """
+    Validate a commit message against conventional commit rules:
+
+    <type>[optional scope]: <description>
+
+    Conventional Commits spec:
+    https://www.conventionalcommits.org/en/v1.0.0/
+    """
+
+    assert isinstance(commit_messages, list), commit_messages
+    assert len(commit_messages) > 0, commit_messages
+
+    bad_commits = 0
+    commit_titles = []
+
+    for commit_message_ in commit_messages:
+        assert len(commit_message_) > 0
+
+        # Only check the first line
+        first_line = commit_message_.splitlines()[0]
+        if "WIP" in first_line and not is_github_ci():
+            commit_titles.append(f"WIP: {first_line}")
+            continue
+
+        # Regex breakdown:
+        # ^(feat|fix|refactor|...)  -> type must be one of the allowed types
+        # (\([^\)]+\))?         -> optional scope inside parentheses
+        # :\s                   -> colon followed by a space
+        # .+                    -> description must have at least one character
+        pattern = r"^(" + "|".join(ALLOWED_TYPES) + r")(\([^\)]+\))?!?: .+"
+
+        if re.match(pattern, first_line) is None:
+            commit_titles.append(f"BAD: {first_line}")
+            commit_titles.append(f"     {'^' * len(first_line)}")
+
+            bad_commits += 1
+        else:
+            commit_titles.append(f"GOOD: {first_line}")
+
+    if bad_commits > 0:
+        commit_titles_list_line = "\n".join(commit_titles)
+
+        message = f"""\
+error: the commit message(s) do not match the Conventional Commits convention:
+
+{commit_titles_list_line}
+
+StrictDoc enforces the Conventional Commits starting from 2026.
+
+The expected format of the commit line:
+
+<type>[optional scope]: <description>
+
+The <type> values accepted by StrictDoc are as follows:
+{", ".join(ALLOWED_TYPES)}
+
+The [optional scope] can be a strictdoc folder, e.g., 'export/html', or a
+feature/topic, such as 'UI', 'html2pdf', 'Static HTML search'.
+
+Examples:
+- docs: update release notes
+- feat(html2pdf): introduce a new "html2pdf_forced_page_break_nodes" option
+- fix(backend/sdoc_source_code): enable support for requirement identifiers
+- refactor(cli): migrate "import excel" and "import reqif" to a command pattern
+- chore(cli): rename shared.py -> _shared.py
+- chore(.github): switch the macOS tests to macos-latest
+
+See the Conventional Commits spec:
+https://www.conventionalcommits.org/en/v1.0.0/
+
+NOTE: During local development, to bypass this check, include WIP anywhere in
+the commit message.\
+"""
+        raise ValueError(message)

--- a/tasks.py
+++ b/tasks.py
@@ -10,6 +10,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Dict, Optional
 
+from developer.git.commit_validator import (
+    validate_commits_locally_or_ci,
+)
+
 if not hasattr(inspect, "getargspec"):
     inspect.getargspec = inspect.getfullargspec
 
@@ -683,6 +687,14 @@ def lint_format_js(context):
         raise invoke.exceptions.UnexpectedExit(result)
 
 
+@task(aliases=["lc"])
+def lint_commit(context):  # noqa: ARG001
+    try:
+        validate_commits_locally_or_ci()
+    except ValueError as e:
+        raise invoke.exceptions.Exit(message=str(e), code=1) from None
+
+
 @task(aliases=["lf"])
 def lint_fixit(context, fix=False, auto=False, path="strictdoc/"):
     if fix:
@@ -707,6 +719,7 @@ def lint_fixit(context, fix=False, auto=False, path="strictdoc/"):
 
 @task(aliases=["l"])
 def lint(context):
+    lint_commit(context)
     lint_ruff_format(context)
     lint_ruff(context)
     lint_mypy(context)

--- a/tests/unit/developer/git/test_commit_validator.py
+++ b/tests/unit/developer/git/test_commit_validator.py
@@ -1,0 +1,28 @@
+import pytest
+
+from developer.git.commit_validator import validate_commits
+
+
+def test_validate_commit():
+    good_commits = [
+        "docs: update release notes",
+        'feat(html2pdf): introduce a new "html2pdf_forced_page_break_nodes" option',
+        "fix(backend/sdoc_source_code): enable support for requirement identifiers",
+        'refactor(cli): migrate "import excel" and "import reqif" to a command pattern',
+        "chore(cli): rename shared.py -> _shared.py",
+        "chore(.github): switch the macOS tests to macos-latest",
+        "docs!: update release notes",
+        "chore(cli)!: rename shared.py -> _shared.py",
+        "WIP",
+        "WIP: Some work",
+    ]
+    for good_commit_ in good_commits:
+        validate_commits([good_commit_])
+
+    bad_commits = [
+        "docs",
+        "foo: bar",
+    ]
+    for bad_commit_ in bad_commits:
+        with pytest.raises(ValueError):
+            validate_commits([bad_commit_])


### PR DESCRIPTION
WHAT:

- This adds a Python script that validates the current branch's commit message against the Conventional Commits convention.
- The lint task is added to the general 'lint' task.

WHY:

The developers of StrictDoc switched to this convention in 2025. Now is a good time to enforce it with automatic linting.