### PR TITLE
feat(markdown): add basic Relations: support

### DIFF
--- a/docs/strictdoc_21_L2_StrictDoc_Requirements.sdoc
+++ b/docs/strictdoc_21_L2_StrictDoc_Requirements.sdoc
@@ -805,6 +805,30 @@ As of Markdown MVP, the default and preferred syntax shall be:
 <<<
 
 [REQUIREMENT]
+MID: 121eb00caee34e3fa6eaa683f211a472
+UID: SDOC-SRS-202
+STATUS: Active
+TITLE: Support node parent relations
+STATEMENT: >>>
+StrictDoc shall support node relations in Markdown using the meta field:
+
+.. code-block:: markdown
+
+    **Relations**: <UID-1>, <UID-2>, ...
+
+When reading Markdown:
+- Each UID from the Relations field shall be converted to a relation with TYPE: Parent and VALUE: <UID>.
+- All extra spaces shall be normalized before parsing to canonical ``<UID-1>, <UID-2>, ...``.
+- The Markdown reader shall not check whether any UID actually exists. This task is deferred to the traceability index builder.
+
+When writing Markdown, SDoc node relations with TYPE: Parent and no ROLE shall be serialized back to the same Relations field as a comma-separated UID list.
+
+NOTE: For MVP, relation roles and Child relation types are out of scope.
+
+NOTE: If the Relations field is not placed as the meta field but as the content field, StrictDoc shall raise a ``StrictDocSemanticError``.
+<<<
+
+[REQUIREMENT]
 MID: 84df59ede0f2477181bfc7667684df59
 UID: SDOC-SRS-193
 STATUS: Active

--- a/tests/integration/features/markdown/05_relations/input.md
+++ b/tests/integration/features/markdown/05_relations/input.md
@@ -1,0 +1,20 @@
+# Markdown relations document
+
+## Parent requirement A
+
+**UID**: REQ-1
+
+Parent requirement shall do A.
+
+## Parent requirement B
+
+**UID**: REQ-2
+
+Parent requirement shall do B.
+
+## Child requirement
+
+**UID**: REQ-3
+**Relations**: REQ-1, REQ-2
+
+Child requirement shall do B.

--- a/tests/integration/features/markdown/05_relations/test.itest
+++ b/tests/integration/features/markdown/05_relations/test.itest
@@ -1,0 +1,14 @@
+RUN: %strictdoc export %S --formats=html --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Markdown relations document
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-FILE
+
+CHECK-HTML-FILE: RELATIONS (Child):
+CHECK-HTML-FILE: class="requirement__link-child" href="{{.*}}#REQ-3"
+
+CHECK-HTML-FILE: RELATIONS (Child):
+CHECK-HTML-FILE: class="requirement__link-child" href="{{.*}}#REQ-3"
+
+CHECK-HTML-FILE: RELATIONS (Parent):
+CHECK-HTML-FILE: class="requirement__link-parent" href="{{.*}}#REQ-1"
+CHECK-HTML-FILE: class="requirement__link-parent" href="{{.*}}#REQ-2"

--- a/tests/unit/strictdoc/backend/sdoc/test_markdown_writer.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_markdown_writer.py
@@ -153,3 +153,28 @@ def test_006_markdown_writer_supports_requirements_nested_in_three_sections():
     output_markdown = writer.write(document)
 
     assert output_markdown == input_markdown
+
+
+def test_007_markdown_writer_serializes_parent_relations_field():
+    input_sdoc = """\
+[DOCUMENT]
+TITLE: Document title
+
+[REQUIREMENT]
+UID: REQ-3
+TITLE: Child requirement
+STATEMENT: Child requirement shall do B.
+RELATIONS:
+- TYPE: Parent
+  VALUE: REQ-1
+- TYPE: Parent
+  VALUE: REQ-2
+"""
+
+    document = SDReader.read(input_sdoc, file_path=None)
+
+    writer = SDMarkdownWriter()
+    output_markdown = writer.write(document)
+
+    assert "**UID**: REQ-3 \\" in output_markdown
+    assert "**Relations**: REQ-1, REQ-2" in output_markdown


### PR DESCRIPTION
**WHAT:** Make Markdown reader/writer recognize the "Relations:" meta field as a special field reserved for managing node relations.

**WHY:** Relating Markdown nodes together is needed for node tracing.

Markdown epic: https://github.com/strictdoc-project/strictdoc/issues/1321.

**HOW:**

- Right now, no Child relations and relation roles are supported. We need to agree on the spec before moving forward with more advances relation types.