### PR TITLE
chore: drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci-linux-ubuntu-latest.yml
+++ b/.github/workflows/ci-linux-ubuntu-latest.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          "3.9", "3.12"
+          "3.10", "3.12"
         ]
         itest_group: [ "main_group", "html2pdf_group" ]
 

--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          "3.9", "3.13"
+          "3.10", "3.13"
         ]
         itest_group: [ "main_group", "html2pdf_group" ]
 

--- a/.github/workflows/ci-windows-powershell.yml
+++ b/.github/workflows/ci-windows-powershell.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
         shard: ["1/2", "2/2"]
         itest_group: [ "main_group", "html2pdf_group" ]
 

--- a/.github/workflows/end2end-tests.yml
+++ b/.github/workflows/end2end-tests.yml
@@ -29,10 +29,10 @@ jobs:
       with:
         fetch-depth: 5
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: "3.10"
 
     - name: Upgrade pip
       run: |
@@ -56,7 +56,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
 
     steps:
     - uses: actions/checkout@v6
@@ -66,7 +66,7 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "${{ matrix.python-version }}"
 
     - name: Upgrade pip
       run: |
@@ -100,10 +100,10 @@ jobs:
       with:
         fetch-depth: 5
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v6
       with:
-        python-version: 3.9
+        python-version: "3.10"
 
     - name: Upgrade pip
       run: |

--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -254,7 +254,7 @@ TITLE: Requirements
 [TEXT]
 MID: e7e4c2982d8e49deaa9b7413a09a4efa
 STATEMENT: >>>
-- Python 3.9+
+- Python 3.10+
 - macOS, Linux or Windows
 - Command-line terminal program
 

--- a/docs/strictdoc_24_development_plan.sdoc
+++ b/docs/strictdoc_24_development_plan.sdoc
@@ -334,7 +334,7 @@ TITLE: Python baseline
 [TEXT]
 MID: 081ee6266bab4a3a80f290c95e055a25
 STATEMENT: >>>
-The supported version of Python is kept to be as low as possible. As of 2025-Q4, the currently supported version is Python 3.9.
+The supported version of Python is kept to be as low as possible. As of 2025-Q4, the currently supported version is Python 3.10.
 
 Ideally, the lowest Python version should only be raised when it is consistently deprecated by the major software platforms like Ubuntu or GitHub Actions.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["version"]
 description = "StrictDoc is open-source software for technical documentation and requirements management."
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Stanislav Pankevich", email = "s.pankevich@gmail.com" },
     { name = "Maryna Balioura", email = "mettta@gmail.com" },
@@ -38,7 +38,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/strictdoc/backend/sdoc_source_code/reader_c.py
+++ b/strictdoc/backend/sdoc_source_code/reader_c.py
@@ -54,12 +54,9 @@ class SourceFileTraceabilityReader_C:
         file_stats = SourceFileStats.create(input_buffer)
         parse_context = ParseContext(file_path, file_stats)
 
-        # Works since Python 3.9 but we also lint this with mypy from Python 3.8.
         language_arg = tree_sitter_cpp.language()
-        py_language = Language(  # type: ignore[call-arg, unused-ignore]
-            language_arg
-        )
-        parser = Parser(py_language)  # type: ignore[call-arg, unused-ignore]
+        py_language = Language(language_arg)
+        parser = Parser(py_language)
 
         tree = parser.parse(input_buffer)
 

--- a/strictdoc/backend/sdoc_source_code/reader_python.py
+++ b/strictdoc/backend/sdoc_source_code/reader_python.py
@@ -50,12 +50,9 @@ class SourceFileTraceabilityReader_Python:
         file_stats = SourceFileStats.create(input_buffer)
         parse_context = ParseContext(file_path, file_stats)
 
-        # Works since Python 3.9 but we also lint this with mypy from Python 3.8.
         language_arg = tree_sitter_python.language()
-        py_language = Language(  # type: ignore[call-arg, unused-ignore]
-            language_arg
-        )
-        parser = Parser(py_language)  # type: ignore[call-arg, unused-ignore]
+        py_language = Language(language_arg)
+        parser = Parser(py_language)
 
         tree = parser.parse(input_buffer)
 

--- a/tasks.py
+++ b/tasks.py
@@ -654,7 +654,7 @@ def lint_mypy(context):
                 --warn-unreachable
                 --warn-unused-ignores
 
-                --python-version=3.9
+                --python-version=3.10
         """,
     )
 

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_c.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_c.py
@@ -13,10 +13,6 @@ from strictdoc.backend.sdoc_source_code.reader_c import (
     SourceFileTraceabilityReader_C,
 )
 
-pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 9), reason="Requires Python 3.9 or higher"
-)
-
 
 def test_00_empty_file():
     input_string = b""""""

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_cpp.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_cpp.py
@@ -17,10 +17,6 @@ from strictdoc.backend.sdoc_source_code.reader_c import (
     SourceFileTraceabilityReader_C,
 )
 
-pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 9), reason="Requires Python 3.9 or higher"
-)
-
 
 def test_01_class_function_declaration():
     input_string = b"""\

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_python.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_python.py
@@ -19,10 +19,6 @@ from strictdoc.backend.sdoc_source_code.reader_python import (
     SourceFileTraceabilityReader_Python,
 )
 
-pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 9), reason="Requires Python 3.9 or higher"
-)
-
 
 def test_00_empty_file():
     input_string = b""""""

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_writer_c.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_writer_c.py
@@ -14,10 +14,6 @@ from strictdoc.backend.sdoc_source_code.reader_c import (
 )
 from strictdoc.backend.sdoc_source_code.source_writer import SourceWriter
 
-pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 9), reason="Requires Python 3.9 or higher"
-)
-
 
 def test_02_c_functions():
     input_string = b"""\

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
@@ -12,10 +12,6 @@ from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
 )
 from strictdoc.backend.sdoc_source_code.models.line_marker import LineMarker
 
-pytestmark = pytest.mark.skipif(
-    sys.version_info < (3, 9), reason="Requires Python 3.9 or higher"
-)
-
 
 def test_01_basic_nominal():
     input_strings = [

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # version?
 # https://stackoverflow.com/a/71195055/598057
 [tox]
-envlist = {py39,py310,py311,py312,py313,py314}-{development,check,documentation,release,release-local,pyinstaller}
+envlist = {py310,py311,py312,py313,py314}-{development,check,documentation,release,release-local,pyinstaller}
 toxworkdir=build/tox
 
 [testenv]
@@ -10,7 +10,7 @@ skip_install = true
 commands =
     echo "Must not reach here!"; exit 1
 
-[testenv:{py39,py310,py311,py312,py313,py314}-development]
+[testenv:{py310,py311,py312,py313,py314}-development]
 package = "skip"
 skip_install = true
 deps =
@@ -21,7 +21,7 @@ commands =
     python developer/pip_install_strictdoc_deps.py
     {posargs}
 
-[testenv:{py39,py310,py311,py312,py313,py314}-check]
+[testenv:{py310,py311,py312,py313,py314}-check]
 package = "skip"
 skip_install = true
 deps =
@@ -34,7 +34,7 @@ commands =
     python developer/pip_install_strictdoc_deps.py
     {posargs}
 
-[testenv:{py39,py310,py311,py312,py313,py314}-documentation]
+[testenv:{py310,py311,py312,py313,py314}-documentation]
 package = "skip"
 skip_install = true
 allowlist_externals =
@@ -51,7 +51,7 @@ commands =
     python developer/pip_install_strictdoc_deps.py
     {posargs}
 
-[testenv:{py39,py310,py311,py312,py313,py314}-release]
+[testenv:{py310,py311,py312,py313,py314}-release]
 package = "skip"
 skip_install = true
 pass_env =
@@ -66,7 +66,7 @@ deps =
 commands =
     {posargs}
 
-[testenv:{py39,py310,py311,py312,py313,py314}-release-local]
+[testenv:{py310,py311,py312,py313,py314}-release-local]
 package = "skip"
 skip_install = true
 allowlist_externals =
@@ -75,7 +75,7 @@ deps =
     -rrequirements.bootstrap.txt
     build
     twine
-    {[testenv:py39-check]deps}
+    {[testenv:py310-check]deps}
 commands =
     python developer/pip_install_strictdoc_deps.py
     {posargs}
@@ -89,7 +89,7 @@ commands =
 # File "pkg_resources/__init__.py", line 90, in <module>
 # ModuleNotFoundError: No module named 'jaraco'
 # [PYI-21537:ERROR] Failed to execute script 'pyi_rth_pkgres' due to unhandled exception!
-[testenv:{py39,py310,py311,py312,py313,py314}-pyinstaller]
+[testenv:{py310,py311,py312,py313,py314}-pyinstaller]
 package = "skip"
 skip_install = true
 deps =


### PR DESCRIPTION
WHAT: Drop python 3.9, require >= 3.10.

WHY: Planned transition, done early to avoid conditional tree-sitter API usage in #2672.