### PR TITLE
feat: trigger mermaid update after node updates

### DIFF
--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -97,6 +97,14 @@
     <script type="module">
       mermaid.initialize({ startOnLoad: true });
     </script>
+  {%- if view_object.is_running_on_server -%}
+    <script>
+      // Re-run mermaid after node updates (i.e. after saving)...
+      document.addEventListener("turbo:before-stream-render", () => {
+        requestAnimationFrame(() => mermaid.run());
+      });
+    </script>
+  {%- endif -%}
   {%- endif -%}
   {{ super() }}
 {% endblock head_scripts %}


### PR DESCRIPTION
Uses the same logic as is already used for mathjax.

Currently mermaid diagrams completely break after editing them. Only a full reload fixes them.
