### PR TITLE
feat(rust): Add language aware parsing for Rust

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -2795,7 +2795,7 @@ To activate language-aware traceability, configure the project with the followin
         )
         return config
 
-Currently, Python, C/C++ and Robot Framework parsers are implemented. Upcoming implementations include parsers for Rust, Bash, and more.
+Currently, Python, C/C++, Rust, and Robot Framework parsers are implemented. Upcoming implementations include parsers for Bash, and more.
 <<<
 
 [[/SECTION]]
@@ -2838,7 +2838,11 @@ The marker must be added to the top comment of a file.
         @relation(REQ-1, scope=class)
         """
 
-**3\) Linking a function to a requirement (Python, C, and C++ only)**
+**3\) Linking language items to a requirement (Python, C, C++, Rust)**
+
+For Python, ``@relation`` markers can be placed inside `doc strings`_ to link functions and classes.
+
+.. _doc strings: https://peps.python.org/pep-0257/#what-is-a-docstring
 
 .. code:: python
 
@@ -2850,7 +2854,8 @@ The marker must be added to the top comment of a file.
             @relation(REQ-1, scope=function)
             """
 
-or
+For the C and C++ languages, if a ``@relation`` marker is included in a function declaration prototype (which is the most
+common practice), StrictDoc also creates a link between the requirement and the corresponding C function definition.
 
 .. code:: c
 
@@ -2863,9 +2868,53 @@ or
         print("Hello, World\n");
     }
 
-.. note::
+For Rust, ``@relation`` marker can be placed inside `doc comments`_ to automatically infer the linked item. This
+works for almost all Rust language elements like modules, functions, traits, enums or structs.
 
-    For the C and C++ languages, if a ``@relation`` marker is included in a function declaration prototype (which is the most common practice), StrictDoc also creates a link between the requirement and the corresponding C function definition.
+.. _doc comments: https://doc.rust-lang.org/rust-by-example/meta/doc.html#doc-comments
+
+.. code:: rust
+
+    /*!
+     * This module does...
+     * @relation(REQ-1)
+     */
+
+    use std::fmt;
+
+    /**
+     * With this enum, ...
+     * @relation(REQ-2)
+     */
+    pub enum Niceness {
+        /// This variant means ...
+        /// @relation(REQ-3)
+        Nice,
+
+        /// And this variant means ...
+        /// @relation(REQ-4)
+        Awesome,
+    }
+
+    /**
+     * Implement Debug trait for Niceness.
+     * @relation(REQ-5)
+     */
+    impl fmt::Debug for Niceness {
+        /// @relation(REQ-6)
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match *self {
+                /// @relation(REQ-7)
+                Niceness::Nice => {
+                    write!(f, ":-)")
+                }
+                /// @relation(REQ-8)
+                Niceness::Awesome => {
+                    write!(f, ":-D")
+                }
+            }
+        }
+    }
 
 **4\) Linking a range to a requirement**
 
@@ -2883,6 +2932,10 @@ or
     def foo():
         # @relation(REQ-1, scope=line)
         print("Hello, World!")
+
+.. note::
+
+    For Rust, line and range marker are supported in normal comments, but not doc comments.
 <<<
 
 [[/SECTION]]
@@ -2925,7 +2978,7 @@ The linking of requirements to source files is arranged with a special RELATION 
       VALUE: file.py
       LINE_RANGE: 2, 4
 
-**3\) Linking a requirement to a function in a source file**
+**3\) Linking a requirement to language items in a source file**
 
 .. code:: strictdoc
 
@@ -2940,10 +2993,17 @@ The linking of requirements to source files is arranged with a special RELATION 
     - TYPE: File
       VALUE: file.c
       FUNCTION: Foo.hello_world_2
+    - TYPE: File
+      VALUE: file.rs
+      FUNCTION: <file::FooTuple as file::FooTrait>::bar
 
 .. note::
 
-    For linking to functions in classes, a class name has to be added in a format: ``<class name>.<function name>``. This is currently only supported for Python source files.
+    Rules for building the full qualified path of an identifier depend on the language of the source file.
+    For linking to Python functions in classes, a class name has to be added in a format: ``<class name>.<function name>``.
+    For linking to any Rust identifier, `canonical paths`_ for a single file are used.
+
+.. _canonical paths: https://doc.rust-lang.org/reference/paths.html#canonical-paths>
 
 **4\) Linking a requirement to a class in a source file (Python only)**
 
@@ -3029,7 +3089,7 @@ In this example, the ``skip``-relation causes StrictDoc to ignore the ``REQ-001`
 [[SECTION]]
 MID: c9da7df725564208971e7ee058ad8d73
 UID: SECTION-UG-Parsing-SDoc-source-nodes
-TITLE: Parsing SDoc nodes from source code comments (experimental, for C/C++ only)
+TITLE: Parsing SDoc nodes from source code comments (experimental, for C/C++ and Rust only)
 
 [TEXT]
 MID: 72fe8c3f618042578850cfdf01868b6c

--- a/docs/strictdoc_21_L2_StrictDoc_Requirements.sdoc
+++ b/docs/strictdoc_21_L2_StrictDoc_Requirements.sdoc
@@ -1353,6 +1353,371 @@ Robot framework's markup has to be handled with a dedicated parser because of th
 
 [[/SECTION]]
 
+[[SECTION]]
+MID: e18dcfcb9b99459d9c7f560f35d01ff8
+TITLE: Language-aware parsing of Rust source code
+
+[REQUIREMENT]
+MID: d83cab2dcd014d328b348acc37c6f4a6
+UID: SDOC-SRS-164
+TITLE: Auto-scoped relation markers in Rust docs
+STATEMENT: >>>
+If a StrictDoc relation marker is inside a `Rust doc comment`_, the marker scope shall be set to exact the item the Rust
+language defines as target of the containing doc comment. The :code:`@relation(scope=...)` parameter shall therefore
+be optional and shall be ignored if provided.
+
+.. code-block:: rust
+   :number-lines:
+
+   /// @relation(REQ-1)
+   impl Foo {
+
+       /// @relation(REQ-2)
+       fn foo() {
+       }
+   }
+
+In the given example, the first marker shall link REQ-1 to the :code:`impl Foo` implementation,
+highlighting lines 1 to 7. The second marker shall link REQ-2 to the :code:`fn foo()` function,
+highlighting lines 4 to 6.
+
+.. _Rust doc comment: https://doc.rust-lang.org/rust-by-example/meta/doc.html#doc-comments
+<<<
+COMMENT: >>>
+Note that doc comments are syntactic sugar for `doc attribute`_ s, which shall also be supported.
+To figure detailed doc comment rules from the rust-lang specification it's sometimes useful
+to check for general attribute rules, if explicit doc comment rules are missing.
+
+.. _doc attribute: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-34
+- TYPE: Parent
+  VALUE: SDOC-SRS-137
+
+[REQUIREMENT]
+MID: 91c7b9fd9c514327bb012639cdf1515b
+UID: SDOC-SRS-165
+TITLE: Inner doc attributes
+STATEMENT: >>>
+StrictDoc shall support relation markers in inner_ `doc attribute`_ s.
+
+.. _inner: https://doc.rust-lang.org/reference/attributes.html#r-attributes.inner
+.. _doc attribute: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#the-doc-attribute
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-164
+
+[REQUIREMENT]
+MID: 002bfab5383e4cb785049c4738651f43
+UID: SDOC-SRS-166
+TITLE: Inner line docs
+STATEMENT: >>>
+StrictDoc shall support auto-scoped relation relation markers in `inner line docs`_.
+
+.. _inner line docs: https://doc.rust-lang.org/reference/comments.html#grammar-INNER_LINE_DOC
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-164
+
+[REQUIREMENT]
+MID: d04b97d76cc848f982610035bf7d3dc2
+UID: SDOC-SRS-167
+TITLE: Inner block docs
+STATEMENT: >>>
+StrictDoc shall support auto-scoped relation relation markers in `inner block docs`_.
+
+.. _inner block docs: https://doc.rust-lang.org/reference/comments.html#grammar-INNER_BLOCK_DOC
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-164
+
+[REQUIREMENT]
+MID: 84b351267cfc4e16b3ff2c5db654e9f0
+UID: SDOC-SRS-168
+TITLE: Outer doc attributes
+STATEMENT: >>>
+StrictDoc shall support auto-scoped relation markers in outer_ `doc attribute`_ s.
+
+.. _outer: https://doc.rust-lang.org/reference/attributes.html#r-attributes.outer
+.. _doc attribute: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#the-doc-attribute
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-164
+
+[REQUIREMENT]
+MID: 171978da9f8f4f40b52fb7599caa67e6
+UID: SDOC-SRS-169
+TITLE: Outer line docs
+STATEMENT: >>>
+StrictDoc shall support auto-scoped relation markers in `outer line docs`_.
+
+.. _outer line docs: https://doc.rust-lang.org/reference/comments.html#grammar-OUTER_LINE_DOC
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-164
+
+[REQUIREMENT]
+MID: 1a8d558fbe244621818b6242be365638
+UID: SDOC-SRS-170
+TITLE: Outer block docs
+STATEMENT: >>>
+StrictDoc shall support auto-scoped relation markers in `outer block docs`_.
+
+.. _outer block docs: https://doc.rust-lang.org/reference/comments.html#railroad-OUTER_BLOCK_DOC
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-164
+
+[REQUIREMENT]
+MID: e1be1f38dd374f82abd9691d081f293b
+UID: SDOC-SRS-171
+TITLE: File, line and range markers
+STATEMENT: >>>
+StrictDoc shall point to lines and line ranges of Rust code by using file, line and range markers.
+These marker types shall be parsed from `regular line and block comments`_.
+
+Note: File markers may also result from the inner doc comments of the top-level module.
+
+.. _regular line and block comments: https://doc.rust-lang.org/rust-by-example/hello/comment.html#comments
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-139
+- TYPE: Parent
+  VALUE: SDOC-SRS-124
+- TYPE: Parent
+  VALUE: SDOC-SRS-138
+
+[REQUIREMENT]
+MID: b9b2e4d377db42f5b3fb7aeabaf3f72a
+UID: SDOC-SRS-172
+TITLE: Source nodes from doc comments
+STATEMENT: >>>
+If a Rust doc comments contains custom tags, and the containing Rust source file matches an entry in the
+source node configuration, StrictDoc shall create document nodes from the custom tags and automatically
+link the created node with the Rust item targeted by the doc comment.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-141
+
+[REQUIREMENT]
+MID: 9d7e371ad7a146e1968cd9bbb7a6790f
+UID: SDOC-SRS-173
+TITLE: Forward relations to Rust items
+STATEMENT: >>>
+StrictDoc shall support linking from a requirement in SDoc to a language item in Rust code by using a :code:`FILE`
+relation of type :code:`FUNCTION`. For example
+
+.. code-block:: strictdoc
+
+   [REQUIREMENT]
+   UID: REQ-1
+   RELATIONS:
+   - TYPE: File
+     VALUE: file.rs
+     FUNCTION: file::foo
+
+This shall work for all kinds of Rust items that have a `canonical path`_, including const, enum, fn, mod, static,
+struct, trait, type, union.
+
+.. _canonical path: https://doc.rust-lang.org/reference/paths.html#canonical-paths
+<<<
+
+[REQUIREMENT]
+MID: d01b2204fcb44882b991ca11ce567f52
+UID: SDOC-SRS-174
+TITLE: Forward relation by canonical path
+STATEMENT: >>>
+The identifier for forward relations shall be the `canonical path`_ as the rustc compiler would set it when invoked for
+a single file like
+
+.. code-block:: shell
+
+   rustc --crate-type rlib --emit=obj src/lib.rs
+
+Note: :code:`cargo build` usually result in a different canonical path, since it considers the file position relative to
+the crate root. Using a single file as root is a simplification, needed because StrictDoc is unaware of the Rust
+file and directory-based module hierarchy.
+
+.. _canonical path: https://doc.rust-lang.org/reference/paths.html#canonical-paths
+<<<
+COMMENT: >>>
+The canonical path of an item can be observed with :code:`objdump -t lib.o --demangle=rust`. For example, given this
+source file
+
+.. code-block:: rust
+   :number-lines:
+
+   pub mod foo {
+
+       pub trait Foo {
+           fn foo(&self) {}
+       }
+
+       pub struct Bar(i32);
+
+       impl Foo for Bar {
+           fn foo(&self) {}
+       }
+   }
+
+:code:`objdump` will show
+
+.. code-block:: shell
+
+   <lib::foo::Bar as lib::foo::Foo>::foo
+
+Alas, a forward relation would be
+
+.. code-block:: strictdoc
+
+   [REQUIREMENT]
+   UID: REQ-1
+   RELATIONS:
+   - TYPE: File
+     VALUE: file.rs
+     FUNCTION: <lib::foo::Bar as lib::foo::Foo>::foo
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-173
+
+[REQUIREMENT]
+MID: 04b5927294c34710995d3671040dd8ae
+UID: SDOC-SRS-175
+TITLE: Collapse doc comments
+STATEMENT: >>>
+Multiple scattered doc comments shall be collapsed as done by the rustdoc_ tool when using the collapse-docs option
+to determine the highlight range(s).
+
+For example, rustdoc would collapse alle these comments into the description of :code:`fn foo()`
+
+.. code-block:: rust
+   :number-lines:
+
+   /// Some
+   /// line
+
+   /// doc,
+
+   /**
+     * and some
+     * block dock,
+     */
+
+   #[doc = "and some"]
+
+   #[doc = "doc attr."]
+
+   fn foo() {
+   }
+
+In the given example, the StrictDoc highlight range for the relation marker shall be from line 1 to line 16.
+
+.. _rustdoc: https://github.com/rust-lang/rust/tree/main/src/tools/rustdoc
+<<<
+
+[REQUIREMENT]
+MID: e67e8258177847138112589e606c0413
+UID: SDOC-SRS-176
+TITLE: Rust marker descriptions
+STATEMENT: >>>
+StrictDoc should use the marker labels as rustdoc_ would set them in the description of a documented node.
+
+.. _rustdoc: https://doc.rust-lang.org/stable/rustdoc/
+<<<
+
+[REQUIREMENT]
+MID: 7bf3f26c335741398a50e9679a0d4c84
+UID: SDOC-SRS-177
+TITLE: Valid positions of doc comments
+STATEMENT: >>>
+StrictDoc shall find doc comments where the language allows_ them and ignore those in other positions.
+
+.. _allows: https://doc.rust-lang.org/reference/attributes.html#r-attributes.allowed-position
+<<<
+COMMENT: >>>
+Since doc comments are syntactic sugar for doc attributes, allowed position rules for attributes apply.
+<<<
+
+[REQUIREMENT]
+MID: 5e9645177af14db7b5fcaba0298a328b
+UID: SDOC-SRS-178
+TITLE: Inner doc comments for functions
+STATEMENT: >>>
+StrictDoc shall find inner doc comments in function blocks.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-177
+
+[REQUIREMENT]
+MID: b70a27cc49f54b0bb7e7956b055957a4
+UID: SDOC-SRS-179
+TITLE: Inner doc comments for modules
+STATEMENT: >>>
+StrictDoc shall find inner doc comments in module blocks.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-177
+
+[REQUIREMENT]
+MID: 012e605921954430ab6c11e245fb7378
+UID: SDOC-SRS-180
+TITLE: Inner doc comments for external blocks
+STATEMENT: >>>
+StrictDoc shall find inner doc comments in external blocks.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-177
+
+[REQUIREMENT]
+MID: 2d955dd847954556aa5a32018a7c41fd
+UID: SDOC-SRS-181
+TITLE: Inner doc comments for implementation blocks
+STATEMENT: >>>
+StrictDoc shall find inner doc comments in implementation blocks.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-177
+
+[REQUIREMENT]
+MID: ef8849024b78477496620eb1bf081900
+UID: SDOC-SRS-182
+TITLE: Allowed position for outer docs
+STATEMENT: >>>
+StrictDoc shall find outer doc comments in `allowed positions`_ as specified by the Rust language:
+
+- All item_ declarations
+- Most statements
+- Block expressions, but only when they are the outer expression of an
+  expression statement or the final expression of another block expression.
+- Enum variants, struct and union fields
+- Generic lifetime or type parameter
+- Expressions in limited situations
+- Function, closure and function pointer parameters
+
+.. _allowed positions: https://doc.rust-lang.org/reference/attributes.html#r-attributes.allowed-position
+.. _item: https://doc.rust-lang.org/reference/items.html#r-items.syntax
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-177
+
+[[/SECTION]]
+
 [REQUIREMENT]
 MID: bdeda4b89d82446281e2c7c2eae46708
 UID: SDOC-SRS-143

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,10 @@ dependencies = [
     "docutils >= 0.22.2, == 0.*",
 
     # Tree Sitter is used for language/AST-aware parsing of Python, C and other files.
-    "tree-sitter",
+    "tree-sitter >= 0.25",
     "tree_sitter_cpp",
     "tree-sitter-python",
+    "tree-sitter-rust",
 
     # Requirements-to-source traceability. Colored syntax for source files.
     "pygments >= 2.10.0, == 2.*",

--- a/strictdoc/backend/sdoc_source_code/caching_reader.py
+++ b/strictdoc/backend/sdoc_source_code/caching_reader.py
@@ -20,6 +20,9 @@ from strictdoc.backend.sdoc_source_code.reader_python import (
 from strictdoc.backend.sdoc_source_code.reader_robot import (
     SourceFileTraceabilityReader_Robot,
 )
+from strictdoc.backend.sdoc_source_code.reader_rust import (
+    SourceFileTraceabilityReader_Rust,
+)
 from strictdoc.core.project_config import ProjectConfig
 
 
@@ -70,6 +73,7 @@ class SourceFileTraceabilityCachingReader:
         SourceFileTraceabilityReader_Python,
         SourceFileTraceabilityReader_C,
         SourceFileTraceabilityReader_Robot,
+        SourceFileTraceabilityReader_Rust,
     ]:
         if project_config.is_activated_source_file_language_parsers():
             if path_to_file.endswith(".py"):
@@ -87,4 +91,8 @@ class SourceFileTraceabilityCachingReader:
                 )
             if path_to_file.endswith(".robot"):
                 return SourceFileTraceabilityReader_Robot()
+            if path_to_file.endswith(".rs"):
+                return SourceFileTraceabilityReader_Rust(
+                    custom_tags=source_node_tags
+                )
         return SourceFileTraceabilityReader()

--- a/strictdoc/backend/sdoc_source_code/marker_parser.py
+++ b/strictdoc/backend/sdoc_source_code/marker_parser.py
@@ -41,20 +41,32 @@ class MarkerParser:
         default_scope: Optional[str] = None,
     ) -> SourceNode:
         """
-        Parse relation markers from source file comments.
+        Parse source nodes and relation markers from source file comments.
 
         Before the actual parsing, the function removes all code comment symbols
         such as /** ... */ or /// Doxygen comments or Python
 
-        The line start/end indicate a range where the comment is located in the
-        source file.
-        The comment_line_start parameter maybe the same as line start but can
-        also be different if the comment is part of a Python or C function in
-        which case the comment_line_start will be several lines below the actual
-        start of the range.
+        The 1-based line start/end provide hints to the parser for the case markers
+        of scope file, class or function are found, in which case the user values are
+        set as highlight range. If the parser finds line or range markers, the user
+        provided line start/end values are ignored. Should be set to the item definition
+        block, *with* leading comment lines if any.
+
+        The 1-based comment_line_start parameter is the first actual comment line.
+        It is required as a base offset for some parser tokens to determine their
+        absolute position in file, as lexing gives only a position relative
+        to comment start.
+
+        custom_tags is a set of valid tags if a comment is expected to contain
+        key-value pairs for source node generation. The caller is responsible to determine
+        valid custom tags from the grammar element associated with the source code file.
 
         filename should be given if input_string comes from a static source file.
         It will be used to create more helpful parsing error messages.
+
+        entity_name is required for language item markers. It's the user-visible
+        description of the marked range in the rendered document. Should be equal
+        to the related LanguageItem.description for consistency with forward markers.
 
         default_scope should be provided if the caller's language-aware parser
         can infer the scope from the semantic comment position. Think of Rust doc
@@ -62,6 +74,10 @@ class MarkerParser:
         in a relation marker. A user provided scope argument always takes preference.
         If neither default nor a user provided value is available,
         StrictDocSemanticError will be raised.
+
+        The function returns a SourceNode. Note: This is also the case if no custom tags were
+        found at all (in which case fields is empty) because SourceNode also acts as a container
+        for markers.
         """
 
         node_fields: Dict[str, str] = {}

--- a/strictdoc/backend/sdoc_source_code/models/language.py
+++ b/strictdoc/backend/sdoc_source_code/models/language.py
@@ -85,7 +85,10 @@ class LanguageItem:
 
         assert parent is not None
         self.parent = parent
+
+        # Full qualified name.
         self.name = name
+
         self.display_name = display_name
 
         # Child functions are supported in programming languages that can nest

--- a/strictdoc/backend/sdoc_source_code/models/source_location.py
+++ b/strictdoc/backend/sdoc_source_code/models/source_location.py
@@ -14,3 +14,12 @@ class ByteRange:
             start=node.start_byte,
             end=node.end_byte,
         )
+
+    @classmethod
+    def create_from_ts_nodes(
+        cls, first_node: Node, last_node: Node
+    ) -> "ByteRange":
+        return cls(
+            start=first_node.start_byte,
+            end=last_node.end_byte,
+        )

--- a/strictdoc/backend/sdoc_source_code/reader_rust.py
+++ b/strictdoc/backend/sdoc_source_code/reader_rust.py
@@ -1,0 +1,606 @@
+"""
+@relation(SDOC-SRS-142, scope=file)
+"""
+
+from enum import IntEnum
+from pathlib import Path
+from typing import Optional, Union
+
+import tree_sitter_rust as ts_rust
+from tree_sitter import Language, Node, Parser, Query, QueryCursor
+
+from strictdoc.backend.sdoc_source_code.constants import FunctionAttribute
+from strictdoc.backend.sdoc_source_code.marker_parser import MarkerParser
+from strictdoc.backend.sdoc_source_code.models.language import LanguageItem
+from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
+    LanguageItemMarker,
+    RangeMarkerType,
+)
+from strictdoc.backend.sdoc_source_code.models.line_marker import LineMarker
+from strictdoc.backend.sdoc_source_code.models.range_marker import (
+    ForwardRangeMarker,
+    RangeMarker,
+)
+from strictdoc.backend.sdoc_source_code.models.source_file_info import (
+    SourceFileTraceabilityInfo,
+)
+from strictdoc.backend.sdoc_source_code.models.source_location import ByteRange
+from strictdoc.backend.sdoc_source_code.parse_context import ParseContext
+from strictdoc.backend.sdoc_source_code.processors.general_language_marker_processors import (
+    language_item_marker_processor,
+    line_marker_processor,
+    range_marker_processor,
+    source_file_traceability_info_processor,
+)
+from strictdoc.helpers.cast import assert_cast
+from strictdoc.helpers.file_stats import SourceFileStats
+from strictdoc.helpers.file_system import file_open_read_bytes
+
+# @relation(SDOC-SRS-177, SDOC-SRS-171, SDOC-SRS-173, scope=line)
+TS_QUERY = """
+; Query 0: Outer doc attribute, line doc, or block doc in allowed positions
+(
+  [
+    (attribute_item
+      (attribute
+        (identifier) @_attribute_id (#eq? @_attribute_id "doc")
+          value: (string_literal (string_content) @doc.comment)))+
+    (line_comment
+      outer: (outer_doc_comment_marker)
+      doc: (doc_comment) @doc.comment)+
+    (block_comment
+      outer: (outer_doc_comment_marker)
+      doc: (doc_comment) @doc.comment)
+  ]
+  .
+  (attribute_item)*
+  .
+  [
+    ; any identifiable item, most notably functions
+    (_ name: [(identifier)(field_identifier)(type_identifier)(lifetime)] @doc.item_identifier)
+
+    ; impl MyStruct
+    (impl_item type: (type_identifier) @doc.item_identifier)
+
+    ; extern "C"
+    (foreign_mod_item (extern_modifier) @doc.item_identifier)
+
+    ; match arm
+    (match_arm (match_pattern) @doc.item_identifier)
+
+    ; assignment inside struct initializer
+    (field_initializer field: (field_identifier) @doc.item_identifier)
+
+    ; Statement like 1;
+    (expression_statement) @doc.item_identifier
+
+    ; Expression like x + y
+    (binary_expression) @doc.item_identifier
+
+    ; Expression like (x + y)
+    (parenthesized_expression) @doc.item_identifier
+
+    ; Named "type" field of any enclosing node (usually body), e.g. type within tuple struct.
+    type: (_)
+  ] @doc.item
+)
+
+; Query 1: Inner doc attribute, line doc or block doc in allowed positions.
+; Note: We have to repeat the identical inner pattern, alternations don't help here.
+;       See https://github.com/tree-sitter/tree-sitter/issues/3480.
+[
+  (function_item
+    name: (identifier) @doc.item_identifier
+    body: (block
+      [
+        (inner_attribute_item
+          (attribute
+            (identifier) @_attribute_id (#eq? @_attribute_id "doc")
+            value: (string_literal (string_content) @doc.comment)))+
+        (line_comment
+          inner: (inner_doc_comment_marker)
+          doc: (doc_comment) @doc.comment)+
+        (block_comment
+          inner: (inner_doc_comment_marker)
+          doc: (doc_comment) @doc.comment)
+      ]
+    )
+  )
+  (mod_item
+    name: (identifier) @doc.item_identifier
+    body: (declaration_list
+      [
+        (inner_attribute_item
+          (attribute
+            (identifier) @_attribute_id (#eq? @_attribute_id "doc")
+            value: (string_literal (string_content) @doc.comment)))+
+        (line_comment
+          inner: (inner_doc_comment_marker)
+          doc: (doc_comment) @doc.comment)+
+        (block_comment
+          inner: (inner_doc_comment_marker)
+          doc: (doc_comment) @doc.comment)
+      ]
+    )
+  )
+  (impl_item
+    type: (type_identifier) @doc.item_identifier
+    body: (declaration_list
+      [
+        (inner_attribute_item
+          (attribute
+            (identifier) @_attribute_id (#eq? @_attribute_id "doc")
+            value: (string_literal (string_content) @doc.comment)))+
+        (line_comment
+          inner: (inner_doc_comment_marker)
+          doc: (doc_comment) @doc.comment)+
+        (block_comment
+          inner: (inner_doc_comment_marker)
+          doc: (doc_comment) @doc.comment)
+      ]
+    )
+  )
+  (foreign_mod_item (extern_modifier) @doc.item_identifier
+    body: (declaration_list
+      [
+        (inner_attribute_item
+          (attribute
+            (identifier) @_attribute_id (#eq? @_attribute_id "doc")
+            value: (string_literal (string_content) @doc.comment)))+
+        (line_comment
+          inner: (inner_doc_comment_marker)
+          doc: (doc_comment) @doc.comment)+
+        (block_comment
+          inner: (inner_doc_comment_marker)
+          doc: (doc_comment) @doc.comment)
+      ]
+    )
+  )
+] @doc.item
+
+; Query 2: Inner line or block doc comment of file-level module.
+(source_file
+  [
+    (line_comment
+      inner: (inner_doc_comment_marker)
+        doc: (doc_comment) @doc.comment)+
+    (block_comment
+      inner: (inner_doc_comment_marker)
+        doc: (doc_comment) @doc.comment)
+  ]
+) @doc.item
+
+; Query 3: normal line or block comment
+[(line_comment !doc)+
+ (block_comment !doc)] @normal_comment
+
+; Query 4: Identifiable items. Those where it's clear how to link by forward relations.
+[
+  (const_item name: (identifier) @doc.item_identifier) @doc.item
+  (enum_item name: (type_identifier) @doc.item_identifier) @doc.item
+  (function_item name: (identifier) @doc.item_identifier) @doc.item
+  (mod_item name: (identifier) @doc.item_identifier) @doc.item
+  (static_item name: (identifier) @doc.item_identifier) @doc.item
+  (struct_item name: (type_identifier) @doc.item_identifier) @doc.item
+  (trait_item name: (type_identifier) @doc.item_identifier) @doc.item
+  (type_item name: (type_identifier) @doc.item_identifier) @doc.item
+  (union_item name: (type_identifier) @doc.item_identifier) @doc.item
+]
+"""
+
+
+class RustTsQuery(IntEnum):
+    """Give the queries from TS_QUERY a friendly name."""
+
+    OUTER_DOC_COMMENT = 0
+    INNER_DOC_COMMENT = 1
+    INNER_DOC_COMMENT_FILEMODULE = 2
+    NORMAL_COMMENT = 3
+    IDENTIFIABLE_ITEM = 4
+
+
+def comments_text_from_comment_nodes(comments: list[Node]) -> str:
+    """
+    Join multiple comment nodes into one multi-line string.
+    @relation(SDOC-SRS-175, scope=function)
+    """
+    comment_text = assert_cast(comments[0].text, bytes).decode("utf-8")
+    last_row = comments[0].start_point.row
+    for comment_part in comments[1:]:
+        new_lines = comment_part.start_point.row - last_row
+        last_row = comment_part.start_point.row
+        comment_text += "\n" * new_lines + assert_cast(
+            comment_part.text, bytes
+        ).decode("utf-8")
+    return comment_text
+
+
+def special_description(item: Node, identifier_text: str) -> Optional[str]:
+    """
+    Make a description for language constructs that are not functions.
+
+    The default Function description assumes the object actually represents a function.
+    However, the Rust reader reuses Function to represent many different Rust specific object types.
+    We have to give them a suitable Rust specific description.
+    """
+    if item.type == "associated_type":
+        return f"associated type {identifier_text}"
+    elif item.type in ("binary_expression", "parenthesized_expression"):
+        return f"expression {identifier_text}"
+    elif item.type == "const_item":
+        return f"const {identifier_text}"
+    elif item.type == "const_parameter":
+        return f"const parameter {identifier_text}"
+    elif item.type == "function_item":
+        return f"fn {identifier_text}()"
+    elif item.type == "enum_item":
+        return f"enum {identifier_text}"
+    elif item.type == "enum_variant":
+        return f"enum variant {identifier_text}"
+    elif item.type == "expression_statement":
+        return f"statement {identifier_text}"
+    elif item.type == "extern_crate_declaration":
+        return f"crate {identifier_text}"
+    elif item.type == "field_declaration":
+        return f"field {identifier_text}"
+    elif item.type == "field_initializer":
+        return f"field initializer {identifier_text}"
+    elif item.type == "foreign_mod_item":
+        return f"foreign module {identifier_text}"
+    elif item.type == "impl_item":
+        return f"impl {identifier_text}"
+    elif item.type == "match_arm":
+        return f"match arm {identifier_text}"
+    elif item.type == "macro_definition":
+        return f"macro {identifier_text}"
+    elif item.type == "mod_item":
+        return f"module {identifier_text}"
+    elif item.type == "lifetime_parameter":
+        return f"lifetime {identifier_text}"
+    elif item.type == "static_item":
+        return f"static {identifier_text}"
+    elif item.type == "struct_item":
+        return f"struct {identifier_text}"
+    elif item.type == "trait_item":
+        return f"trait {identifier_text}"
+    elif item.type == "type_item":
+        return f"type {identifier_text}"
+    elif item.type == "type_parameter":
+        return f"type parameter {identifier_text}"
+    elif item.type == "union_item":
+        return f"union {identifier_text}"
+    elif item.type in ("primitive_type", "type_identifier"):
+        return f"type {identifier_text}"
+    return None
+
+
+class SourceFileTraceabilityReader_Rust:
+    def __init__(self, custom_tags: Optional[set[str]] = None) -> None:
+        self.custom_tags: Optional[set[str]] = custom_tags
+
+    def read(
+        self,
+        input_buffer: bytes,
+        file_path: Optional[str] = None,
+    ) -> SourceFileTraceabilityInfo:
+        file_stats = SourceFileStats.create(input_buffer)
+        parse_context = ParseContext(file_path, file_stats)
+        traceability_info = SourceFileTraceabilityInfo([])
+        parser = ParserRun(
+            input_buffer, parse_context, traceability_info, self.custom_tags
+        )
+        parser()
+        source_file_traceability_info_processor(
+            traceability_info, parse_context
+        )
+        return traceability_info
+
+    def read_from_file(self, file_path: str) -> SourceFileTraceabilityInfo:
+        """
+        Generate the source file traceability info for one particular Rust file.
+
+        The created SourceFileTraceabilityInfo is filled partially local information:
+        - functions: Markers are associated, but only those resulting from local markers.
+        - markers: Markers that stem from markup in this file.
+        - ng_map_reqs_to_markers: Mapping of requirement IDs to Marker objects for markers directly defined in the source file.
+        """
+        with file_open_read_bytes(file_path) as file:
+            sdoc_content = file.read()
+            sdoc = self.read(sdoc_content, file_path=file_path)
+            return sdoc
+
+
+class ParserRun:
+    def __init__(
+        self,
+        input_buffer: bytes,
+        parse_context: ParseContext,
+        traceability_info: SourceFileTraceabilityInfo,
+        custom_tags: Optional[set[str]],
+    ):
+        rust_language = Language(ts_rust.language())
+        self.parser = Parser(rust_language)  # type: ignore[call-arg, unused-ignore]
+        self.TS_QUERY = Query(rust_language, TS_QUERY)
+        self.input_buffer: bytes = input_buffer
+        self.parse_context = parse_context
+        self.traceability_info = traceability_info
+        self.custom_tags: Optional[set[str]] = custom_tags
+
+    def __call__(self) -> None:
+        tree = self.parser.parse(self.input_buffer)
+        cursor = QueryCursor(self.TS_QUERY)
+        matches = cursor.matches(tree.root_node)
+
+        seen_nodes = set()
+        deferred_matches = []
+        for query_index, captures in matches:
+            if query_index == RustTsQuery.IDENTIFIABLE_ITEM:
+                # The query for identifiable items overlaps with comment based queries. Move results for identifiable
+                # items last, so that a result can be skipped if a LanguageItem was already created.
+                deferred_matches.append(captures)
+            elif query_index in (
+                RustTsQuery.OUTER_DOC_COMMENT,
+                RustTsQuery.INNER_DOC_COMMENT,
+                RustTsQuery.INNER_DOC_COMMENT_FILEMODULE,
+            ):
+                assert len(captures["doc.item"]) == 1
+                item = captures["doc.item"][0]
+                doc_comment = captures["doc.comment"]
+                if (
+                    item.type == "source_file"
+                    and "doc.item_identifier" not in captures
+                ):
+                    self._process_anonymous_module_comment(
+                        doc_comment,
+                        item,
+                    )
+                else:
+                    if "doc.item_identifier" in captures:
+                        # doc comment on named item
+                        assert len(captures["doc.item_identifier"]) == 1
+                        identifier = assert_cast(
+                            captures["doc.item_identifier"][0].text, bytes
+                        ).decode()
+                    else:
+                        # doc comment on anonymous item
+                        identifier = assert_cast(item.text, bytes).decode()
+                    self._process_doc_comment(
+                        doc_comment,
+                        item,
+                        identifier,
+                    )
+                seen_nodes.add(item.id)
+            elif query_index == RustTsQuery.NORMAL_COMMENT:
+                self._process_normal_comment(captures["normal_comment"])
+
+        for captures in deferred_matches:
+            assert len(captures["doc.item"]) == 1
+            assert len(captures["doc.item_identifier"]) == 1
+            item = captures["doc.item"][0]
+            if item.id not in seen_nodes:
+                identifier = assert_cast(
+                    captures["doc.item_identifier"][0].text, bytes
+                ).decode()
+                self._process_item_for_forward_relation(item, identifier)
+
+    def _process_anonymous_module_comment(
+        self, comments: list[Node], module: Node
+    ) -> None:
+        """
+        Create marker, item and source nodes for file-level module from tree-sitter doc comment nodes.
+        @relation(SDOC-SRS-164, SDOC-SRS-172, scope=function)
+        """
+        comment_text = comments_text_from_comment_nodes(comments)
+        source_node = MarkerParser.parse(
+            input_string=comment_text,
+            line_start=1,
+            line_end=self.parse_context.file_stats.lines_total,
+            comment_line_start=module.start_point.row + 1,
+            comment_byte_range=ByteRange.create_from_ts_nodes(
+                comments[0], comments[-1]
+            ),
+            custom_tags=self.custom_tags,
+            default_scope="file",
+        )
+        for marker_ in source_node.markers:
+            if not isinstance(marker_, LanguageItemMarker):
+                continue
+            # At the top level, only accept the scope=file markers.
+            # Everything else will be handled by functions and classes.
+            if marker_.scope != RangeMarkerType.FILE:
+                print(  # noqa: T201
+                    "warning: comment to top-level module is not scope=file, ignoring"
+                )
+                continue
+            language_item_marker_processor(marker_, self.parse_context)
+            self.traceability_info.markers.append(marker_)
+
+    def _process_doc_comment(
+        self,
+        comments: list[Node],
+        item: Node,
+        identifier_text: str,
+    ) -> None:
+        """
+        Create markers, items and source nodes from tree-sitter doc comment nodes.
+        @relation(SDOC-SRS-164, SDOC-SRS-172, scope=function)
+        """
+        assert len(comments) >= 1
+        comment_text = comments_text_from_comment_nodes(comments)
+        line_start_0_based = min(
+            item.start_point[0], comments[0].start_point[0]
+        )
+        line_end_0_based = max(item.end_point[0], comments[-1].end_point[0])
+        source_node = MarkerParser.parse(
+            input_string=comment_text,
+            line_start=line_start_0_based + 1,
+            line_end=line_end_0_based + 1
+            if self.input_buffer[-1] == 10
+            else line_end_0_based,
+            comment_line_start=comments[0].start_point[0] + 1,
+            comment_byte_range=ByteRange.create_from_ts_nodes(
+                comments[0], comments[-1]
+            ),
+            custom_tags=self.custom_tags,
+            entity_name=identifier_text,
+            default_scope="function",
+        )
+
+        function_markers: list[
+            Union[
+                LanguageItemMarker, LineMarker, RangeMarker, ForwardRangeMarker
+            ]
+        ] = []
+        for marker_ in source_node.markers:
+            if isinstance(marker_, LanguageItemMarker) and (
+                language_item_marker_ := marker_
+            ):
+                if (
+                    description := special_description(item, identifier_text)
+                ) is not None:
+                    language_item_marker_.set_description(description)
+
+                # adds marker to context, and connects context requirements with marker
+                language_item_marker_processor(
+                    language_item_marker_, self.parse_context
+                )
+                self.traceability_info.markers.append(language_item_marker_)
+                function_markers.append(marker_)
+
+        name = self.canonical_path(item.parent, identifier_text)
+        new_function_for_rust_item = LanguageItem(
+            parent=self.traceability_info,
+            name=name,
+            display_name=name,
+            line_begin=item.start_point[0] + 1,
+            line_end=item.end_point[0] + 1,
+            code_byte_range=ByteRange.create_from_ts_node(item),
+            child_functions=[],
+            markers=[],
+            attributes={FunctionAttribute.DEFINITION},
+        )
+        if len(source_node.fields) > 0:
+            source_node.function = new_function_for_rust_item
+        self.traceability_info.source_nodes.append(source_node)
+        self.traceability_info.functions.append(new_function_for_rust_item)
+        self.traceability_info.ng_map_names_to_markers[identifier_text] = (
+            function_markers
+        )
+
+    def _process_normal_comment(self, comments: list[Node]) -> None:
+        """
+        Create markers and items from tree-sitter normal comment nodes.
+        @relation(SDOC-SRS-171, scope=function)
+        """
+        comment_text = comments_text_from_comment_nodes(comments)
+        line_start_0_based = comments[0].start_point.row
+        line_end_0_based = comments[-1].end_point.row
+        source_node = MarkerParser.parse(
+            input_string=comment_text,
+            line_start=line_start_0_based + 1,
+            line_end=line_end_0_based + 1,
+            comment_line_start=line_start_0_based + 1,
+            comment_byte_range=ByteRange.create_from_ts_nodes(
+                comments[0], comments[-1]
+            ),
+        )
+        for marker_ in source_node.markers:
+            if (
+                isinstance(marker_, LanguageItemMarker)
+                and (marker_.scope is RangeMarkerType.FILE)
+                and (language_item_marker := marker_)
+            ):
+                language_item_marker.ng_range_line_begin = 1
+                language_item_marker.ng_range_line_end = (
+                    self.parse_context.file_stats.lines_total
+                )
+                language_item_marker_processor(
+                    language_item_marker, self.parse_context
+                )
+            elif isinstance(marker_, RangeMarker) and (range_marker := marker_):
+                range_marker_processor(range_marker, self.parse_context)
+            elif isinstance(marker_, LineMarker) and (line_marker := marker_):
+                line_marker_processor(line_marker, self.parse_context)
+            else:
+                print(  # noqa: T201
+                    "warning: Ignoring @relation. Only scope=file|line|range_start is supported in regular "
+                    "Rust comments. Use doc comments otherwise."
+                )
+
+    def _process_item_for_forward_relation(
+        self, item: Node, identifier: str
+    ) -> None:
+        """
+        Create item objects from tree-sitter doc comment nodes to support forward relations.
+
+        Corresponding markers will be created and resolved later by FileTraceabilityIndex,
+        see validate_and_resolve.
+
+        @relation(SDOC-SRS-173, scope=function)
+        """
+        name = self.canonical_path(item.parent, identifier)
+        function = LanguageItem(
+            parent=self.traceability_info,
+            name=name,
+            display_name=name,
+            line_begin=item.start_point[0] + 1,
+            line_end=max(item.end_point[0] + 1, item.start_point[0] + 2),
+            code_byte_range=ByteRange.create_from_ts_node(item),
+            child_functions=[],
+            markers=[],
+            attributes={FunctionAttribute.DEFINITION},
+        )
+        self.traceability_info.functions.append(function)
+
+    def canonical_path(
+        self, parent_scope: Optional[Node], item_path_segment: str
+    ) -> str:
+        """
+        Construct a canonical path in best-effort.
+        @relation(SDOC-SRS-174, scope=function)
+        """
+        cursor: Optional[Node] = parent_scope
+
+        if (
+            cursor is not None
+            and cursor.type == "declaration_list"
+            and cursor.parent is not None
+            and cursor.parent.type == "impl_item"
+        ):
+            cursor = cursor.parent
+            item_being_implemented = cursor.child_by_field_name("type")
+            assert item_being_implemented is not None
+            canonical_path_item_being_implemented = self.canonical_path(
+                cursor,
+                assert_cast(item_being_implemented.text, bytes).decode("utf-8"),
+            )
+            impl_trait_node = cursor.child_by_field_name("trait")
+            if impl_trait_node is not None:
+                # rust-lang.org: For trait implementations, [the path prefix] is the canonical path of the item being
+                # implemented followed by as followed by the canonical path to the trait all surrounded in angle (<>)
+                # brackets.
+                trait = self.canonical_path(
+                    None,
+                    assert_cast(impl_trait_node.text, bytes).decode("utf-8"),
+                )
+                path_prefix = (
+                    f"<{canonical_path_item_being_implemented} as {trait}>"
+                )
+            else:
+                # rust-lang.org: For bare implementations, [the path prefix] is the canonical path of the item being
+                # implemented surrounded by angle (<>) brackets.
+                path_prefix = f"<{canonical_path_item_being_implemented}>"
+        else:
+            path_prefix_segments = []
+            while cursor is not None:
+                name_node = cursor.child_by_field_name("name")
+                if name_node is not None:
+                    name = assert_cast(name_node.text, bytes).decode("utf-8")
+                    path_prefix_segments.append(name)
+                cursor = cursor.parent
+            path_prefix_segments.append(Path(self.parse_context.filename).stem)
+            path_prefix = "::".join(reversed(path_prefix_segments))
+
+        # rust-lang.org: The canonical path is defined as a path prefix appended by the path segment the item itself
+        # defines.
+        return f"{path_prefix}::{item_path_segment}"

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/inner_block_docs.rs
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/inner_block_docs.rs
@@ -1,0 +1,154 @@
+/*!
+ * Top-level module
+ * @relation(REQ-INNER-BLOCK-DOC)
+ */
+
+#![feature(extern_types, trait_alias)]
+
+pub trait Processor {
+    type Output;
+    const MAX_SIZE: usize;
+
+    fn process(&self, input: &str) -> Self::Output;
+
+    fn validate(&self) -> bool {
+        /*!
+         * Default method with
+         * @relation(REQ-INNER-BLOCK-DOC)
+         * Description: validation check routine
+         */
+
+        true
+    }
+}
+
+pub trait ProcessorClone = Processor + Clone;
+
+pub struct Container {
+    pub name: String,
+    value: i32,
+}
+
+impl Processor for Container {
+    type Output = String;
+    const MAX_SIZE: usize = 1024;
+
+    fn process(&self, input: &str) -> Self::Output {
+        /*!
+         * Impl method with
+         * @relation(REQ-INNER-BLOCK-DOC)
+         * Description: implementation of a process
+         */
+
+        format!("{}: {}", self.name, input)
+    }
+}
+
+impl Container {
+    /*!
+     * Inherent impl with
+     * @relation(REQ-INNER-BLOCK-DOC)
+     * Text: inherent method block
+     */
+
+    pub fn new(name: String) -> Self {
+        /*!
+         * Inherent method with
+         * @relation(REQ-INNER-BLOCK-DOC)
+         * Words: constructor function pattern
+         */
+
+        Self { name, value: 0 }
+    }
+
+    pub fn get_value(&self) -> i32 {
+        /*!
+         * Another method with
+         * @relation(REQ-INNER-BLOCK-DOC)
+         * Random: getter accessor method
+         */
+
+        self.value
+    }
+}
+
+pub fn process_data(input: &str) -> String {
+    /*!
+     * Function with
+     * @relation(REQ-INNER-BLOCK-DOC)
+     * Description: top-level function utility
+     */
+
+    input.to_uppercase()
+}
+
+pub async fn async_process(data: Vec<u8>) -> Result<(), std::io::Error> {
+    /*!
+     * Async function with
+     * @relation(REQ-INNER-BLOCK-DOC)
+     * Random: asynchronous operation handler
+     */
+
+    Ok(())
+}
+
+pub const fn compute_magic(x: u32) -> u32 {
+    /*!
+     * Const function with
+     * @relation(REQ-INNER-BLOCK-DOC)
+     * Text: compile-time evaluable function
+     */
+
+    x * 42
+}
+
+pub unsafe fn dangerous_operation(ptr: *mut u8) {
+    /*!
+     * Unsafe function with
+     * @relation(REQ-INNER-BLOCK-DOC)
+     * Words: unchecked operation wrapper
+     */
+
+    if !ptr.is_null() {
+        *ptr = 0;
+    }
+}
+
+pub mod submodule {
+    /*!
+     * Module with
+     * @relation(REQ-INNER-BLOCK-DOC)
+     * Description: nested module container
+     */
+
+    pub struct Inner {
+        data: Vec<u8>,
+    }
+}
+
+extern "C" {
+    /*!
+     * Foreign function interface with
+     * @relation(REQ-INNER-BLOCK-DOC)
+     * Text: external C interface block
+     */
+
+    fn external_func(x: i32) -> i32;
+
+    static EXTERNAL_VAR: i32;
+
+    type OpaqueType;
+}
+
+mod tests {
+    #[test]
+    fn test_basic() {
+        /*!
+         * Test function with
+         * @relation(REQ-INNER-BLOCK-DOC)
+         * Random: unit test case definition
+         */
+
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/inner_doc_attrs.rs
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/inner_doc_attrs.rs
@@ -1,0 +1,128 @@
+#![doc = " Top-level module"]
+#![doc = " @relation(REQ-INNER-DOC-ATTR)"]
+
+#![feature(extern_types, trait_alias)]
+
+pub trait Processor {
+    type Output;
+    const MAX_SIZE: usize;
+
+    fn process(&self, input: &str) -> Self::Output;
+
+    fn validate(&self) -> bool {
+        #![doc = " Default method with"]
+        #![doc = " @relation(REQ-INNER-DOC-ATTR)"]
+        #![doc = " Description: validation check routine"]
+
+        true
+    }
+}
+
+pub trait ProcessorClone = Processor + Clone;
+
+pub struct Container {
+    pub name: String,
+    value: i32,
+}
+
+impl Processor for Container {
+    type Output = String;
+    const MAX_SIZE: usize = 1024;
+
+    fn process(&self, input: &str) -> Self::Output {
+        #![doc = " Impl method with"]
+        #![doc = " @relation(REQ-INNER-DOC-ATTR)"]
+        #![doc = " Description: implementation of a process"]
+
+        format!("{}: {}", self.name, input)
+    }
+}
+
+impl Container {
+    #![doc = " Inherent impl with"]
+    #![doc = " @relation(REQ-INNER-DOC-ATTR)"]
+    #![doc = " Text: inherent method block"]
+
+    pub fn new(name: String) -> Self {
+        #![doc = " Inherent method with"]
+        #![doc = " @relation(REQ-INNER-DOC-ATTR)"]
+        #![doc = " Words: constructor function pattern"]
+
+        Self { name, value: 0 }
+    }
+
+    pub fn get_value(&self) -> i32 {
+        #![doc = " Another method with"]
+        #![doc = " @relation(REQ-INNER-DOC-ATTR)"]
+        #![doc = " Random: getter accessor method"]
+
+        self.value
+    }
+}
+
+pub fn process_data(input: &str) -> String {
+    #![doc = " Function with"]
+    #![doc = " @relation(REQ-INNER-DOC-ATTR)"]
+    #![doc = " Description: top-level function utility"]
+
+    input.to_uppercase()
+}
+
+pub async fn async_process(data: Vec<u8>) -> Result<(), std::io::Error> {
+    #![doc = " Async function with"]
+    #![doc = " @relation(REQ-INNER-DOC-ATTR)"]
+    #![doc = " Random: asynchronous operation handler"]
+
+    Ok(())
+}
+
+pub const fn compute_magic(x: u32) -> u32 {
+    #![doc = " Const function with"]
+    #![doc = " @relation(REQ-INNER-DOC-ATTR)"]
+    #![doc = " Text: compile-time evaluable function"]
+
+    x * 42
+}
+
+pub unsafe fn dangerous_operation(ptr: *mut u8) {
+    #![doc = " Unsafe function with"]
+    #![doc = " @relation(REQ-INNER-DOC-ATTR)"]
+    #![doc = " Words: unchecked operation wrapper"]
+
+    if !ptr.is_null() {
+        *ptr = 0;
+    }
+}
+
+pub mod submodule {
+    #![doc = " Module with"]
+    #![doc = " @relation(REQ-INNER-DOC-ATTR)"]
+    #![doc = " Description: nested module container"]
+
+    pub struct Inner {
+        data: Vec<u8>,
+    }
+}
+
+extern "C" {
+    #![doc = " Foreign function interface with"]
+    #![doc = " @relation(REQ-INNER-DOC-ATTR)"]
+    #![doc = " Text: external C interface block"]
+
+    fn external_func(x: i32) -> i32;
+
+    static EXTERNAL_VAR: i32;
+
+    type OpaqueType;
+}
+
+mod tests {
+    #[test]
+    fn test_basic() {
+        #![doc = " Test function with"]
+        #![doc = " @relation(REQ-INNER-DOC-ATTR)"]
+        #![doc = " Random: unit test case definition"]
+
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/inner_line_docs.rs
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/inner_line_docs.rs
@@ -1,0 +1,128 @@
+//! Top-level module
+//! @relation(REQ-INNER-LINE-DOC)
+
+#![feature(extern_types, trait_alias)]
+
+pub trait Processor {
+    type Output;
+    const MAX_SIZE: usize;
+
+    fn process(&self, input: &str) -> Self::Output;
+
+    fn validate(&self) -> bool {
+        //! Default method with
+        //! @relation(REQ-INNER-LINE-DOC)
+        //! Description: validation check routine
+
+        true
+    }
+}
+
+pub trait ProcessorClone = Processor + Clone;
+
+pub struct Container {
+    pub name: String,
+    value: i32,
+}
+
+impl Processor for Container {
+    type Output = String;
+    const MAX_SIZE: usize = 1024;
+
+    fn process(&self, input: &str) -> Self::Output {
+        //! Impl method with
+        //! @relation(REQ-INNER-LINE-DOC)
+        //! Description: implementation of a process
+
+        format!("{}: {}", self.name, input)
+    }
+}
+
+impl Container {
+    //! Inherent impl with
+    //! @relation(REQ-INNER-LINE-DOC)
+    //! Text: inherent method block
+
+    pub fn new(name: String) -> Self {
+        //! Inherent method with
+        //! @relation(REQ-INNER-LINE-DOC)
+        //! Words: constructor function pattern
+
+        Self { name, value: 0 }
+    }
+
+    pub fn get_value(&self) -> i32 {
+        //! Another method with
+        //! @relation(REQ-INNER-LINE-DOC)
+        //! Random: getter accessor method
+
+        self.value
+    }
+}
+
+pub fn process_data(input: &str) -> String {
+    //! Function with
+    //! @relation(REQ-INNER-LINE-DOC)
+    //! Description: top-level function utility
+
+    input.to_uppercase()
+}
+
+pub async fn async_process(data: Vec<u8>) -> Result<(), std::io::Error> {
+    //! Async function with
+    //! @relation(REQ-INNER-LINE-DOC)
+    //! Random: asynchronous operation handler
+
+    Ok(())
+}
+
+pub const fn compute_magic(x: u32) -> u32 {
+    //! Const function with
+    //! @relation(REQ-INNER-LINE-DOC)
+    //! Text: compile-time evaluable function
+
+    x * 42
+}
+
+pub unsafe fn dangerous_operation(ptr: *mut u8) {
+    //! Unsafe function with
+    //! @relation(REQ-INNER-LINE-DOC)
+    //! Words: unchecked operation wrapper
+
+    if !ptr.is_null() {
+        *ptr = 0;
+    }
+}
+
+pub mod submodule {
+    //! Module with
+    //! @relation(REQ-INNER-LINE-DOC)
+    //! Description: nested module container
+
+    pub struct Inner {
+        data: Vec<u8>,
+    }
+}
+
+extern "C" {
+    //! Foreign function interface with
+    //! @relation(REQ-INNER-LINE-DOC)
+    //! Text: external C interface block
+
+    fn external_func(x: i32) -> i32;
+
+    static EXTERNAL_VAR: i32;
+
+    type OpaqueType;
+}
+
+mod tests {
+    #[test]
+    fn test_basic() {
+        //! Test function with
+        //! @relation(REQ-INNER-LINE-DOC)
+        //! Random: unit test case definition
+
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/input.sdoc
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/input.sdoc
@@ -1,0 +1,32 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ-INNER-LINE-DOC
+TITLE: Inner line doc comments
+STATEMENT: Test inner line doc comments
+
+[REQUIREMENT]
+UID: REQ-INNER-BLOCK-DOC
+TITLE: Inner block doc comments
+STATEMENT: Test inner block doc comments
+
+[REQUIREMENT]
+UID: REQ-INNER-DOC-ATTR
+TITLE: Inner doc attributes
+STATEMENT: Test inner doc attributes
+
+[REQUIREMENT]
+UID: REQ-OUTER-LINE-DOC
+TITLE: Outer line doc comments
+STATEMENT: Test outer line doc comments
+
+[REQUIREMENT]
+UID: REQ-OUTER-BLOCK-DOC
+TITLE: Outer block doc comments
+STATEMENT: Test outer block doc comments
+
+[REQUIREMENT]
+UID: REQ-OUTER-DOC-ATTR
+TITLE: Outer doc attributes
+STATEMENT: Test outer doc attributes

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/outer_block_docs.rs
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/outer_block_docs.rs
@@ -1,0 +1,450 @@
+#![feature(extern_types, stmt_expr_attributes, trait_alias)]
+
+/**
+ * Top-level const with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * quantum cascade amplifier
+ */
+pub const MAGIC_NUMBER: u32 = 42;
+
+/**
+ * Static item with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * nebula crystalline matrix
+ */
+pub static GLOBAL_STATE: &str = "initialized";
+
+/**
+ * Type alias with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * temporal flux capacitor
+ */
+pub type CustomResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+/**
+ * Struct with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * polymorphic data structure
+ */
+pub struct Container {
+    /**
+     * Field doc with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * ethereal quantum state
+     */
+    pub name: String,
+
+    /**
+     * Another field with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * cascading resonance field
+     */
+    value: i32,
+}
+
+/**
+ * Enum with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * enumerated variant collection
+ */
+pub enum Status {
+    /**
+     * Variant doc with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * active processing node
+     */
+    Active,
+
+    /**
+     * Another variant with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * suspended animation chamber
+     */
+    Idle {
+        /**
+         * Field in variant with random docs:
+         * @relation(REQ-OUTER-BLOCK-DOC)
+         * temporal duration metric
+         */
+        duration: u64,
+    },
+
+    /**
+     * Tuple variant with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * error state container
+     */
+    Error(
+        /**
+         * Tuple field with random docs:
+         * @relation(REQ-OUTER-BLOCK-DOC)
+         * diagnostic error code
+         */
+        i32
+    ),
+}
+
+/**
+ * Union with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * memory-aligned data union
+ */
+pub union FloatOrInt {
+    /**
+     * Union field with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * floating-point representation
+     */
+    f: f32,
+
+    /**
+     * Another union field with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * integer bit pattern
+     */
+    i: i32,
+}
+
+/**
+ * Trait definition with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * behavioral interface contract
+ */
+pub trait Processor {
+    /**
+     * Associated type with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * output data type
+     */
+    type Output;
+
+    /**
+     * Associated const with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * maximum buffer capacity
+     */
+    const MAX_SIZE: usize;
+
+    /**
+     * Trait method with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * processing operation handler
+     */
+    fn process(&self, input: &str) -> Self::Output;
+
+    /**
+     * Default method with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * validation check routine
+     */
+    fn validate(&self) -> bool {
+        true
+    }
+}
+
+/**
+ * Trait alias with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * combined trait bounds
+ */
+pub trait ProcessorClone = Processor + Clone;
+
+/**
+ * Implementation block with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * trait implementation container
+ */
+impl Processor for Container {
+    /**
+     * Impl associated type with
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * Words: concrete output type
+     */
+    type Output = String;
+
+    /**
+     * Impl const with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * size constant value
+     */
+    const MAX_SIZE: usize = 1024;
+
+    /**
+     * Impl method with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * implementation of a process
+     */
+    fn process(&self, input: &str) -> Self::Output {
+        format!("{}: {}", self.name, input)
+    }
+}
+
+/**
+ * Inherent impl with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * inherent method block
+ */
+impl Container {
+    /**
+     * Inherent method with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * constructor function pattern
+     */
+    pub fn new(name: String) -> Self {
+        Self { name, value: 0 }
+    }
+
+    /**
+     * Another method with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * getter accessor method
+     */
+    pub fn get_value(&self) -> i32 {
+        self.value
+    }
+}
+
+/**
+ * Function with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * top-level function utility
+ */
+pub fn process_data(input: &str) -> String {
+    input.to_uppercase()
+}
+
+/**
+ * Async function with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * asynchronous operation handler
+ */
+pub async fn async_process(data: Vec<u8>) -> Result<(), std::io::Error> {
+    Ok(())
+}
+
+/**
+ * Const function with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * compile-time evaluable function
+ */
+pub const fn compute_magic(x: u32) -> u32 {
+    x * 42
+}
+
+/**
+ * Unsafe function with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * unchecked operation wrapper
+ */
+pub unsafe fn dangerous_operation(ptr: *mut u8) {
+    if !ptr.is_null() {
+        *ptr = 0;
+    }
+}
+
+/**
+ * External crate import with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * external dependency reference
+ */
+extern crate std;
+
+/**
+ * Module with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * nested module container
+ */
+pub mod submodule {
+    //! Inner module doc with random docs:
+    //! @relation(REQ-OUTER-LINE-DOC)
+    //! module-level documentation
+
+    /**
+     * Nested struct with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * encapsulated data structure
+     */
+    pub struct Inner {
+        /**
+         * Field with random docs:
+         * @relation(REQ-OUTER-BLOCK-DOC)
+         * internal state variable
+         */
+        data: Vec<u8>,
+    }
+}
+
+/**
+ * Foreign function interface with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * external C interface block
+ */
+extern "C" {
+    /**
+     * Foreign function with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * C library function binding
+     */
+    fn external_func(x: i32) -> i32;
+
+    /**
+     * Foreign static with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * global C variable reference
+     */
+    static EXTERNAL_VAR: i32;
+
+    /**
+     * Foreign type with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * C type declaration
+     */
+    type OpaqueType;
+}
+
+/**
+ * Macro invocation with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * declarative macro call
+ */
+macro_rules! test_macro {
+    () => {
+        println!("test");
+    };
+}
+
+/**
+ * Function with match arms containing doc attributes
+ * This function demonstrates
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ */
+pub fn match_example(x: Option<i32>) -> i32 {
+    match x {
+        /**
+         * Match arm with random docs:
+         * @relation(REQ-OUTER-BLOCK-DOC)
+         * some variant pattern
+         */
+        Some(val) => val,
+
+        /**
+         * None arm with random docs:
+         * @relation(REQ-OUTER-BLOCK-DOC)
+         * default fallback case
+         */
+        None => 0,
+    }
+}
+
+/**
+ * Generic function with random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * parameterized function template
+ */
+pub fn generic_fn<
+    /**
+     * Type parameter with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * generic type variable
+     */
+    T: Clone,
+
+    /**
+     * Const parameter with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * compile-time constant value
+     */
+    const N: usize,
+>(
+    input: [T; N],
+) -> Vec<T> {
+    input.to_vec()
+}
+
+/**
+ * Struct with generic parameters random docs:
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ * generic container structure
+ */
+pub struct GenericContainer<
+    /**
+     * Lifetime param with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * reference lifetime bound
+     */
+    'a,
+
+    /**
+     * Generic type param with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * primary type parameter
+     */
+    T,
+> where
+    T: 'a,
+{
+    /**
+     * Reference field with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * borrowed data reference
+     */
+    pub data: &'a T,
+}
+
+/**
+ * Test struct for field value attributes in expressions
+ */
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+/**
+ * This demonstrates
+ * @relation(REQ-OUTER-BLOCK-DOC)
+ */
+pub fn struct_expression_test() {
+    let _ = Container {
+        /**
+         * Field value with random docs:
+         * @relation(REQ-OUTER-BLOCK-DOC)
+         */
+        name: String::from("test"),
+        value: 42,
+    };
+}
+
+/**
+ * Test if we can add a docstring to an expression literal
+ */
+fn expr_lit(x: i32) -> i32 {
+    /**
+     * Test an expression
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     */
+    8675309;
+    /**
+     * SURPRISING: We are documenting
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * the first part of the expression, not the entire expression,
+     * see `test_not_surprising` for how to fix this
+     */
+    x + 2
+}
+
+fn test_not_surprising(x: i32) -> i32 {
+    /**
+     * Test documenting the
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     */
+    (x + 2)
+}
+
+#[cfg(any(test, doc))]
+mod tests {
+    /**
+     * Test function with random docs:
+     * @relation(REQ-OUTER-BLOCK-DOC)
+     * unit test case definition
+     */
+    #[cfg_attr(not(doc), test)]
+    fn test_basic() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/outer_doc_attrs.rs
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/outer_doc_attrs.rs
@@ -1,0 +1,332 @@
+#![feature(extern_types, stmt_expr_attributes, trait_alias)]
+
+#[doc = " Top-level const with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " quantum cascade amplifier"]
+pub const MAGIC_NUMBER: u32 = 42;
+
+#[doc = " Static item with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " nebula crystalline matrix"]
+pub static GLOBAL_STATE: &str = "initialized";
+
+#[doc = " Type alias with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " temporal flux capacitor"]
+pub type CustomResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+#[doc = " Struct with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " polymorphic data structure"]
+pub struct Container {
+    #[doc = " Field doc with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " ethereal quantum state"]
+    pub name: String,
+
+    #[doc = " Another field with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " cascading resonance field"]
+    value: i32,
+}
+
+#[doc = " Enum with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " enumerated variant collection"]
+pub enum Status {
+    #[doc = " Variant doc with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " active processing node"]
+    Active,
+
+    #[doc = " Another variant with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " suspended animation chamber"]
+    Idle {
+        #[doc = " Field in variant with random docs:"]
+        #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+        #[doc = " temporal duration metric"]
+        duration: u64,
+    },
+
+    #[doc = " Tuple variant with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " error state container"]
+    Error(
+        #[doc = " Tuple field with random docs:"]
+        #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+        #[doc = " diagnostic error code"]
+        i32
+    ),
+}
+
+#[doc = " Union with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " memory-aligned data union"]
+pub union FloatOrInt {
+    #[doc = " Union field with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " floating-point representation"]
+    f: f32,
+
+    #[doc = " Another union field with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " integer bit pattern"]
+    i: i32,
+}
+
+#[doc = " Trait definition with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " behavioral interface contract"]
+pub trait Processor {
+    #[doc = " Associated type with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " output data type"]
+    type Output;
+
+    #[doc = " Associated const with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " maximum buffer capacity"]
+    const MAX_SIZE: usize;
+
+    #[doc = " Trait method with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " processing operation handler"]
+    fn process(&self, input: &str) -> Self::Output;
+
+    #[doc = " Default method with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " validation check routine"]
+    fn validate(&self) -> bool {
+        true
+    }
+}
+
+#[doc = " Trait alias with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " combined trait bounds"]
+pub trait ProcessorClone = Processor + Clone;
+
+#[doc = " Implementation block with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " trait implementation container"]
+impl Processor for Container {
+    #[doc = " Impl associated type with"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " Words: concrete output type"]
+    type Output = String;
+
+    #[doc = " Impl const with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " size constant value"]
+    const MAX_SIZE: usize = 1024;
+
+    #[doc = " Impl method with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " implementation of a process"]
+    fn process(&self, input: &str) -> Self::Output {
+        format!("{}: {}", self.name, input)
+    }
+}
+
+#[doc = " Inherent impl with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " inherent method block"]
+impl Container {
+    #[doc = " Inherent method with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " constructor function pattern"]
+    pub fn new(name: String) -> Self {
+        Self { name, value: 0 }
+    }
+
+    #[doc = " Another method with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " getter accessor method"]
+    pub fn get_value(&self) -> i32 {
+        self.value
+    }
+}
+
+#[doc = " Function with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " top-level function utility"]
+pub fn process_data(input: &str) -> String {
+    input.to_uppercase()
+}
+
+#[doc = " Async function with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " asynchronous operation handler"]
+pub async fn async_process(data: Vec<u8>) -> Result<(), std::io::Error> {
+    Ok(())
+}
+
+#[doc = " Const function with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " compile-time evaluable function"]
+pub const fn compute_magic(x: u32) -> u32 {
+    x * 42
+}
+
+#[doc = " Unsafe function with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " unchecked operation wrapper"]
+pub unsafe fn dangerous_operation(ptr: *mut u8) {
+    if !ptr.is_null() {
+        *ptr = 0;
+    }
+}
+
+#[doc = " External crate import with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " external dependency reference"]
+extern crate std;
+
+#[doc = " Module with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " nested module container"]
+pub mod submodule {
+    //! Inner module doc with random docs:
+    //! @relation(REQ-OUTER-LINE-DOC)
+    //! module-level documentation
+
+    #[doc = " Nested struct with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " encapsulated data structure"]
+    pub struct Inner {
+        #[doc = " Field with random docs:"]
+        #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+        #[doc = " internal state variable"]
+        data: Vec<u8>,
+    }
+}
+
+#[doc = " Foreign function interface with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " external C interface block"]
+extern "C" {
+    #[doc = " Foreign function with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " C library function binding"]
+    fn external_func(x: i32) -> i32;
+
+    #[doc = " Foreign static with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " global C variable reference"]
+    static EXTERNAL_VAR: i32;
+
+    #[doc = " Foreign type with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " C type declaration"]
+    type OpaqueType;
+}
+
+#[doc = " Macro invocation with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " declarative macro call"]
+macro_rules! test_macro {
+    () => {
+        println!("test");
+    };
+}
+
+#[doc = " Function with match arms containing doc attributes"]
+#[doc = " This function demonstrates"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+pub fn match_example(x: Option<i32>) -> i32 {
+    match x {
+        #[doc = " Match arm with random docs:"]
+        #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+        #[doc = " some variant pattern"]
+        Some(val) => val,
+
+        #[doc = " None arm with random docs:"]
+        #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+        #[doc = " default fallback case"]
+        None => 0,
+    }
+}
+
+#[doc = " Generic function with random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " parameterized function template"]
+pub fn generic_fn<
+    #[doc = " Type parameter with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " generic type variable"]
+    T: Clone,
+
+    #[doc = " Const parameter with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " compile-time constant value"]
+    const N: usize,
+>(
+    input: [T; N],
+) -> Vec<T> {
+    input.to_vec()
+}
+
+#[doc = " Struct with generic parameters random docs:"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+#[doc = " generic container structure"]
+pub struct GenericContainer<
+    #[doc = " Lifetime param with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " reference lifetime bound"]
+    'a,
+
+    #[doc = " Generic type param with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " primary type parameter"]
+    T,
+> where
+    T: 'a,
+{
+    #[doc = " Reference field with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " borrowed data reference"]
+    pub data: &'a T,
+}
+
+#[doc = " Test struct for field value attributes in expressions"]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[doc = " This demonstrates"]
+#[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+pub fn struct_expression_test() {
+    let _ = Container {
+        #[doc = " Field value with random docs:"]
+        #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+        name: String::from("test"),
+        value: 42,
+    };
+}
+
+#[doc = " Test if we can add a docstring to an expression literal"]
+fn expr_lit(x: i32) -> i32 {
+    #[doc = " Test an expression"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    8675309;
+    #[doc = " SURPRISING: We are documenting"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " the first part of the expression, not the entire expression,"]
+    #[doc = " see `test_not_surprising` for how to fix this"]
+    x + 2
+}
+
+fn test_not_surprising(x: i32) -> i32 {
+    #[doc = " Test documenting the"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    (x + 2)
+}
+
+#[cfg(any(test, doc))]
+mod tests {
+    #[doc = " Test function with random docs:"]
+    #[doc = " @relation(REQ-OUTER-DOC-ATTR)"]
+    #[doc = " unit test case definition"]
+    #[cfg_attr(not(doc), test)]
+    fn test_basic() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/outer_line_docs.rs
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/outer_line_docs.rs
@@ -1,0 +1,332 @@
+#![feature(extern_types, stmt_expr_attributes, trait_alias)]
+
+/// Top-level const with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// quantum cascade amplifier
+pub const MAGIC_NUMBER: u32 = 42;
+
+/// Static item with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// nebula crystalline matrix
+pub static GLOBAL_STATE: &str = "initialized";
+
+/// Type alias with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// temporal flux capacitor
+pub type CustomResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+/// Struct with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// polymorphic data structure
+pub struct Container {
+    /// Field doc with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// ethereal quantum state
+    pub name: String,
+
+    /// Another field with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// cascading resonance field
+    value: i32,
+}
+
+/// Enum with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// enumerated variant collection
+pub enum Status {
+    /// Variant doc with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// active processing node
+    Active,
+
+    /// Another variant with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// suspended animation chamber
+    Idle {
+        /// Field in variant with random docs:
+        /// @relation(REQ-OUTER-LINE-DOC)
+        /// temporal duration metric
+        duration: u64,
+    },
+
+    /// Tuple variant with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// error state container
+    Error(
+        /// Tuple field with random docs:
+        /// @relation(REQ-OUTER-LINE-DOC)
+        /// diagnostic error code
+        i32
+    ),
+}
+
+/// Union with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// memory-aligned data union
+pub union FloatOrInt {
+    /// Union field with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// floating-point representation
+    f: f32,
+
+    /// Another union field with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// integer bit pattern
+    i: i32,
+}
+
+/// Trait definition with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// behavioral interface contract
+pub trait Processor {
+    /// Associated type with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// output data type
+    type Output;
+
+    /// Associated const with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// maximum buffer capacity
+    const MAX_SIZE: usize;
+
+    /// Trait method with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// processing operation handler
+    fn process(&self, input: &str) -> Self::Output;
+
+    /// Default method with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// validation check routine
+    fn validate(&self) -> bool {
+        true
+    }
+}
+
+/// Trait alias with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// combined trait bounds
+pub trait ProcessorClone = Processor + Clone;
+
+/// Implementation block with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// trait implementation container
+impl Processor for Container {
+    /// Impl associated type with
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// Words: concrete output type
+    type Output = String;
+
+    /// Impl const with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// size constant value
+    const MAX_SIZE: usize = 1024;
+
+    /// Impl method with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// implementation of a process
+    fn process(&self, input: &str) -> Self::Output {
+        format!("{}: {}", self.name, input)
+    }
+}
+
+/// Inherent impl with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// inherent method block
+impl Container {
+    /// Inherent method with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// constructor function pattern
+    pub fn new(name: String) -> Self {
+        Self { name, value: 0 }
+    }
+
+    /// Another method with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// getter accessor method
+    pub fn get_value(&self) -> i32 {
+        self.value
+    }
+}
+
+/// Function with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// top-level function utility
+pub fn process_data(input: &str) -> String {
+    input.to_uppercase()
+}
+
+/// Async function with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// asynchronous operation handler
+pub async fn async_process(data: Vec<u8>) -> Result<(), std::io::Error> {
+    Ok(())
+}
+
+/// Const function with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// compile-time evaluable function
+pub const fn compute_magic(x: u32) -> u32 {
+    x * 42
+}
+
+/// Unsafe function with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// unchecked operation wrapper
+pub unsafe fn dangerous_operation(ptr: *mut u8) {
+    if !ptr.is_null() {
+        *ptr = 0;
+    }
+}
+
+/// External crate import with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// external dependency reference
+extern crate std;
+
+/// Module with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// nested module container
+pub mod submodule {
+    //! Inner module doc with random docs:
+    //! @relation(REQ-OUTER-LINE-DOC)
+    //! module-level documentation
+
+    /// Nested struct with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// encapsulated data structure
+    pub struct Inner {
+        /// Field with random docs:
+        /// @relation(REQ-OUTER-LINE-DOC)
+        /// internal state variable
+        data: Vec<u8>,
+    }
+}
+
+/// Foreign function interface with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// external C interface block
+extern "C" {
+    /// Foreign function with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// C library function binding
+    fn external_func(x: i32) -> i32;
+
+    /// Foreign static with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// global C variable reference
+    static EXTERNAL_VAR: i32;
+
+    /// Foreign type with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// C type declaration
+    type OpaqueType;
+}
+
+/// Macro invocation with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// declarative macro call
+macro_rules! test_macro {
+    () => {
+        println!("test");
+    };
+}
+
+/// Function with match arms containing doc attributes
+/// This function demonstrates
+/// @relation(REQ-OUTER-LINE-DOC)
+pub fn match_example(x: Option<i32>) -> i32 {
+    match x {
+        /// Match arm with random docs:
+        /// @relation(REQ-OUTER-LINE-DOC)
+        /// some variant pattern
+        Some(val) => val,
+
+        /// None arm with random docs:
+        /// @relation(REQ-OUTER-LINE-DOC)
+        /// default fallback case
+        None => 0,
+    }
+}
+
+/// Generic function with random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// parameterized function template
+pub fn generic_fn<
+    /// Type parameter with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// generic type variable
+    T: Clone,
+
+    /// Const parameter with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// compile-time constant value
+    const N: usize,
+>(
+    input: [T; N],
+) -> Vec<T> {
+    input.to_vec()
+}
+
+/// Struct with generic parameters random docs:
+/// @relation(REQ-OUTER-LINE-DOC)
+/// generic container structure
+pub struct GenericContainer<
+    /// Lifetime param with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// reference lifetime bound
+    'a,
+
+    /// Generic type param with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// primary type parameter
+    T,
+> where
+    T: 'a,
+{
+    /// Reference field with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// borrowed data reference
+    pub data: &'a T,
+}
+
+/// Test struct for field value attributes in expressions
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+/// This demonstrates
+/// @relation(REQ-OUTER-LINE-DOC)
+pub fn struct_expression_test() {
+    let _ = Container {
+        /// Field value with random docs:
+        /// @relation(REQ-OUTER-LINE-DOC)
+        name: String::from("test"),
+        value: 42,
+    };
+}
+
+/// Test if we can add a docstring to an expression literal
+fn expr_lit(x: i32) -> i32 {
+    /// Test an expression
+    /// @relation(REQ-OUTER-LINE-DOC)
+    8675309;
+    /// SURPRISING: We are documenting
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// the first part of the expression, not the entire expression,
+    /// see `test_not_surprising` for how to fix this
+    x + 2
+}
+
+fn test_not_surprising(x: i32) -> i32 {
+    /// Test documenting the
+    /// @relation(REQ-OUTER-LINE-DOC)
+    (x + 2)
+}
+
+#[cfg(any(test, doc))]
+mod tests {
+    /// Test function with random docs:
+    /// @relation(REQ-OUTER-LINE-DOC)
+    /// unit test case definition
+    #[cfg_attr(not(doc), test)]
+    fn test_basic() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/strictdoc_config.py
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/strictdoc_config.py
@@ -1,0 +1,15 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=[
+            "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+            "SOURCE_FILE_LANGUAGE_PARSERS",
+            "PROJECT_STATISTICS_SCREEN",
+        ],
+        exclude_source_paths = [
+            "test.itest",
+        ],
+    )
+    return config

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/test.itest
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/test.itest
@@ -1,0 +1,440 @@
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
+CHECK: Published: Hello world doc
+
+# Check that all source files are generated
+RUN: %check_exists --file "%T/html/_source_files/outer_line_docs.rs.html"
+RUN: %check_exists --file "%T/html/_source_files/outer_block_docs.rs.html"
+RUN: %check_exists --file "%T/html/_source_files/outer_doc_attrs.rs.html"
+RUN: %check_exists --file "%T/html/_source_files/inner_line_docs.rs.html"
+RUN: %check_exists --file "%T/html/_source_files/inner_block_docs.rs.html"
+RUN: %check_exists --file "%T/html/_source_files/inner_doc_attrs.rs.html"
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-INPUT-HTML
+
+# @relation(SDOC-SRS-166 , scope=line)
+CHECK-INPUT-HTML: href="../_source_files/inner_line_docs.rs.html#REQ-INNER-LINE-DOC#1#128"
+CHECK-INPUT-HTML: entire file
+CHECK-INPUT-HTML: href="../_source_files/inner_line_docs.rs.html#REQ-INNER-LINE-DOC#12#18"
+CHECK-INPUT-HTML: fn validate()
+CHECK-INPUT-HTML: href="../_source_files/inner_line_docs.rs.html#REQ-INNER-LINE-DOC#32#38"
+CHECK-INPUT-HTML: fn process()
+CHECK-INPUT-HTML: href="../_source_files/inner_line_docs.rs.html#REQ-INNER-LINE-DOC#41#61"
+CHECK-INPUT-HTML: impl Container
+CHECK-INPUT-HTML: href="../_source_files/inner_line_docs.rs.html#REQ-INNER-LINE-DOC#46#52"
+CHECK-INPUT-HTML: fn new()
+CHECK-INPUT-HTML: href="../_source_files/inner_line_docs.rs.html#REQ-INNER-LINE-DOC#54#60"
+CHECK-INPUT-HTML: fn get_value()
+CHECK-INPUT-HTML: href="../_source_files/inner_line_docs.rs.html#REQ-INNER-LINE-DOC#63#69"
+CHECK-INPUT-HTML: fn process_data()
+CHECK-INPUT-HTML: href="../_source_files/inner_line_docs.rs.html#REQ-INNER-LINE-DOC#71#77"
+CHECK-INPUT-HTML: fn async_process()
+CHECK-INPUT-HTML: href="../_source_files/inner_line_docs.rs.html#REQ-INNER-LINE-DOC#79#85"
+CHECK-INPUT-HTML: fn compute_magic()
+CHECK-INPUT-HTML: href="../_source_files/inner_line_docs.rs.html#REQ-INNER-LINE-DOC#87#95"
+CHECK-INPUT-HTML: fn dangerous_operation()
+CHECK-INPUT-HTML: href="../_source_files/inner_line_docs.rs.html#REQ-INNER-LINE-DOC#97#105"
+CHECK-INPUT-HTML: module submodule
+CHECK-INPUT-HTML: href="../_source_files/inner_line_docs.rs.html#REQ-INNER-LINE-DOC#107#117"
+CHECK-INPUT-HTML: foreign module extern &#34;C&#34;
+CHECK-INPUT-HTML: href="../_source_files/inner_line_docs.rs.html#REQ-INNER-LINE-DOC#121#127"
+CHECK-INPUT-HTML: fn test_basic()
+# @relation(SDOC-SRS-166 , scope=end)
+
+# @relation(SDOC-SRS-167 , scope=range_start)
+CHECK-INPUT-HTML: href="../_source_files/inner_block_docs.rs.html#REQ-INNER-BLOCK-DOC#1#154"
+CHECK-INPUT-HTML: entire file
+CHECK-INPUT-HTML: href="../_source_files/inner_block_docs.rs.html#REQ-INNER-BLOCK-DOC#14#22"
+CHECK-INPUT-HTML: fn validate()
+CHECK-INPUT-HTML: href="../_source_files/inner_block_docs.rs.html#REQ-INNER-BLOCK-DOC#36#44"
+CHECK-INPUT-HTML: fn process()
+CHECK-INPUT-HTML: href="../_source_files/inner_block_docs.rs.html#REQ-INNER-BLOCK-DOC#47#73"
+CHECK-INPUT-HTML: impl Container
+CHECK-INPUT-HTML: href="../_source_files/inner_block_docs.rs.html#REQ-INNER-BLOCK-DOC#54#62"
+CHECK-INPUT-HTML: fn new()
+CHECK-INPUT-HTML: href="../_source_files/inner_block_docs.rs.html#REQ-INNER-BLOCK-DOC#64#72"
+CHECK-INPUT-HTML: fn get_value()
+CHECK-INPUT-HTML: href="../_source_files/inner_block_docs.rs.html#REQ-INNER-BLOCK-DOC#75#83"
+CHECK-INPUT-HTML: fn process_data()
+CHECK-INPUT-HTML: href="../_source_files/inner_block_docs.rs.html#REQ-INNER-BLOCK-DOC#85#93"
+CHECK-INPUT-HTML: fn async_process()
+CHECK-INPUT-HTML: href="../_source_files/inner_block_docs.rs.html#REQ-INNER-BLOCK-DOC#95#103"
+CHECK-INPUT-HTML: fn compute_magic()
+CHECK-INPUT-HTML: href="../_source_files/inner_block_docs.rs.html#REQ-INNER-BLOCK-DOC#105#115"
+CHECK-INPUT-HTML: fn dangerous_operation()
+CHECK-INPUT-HTML: href="../_source_files/inner_block_docs.rs.html#REQ-INNER-BLOCK-DOC#117#127"
+CHECK-INPUT-HTML: module submodule
+CHECK-INPUT-HTML: href="../_source_files/inner_block_docs.rs.html#REQ-INNER-BLOCK-DOC#129#141"
+CHECK-INPUT-HTML: foreign module extern &#34;C&#34;
+CHECK-INPUT-HTML: href="../_source_files/inner_block_docs.rs.html#REQ-INNER-BLOCK-DOC#145#153"
+CHECK-INPUT-HTML: fn test_basic()
+# @relation(SDOC-SRS-167 , scope=range_end)
+
+# @relation(SDOC-SRS-165, scope=range_start)
+CHECK-INPUT-HTML: href="../_source_files/inner_doc_attrs.rs.html#REQ-INNER-DOC-ATTR#12#18"
+CHECK-INPUT-HTML: fn validate()
+CHECK-INPUT-HTML: href="../_source_files/inner_doc_attrs.rs.html#REQ-INNER-DOC-ATTR#32#38"
+CHECK-INPUT-HTML: fn process()
+CHECK-INPUT-HTML: href="../_source_files/inner_doc_attrs.rs.html#REQ-INNER-DOC-ATTR#41#61"
+CHECK-INPUT-HTML: impl Container
+CHECK-INPUT-HTML: href="../_source_files/inner_doc_attrs.rs.html#REQ-INNER-DOC-ATTR#46#52"
+CHECK-INPUT-HTML: fn new()
+CHECK-INPUT-HTML: href="../_source_files/inner_doc_attrs.rs.html#REQ-INNER-DOC-ATTR#54#60"
+CHECK-INPUT-HTML: fn get_value()
+CHECK-INPUT-HTML: href="../_source_files/inner_doc_attrs.rs.html#REQ-INNER-DOC-ATTR#63#69"
+CHECK-INPUT-HTML: fn process_data()
+CHECK-INPUT-HTML: href="../_source_files/inner_doc_attrs.rs.html#REQ-INNER-DOC-ATTR#71#77"
+CHECK-INPUT-HTML: fn async_process()
+CHECK-INPUT-HTML: href="../_source_files/inner_doc_attrs.rs.html#REQ-INNER-DOC-ATTR#79#85"
+CHECK-INPUT-HTML: fn compute_magic()
+CHECK-INPUT-HTML: href="../_source_files/inner_doc_attrs.rs.html#REQ-INNER-DOC-ATTR#87#95"
+CHECK-INPUT-HTML: fn dangerous_operation()
+CHECK-INPUT-HTML: href="../_source_files/inner_doc_attrs.rs.html#REQ-INNER-DOC-ATTR#97#105"
+CHECK-INPUT-HTML: module submodule
+CHECK-INPUT-HTML: href="../_source_files/inner_doc_attrs.rs.html#REQ-INNER-DOC-ATTR#107#117"
+CHECK-INPUT-HTML: foreign module extern &#34;C&#34;
+CHECK-INPUT-HTML: href="../_source_files/inner_doc_attrs.rs.html#REQ-INNER-DOC-ATTR#121#127"
+CHECK-INPUT-HTML: fn test_basic()
+# @relation(SDOC-SRS-165, scope=range_end)
+
+# @relation(SDOC-SRS-169 , scope=range_start)
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-LINE-DOC#257#275"
+CHECK-INPUT-HTML: module submodule
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-LINE-DOC#189#203"
+CHECK-INPUT-HTML: module submodule
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#3#6"
+CHECK-INPUT-HTML: const MAGIC_NUMBER
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#8#11"
+CHECK-INPUT-HTML: static GLOBAL_STATE
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#13#16"
+CHECK-INPUT-HTML: type CustomResult
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#18#31"
+CHECK-INPUT-HTML: struct Container
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#22#25"
+CHECK-INPUT-HTML: field name
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#27#30"
+CHECK-INPUT-HTML: field value
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#33#61"
+CHECK-INPUT-HTML: enum Status
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#37#40"
+CHECK-INPUT-HTML: enum variant Active
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#42#50"
+CHECK-INPUT-HTML: enum variant Idle
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#46#49"
+CHECK-INPUT-HTML: field duration
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#52#60"
+CHECK-INPUT-HTML: enum variant Error
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#56#59"
+CHECK-INPUT-HTML: type i32
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#63#76"
+CHECK-INPUT-HTML: union FloatOrInt
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#67#70"
+CHECK-INPUT-HTML: field f
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#72#75"
+CHECK-INPUT-HTML: field i
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#78#103"
+CHECK-INPUT-HTML: trait Processor
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#82#85"
+CHECK-INPUT-HTML: associated type Output
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#87#90"
+CHECK-INPUT-HTML: const MAX_SIZE
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#92#95"
+CHECK-INPUT-HTML: function process()
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#97#102"
+CHECK-INPUT-HTML: fn validate()
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#114#117"
+CHECK-INPUT-HTML: type Output
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#119#122"
+CHECK-INPUT-HTML: const MAX_SIZE
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#124#129"
+CHECK-INPUT-HTML: fn process()
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#132#149"
+CHECK-INPUT-HTML: impl Container
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#136#141"
+CHECK-INPUT-HTML: fn new()
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#143#148"
+CHECK-INPUT-HTML: fn get_value()
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#151#156"
+CHECK-INPUT-HTML: fn process_data()
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#158#163"
+CHECK-INPUT-HTML: fn async_process()
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#165#170"
+CHECK-INPUT-HTML: fn compute_magic()
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#172#179"
+CHECK-INPUT-HTML: fn dangerous_operation()
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#181#184"
+CHECK-INPUT-HTML: crate std
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#186#203"
+CHECK-INPUT-HTML: module submodule
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#189#203"
+CHECK-INPUT-HTML: module submodule
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#194#202"
+CHECK-INPUT-HTML: struct Inner
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#198#201"
+CHECK-INPUT-HTML: field data
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#205#223"
+CHECK-INPUT-HTML: foreign module extern &#34;C&#34;
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#209#212"
+CHECK-INPUT-HTML: function external_func()
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#214#217"
+CHECK-INPUT-HTML: static EXTERNAL_VAR
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#219#222"
+CHECK-INPUT-HTML: associated type OpaqueType
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#225#232"
+CHECK-INPUT-HTML: macro test_macro
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#234#249"
+CHECK-INPUT-HTML: fn match_example()
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#239#242"
+CHECK-INPUT-HTML: match arm Some(val)
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#244#247"
+CHECK-INPUT-HTML: match arm None
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#251#268"
+CHECK-INPUT-HTML: fn generic_fn()
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#255#258"
+CHECK-INPUT-HTML: type parameter T
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#260#263"
+CHECK-INPUT-HTML: const parameter N
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#270#290"
+CHECK-INPUT-HTML: struct GenericContainer
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#274#277"
+CHECK-INPUT-HTML: lifetime &#39;a
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#279#282"
+CHECK-INPUT-HTML: type parameter T
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#286#289"
+CHECK-INPUT-HTML: field data
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#294#303"
+CHECK-INPUT-HTML: fn struct_expression_test()
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#298#300"
+CHECK-INPUT-HTML: field initializer name
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#307#309"
+CHECK-INPUT-HTML: statement 8675309;
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#310#314"
+CHECK-INPUT-HTML: expression x + 2
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#318#320"
+CHECK-INPUT-HTML: expression (x + 2)
+CHECK-INPUT-HTML: href="../_source_files/outer_line_docs.rs.html#REQ-OUTER-LINE-DOC#325#331"
+CHECK-INPUT-HTML: fn test_basic()
+# @relation(SDOC-SRS-169 , scope=range_end)
+
+# @relation(SDOC-SRS-170 , scope=range_start)
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#3#8"
+CHECK-INPUT-HTML: const MAGIC_NUMBER
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#10#15"
+CHECK-INPUT-HTML: static GLOBAL_STATE
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#17#22"
+CHECK-INPUT-HTML: type CustomResult
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#24#43"
+CHECK-INPUT-HTML: struct Container
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#30#35"
+CHECK-INPUT-HTML: field name
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#37#42"
+CHECK-INPUT-HTML: field value
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#45#85"
+CHECK-INPUT-HTML: enum Status
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#51#56"
+CHECK-INPUT-HTML: enum variant Active
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#58#70"
+CHECK-INPUT-HTML: enum variant Idle
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#64#69"
+CHECK-INPUT-HTML: field duration
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#72#84"
+CHECK-INPUT-HTML: enum variant Error
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#78#83"
+CHECK-INPUT-HTML: type i32
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#87#106"
+CHECK-INPUT-HTML: union FloatOrInt
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#93#98"
+CHECK-INPUT-HTML: field f
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#100#105"
+CHECK-INPUT-HTML: field i
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#108#143"
+CHECK-INPUT-HTML: trait Processor
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#114#119"
+CHECK-INPUT-HTML: associated type Output
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#121#126"
+CHECK-INPUT-HTML: const MAX_SIZE
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#128#133"
+CHECK-INPUT-HTML: function process()
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#135#142"
+CHECK-INPUT-HTML: fn validate()
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#152#180"
+CHECK-INPUT-HTML: impl Container
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#158#163"
+CHECK-INPUT-HTML: type Output
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#165#170"
+CHECK-INPUT-HTML: const MAX_SIZE
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#172#179"
+CHECK-INPUT-HTML: fn process()
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#182#205"
+CHECK-INPUT-HTML: impl Container
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#188#195"
+CHECK-INPUT-HTML: fn new()
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#197#204"
+CHECK-INPUT-HTML: fn get_value()
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#207#214"
+CHECK-INPUT-HTML: fn process_data()
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#216#223"
+CHECK-INPUT-HTML: fn async_process()
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#225#232"
+CHECK-INPUT-HTML: fn compute_magic()
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#234#243"
+CHECK-INPUT-HTML: fn dangerous_operation()
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#245#250"
+CHECK-INPUT-HTML: crate std
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#252#275"
+CHECK-INPUT-HTML: module submodule
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#262#274"
+CHECK-INPUT-HTML: struct Inner
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#268#273"
+CHECK-INPUT-HTML: field data
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#277#303"
+CHECK-INPUT-HTML: foreign module extern &#34;C&#34;
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#283#288"
+CHECK-INPUT-HTML: function external_func()
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#290#295"
+CHECK-INPUT-HTML: static EXTERNAL_VAR
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#297#302"
+CHECK-INPUT-HTML: associated type OpaqueType
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#305#314"
+CHECK-INPUT-HTML: macro test_macro
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#316#337"
+CHECK-INPUT-HTML: fn match_example()
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#323#328"
+CHECK-INPUT-HTML: match arm Some(val)
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#330#335"
+CHECK-INPUT-HTML: match arm None
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#339#362"
+CHECK-INPUT-HTML: fn generic_fn()
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#345#350"
+CHECK-INPUT-HTML: type parameter T
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#352#357"
+CHECK-INPUT-HTML: const parameter N
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#364#392"
+CHECK-INPUT-HTML: struct GenericContainer
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#370#375"
+CHECK-INPUT-HTML: lifetime &#39;a
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#377#382"
+CHECK-INPUT-HTML: type parameter T
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#386#391"
+CHECK-INPUT-HTML: field data
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#398#411"
+CHECK-INPUT-HTML: fn struct_expression_test()
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#404#408"
+CHECK-INPUT-HTML: field initializer name
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#417#421"
+CHECK-INPUT-HTML: statement 8675309;
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#422#428"
+CHECK-INPUT-HTML: expression x + 2
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#432#436"
+CHECK-INPUT-HTML: expression (x + 2)
+CHECK-INPUT-HTML: href="../_source_files/outer_block_docs.rs.html#REQ-OUTER-BLOCK-DOC#441#449"
+CHECK-INPUT-HTML: fn test_basic()
+# @relation(SDOC-SRS-170 , scope=range_end)
+
+# @relation(SDOC-SRS-168 , scope=range_start)
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#3#6"
+CHECK-INPUT-HTML: const MAGIC_NUMBER
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#8#11"
+CHECK-INPUT-HTML: static GLOBAL_STATE
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#13#16"
+CHECK-INPUT-HTML: type CustomResult
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#18#31"
+CHECK-INPUT-HTML: struct Container
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#22#25"
+CHECK-INPUT-HTML: field name
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#27#30"
+CHECK-INPUT-HTML: field value
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#33#61"
+CHECK-INPUT-HTML: enum Status
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#37#40"
+CHECK-INPUT-HTML: enum variant Active
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#42#50"
+CHECK-INPUT-HTML: enum variant Idle
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#46#49"
+CHECK-INPUT-HTML: field duration
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#52#60"
+CHECK-INPUT-HTML: enum variant Error
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#56#59"
+CHECK-INPUT-HTML: type i32
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#63#76"
+CHECK-INPUT-HTML: union FloatOrInt
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#67#70"
+CHECK-INPUT-HTML: field f
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#72#75"
+CHECK-INPUT-HTML: field i
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#78#103"
+CHECK-INPUT-HTML: trait Processor
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#82#85"
+CHECK-INPUT-HTML: associated type Output
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#87#90"
+CHECK-INPUT-HTML: const MAX_SIZE
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#92#95"
+CHECK-INPUT-HTML: function process()
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#97#102"
+CHECK-INPUT-HTML: fn validate()
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#110#130"
+CHECK-INPUT-HTML: impl Container
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#114#117"
+CHECK-INPUT-HTML: type Output
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#119#122"
+CHECK-INPUT-HTML: const MAX_SIZE
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#124#129"
+CHECK-INPUT-HTML: fn process()
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#132#149"
+CHECK-INPUT-HTML: impl Container
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#136#141"
+CHECK-INPUT-HTML: fn new()
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#143#148"
+CHECK-INPUT-HTML: fn get_value()
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#151#156"
+CHECK-INPUT-HTML: fn process_data()
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#158#163"
+CHECK-INPUT-HTML: fn async_process()
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#165#170"
+CHECK-INPUT-HTML: fn compute_magic()
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#172#179"
+CHECK-INPUT-HTML: fn dangerous_operation()
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#181#184"
+CHECK-INPUT-HTML: crate std
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#186#203"
+CHECK-INPUT-HTML: module submodule
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#194#202"
+CHECK-INPUT-HTML: struct Inner
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#198#201"
+CHECK-INPUT-HTML: field data
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#205#223"
+CHECK-INPUT-HTML: foreign module extern &#34;C&#34;
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#209#212"
+CHECK-INPUT-HTML: function external_func()
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#214#217"
+CHECK-INPUT-HTML: static EXTERNAL_VAR
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#219#222"
+CHECK-INPUT-HTML: associated type OpaqueType
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#225#232"
+CHECK-INPUT-HTML: macro test_macro
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#234#249"
+CHECK-INPUT-HTML: fn match_example()
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#251#268"
+CHECK-INPUT-HTML: fn generic_fn()
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#255#258"
+CHECK-INPUT-HTML: type parameter T
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#260#263"
+CHECK-INPUT-HTML: const parameter N
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#270#290"
+CHECK-INPUT-HTML: struct GenericContainer
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#274#277"
+CHECK-INPUT-HTML: lifetime &#39;a
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#279#282"
+CHECK-INPUT-HTML: type parameter T
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#286#289"
+CHECK-INPUT-HTML: field data
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#294#303"
+CHECK-INPUT-HTML: fn struct_expression_test()
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#307#309"
+CHECK-INPUT-HTML: statement 8675309;
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#310#314"
+CHECK-INPUT-HTML: expression x + 2
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#318#320"
+CHECK-INPUT-HTML: expression (x + 2)
+CHECK-INPUT-HTML: href="../_source_files/outer_doc_attrs.rs.html#REQ-OUTER-DOC-ATTR#325#331"
+CHECK-INPUT-HTML: fn test_basic()
+# @relation(SDOC-SRS-168 , scope=range_end)

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/02_rust_forward_relation/forward_relations.rs
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/02_rust_forward_relation/forward_relations.rs
@@ -1,0 +1,35 @@
+mod foo_module {
+    pub trait FooTrait {
+        fn foo(&self) {}
+    }
+
+    fn foo() {
+        fn bar() -> u32 {
+            pub const BAR_CONST: u32 = 42;
+            BAR_CONST
+        }
+
+        println!("{}", bar());
+    }
+}
+
+struct FooTuple(i32);
+
+impl foo_module::FooTrait for FooTuple {
+    fn foo(&self) {}
+}
+
+union FooUnion {a: i32}
+
+pub const FOO_CONST: u32 = 42;
+
+trait FooTrait {
+    fn foo() {}
+}
+
+pub enum FooEnum {
+    Foo,
+    Bar {
+        baz: u64,
+    },
+}

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/02_rust_forward_relation/input.sdoc
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/02_rust_forward_relation/input.sdoc
@@ -1,0 +1,38 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ-FWD-RELATIONS
+TITLE: Forward relations
+STATEMENT: Test forward relations
+RELATIONS:
+- TYPE: File
+  VALUE: forward_relations.rs
+  FUNCTION: forward_relations::foo_module
+- TYPE: File
+  VALUE: forward_relations.rs
+  FUNCTION: forward_relations::foo_module::foo
+- TYPE: File
+  VALUE: forward_relations.rs
+  FUNCTION: forward_relations::foo_module::foo::bar
+- TYPE: File
+  VALUE: forward_relations.rs
+  FUNCTION: forward_relations::foo_module::foo::bar::BAR_CONST
+- TYPE: File
+  VALUE: forward_relations.rs
+  FUNCTION: forward_relations::FooTuple
+- TYPE: File
+  VALUE: forward_relations.rs
+  FUNCTION: forward_relations::FooUnion
+- TYPE: File
+  VALUE: forward_relations.rs
+  FUNCTION: forward_relations::FooTrait
+- TYPE: File
+  VALUE: forward_relations.rs
+  FUNCTION: <forward_relations::FooTuple as forward_relations::foo_module::FooTrait>::foo
+- TYPE: File
+  VALUE: forward_relations.rs
+  FUNCTION: forward_relations::FOO_CONST
+- TYPE: File
+  VALUE: forward_relations.rs
+  FUNCTION: forward_relations::FooEnum

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/02_rust_forward_relation/strictdoc_config.py
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/02_rust_forward_relation/strictdoc_config.py
@@ -1,0 +1,15 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=[
+            "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+            "SOURCE_FILE_LANGUAGE_PARSERS",
+            "PROJECT_STATISTICS_SCREEN",
+        ],
+        exclude_source_paths = [
+            "test.itest",
+        ],
+    )
+    return config

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/02_rust_forward_relation/test.itest
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/02_rust_forward_relation/test.itest
@@ -1,0 +1,29 @@
+# @relation(SDOC-SRS-173, scope=file)
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
+CHECK: Published: Hello world doc
+
+# Check that all source files are generated
+RUN: %check_exists --file "%T/html/_source_files/forward_relations.rs.html"
+
+# Check links and names from document to source file
+CHECK-INPUT-HTML: href="../_source_files/forward_relations.rs.html#REQ-FWD-RELATIONS#1#14"
+CHECK-INPUT-HTML: function forward_relations::foo_module()
+CHECK-INPUT-HTML: href="../_source_files/forward_relations.rs.html#REQ-FWD-RELATIONS#6#13"
+CHECK-INPUT-HTML: function forward_relations::foo_module::foo()
+CHECK-INPUT-HTML: href="../_source_files/forward_relations.rs.html#REQ-FWD-RELATIONS#7#10"
+CHECK-INPUT-HTML: function forward_relations::foo_module::foo::bar()
+CHECK-INPUT-HTML: href="../_source_files/forward_relations.rs.html#REQ-FWD-RELATIONS#8#9"
+CHECK-INPUT-HTML: function forward_relations::foo_module::foo::bar::BAR_CONST()
+CHECK-INPUT-HTML: href="../_source_files/forward_relations.rs.html#REQ-FWD-RELATIONS#16#17"
+CHECK-INPUT-HTML: function forward_relations::FooTuple()
+CHECK-INPUT-HTML: href="../_source_files/forward_relations.rs.html#REQ-FWD-RELATIONS#19#20"
+CHECK-INPUT-HTML: function &lt;forward_relations::FooTuple as forward_relations::foo_module::FooTrait&gt;::foo()
+CHECK-INPUT-HTML: href="../_source_files/forward_relations.rs.html#REQ-FWD-RELATIONS#22#23"
+CHECK-INPUT-HTML: function forward_relations::FooUnion()
+CHECK-INPUT-HTML: href="../_source_files/forward_relations.rs.html#REQ-FWD-RELATIONS#24#25"
+CHECK-INPUT-HTML: function forward_relations::FOO_CONST()
+CHECK-INPUT-HTML: href="../_source_files/forward_relations.rs.html#REQ-FWD-RELATIONS#26#28"
+CHECK-INPUT-HTML: function forward_relations::FooTrait()
+CHECK-INPUT-HTML: href="../_source_files/forward_relations.rs.html#REQ-FWD-RELATIONS#30#35"
+CHECK-INPUT-HTML: function forward_relations::FooEnum()

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/03_rust_range_marker/input.sdoc
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/03_rust_range_marker/input.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ-LINE-RANGE
+TITLE: Requirement Title
+STATEMENT: Requirement Statement

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/03_rust_range_marker/line_range.rs
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/03_rust_range_marker/line_range.rs
@@ -1,0 +1,26 @@
+fn main() {
+    // Make `optional` of type `Option<i32>`
+    // @relation(REQ-LINE-RANGE, scope=line)
+    let mut optional = Some(0);
+
+    // This reads: "while `let` destructures `optional` into
+    // `Some(i)`, evaluate the block (`{}`). Else `break`.
+    // @relation(REQ-LINE-RANGE, scope=range_start)
+    while let Some(i) = optional {
+        if i > 9 {
+            println!("Greater than 9, quit!");
+            optional = None;
+        } else {
+            println!("`i` is `{:?}`. Try again.", i);
+            optional = Some(i + 1);
+        }
+        // ^ Less rightward drift and doesn't require
+        // explicitly handling the failing case.
+    }
+    // @relation(REQ-LINE-RANGE, scope=range_end)
+
+    // ^ `if let` had additional optional `else`/`else if`
+    // clauses. `while let` does not have these.
+
+    // @relation(REQ-LINE-RANGE, scope=file)
+}

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/03_rust_range_marker/strictdoc_config.py
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/03_rust_range_marker/strictdoc_config.py
@@ -1,0 +1,15 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=[
+            "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+            "SOURCE_FILE_LANGUAGE_PARSERS",
+            "PROJECT_STATISTICS_SCREEN",
+        ],
+        exclude_source_paths = [
+            "test.itest",
+        ],
+    )
+    return config

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/03_rust_range_marker/test.itest
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/03_rust_range_marker/test.itest
@@ -1,0 +1,15 @@
+# @relation(SDOC-SRS-171, scope=file)
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
+CHECK: Published: Hello world doc
+
+# Check that all source files are generated
+RUN: %check_exists --file "%T/html/_source_files/line_range.rs.html"
+
+# Check links and names from document to source file
+CHECK-INPUT-HTML: href="../_source_files/line_range.rs.html#REQ-LINE-RANGE#1#26"
+CHECK-INPUT-HTML: entire file
+CHECK-INPUT-HTML: href="../_source_files/line_range.rs.html#REQ-LINE-RANGE#3#4"
+CHECK-INPUT-HTML: line
+CHECK-INPUT-HTML: href="../_source_files/line_range.rs.html#REQ-LINE-RANGE#8#20"
+CHECK-INPUT-HTML: range


### PR DESCRIPTION
### WHAT
This adds Rust-support to StrictDoc's language aware parsing feature. It notably supports Rust doc comment semantics to automatically bind comments to language constructs. It supports line/range markers from normal comments, custom tags from doc comments and forward relations by qualified path for an opinionated set of identifiable items.

A demo of all features is available at [haxtibal.github.io/strictdoc-rust-demo](https://haxtibal.github.io/strictdoc-rust-demo/src/requirements.html).

Additional related changes are described in commit messages.

### WHY
Rust is a frequently used language in domains where also StrictDoc is used (system programming, safety critical, security critical). See related feature request #2213.

### HOW
We have two alternative proposals for doing Rust parsing:

1) Use tree-sitter-rust Python module and reimplement some of the high-level Rust doc comment semantics on our own.
2) Use syn crate (has doc comments semantics built-in), use json to transfer results to Python world.

This implements 1) and can be used to study pros and cons. It uses tree-sitter queries to match the parse tree for valid doc comment and normal comment patterns, where captures record relevant information, then python side post processing transforms captures to StrictDoc structures.