### PR TITLE
fix: pyinstaller: fix html2pdf4doc/Selenium-related issue

### DIFF
--- a/developer/pyinstaller_hooks/hook-html2pdf4doc.py
+++ b/developer/pyinstaller_hooks/hook-html2pdf4doc.py
@@ -1,6 +1,10 @@
 # https://stackoverflow.com/a/64473931/598057
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 # The following ensures that the HTML2PDF4Doc.js file is present in the
 # PyInstaller bundle of StrictDoc.
 datas = collect_data_files("html2pdf4doc")
+
+# Selenium's webdriver modules are imported lazily via selenium.webdriver's
+# __getattr__, so PyInstaller does not always detect them automatically.
+hiddenimports = collect_submodules("selenium.webdriver")


### PR DESCRIPTION
**WHAT:** Make Selenium webmodules be collected for html2pdf4doc when StrictDoc is installed via PyInstaller.

**WHY:** Fixes a regression:

```
error: expect_exit: expected exit code: 0, actual: 1.
Traceback (most recent call last):
  File "main.py", line 12, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "strictdoc/commands/export.py", line 8, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "strictdoc/core/actions/export_action.py", line 18, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "strictdoc/export/html2pdf/html2pdf_generator.py", line 18, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "strictdoc/export/html2pdf/pdf_print_driver.py", line 9, in <module>
  File "pyimod02_importers.py", line 457, in exec_module
  File "html2pdf4doc/main.py", line 314, in <module>
  File "selenium/webdriver/__init__.py", line 95, in __getattr__
  File "importlib/__init__.py", line 126, in import_module
ModuleNotFoundError: No module named 'selenium.webdriver.chrome.webdriver'
[PYI-6128:ERROR] Failed to execute script 'main' due to unhandled exception!
```