### PR TITLE
refactor(Function): Rename Function to LanguageItem

### DIFF
--- a/strictdoc/backend/sdoc/error_handling.py
+++ b/strictdoc/backend/sdoc/error_handling.py
@@ -20,9 +20,9 @@ from strictdoc.backend.sdoc.models.node import (
     SDocNodeField,
 )
 from strictdoc.backend.sdoc.models.reference import Reference
-from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
-    ForwardFunctionRangeMarker,
-    FunctionRangeMarker,
+from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
+    ForwardLanguageItemMarker,
+    LanguageItemMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.line_marker import LineMarker
 from strictdoc.backend.sdoc_source_code.models.range_marker import (
@@ -323,8 +323,8 @@ ELEMENTS:
     def invalid_marker_role(
         node: SDocNode,
         marker: Union[
-            ForwardFunctionRangeMarker,
-            FunctionRangeMarker,
+            ForwardLanguageItemMarker,
+            LanguageItemMarker,
             LineMarker,
             RangeMarker,
             ForwardRangeMarker,

--- a/strictdoc/backend/sdoc_source_code/grammar.py
+++ b/strictdoc/backend/sdoc_source_code/grammar.py
@@ -9,7 +9,7 @@ Part[noskipws]:
   // The EmptyLine is needed in addition to the SingleLineString because
   // otherwise textX's get_location() ignores the whitespaces.
   // TODO: Maybe there is a trick to disable that and only use SingleLineString.
-  EmptyLine | RangeMarker | LineMarker | FunctionRangeMarker | SingleLineString
+  EmptyLine | RangeMarker | LineMarker | LanguageItemMarker | SingleLineString
 ;
 
 EmptyLine[noskipws]:
@@ -25,7 +25,7 @@ RangeMarker[noskipws]:
   (reqs_objs += Req[', ']) ', scope=' scope=/(range_start|range_end)/ (", role=" role=/{REGEX_ROLE}/)? ')' '\n'?
 ;
 
-FunctionRangeMarker[noskipws]:
+LanguageItemMarker[noskipws]:
   /^.*?@relation/
   "(" (reqs_objs += Req[', ']) ', scope=' scope="file" (", role=" role=/{REGEX_ROLE}/)? ')' '\n'?
 ;

--- a/strictdoc/backend/sdoc_source_code/marker_parser.py
+++ b/strictdoc/backend/sdoc_source_code/marker_parser.py
@@ -12,8 +12,8 @@ from strictdoc.backend.sdoc_source_code.comment_parser.marker_lexer import (
 from strictdoc.backend.sdoc_source_code.helpers.comment_preprocessor import (
     preprocess_source_code_comment,
 )
-from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
-    FunctionRangeMarker,
+from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
+    LanguageItemMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.line_marker import LineMarker
 from strictdoc.backend.sdoc_source_code.models.range_marker import (
@@ -104,8 +104,8 @@ class MarkerParser:
         comment_line_start: int,
         entity_name: Optional[str] = None,
         col_offset: int = 0,
-    ) -> List[Union[FunctionRangeMarker, RangeMarker, LineMarker]]:
-        markers: List[Union[FunctionRangeMarker, RangeMarker, LineMarker]] = []
+    ) -> List[Union[LanguageItemMarker, RangeMarker, LineMarker]]:
+        markers: List[Union[LanguageItemMarker, RangeMarker, LineMarker]] = []
 
         relation_uid_elements = []
         relation_scope_element: Optional[Tree[Token]] = None
@@ -155,24 +155,26 @@ class MarkerParser:
             requirements.append(requirement)
 
         if relation_scope in ("file", "class", "function"):
-            function_marker = FunctionRangeMarker(
+            language_item_marker = LanguageItemMarker(
                 None, requirements, scope=relation_scope, role=relation_role
             )
-            function_marker.ng_source_line_begin = (
+            language_item_marker.ng_source_line_begin = (
                 comment_line_start + element_.meta.line - 1
             )
-            function_marker.ng_source_column_begin = (
+            language_item_marker.ng_source_column_begin = (
                 element_.meta.column + col_offset
             )
-            function_marker.ng_range_line_begin = line_start
-            function_marker.ng_range_line_end = line_end
+            language_item_marker.ng_range_line_begin = line_start
+            language_item_marker.ng_range_line_end = line_end
             if relation_scope == "file":
-                function_marker.set_description("entire file")
+                language_item_marker.set_description("entire file")
             elif relation_scope == "function":
-                function_marker.set_description(f"function {entity_name}()")
+                language_item_marker.set_description(
+                    f"function {entity_name}()"
+                )
             elif relation_scope == "class":
-                function_marker.set_description(f"class {entity_name}")
-            markers.append(function_marker)
+                language_item_marker.set_description(f"class {entity_name}")
+            markers.append(language_item_marker)
         elif relation_scope in ("range_start", "range_end"):
             range_marker = RangeMarker(
                 None,

--- a/strictdoc/backend/sdoc_source_code/models/language.py
+++ b/strictdoc/backend/sdoc_source_code/models/language.py
@@ -5,15 +5,15 @@
 from typing import Any, List, Optional, Set
 
 from strictdoc.backend.sdoc_source_code.constants import FunctionAttribute
-from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
-    FunctionRangeMarker,
+from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
+    LanguageItemMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.source_location import ByteRange
 from strictdoc.helpers.auto_described import auto_described
 
 
 @auto_described
-class Function:
+class LanguageItem:
     def __init__(
         self,
         *,
@@ -24,7 +24,7 @@ class Function:
         line_end: int,
         code_byte_range: Optional[ByteRange],
         child_functions: List[Any],
-        markers: List[FunctionRangeMarker],
+        markers: List[LanguageItemMarker],
         attributes: Set[FunctionAttribute],
     ):
         assert parent is not None
@@ -34,8 +34,8 @@ class Function:
 
         # Child functions are supported in programming languages that can nest
         # functions, for example, Python.
-        self.child_functions: List[Function] = child_functions
-        self.markers: List[FunctionRangeMarker] = markers
+        self.child_functions: List[LanguageItem] = child_functions
+        self.markers: List[LanguageItemMarker] = markers
         self.line_begin = line_begin
         self.line_end = line_end
 

--- a/strictdoc/backend/sdoc_source_code/models/language.py
+++ b/strictdoc/backend/sdoc_source_code/models/language.py
@@ -27,6 +27,62 @@ class LanguageItem:
         markers: List[LanguageItemMarker],
         attributes: Set[FunctionAttribute],
     ):
+        """
+        Create a LanguageItem object.
+
+        A LanguageItem records essential data like name and location of
+        programming language items from language-aware parsing. It's up to a
+        StrictDoc language parser what items they want to support.
+
+        For languages that scatter parts of a function over different places
+        (e.g. declaration and definition in C), the caller is responsible to
+        create a separate LanguageItem object for each part, where the parts
+        match on name. Since it's more common to stick documentation to the
+        declaration part, StrictDoc will automatically find and link
+        corresponding definition parts. Not vice versa: If definition parts are
+        documented, only the definition will be linked.
+
+        parent should be set to the SourceFileTraceabilityInfo that corresponds
+        to the file where the function is defined. Purpose is to provide meta
+        information like file name and path while the FileTraceabilityIndex is
+        not yet fully resolved.
+
+        name is an identifier that should be globally unique for a set of
+        declarations/definitions. Its purpose is to tie declarations and
+        definitions. It's up to StrictDoc language parsers to define a naming
+        convention for their language. The convention should follow language
+        specific notation for qualified names. E.g. in C++, a member bar in
+        class Foo will be named "Foo:bar(const CanFrame &frame)". It may be
+        hard to reimplement the full module and naming system of each language,
+        so naming is best-effort.
+
+        display_name is an identifier used to resolve forward relations from
+        users to function objects created by language parsers. The display_name
+        must thus be predictable for users and as unique as possible. It's up
+        to StrictDoc language parsers to define a naming convention for their
+        language. The convention should follow language specific notation for
+        qualified identifiers. E.g. in C++, a member bar in class Foo will be
+        named "Foo:bar".
+
+        line start/end (1-based) mark first and last line of the definition
+        block, *without* leading comment lines, if any. Used to jump to and
+        highlight the function in source file view in case of forward
+        relations.
+
+        child_functions could store LanguageItem objects that represent nested
+        functions. It's currently unused and may be removed.
+
+        markers are only needed if the LanguageItem is a declaration function
+        (C, C++) that shall be automatically linked to the corresponding
+        definition function, or if it is a test framework function that shall
+        be automatically linked with requirements and test results. Otherwise,
+        it can be empty.
+
+        attributes: For example static, declaration, definition. Enables some
+        special handling, e.g. automatic linking of definitions if the
+        LanguageItem is a declaration.
+        """
+
         assert parent is not None
         self.parent = parent
         self.name = name

--- a/strictdoc/backend/sdoc_source_code/models/language_item_marker.py
+++ b/strictdoc/backend/sdoc_source_code/models/language_item_marker.py
@@ -17,7 +17,7 @@ class RangeMarkerType(Enum):
 
 
 @auto_described
-class FunctionRangeMarker:
+class LanguageItemMarker:
     def __init__(
         self, parent: Any, reqs_objs: List[Req], scope: str, role: Optional[str]
     ):
@@ -78,7 +78,7 @@ class FunctionRangeMarker:
         assert isinstance(description, str)
         self._description = description
 
-    def create_end_marker(self) -> "FunctionRangeMarker":
+    def create_end_marker(self) -> "LanguageItemMarker":
         marker_copy = copy(self)
         marker_copy.begin_or_end = False
         marker_copy.ng_range_line_begin = self.ng_range_line_begin
@@ -87,7 +87,7 @@ class FunctionRangeMarker:
 
 
 @auto_described
-class ForwardFunctionRangeMarker(FunctionRangeMarker):
+class ForwardLanguageItemMarker(LanguageItemMarker):
     def __init__(
         self,
         parent: Any,

--- a/strictdoc/backend/sdoc_source_code/models/source_file_info.py
+++ b/strictdoc/backend/sdoc_source_code/models/source_file_info.py
@@ -2,9 +2,9 @@ from typing import Any, Dict, List, Optional, Union
 
 from typing_extensions import TypeAlias
 
-from strictdoc.backend.sdoc_source_code.models.function import Function
-from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
-    FunctionRangeMarker,
+from strictdoc.backend.sdoc_source_code.models.language import LanguageItem
+from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
+    LanguageItemMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.line_marker import LineMarker
 from strictdoc.backend.sdoc_source_code.models.range_marker import (
@@ -17,7 +17,7 @@ from strictdoc.helpers.auto_described import auto_described
 from strictdoc.helpers.file_stats import SourceFileStats
 
 RelationMarkerType: TypeAlias = Union[
-    FunctionRangeMarker, LineMarker, RangeMarker, ForwardRangeMarker
+    LanguageItemMarker, LineMarker, RangeMarker, ForwardRangeMarker
 ]
 
 
@@ -41,7 +41,7 @@ class SourceFileTraceabilityInfo:
     def __init__(self, g_parts: List[Any]):  # noqa: ARG002
         self.source_file: Optional[SourceFile] = None
         self.source_nodes: List[SourceNode] = []
-        self.functions: List[Function] = []
+        self.functions: List[LanguageItem] = []
 
         #
         # {                                              # noqa: ERA001
@@ -51,7 +51,7 @@ class SourceFileTraceabilityInfo:
         self.ng_map_reqs_to_markers: Dict[str, List[RelationMarkerType]] = {}
 
         self.ng_map_names_to_markers: Dict[str, List[RelationMarkerType]] = {}
-        self.ng_map_names_to_definition_functions: Dict[str, Function] = {}
+        self.ng_map_names_to_definition_functions: Dict[str, LanguageItem] = {}
 
         #
         # Merged ranges contain ranges that are fully covered by one or more

--- a/strictdoc/backend/sdoc_source_code/models/source_node.py
+++ b/strictdoc/backend/sdoc_source_code/models/source_node.py
@@ -5,9 +5,9 @@
 from dataclasses import dataclass, field
 from typing import Any, List, Optional, Union
 
-from strictdoc.backend.sdoc_source_code.models.function import Function
-from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
-    FunctionRangeMarker,
+from strictdoc.backend.sdoc_source_code.models.language import LanguageItem
+from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
+    LanguageItemMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.line_marker import LineMarker
 from strictdoc.backend.sdoc_source_code.models.range_marker import (
@@ -29,12 +29,12 @@ class SourceNode:
 
     entity_name: Optional[str]
     comment_byte_range: Optional[ByteRange]
-    markers: List[Union[FunctionRangeMarker, RangeMarker, LineMarker]] = field(
+    markers: List[Union[LanguageItemMarker, RangeMarker, LineMarker]] = field(
         default_factory=list
     )
     fields: dict[str, str] = field(default_factory=dict)
     fields_locations: dict[str, tuple[int, int]] = field(default_factory=dict)
-    function: Optional[Function] = None
+    function: Optional[LanguageItem] = None
     # FIXME: Adding SDocNode here causes circular import problem.
     sdoc_node: Optional[Any] = None
 

--- a/strictdoc/backend/sdoc_source_code/parse_context.py
+++ b/strictdoc/backend/sdoc_source_code/parse_context.py
@@ -4,8 +4,8 @@
 
 from typing import Any, Dict, List, Optional, Union
 
-from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
-    FunctionRangeMarker,
+from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
+    LanguageItemMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.line_marker import LineMarker
 from strictdoc.backend.sdoc_source_code.models.range_marker import RangeMarker
@@ -20,6 +20,6 @@ class ParseContext:
         self.file_stats: SourceFileStats = file_stats
         self.markers: List[Any] = []
         self.marker_stack: List[
-            Union[RangeMarker, FunctionRangeMarker, LineMarker]
+            Union[RangeMarker, LanguageItemMarker, LineMarker]
         ] = []
         self.map_reqs_to_markers: Dict[str, Any] = {}

--- a/strictdoc/backend/sdoc_source_code/processors/general_language_marker_processors.py
+++ b/strictdoc/backend/sdoc_source_code/processors/general_language_marker_processors.py
@@ -7,8 +7,8 @@ from typing import List, Optional, Tuple, Union
 from textx import get_location
 
 from strictdoc.backend.sdoc.error_handling import StrictDocSemanticError
-from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
-    FunctionRangeMarker,
+from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
+    LanguageItemMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.line_marker import LineMarker
 from strictdoc.backend.sdoc_source_code.models.range_marker import (
@@ -23,7 +23,7 @@ from strictdoc.helpers.list import find_duplicates
 
 
 def validate_marker_uids(
-    marker: Union[FunctionRangeMarker, LineMarker, RangeMarker],
+    marker: Union[LanguageItemMarker, LineMarker, RangeMarker],
     parse_context: ParseContext,
 ) -> None:
     possible_duplicates = find_duplicates(marker.reqs)
@@ -37,7 +37,7 @@ def validate_marker_uids(
 
 
 def _handle_skip_marker(
-    marker: Union[RangeMarker, FunctionRangeMarker, LineMarker],
+    marker: Union[RangeMarker, LanguageItemMarker, LineMarker],
     parse_context: ParseContext,
 ) -> None:
     assert marker.ng_is_nodoc, marker
@@ -139,7 +139,7 @@ Content...
 
 
 def create_unmatch_range_error(
-    unmatched_ranges: List[Union[RangeMarker, FunctionRangeMarker, LineMarker]],
+    unmatched_ranges: List[Union[RangeMarker, LanguageItemMarker, LineMarker]],
     filename: Optional[str],
 ) -> StrictDocSemanticError:
     assert isinstance(unmatched_ranges, list)
@@ -178,8 +178,8 @@ def create_unmatch_range_error(
     )
 
 
-def function_range_marker_processor(
-    marker: FunctionRangeMarker, parse_context: ParseContext
+def language_item_marker_processor(
+    marker: LanguageItemMarker, parse_context: ParseContext
 ) -> None:
     if marker.ng_is_nodoc:
         _handle_skip_marker(marker, parse_context)

--- a/strictdoc/backend/sdoc_source_code/reader.py
+++ b/strictdoc/backend/sdoc_source_code/reader.py
@@ -8,8 +8,8 @@ from typing import Optional, TypedDict
 from textx import get_location, metamodel_from_str
 
 from strictdoc.backend.sdoc_source_code.grammar import SOURCE_FILE_GRAMMAR
-from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
-    FunctionRangeMarker,
+from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
+    LanguageItemMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.line_marker import LineMarker
 from strictdoc.backend.sdoc_source_code.models.range_marker import (
@@ -120,24 +120,24 @@ def range_marker_processor(
         raise NotImplementedError
 
 
-def function_range_marker_processor(
-    function_range_marker: FunctionRangeMarker, parse_context: ParseContext
+def language_item_marker_processor(
+    language_item_marker: LanguageItemMarker, parse_context: ParseContext
 ) -> None:
-    validate_marker_uids(function_range_marker, parse_context)
+    validate_marker_uids(language_item_marker, parse_context)
 
-    location = get_location(function_range_marker)
+    location = get_location(language_item_marker)
     line = location["line"]
     column = location["col"]
 
-    function_range_marker.ng_source_line_begin = line
-    function_range_marker.ng_source_column_begin = column
-    function_range_marker.ng_range_line_begin = 1
-    function_range_marker.ng_range_line_end = (
+    language_item_marker.ng_source_line_begin = line
+    language_item_marker.ng_source_column_begin = column
+    language_item_marker.ng_range_line_begin = 1
+    language_item_marker.ng_range_line_end = (
         parse_context.file_stats.lines_total
     )
 
-    if function_range_marker.ng_is_nodoc:
-        _handle_skip_marker(function_range_marker, parse_context)
+    if language_item_marker.ng_is_nodoc:
+        _handle_skip_marker(language_item_marker, parse_context)
         return
 
     if (
@@ -147,21 +147,21 @@ def function_range_marker_processor(
         # This marker is within a "@relation(skip...)" block, so we ignore it.
         return
 
-    parse_context.markers.append(function_range_marker)
+    parse_context.markers.append(language_item_marker)
 
-    # Function range markers supported by this general reader can only
+    # Language item markers supported by this general reader can only
     # be of scope=file. Only the language-aware parsing results in
     # markers also having scope=function or scope=class.
-    function_range_marker.set_description("entire file")
+    language_item_marker.set_description("entire file")
 
-    for req in function_range_marker.reqs:
+    for req in language_item_marker.reqs:
         markers = parse_context.map_reqs_to_markers.setdefault(req, [])
-        markers.append(function_range_marker)
+        markers.append(language_item_marker)
 
 
 class SourceFileTraceabilityReader:
     SOURCE_FILE_MODELS = [
-        FunctionRangeMarker,
+        LanguageItemMarker,
         LineMarker,
         Req,
         SourceFileTraceabilityInfo,
@@ -197,12 +197,12 @@ class SourceFileTraceabilityReader:
         parse_line_marker_processor = partial(
             line_marker_processor, parse_context=parse_context
         )
-        parse_function_range_marker_processor = partial(
-            function_range_marker_processor, parse_context=parse_context
+        parse_language_item_marker_processor = partial(
+            language_item_marker_processor, parse_context=parse_context
         )
 
         obj_processors = {
-            "FunctionRangeMarker": parse_function_range_marker_processor,
+            "LanguageItemMarker": parse_language_item_marker_processor,
             "LineMarker": parse_line_marker_processor,
             "RangeMarker": parse_range_marker_processor,
             "Req": parse_req_processor,

--- a/strictdoc/export/html/generators/source_file_view_generator.py
+++ b/strictdoc/export/html/generators/source_file_view_generator.py
@@ -21,9 +21,9 @@ from pygments.lexers.templates import HtmlDjangoLexer
 from pygments.util import ClassNotFound
 
 from strictdoc.backend.sdoc.constants import SDocMarkup
-from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
-    ForwardFunctionRangeMarker,
-    FunctionRangeMarker,
+from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
+    ForwardLanguageItemMarker,
+    LanguageItemMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.line_marker import LineMarker
 from strictdoc.backend.sdoc_source_code.models.range_marker import (
@@ -278,8 +278,8 @@ class SourceFileViewHTMLGenerator:
                 marker,
                 (
                     ForwardRangeMarker,
-                    ForwardFunctionRangeMarker,
-                    FunctionRangeMarker,
+                    ForwardLanguageItemMarker,
+                    LanguageItemMarker,
                     RangeMarker,
                     LineMarker,
                 ),

--- a/strictdoc/export/html/generators/view_objects/source_file_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/source_file_view_object.py
@@ -14,8 +14,8 @@ from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_view import NullViewElement
 from strictdoc.backend.sdoc.models.model import SDocDocumentIF, SDocNodeIF
 from strictdoc.backend.sdoc.models.node import SDocNode, SDocNodeField
-from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
-    FunctionRangeMarker,
+from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
+    LanguageItemMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.line_marker import LineMarker
 from strictdoc.backend.sdoc_source_code.models.range_marker import (
@@ -43,7 +43,7 @@ class SourceMarkerTuple:
     ng_range_line_end: int
     source_line: Markup
     markers: List[
-        Union[FunctionRangeMarker, ForwardRangeMarker, LineMarker, RangeMarker]
+        Union[LanguageItemMarker, ForwardRangeMarker, LineMarker, RangeMarker]
     ]
 
     def is_end(self) -> bool:

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_cpp.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_cpp.py
@@ -2,9 +2,9 @@
 @relation(SDOC-SRS-146, scope=file)
 """
 
-from strictdoc.backend.sdoc_source_code.models.function import Function
-from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
-    FunctionRangeMarker,
+from strictdoc.backend.sdoc_source_code.models.language import LanguageItem
+from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
+    LanguageItemMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.source_file_info import (
     SourceFileTraceabilityInfo,
@@ -34,13 +34,13 @@ class Foo
     assert len(info.functions) == 1
     assert len(info.markers) == 1
 
-    function: Function = info.functions[0]
+    function: LanguageItem = info.functions[0]
     assert function.name == "Foo::CanSend(const CanFrame &frame)"
     assert function.display_name == "Foo::CanSend"
     assert function.line_begin == 4
     assert function.line_end == 7
 
-    marker: FunctionRangeMarker = info.markers[0]
+    marker: LanguageItemMarker = info.markers[0]
     assert marker.ng_range_line_begin == 4
     assert marker.ng_range_line_end == 7
 
@@ -66,13 +66,13 @@ class Bar {
     assert len(info.functions) == 1
     assert len(info.markers) == 1
 
-    function: Function = info.functions[0]
+    function: LanguageItem = info.functions[0]
     assert function.name == "Foo::Bar::CanSend(const CanFrame &frame)"
     assert function.display_name == "Foo::Bar::CanSend"
     assert function.line_begin == 4
     assert function.line_end == 7
 
-    marker: FunctionRangeMarker = info.markers[0]
+    marker: LanguageItemMarker = info.markers[0]
     assert marker.ng_range_line_begin == 4
     assert marker.ng_range_line_end == 7
 
@@ -95,13 +95,13 @@ bool Foo::Bar::CanSend(const CanFrame &frame) {
     assert len(info.functions) == 1
     assert len(info.markers) == 1
 
-    function: Function = info.functions[0]
+    function: LanguageItem = info.functions[0]
     assert function.name == "Foo::Bar::CanSend(const CanFrame &frame)"
     assert function.display_name == "Foo::Bar::CanSend"
     assert function.line_begin == 1
     assert function.line_end == 6
 
-    marker: FunctionRangeMarker = info.markers[0]
+    marker: LanguageItemMarker = info.markers[0]
     assert marker.ng_range_line_begin == 1
     assert marker.ng_range_line_end == 6
 
@@ -129,13 +129,13 @@ class TrkVertex
     assert len(info.functions) == 1
     assert len(info.markers) == 1
 
-    function: Function = info.functions[0]
+    function: LanguageItem = info.functions[0]
     assert function.name == "TrkVertex::operator-=(const TrkVertex& c)"
     assert function.display_name == "TrkVertex::operator-="
     assert function.line_begin == 7
     assert function.line_end == 10
 
-    marker: FunctionRangeMarker = info.markers[0]
+    marker: LanguageItemMarker = info.markers[0]
     assert marker.ng_range_line_begin == 7
     assert marker.ng_range_line_end == 10
 
@@ -170,33 +170,33 @@ class TrkVertex
     assert len(info.functions) == 3
     assert len(info.markers) == 3
 
-    function_1: Function = info.functions[0]
+    function_1: LanguageItem = info.functions[0]
     assert function_1.name == "TrkVertex::TrkVertex()"
     assert function_1.display_name == "TrkVertex::TrkVertex"
     assert function_1.line_begin == 4
     assert function_1.line_end == 7
 
-    function_2: Function = info.functions[1]
+    function_2: LanguageItem = info.functions[1]
     assert function_2.name == "TrkVertex::TrkVertex(double x, double y)"
     assert function_2.display_name == "TrkVertex::TrkVertex"
     assert function_2.line_begin == 9
     assert function_2.line_end == 12
 
-    function_3: Function = info.functions[2]
+    function_3: LanguageItem = info.functions[2]
     assert function_3.name == "TrkVertex::~TrkVertex()"
     assert function_3.display_name == "TrkVertex::~TrkVertex"
     assert function_3.line_begin == 14
     assert function_3.line_end == 17
 
-    marker_1: FunctionRangeMarker = info.markers[0]
+    marker_1: LanguageItemMarker = info.markers[0]
     assert marker_1.ng_range_line_begin == 4
     assert marker_1.ng_range_line_end == 7
 
-    marker_2: FunctionRangeMarker = info.markers[1]
+    marker_2: LanguageItemMarker = info.markers[1]
     assert marker_2.ng_range_line_begin == 9
     assert marker_2.ng_range_line_end == 12
 
-    marker_3: FunctionRangeMarker = info.markers[2]
+    marker_3: LanguageItemMarker = info.markers[2]
     assert marker_3.ng_range_line_begin == 14
     assert marker_3.ng_range_line_end == 17
 
@@ -231,33 +231,33 @@ class TrkVertex
     assert len(info.functions) == 3
     assert len(info.markers) == 3
 
-    function_1: Function = info.functions[0]
+    function_1: LanguageItem = info.functions[0]
     assert function_1.name == "TrkVertex::TrkVertex()"
     assert function_1.display_name == "TrkVertex::TrkVertex"
     assert function_1.line_begin == 4
     assert function_1.line_end == 7
 
-    function_2: Function = info.functions[1]
+    function_2: LanguageItem = info.functions[1]
     assert function_2.name == "TrkVertex::TrkVertex(double x, double y)"
     assert function_2.display_name == "TrkVertex::TrkVertex"
     assert function_2.line_begin == 9
     assert function_2.line_end == 12
 
-    function_3: Function = info.functions[2]
+    function_3: LanguageItem = info.functions[2]
     assert function_3.name == "TrkVertex::~TrkVertex()"
     assert function_3.display_name == "TrkVertex::~TrkVertex"
     assert function_3.line_begin == 14
     assert function_3.line_end == 17
 
-    marker_1: FunctionRangeMarker = info.markers[0]
+    marker_1: LanguageItemMarker = info.markers[0]
     assert marker_1.ng_range_line_begin == 4
     assert marker_1.ng_range_line_end == 7
 
-    marker_2: FunctionRangeMarker = info.markers[1]
+    marker_2: LanguageItemMarker = info.markers[1]
     assert marker_2.ng_range_line_begin == 9
     assert marker_2.ng_range_line_end == 12
 
-    marker_3: FunctionRangeMarker = info.markers[2]
+    marker_3: LanguageItemMarker = info.markers[2]
     assert marker_3.ng_range_line_begin == 14
     assert marker_3.ng_range_line_end == 17
 
@@ -294,24 +294,24 @@ Foo& Foo::operator+(const Foo& c) { return *this; }
     assert len(info.functions) == 4
     assert len(info.markers) == 1
 
-    function_1: Function = info.functions[0]
+    function_1: LanguageItem = info.functions[0]
     assert function_1.name == "Foo::Foo()"
     assert function_1.display_name == "Foo::Foo"
     assert function_1.line_begin == 6
     assert function_1.line_end == 6
 
-    function_2: Function = info.functions[1]
+    function_2: LanguageItem = info.functions[1]
     assert function_2.name == "Foo::Foo(int a, int b)"
     assert function_2.display_name == "Foo::Foo"
     assert function_2.line_begin == 7
     assert function_2.line_end == 7
 
-    function_3: Function = info.functions[2]
+    function_3: LanguageItem = info.functions[2]
     assert function_3.name == "Foo::operator+(const Foo& c)"
     assert function_3.display_name == "Foo::operator+"
     assert function_3.line_begin == 9
     assert function_3.line_end == 12
 
-    marker_1: FunctionRangeMarker = info.markers[0]
+    marker_1: LanguageItemMarker = info.markers[0]
     assert marker_1.ng_range_line_begin == 9
     assert marker_1.ng_range_line_end == 12

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_python.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_python.py
@@ -9,7 +9,7 @@ from typing import List
 import pytest
 
 from strictdoc.backend.sdoc.error_handling import StrictDocSemanticError
-from strictdoc.backend.sdoc_source_code.models.function import Function
+from strictdoc.backend.sdoc_source_code.models.language import LanguageItem
 from strictdoc.backend.sdoc_source_code.models.range_marker import RangeMarker
 from strictdoc.backend.sdoc_source_code.models.source_file_info import (
     SourceFileTraceabilityInfo,
@@ -83,47 +83,47 @@ def hello_3():
     assert len(info.functions) == 9
 
     function_1 = info.functions[0]
-    assert isinstance(function_1, Function)
+    assert isinstance(function_1, LanguageItem)
     assert function_1.name == "hello_1"
     assert len(function_1.child_functions) == 1
 
     function_1_1 = function_1.child_functions[0]
-    assert isinstance(function_1_1, Function)
+    assert isinstance(function_1_1, LanguageItem)
     assert function_1_1.name == "hello_1.hello_1_1"
     assert len(function_1_1.child_functions) == 1
 
     function_1_1_1 = function_1_1.child_functions[0]
-    assert isinstance(function_1_1_1, Function)
+    assert isinstance(function_1_1_1, LanguageItem)
     assert function_1_1_1.name == "hello_1.hello_1_1.hello_1_1_1"
     assert len(function_1_1_1.child_functions) == 0
 
     function_2 = info.functions[3]
-    assert isinstance(function_2, Function)
+    assert isinstance(function_2, LanguageItem)
     assert function_2.name == "hello_2"
     assert len(function_2.child_functions) == 1
 
     function_2_1 = function_2.child_functions[0]
-    assert isinstance(function_2_1, Function)
+    assert isinstance(function_2_1, LanguageItem)
     assert function_2_1.name == "hello_2.hello_2_1"
     assert len(function_2_1.child_functions) == 1
 
     function_2_1_1 = function_2_1.child_functions[0]
-    assert isinstance(function_2_1_1, Function)
+    assert isinstance(function_2_1_1, LanguageItem)
     assert function_2_1_1.name == "hello_2.hello_2_1.hello_2_1_1"
     assert len(function_2_1_1.child_functions) == 0
 
     function_3 = info.functions[6]
-    assert isinstance(function_3, Function)
+    assert isinstance(function_3, LanguageItem)
     assert function_3.name == "hello_3"
     assert len(function_3.child_functions) == 1
 
     function_3_1 = function_3.child_functions[0]
-    assert isinstance(function_3_1, Function)
+    assert isinstance(function_3_1, LanguageItem)
     assert function_3_1.name == "hello_3.hello_3_1"
     assert len(function_3_1.child_functions) == 1
 
     function_3_1_1 = function_3_1.child_functions[0]
-    assert isinstance(function_3_1_1, Function)
+    assert isinstance(function_3_1_1, LanguageItem)
     assert function_3_1_1.name == "hello_3.hello_3_1.hello_3_1_1"
     assert len(function_3_1_1.child_functions) == 0
 

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_marker_parser.py
@@ -3,8 +3,8 @@
 """
 
 from strictdoc.backend.sdoc_source_code.marker_parser import MarkerParser
-from strictdoc.backend.sdoc_source_code.models.function_range_marker import (
-    FunctionRangeMarker,
+from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
+    LanguageItemMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.line_marker import LineMarker
 
@@ -26,7 +26,7 @@ def test_01_basic_nominal():
             comment_byte_range=None,
         )
         function_range = source_node.markers[0]
-        assert isinstance(function_range, FunctionRangeMarker)
+        assert isinstance(function_range, LanguageItemMarker)
         assert function_range.ng_source_line_begin == 1
         assert function_range.ng_range_line_begin == 1
         assert function_range.ng_range_line_end == 1
@@ -50,7 +50,7 @@ def test_10_parses_with_leading_newlines():
     )
     function_range = source_node.markers[0]
 
-    assert isinstance(function_range, FunctionRangeMarker)
+    assert isinstance(function_range, LanguageItemMarker)
     assert function_range.ng_source_line_begin == 3
     assert function_range.ng_range_line_begin == 1
     assert function_range.ng_range_line_end == 5
@@ -74,7 +74,7 @@ def test_11_parses_with_leading_whitespace():
     )
     function_range = source_node.markers[0]
 
-    assert isinstance(function_range, FunctionRangeMarker)
+    assert isinstance(function_range, LanguageItemMarker)
     assert function_range.ng_source_line_begin == 3
     assert function_range.ng_range_line_begin == 1
     assert function_range.ng_range_line_end == 3
@@ -100,7 +100,7 @@ def test_20_parses_within_doxygen_comment():
     )
     function_range = source_node.markers[0]
 
-    assert isinstance(function_range, FunctionRangeMarker)
+    assert isinstance(function_range, LanguageItemMarker)
     assert function_range.ng_source_line_begin == 4
     assert function_range.ng_range_line_begin == 1
     assert function_range.ng_range_line_end == 5
@@ -127,7 +127,7 @@ def test_21_parses_within_doxygen_comment_two_markers():
     )
     function_range = source_node.markers[0]
 
-    assert isinstance(function_range, FunctionRangeMarker)
+    assert isinstance(function_range, LanguageItemMarker)
     assert function_range.ng_source_line_begin == 4
     assert function_range.ng_range_line_begin == 1
     assert function_range.ng_range_line_end == 6
@@ -153,7 +153,7 @@ def test_22_parses_within_doxygen_comment_curly_braces():
     )
     function_range = source_node.markers[0]
 
-    assert isinstance(function_range, FunctionRangeMarker)
+    assert isinstance(function_range, LanguageItemMarker)
     assert function_range.ng_source_line_begin == 4
     assert function_range.ng_range_line_begin == 1
     assert function_range.ng_range_line_end == 5
@@ -190,7 +190,7 @@ def test_23_parses_within_doxygen_comment():
     )
 
     function_range = source_node.markers[0]
-    assert isinstance(function_range, FunctionRangeMarker)
+    assert isinstance(function_range, LanguageItemMarker)
     assert function_range.ng_source_line_begin == 4
     assert function_range.ng_range_line_begin == 1
     assert function_range.ng_range_line_end == 16
@@ -205,7 +205,7 @@ def test_23_parses_within_doxygen_comment():
     assert function_range.reqs_objs[2].ng_source_column == 8
 
     function_range = source_node.markers[1]
-    assert isinstance(function_range, FunctionRangeMarker)
+    assert isinstance(function_range, LanguageItemMarker)
     assert function_range.ng_source_line_begin == 10
     assert function_range.ng_range_line_begin == 1
     assert function_range.ng_range_line_end == 16


### PR DESCRIPTION
### What

Rename the class and associated variables and comments.

### Why

This was triggered by https://github.com/strictdoc-project/strictdoc/pull/2672. Rust language-aware parsing made evident we want to represent many more things that can occur in source code (enums, structs, modules, traits, expressions, type parameters, ...) - not only functions and classes. The possible list of items is long and unpredictable since it depends on supported languages which will increase over time. So it's best to represent items with a single generic class.

### How

Rename internal items only, without changing public API or functionality. For example, we keep `@relation(scope=function)` and `RELATIONS: - FUNCTIONS: ...` for now. The generalization should be exposed to users eventually, but requires backward compatibility considerations and therefore is deferred to not block other PRs.