### PR TITLE
fix(path_filter): allow filters with parentheses and range expressions

### DIFF
--- a/strictdoc/helpers/path_filter.py
+++ b/strictdoc/helpers/path_filter.py
@@ -13,7 +13,7 @@ REGEX_DOUBLE_WILDCARD = (
 
 REGEX_MASK_VALIDATION = rf"[^(\\|\/)]{REGEX_DOUBLE_WILDCARD}"
 
-DISALLOWED_CHARACTERS = ("..", "[", "]", "(", ")", "{", "}", "?", "+", "!")
+DISALLOWED_CHARACTERS = ("..", "{", "}", "?", "+", "!")
 
 # "~"" comes from Windows.
 ALLOWED_FIRST_CHARACTERS = ("*", "/", ".", "_", "~")
@@ -67,6 +67,9 @@ class PathFilter:
             filtered_path = filtered_path_
 
             validate_mask(filtered_path)
+
+            filtered_path = filtered_path.replace("(", r"\(")
+            filtered_path = filtered_path.replace(")", r"\)")
 
             if filtered_path.startswith("/"):
                 filtered_path = filtered_path.lstrip("/")

--- a/tasks.py
+++ b/tasks.py
@@ -320,7 +320,7 @@ def test_end2end(
 
 
 @task(aliases=["tu"])
-def test_unit(context, focus=None, path=None, output=False):
+def test_unit(context, coverage=False, focus=None, path=None, output=False):
     """
     @relation(SDOC-SRS-44, scope=function)
     """
@@ -354,7 +354,7 @@ def test_unit(context, focus=None, path=None, output=False):
             {path}
         """,
     )
-    if not focus and path == "tests/unit":
+    if coverage and not focus and path == "tests/unit":
         run_invoke_with_tox(
             context,
             ToxEnvironment.CHECK,
@@ -730,7 +730,7 @@ def test(context, shard=None):
 
 @task(aliases=["ta"])
 def test_all(context, coverage=False, headless=False):
-    test_unit(context)
+    test_unit(context, coverage=coverage)
     test_unit_server(context)
     test_integration(context, coverage=coverage)
     test_integration(context, coverage=coverage, html2pdf=True)

--- a/tests/unit/strictdoc/helpers/test_path_filter.py
+++ b/tests/unit/strictdoc/helpers/test_path_filter.py
@@ -37,8 +37,6 @@ def test_case_03_single_wildcard():
     # This is possible, but it will be filtered by extension before this filter
     # anyway.
     assert path_filter.match("docs/01_user_manual_sdoc")
-
-    # FIXME: Disallow this?
     assert path_filter.match("docs/.sdoc")
 
     # NEGATIVE
@@ -170,6 +168,47 @@ def test_case_15_ending_slashes_act_like_double_wildcards():
     assert not path_filter.match("build/foo")
     assert not path_filter.match("build/foo.txt")
     assert not path_filter.match("build/foo/bar")
+
+
+def test_case_16_range_of_characters():
+    mask = "*.py[codz]"
+    path_filter = PathFilter([mask], positive_or_negative=False)
+
+    assert path_filter.match("foo.pyc")
+    assert path_filter.match("foo/foo.pyo")
+    assert path_filter.match("foo/foo/foo.pyo")
+
+
+def test_case_17_range_of_characters():
+    mask = "fo[o-]"
+    path_filter = PathFilter([mask], positive_or_negative=True)
+
+    assert path_filter.match("foo")
+    assert path_filter.match("fo-")
+    assert path_filter.match("foo/fo-")
+
+    assert not path_filter.match("foz")
+
+
+def test_case_18_known_dollar_character_use():
+    """
+    The Jython files are generated as: example.py -> example$py.class.
+    """
+
+    mask = "*$py.class"
+    path_filter = PathFilter([mask], positive_or_negative=False)
+
+    assert path_filter.match("foo$py.class")
+    assert path_filter.match("foo/foo$py.class")
+    assert path_filter.match("foo/foo/foo$py.class")
+
+
+def test_case_19_parentheses():
+    mask = "tree(not_in_use).css"
+    path_filter = PathFilter([mask], positive_or_negative=False)
+
+    assert path_filter.match("tree(not_in_use).css")
+    assert path_filter.match("foo/tree(not_in_use).css")
 
 
 def test_case_20_file_with_double_wildcard():

--- a/tests/unit/strictdoc/helpers/test_path_filter_mask_validation.py
+++ b/tests/unit/strictdoc/helpers/test_path_filter_mask_validation.py
@@ -36,8 +36,8 @@ def test_case_01_empty_mask_allows_everything():
     assert "Invalid wildcard: '***'." in exc_info.value.args[0]
 
     with pytest.raises(SyntaxError) as exc_info:
-        validate_mask("a[")
+        validate_mask("a+")
     assert (
         "Path mask must not contain any of the special characters: "
-        "('..', '[', ']', '(', ')', '{', '}', '?', '+', '!')."
+        "('..', '{', '}', '?', '+', '!')."
     ) in exc_info.value.args[0]


### PR DESCRIPTION
WHY:

User projects contain these types of expressions.

Closes #2650