### PR TITLE
fix(tests/end2end): switch to running strictdoc as a Python module

### DIFF
--- a/.github/workflows/end2end-tests.yml
+++ b/.github/workflows/end2end-tests.yml
@@ -8,13 +8,6 @@ on:
   pull_request:
     branches: [ "**" ]
 
-    # UI tests take 10+ minutes and will continue to grow.
-    # Reducing the trigger to only changes in the Web frontend-related code.
-    paths:
-      - 'strictdoc/export/html/**'
-      - 'strictdoc/server/**'
-      - 'tests/end2end/**'
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/tests/end2end/__init__.py
+++ b/tests/end2end/__init__.py
@@ -1,1 +1,0 @@
-# Dummy comment.

--- a/tests/end2end/exporter.py
+++ b/tests/end2end/exporter.py
@@ -58,7 +58,8 @@ class SDocTestHTMLExporter:
     def run(self) -> None:
         args = [
             "python",
-            "strictdoc/cli/main.py",
+            "-m",
+            "strictdoc.cli.main",
             "export",
         ]
         if self.config_path:

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_delete_requirement/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_delete_requirement/test_case.py
@@ -28,8 +28,6 @@ class Test(E2ECase):
             requirement = screen_document.get_node(1)
             requirement.do_delete_node()
 
-            screen_document.get_root_node().assert_document_title_contains(
-                "Document 1"
-            )
+            screen_document.assert_no_text("First requirement")
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_delete_section/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_delete_section/test_case.py
@@ -28,8 +28,6 @@ class Test(E2ECase):
             section = screen_document.get_node(1)
             section.do_delete_node()
 
-            screen_document.get_root_node().assert_document_title_contains(
-                "Document 1"
-            )
+            screen_document.assert_no_text("First section")
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/server.py
+++ b/tests/end2end/server.py
@@ -330,6 +330,7 @@ class SDocTestServer:
         # It is important that the current environment is passed along with the
         # server command, otherwise the Python packages will not be discovered.
         strictdoc_env: Dict[str, str] = dict(os.environ)
+        strictdoc_env["PYTHONPATH"] = os.getcwd()
 
         should_collect_coverage = test_environment.coverage
         strictdoc_args: List[str] = [sys.executable]
@@ -362,7 +363,8 @@ class SDocTestServer:
 
         strictdoc_args.extend(
             [
-                self.path_to_strictdoc,
+                "-m",
+                "strictdoc.cli.main",
                 "server",
                 "--no-reload",
                 "--port",


### PR DESCRIPTION
WHAT/WHY: This is a follow-up to https://github.com/strictdoc-project/strictdoc/pull/2635.