### PR TITLE
fix(tests/unit): fix pytest warning

### DIFF
--- a/tests/unit/helpers/pygments_helpers.py
+++ b/tests/unit/helpers/pygments_helpers.py
@@ -1,0 +1,12 @@
+from pygments import highlight
+from pygments.formatters import (
+    HtmlFormatter,
+    RawTokenFormatter,
+    TestcaseFormatter,
+)
+
+
+def dump_lexed_code(lexer, code) -> None:
+    print(highlight(code, lexer, RawTokenFormatter()))  # noqa: T201
+    print(highlight(code, lexer, HtmlFormatter()))  # noqa: T201
+    print(highlight(code, lexer, TestcaseFormatter()))  # noqa: T201

--- a/tests/unit/strictdoc/export/rst/test_strictdoc_lexer.py
+++ b/tests/unit/strictdoc/export/rst/test_strictdoc_lexer.py
@@ -1,21 +1,9 @@
-from pygments import highlight
-from pygments.formatters import (
-    HtmlFormatter,
-    RawTokenFormatter,
-    TestcaseFormatter,
-)
 from pygments.token import Token
 
 from strictdoc.export.rst.strictdoc_lexer import (
     SDocPygmentsToken,
     StrictDocLexer,
 )
-
-
-def dump_lexed_code(lexer, code) -> None:
-    print(highlight(code, lexer, RawTokenFormatter()))  # noqa: T201
-    print(highlight(code, lexer, HtmlFormatter()))  # noqa: T201
-    print(highlight(code, lexer, TestcaseFormatter()))  # noqa: T201
 
 
 def test_01_document_tag_only():


### PR DESCRIPTION
```
=============================== warnings summary ===============================
build/tox/py313-check/lib/python3.13/site-packages/pygments/formatters/other.py:129: PytestCollectionWarning: cannot collect test class 'TestcaseFormatter' because it has a __init__ constructor (from: tests/unit/strictdoc/export/rst/test_strictdoc_lexer.py)
    class TestcaseFormatter(Formatter):
```