### PR TITLE
feat(parsing): Allow to infer default scope for markers

### DIFF
--- a/strictdoc/backend/sdoc_source_code/comment_parser/marker_lexer.py
+++ b/strictdoc/backend/sdoc_source_code/comment_parser/marker_lexer.py
@@ -32,7 +32,7 @@ _NORMAL_STRING_NO_MARKER_NO_NODE: /(?!\\s*##RELATION_MARKER_START)((?!\\s*(##CUS
 GRAMMAR = GrammarTemplate("""
 start: ##START
 
-relation_marker: _RELATION_MARKER_START _WS? (relation_node_uid _SEP _WS)+ "scope=" relation_scope ("," _WS "role=" relation_role)? _WS? _BRACE_RIGHT
+relation_marker: _RELATION_MARKER_START _WS? relation_node_uid (_SEP _WS relation_node_uid)* (_SEP _WS "scope=" relation_scope)? (_SEP _WS "role=" relation_role)? _WS? _BRACE_RIGHT
 
 _RELATION_MARKER_START: /##RELATION_MARKER_START/
 relation_node_uid: /##REGEX_REQ/

--- a/strictdoc/backend/sdoc_source_code/constants.py
+++ b/strictdoc/backend/sdoc_source_code/constants.py
@@ -4,7 +4,7 @@
 
 from enum import Enum
 
-REGEX_REQ = r"(?!scope=)[A-Za-z][A-Za-z0-9_\/\.\\-]+"
+REGEX_REQ = r"(?!scope=)(?!role=)[A-Za-z][A-Za-z0-9_\/\.\\-]+"
 REGEX_ROLE = r"[A-Za-z][A-Za-z0-9\\-]+"
 RESERVED_KEYWORDS = "FIXME|NOTE|TODO|TBD|WARNING"
 

--- a/strictdoc/backend/sdoc_source_code/reader_c.py
+++ b/strictdoc/backend/sdoc_source_code/reader_c.py
@@ -89,6 +89,7 @@ class SourceFileTraceabilityReader_C:
                             comment_byte_range=ByteRange.create_from_ts_node(
                                 comment_node
                             ),
+                            filename=parse_context.filename,
                             custom_tags=self.custom_tags,
                         )
                         for marker_ in source_node.markers:
@@ -191,6 +192,7 @@ class SourceFileTraceabilityReader_C:
                         comment_byte_range=ByteRange.create_from_ts_node(
                             function_comment_node
                         ),
+                        filename=parse_context.filename,
                         entity_name=function_display_name,
                         custom_tags=self.custom_tags,
                     )
@@ -304,6 +306,7 @@ class SourceFileTraceabilityReader_C:
                         comment_byte_range=ByteRange.create_from_ts_node(
                             function_comment_node
                         ),
+                        filename=parse_context.filename,
                         entity_name=function_display_name,
                         custom_tags=self.custom_tags,
                     )
@@ -364,6 +367,7 @@ class SourceFileTraceabilityReader_C:
                     line_end=node_.end_point[0] + 1,
                     comment_line_start=node_.start_point[0] + 1,
                     comment_byte_range=ByteRange.create_from_ts_node(node_),
+                    filename=parse_context.filename,
                     custom_tags=None,
                 )
 

--- a/strictdoc/backend/sdoc_source_code/reader_python.py
+++ b/strictdoc/backend/sdoc_source_code/reader_python.py
@@ -113,6 +113,7 @@ class SourceFileTraceabilityReader_Python:
                             comment_byte_range=ByteRange.create_from_ts_node(
                                 string_content
                             ),
+                            filename=parse_context.filename,
                         )
                         for marker_ in source_node.markers:
                             if isinstance(marker_, LanguageItemMarker) and (
@@ -175,6 +176,7 @@ class SourceFileTraceabilityReader_Python:
                                 comment_byte_range=ByteRange.create_from_ts_node(
                                     string_content
                                 ),
+                                filename=parse_context.filename,
                                 entity_name=function_name,
                             )
                             for marker_ in source_node.markers:
@@ -256,6 +258,7 @@ class SourceFileTraceabilityReader_Python:
                     comment_byte_range=ByteRange(
                         node_.start_byte, last_comment.end_byte
                     ),
+                    filename=parse_context.filename,
                     entity_name=None,
                 )
                 for marker_ in source_node.markers:

--- a/strictdoc/backend/sdoc_source_code/reader_robot.py
+++ b/strictdoc/backend/sdoc_source_code/reader_robot.py
@@ -100,6 +100,7 @@ class SdocRelationVisitor(ModelVisitor):  # type: ignore[misc]
                         line_end=token.lineno,
                         # FIXME: Byte range is currently not used for Robot framework.
                         comment_byte_range=None,
+                        filename=self.parse_context.filename,
                         comment_line_start=token.lineno,
                         entity_name=node.name,
                         col_offset=token.col_offset,
@@ -145,6 +146,7 @@ class SdocRelationVisitor(ModelVisitor):  # type: ignore[misc]
                 line_end=node.lineno,
                 # FIXME: Byte range is currently not used for Robot framework.
                 comment_byte_range=None,
+                filename=self.parse_context.filename,
                 comment_line_start=node.lineno,
                 entity_name=None,
                 col_offset=token.col_offset,


### PR DESCRIPTION
### WHAT
This allows language readers to provide an inferred default scope to the marker parser.

### WHY
In some situations, the explicit scope in `@relation(REQ-1, scope=function)` provided by the user would be redundant. A good example are Rust doc comments, which unambiguously determine the targeted language construct. The construct in turn determines the scope. If a language reader has the ability to infer the scope, it should do so and not urge the user to provide it explicitly. This was triggered by https://github.com/strictdoc-project/strictdoc/pull/2672.

### HOW
We slightly change lark grammar for `@relation` to:
- at least one requirement uid,
- then maybe more separated requirement uids,
- then maybe separated scope,
- then maybe separated role.

The default scope is used if the marker contained no user provided scope. We exit with error if neither default nor user provided scope were given.
