### PR TITLE
feat(project_config): simplify API for use outside StrictDoc CLI

### DIFF
--- a/strictdoc/commands/export.py
+++ b/strictdoc/commands/export.py
@@ -193,12 +193,9 @@ class ExportCommand(BaseCommand):
             export_config.validate()
         except CLIValidationError as exception_:
             raise exception_
-        project_config = ProjectConfigLoader.load_from_path_or_get_default(
-            path_to_config=export_config.get_path_to_config(),
+        project_config = ProjectConfigLoader.load_using_export_config(
+            export_config
         )
-        project_config.integrate_export_config(export_config)
-        project_config.validate_and_finalize()
-
         parallelization_value = (
             "Disabled" if export_config.no_parallelization else "Enabled"
         )

--- a/strictdoc/commands/import_excel.py
+++ b/strictdoc/commands/import_excel.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 
 from strictdoc.cli.base_command import BaseCommand
 from strictdoc.commands.import_excel_config import ImportExcelCommandConfig
@@ -50,9 +49,8 @@ class ImportExcelCommand(BaseCommand):
         )
 
     def run(self, parallelizer: Parallelizer) -> None:  # noqa: ARG002
-        project_config = ProjectConfigLoader.load_from_path_or_get_default(
-            path_to_config=os.getcwd(),
+        project_config = ProjectConfigLoader.load_using_import_excel_config(
+            self.config
         )
-
         import_action = ImportAction()
         import_action.do_import(self.config, project_config)

--- a/strictdoc/commands/import_reqif.py
+++ b/strictdoc/commands/import_reqif.py
@@ -1,5 +1,4 @@
 import argparse
-import os
 from typing import Optional
 
 from strictdoc.backend.reqif.sdoc_reqif_fields import ReqIFProfile
@@ -72,9 +71,8 @@ class ImportReqIFCommand(BaseCommand):
         )
 
     def run(self, parallelizer: Parallelizer) -> None:  # noqa: ARG002
-        project_config = ProjectConfigLoader.load_from_path_or_get_default(
-            path_to_config=os.getcwd(),
+        project_config = ProjectConfigLoader.load_using_import_reqif_config(
+            self.config
         )
-
         import_action = ImportAction()
         import_action.do_import(self.config, project_config)

--- a/strictdoc/commands/manage_autouid_command.py
+++ b/strictdoc/commands/manage_autouid_command.py
@@ -1,6 +1,5 @@
 import argparse
 import sys
-from pathlib import Path
 from typing import Dict, Optional
 
 from strictdoc.backend.sdoc.errors.document_tree_error import DocumentTreeError
@@ -95,24 +94,9 @@ the document's PREFIX (if provided or "REQ-" by default).
         except CLIValidationError as exception_:
             raise exception_
 
-        project_config = ProjectConfigLoader.load_from_path_or_get_default(
-            path_to_config=manage_config.get_path_to_config(),
+        project_config = ProjectConfigLoader.load_using_manage_autouid_config(
+            manage_config
         )
-
-        # FIXME: Encapsulate all this in project_config.integrate_manage_autouid_config(),
-        #        following the example of integrate_export_config().
-        project_config.input_paths = [manage_config.input_path]
-        project_config.source_root_path = str(
-            Path(manage_config.input_path).resolve()
-        )
-        project_config.auto_uid_mode = True
-        project_config.autouuid_include_sections = (
-            manage_config.include_sections
-        )
-        project_config.validate_and_finalize()
-
-        # FIXME: Traceability Index is coupled with HTML output.
-        project_config.export_output_html_root = "NOT_RELEVANT"
 
         try:
             traceability_index: TraceabilityIndex = (

--- a/strictdoc/commands/server.py
+++ b/strictdoc/commands/server.py
@@ -52,8 +52,8 @@ class ServerCommand(BaseCommand):
             server_config.validate()
         except CLIValidationError as exception_:
             raise exception_
-        project_config = ProjectConfigLoader.load_from_path_or_get_default(
-            path_to_config=server_config.get_path_to_config(),
+        project_config = ProjectConfigLoader.load_using_server_config(
+            server_config
         )
         run_strictdoc_server(
             server_config=server_config, project_config=project_config

--- a/strictdoc/server/server.py
+++ b/strictdoc/server/server.py
@@ -39,14 +39,6 @@ def run_strictdoc_server(
     print_warning_message()
 
     with ExitStack() as stack:
-        if server_config.output_path is None:
-            server_config.output_path = stack.enter_context(
-                tempfile.TemporaryDirectory()
-            )
-
-        project_config.integrate_server_config(server_config)
-        project_config.validate_and_finalize()
-
         reload_config = UvicornReloadConfig.create(
             project_config, server_config
         )

--- a/tasks.py
+++ b/tasks.py
@@ -114,7 +114,6 @@ def server(context, input_path=".", config=None):
                 --debug
                 server {input_path} {config_argument}
                     --host 127.0.0.1
-                    --output-path ./output/server
                     --reload
         """,
     )

--- a/tests/integration/examples/python_api/export_excel_questionnaire/export_questionnaires.py
+++ b/tests/integration/examples/python_api/export_excel_questionnaire/export_questionnaires.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import sys
 from typing import Optional
@@ -8,11 +9,6 @@ from strictdoc.backend.excel.export.excel_generator import ExcelGenerator
 from strictdoc.backend.sdoc.errors.document_tree_error import DocumentTreeError
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.node import SDocNode
-from strictdoc.cli.cli_arg_parser import (
-    SDocArgsParser,
-)
-from strictdoc.cli.main import COMMAND_REGISTRY
-from strictdoc.commands.export_config import ExportCommandConfig
 from strictdoc.core.document_iterator import SDocDocumentIterator
 from strictdoc.core.graph.abstract_bucket import ALL_EDGES
 from strictdoc.core.project_config import ProjectConfig, ProjectConfigLoader
@@ -120,14 +116,32 @@ class ExportQuestionnaires:
 
 
 if __name__ == "__main__":
-    parser = SDocArgsParser.create_sdoc_args_parser(COMMAND_REGISTRY)
-    project_config: ProjectConfig
-
-    export_config: ExportCommandConfig = ExportCommandConfig(**vars(parser.args))
-    project_config = ProjectConfigLoader.load_from_path_or_get_default(
-        path_to_config=export_config.get_path_to_config()
+    parser = argparse.ArgumentParser(
+        description="Export questionnaires from SDoc documents."
     )
-    project_config.integrate_export_config(export_config)
+
+    parser.add_argument(
+        "input_path",
+        type=str,
+        help="Path to the input path."
+    )
+
+    # Optional argument
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Optional directory to save output."
+    )
+
+    args = parser.parse_args()
+
+    input_path = args.input_path
+    output_dir = args.output_dir
+
+    project_config: ProjectConfig = ProjectConfigLoader.load(
+        input_path=input_path, output_dir=output_dir
+    )
 
     parallelizer = Parallelizer.create(False)
 

--- a/tests/integration/examples/python_api/export_excel_questionnaire/test.itest
+++ b/tests/integration/examples/python_api/export_excel_questionnaire/test.itest
@@ -1,6 +1,6 @@
 RUN: cd %S
 
-RUN: python %S/export_questionnaires.py export . --output-dir=%T/
+RUN: python %S/export_questionnaires.py . --output-dir=%T/
 
 RUN: %check_exists --file "%T/tsrm_questionnaires.xlsx"
 

--- a/tests/integration/features/_integration_/python_api_and_source_trace/python_api_use_compatible_with_source_path/export_questionnaires.py
+++ b/tests/integration/features/_integration_/python_api_and_source_trace/python_api_use_compatible_with_source_path/export_questionnaires.py
@@ -1,0 +1,36 @@
+import argparse
+import os
+
+from strictdoc.core.project_config import ProjectConfig, ProjectConfigLoader
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Export questionnaires from SDoc documents."
+    )
+
+    parser.add_argument(
+        "input_path",
+        type=str,
+        help="Path to the input path."
+    )
+
+    # Optional argument
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Optional directory to save output."
+    )
+
+    args = parser.parse_args()
+
+    input_path = args.input_path
+    output_dir = args.output_dir
+
+    project_config: ProjectConfig = ProjectConfigLoader.load(
+        input_path=input_path, output_dir=output_dir
+    )
+    # Verify that the source root path is resolved from the original form "src"
+    # to an absolute path. This confirms that the project config is correctly
+    # validated and finalized.
+    assert os.path.isabs(project_config.source_root_path), project_config.source_root_path

--- a/tests/integration/features/_integration_/python_api_and_source_trace/python_api_use_compatible_with_source_path/strictdoc_config.py
+++ b/tests/integration/features/_integration_/python_api_and_source_trace/python_api_use_compatible_with_source_path/strictdoc_config.py
@@ -1,0 +1,11 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        source_root_path="src",
+        project_features=[
+            "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+        ],
+    )
+    return config

--- a/tests/integration/features/_integration_/python_api_and_source_trace/python_api_use_compatible_with_source_path/test.itest
+++ b/tests/integration/features/_integration_/python_api_and_source_trace/python_api_use_compatible_with_source_path/test.itest
@@ -1,0 +1,6 @@
+#
+# Verify that there is no regression as reported here:
+# https://github.com/strictdoc-project/strictdoc/issues/2663
+#
+RUN: cd %S
+RUN: python %S/export_questionnaires.py . --output-dir=%T/

--- a/tests/unit_server/strictdoc/server/20_feature_diff/test_case.py
+++ b/tests/unit_server/strictdoc/server/20_feature_diff/test_case.py
@@ -29,11 +29,8 @@ def project_config():
         port=8001,
     )
     project_config: ProjectConfig = (
-        ProjectConfigLoader.load_from_path_or_get_default(
-            path_to_config=PATH_TO_CONFIG,
-        )
+        ProjectConfigLoader.load_using_server_config(server_config)
     )
-    project_config.integrate_server_config(server_config)
     return project_config
 
 


### PR DESCRIPTION
WHAT:

Encapsulate `validate_and_finalize()` inside ProjectConfigLoader. Introduce dedicated `load...` methods on the ProjectConfigLoader class that handle merging the project config with command-line config objects.

As part of this work, the server command now generates output files in `./output/server` by default. Previously, the output folder was created in a temporary location if not specified by the user.

WHY:

This improves encapsulation of how project and CLI command configs are merged, reducing the risk of undefined behavior when the project config is not initialized correctly, especially when the StrictDoc Python API is used outside the standard CLI workflow.

This also fixes a user report where undefined behavior occurred due to a missing `validate_and_finalize()` call. The affected Python API example (export questionnaire) has been updated to use the new, better-encapsulated API.

Closes #2663