### PR TITLE
fix(helpers/path_filter): support Windows paths with "~" character

### DIFF
--- a/tests/integration/features/options/options_per_project/include_doc_paths/02_invalid_option/test.itest
+++ b/tests/integration/features/options/options_per_project/include_doc_paths/02_invalid_option/test.itest
@@ -1,3 +1,3 @@
 RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
 
-CHECK: error: strictdoc.toml: 'include_doc_paths': Path mask must start with an alphanumeric character, a forward slash, a dot, or a wildcard symbol '*'. Provided mask: ' '.
+CHECK: error: strictdoc.toml: 'include_doc_paths': Path mask must start with an alphanumeric character or one of these characters: {{.*}}. Provided mask: ' '.

--- a/tests/unit/strictdoc/helpers/test_path_filter.py
+++ b/tests/unit/strictdoc/helpers/test_path_filter.py
@@ -244,3 +244,20 @@ def test_case_80_windows_supported():
     path_filter = PathFilter([mask], positive_or_negative=False)
 
     assert not path_filter.match("docs\\hello.sdoc")
+
+
+def test_case_81_windows_hidden_files_with_dollar_are_supported():
+    mask = "~$ProjectPlan.docx"
+    path_filter = PathFilter([mask], positive_or_negative=True)
+
+    assert path_filter.match("~$ProjectPlan.docx")
+
+
+def test_case_82_windows_hidden_files_with_dollar_are_supported():
+    mask = "~$*"
+    path_filter = PathFilter([mask], positive_or_negative=True)
+
+    assert path_filter.match("~$ProjectPlan.docx")
+    assert path_filter.match("foo/bar/~$ProjectPlan.docx")
+
+    assert not path_filter.match("$ProjectPlan.docx")

--- a/tests/unit/strictdoc/helpers/test_path_filter_mask_validation.py
+++ b/tests/unit/strictdoc/helpers/test_path_filter_mask_validation.py
@@ -15,8 +15,8 @@ def test_case_01_empty_mask_allows_everything():
     with pytest.raises(SyntaxError) as exc_info:
         validate_mask(" ")
     assert (
-        "Path mask must start with an alphanumeric character, a forward slash, "
-        "a dot, or a wildcard symbol '*'."
+        "Path mask must start with an alphanumeric character or one of these "
+        "characters: "
     ) in exc_info.value.args[0]
 
     with pytest.raises(SyntaxError) as exc_info:


### PR DESCRIPTION
WHAT: Make PathFilter class support inputs with "~" character.

WHY: On Windows there are naming conventions where some hidden files can contain the "~" character. For example, the users want the following masks to be supported:

```
~$*
```

Closes #2642