### PR TITLE
feat(project_config): drop "./" from relative grammar path definition

### DIFF
--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -420,7 +420,7 @@ class ProjectConfig:
         # Validate that the provided grammar shortcuts all point to existing
         # grammar files.
         #
-        for grammar_alias_, grammar_path_ in self.grammars.items():
+        for grammar_alias_, grammar_path_ in list(self.grammars.items()):
             assert grammar_alias_.startswith("@"), (
                 "Grammar alias must start with an '@' character."
             )
@@ -431,6 +431,8 @@ class ProjectConfig:
                 "Grammar path must point to an existing path relative to the "
                 f"project config file: {grammar_path_}."
             )
+            if grammar_path_.startswith("./"):
+                self.grammars[grammar_alias_] = grammar_path_.removeprefix("./")
 
     def is_feature_activated(self, feature: ProjectFeature) -> bool:
         return feature in self.project_features

--- a/tests/integration/features/sdoc/document_grammar/_grammar_from_file/11_basic_grammar_from_alias_dot_slash/nested/subnested/input.sdoc
+++ b/tests/integration/features/sdoc/document_grammar/_grammar_from_file/11_basic_grammar_from_alias_dot_slash/nested/subnested/input.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: Test document
+
+[GRAMMAR]
+IMPORT_FROM_FILE: @my_grammar
+
+[REQUIREMENT]
+UID: ABC-123
+STATEMENT: Requirement 7.8.9
+ASIL: A
+STATUS: Draft
+COMMENT: Test comment.

--- a/tests/integration/features/sdoc/document_grammar/_grammar_from_file/11_basic_grammar_from_alias_dot_slash/nested/subnested_grammar/grammar.sgra
+++ b/tests/integration/features/sdoc/document_grammar/_grammar_from_file/11_basic_grammar_from_alias_dot_slash/nested/subnested_grammar/grammar.sgra
@@ -1,0 +1,19 @@
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: True
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+  - TITLE: ASIL
+    TYPE: String
+    REQUIRED: True
+  - TITLE: STATUS
+    TYPE: String
+    REQUIRED: True
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: True

--- a/tests/integration/features/sdoc/document_grammar/_grammar_from_file/11_basic_grammar_from_alias_dot_slash/strictdoc_config.py
+++ b/tests/integration/features/sdoc/document_grammar/_grammar_from_file/11_basic_grammar_from_alias_dot_slash/strictdoc_config.py
@@ -1,0 +1,14 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_title="StrictDoc Documentation",
+        project_features=[
+            # Intentionally nothing.
+        ],
+        grammars={
+            "@my_grammar": "./nested/subnested_grammar/grammar.sgra",
+        },
+    )
+    return config

--- a/tests/integration/features/sdoc/document_grammar/_grammar_from_file/11_basic_grammar_from_alias_dot_slash/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/_grammar_from_file/11_basic_grammar_from_alias_dot_slash/test.itest
@@ -1,0 +1,11 @@
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
+CHECK: Published: Test document
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/nested/subnested/input.html | filecheck %s --check-prefix CHECK-HTML
+
+CHECK-HTML:UID
+CHECK-HTML:ABC-123
+CHECK-HTML:ASIL
+CHECK-HTML:A
+CHECK-HTML:STATUS
+CHECK-HTML:Draft


### PR DESCRIPTION
WHY:

Fixes an issue where a user expects the expression "./<relative path>" to work when specifying a path to a grammar alias.

Fixes #2647