### PR TITLE
feat(export/rst): make WildcardEnhancedImage support concurrent use

### DIFF
--- a/strictdoc/export/rst/directives/wildcard_enhanced_image.py
+++ b/strictdoc/export/rst/directives/wildcard_enhanced_image.py
@@ -4,11 +4,11 @@ from typing import List
 from docutils import nodes
 from docutils.parsers.rst.directives.images import Image
 
+STRICTDOC_REFERENCE_PATH_SETTING = "strictdoc_reference_path"
+
 
 class WildcardEnhancedImage(Image):  # type: ignore[misc]
     WILDCARD_EXTENSIONS = ["svg", "png", "gif", "jpg", "jpeg"]
-
-    current_reference_path = os.getcwd()
 
     def run(self) -> List[nodes.Node]:
         # A user has suggested that StrictDoc could be capable of rendering
@@ -39,6 +39,11 @@ class WildcardEnhancedImage(Image):  # type: ignore[misc]
         messages: List[nodes.Node] = []
 
         assert len(self.arguments) > 0
+        current_reference_path = getattr(
+            self.state.document.settings,
+            STRICTDOC_REFERENCE_PATH_SETTING,
+            os.getcwd(),
+        )
         rel_path_to_image = self.arguments[0]
         if rel_path_to_image.endswith(".*"):
             rel_path_to_image_no_wc = rel_path_to_image[:-2]
@@ -47,7 +52,7 @@ class WildcardEnhancedImage(Image):  # type: ignore[misc]
                     rel_path_to_image_no_wc + "." + extension
                 )
                 full_path_to_image_with_extension = os.path.join(
-                    WildcardEnhancedImage.current_reference_path,
+                    current_reference_path,
                     rel_path_to_image_with_extension,
                 )
                 if os.path.exists(full_path_to_image_with_extension):

--- a/strictdoc/export/rst/rst_to_html_fragment_writer.py
+++ b/strictdoc/export/rst/rst_to_html_fragment_writer.py
@@ -27,6 +27,7 @@ from strictdoc.export.rst.directives.sphinx_style_math import (
     math_role_for_server,
 )
 from strictdoc.export.rst.directives.wildcard_enhanced_image import (
+    STRICTDOC_REFERENCE_PATH_SETTING,
     WildcardEnhancedImage,
 )
 from strictdoc.helpers.file_system import file_open_read_bytes
@@ -65,10 +66,11 @@ class RstToHtmlFragmentWriter:
         self.path_to_rst_cache_dir = os.path.join(
             path_to_tmp_dir, "rst", path_to_output_dir_md5
         )
+        self.reference_path = os.getcwd()
 
         if context_document is not None:
             assert context_document.meta is not None
-            WildcardEnhancedImage.current_reference_path = (
+            self.reference_path = (
                 context_document.meta.output_document_dir_full_path
             )
 
@@ -143,7 +145,11 @@ class RstToHtmlFragmentWriter:
         # being printed to sys.stderr.
         # https://www.programcreek.com/python/example/88126/docutils.core.publish_parts
         warning_stream = io.StringIO()
-        settings = {**self.BASE_SETTINGS, "warning_stream": warning_stream}
+        settings = {
+            **self.BASE_SETTINGS,
+            "warning_stream": warning_stream,
+            STRICTDOC_REFERENCE_PATH_SETTING: self.reference_path,
+        }
 
         output = publish_parts(
             rst_fragment,
@@ -190,7 +196,11 @@ class RstToHtmlFragmentWriter:
         # being printed to sys.stderr.
         # https://www.programcreek.com/python/example/88126/docutils.core.publish_parts
         warning_stream = io.StringIO()
-        settings = {**self.BASE_SETTINGS, "warning_stream": warning_stream}
+        settings = {
+            **self.BASE_SETTINGS,
+            "warning_stream": warning_stream,
+            STRICTDOC_REFERENCE_PATH_SETTING: self.reference_path,
+        }
 
         try:
             output = publish_parts(


### PR DESCRIPTION
**WHY:**

This is one step towards making StrictDoc server be usable by multiple users concurrently.