### PR TITLE
Implement project tree scroll persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ __pycache__
 /downloaded_files/
 
 ### StrictDoc developer
+/.local/
 /*.local.toml
 /__*.sdoc
 /__*.sgra

--- a/strictdoc/export/html/_static/project_tree_preserve_scroll.js
+++ b/strictdoc/export/html/_static/project_tree_preserve_scroll.js
@@ -1,0 +1,182 @@
+/*
+How this script works:
+1. On page load, restores left project-tree scroll position from localStorage
+   (if a saved value exists for the current project).
+2. Persists tree scroll only when user clicks a tree link (navigation intent).
+3. Applies safety fallback: if the active tree item is outside the visible
+   tree viewport, scrolls it to container center.
+4. Persists resulting position after fallback-centering too, so next reload
+   keeps centered state.
+
+Required DOM:
+1. Project tree root:
+   <div class="tree" js-project_tree_preserve_scroll="tree">...</div>
+2. Scroll container created by resizable bar:
+   <div js-resizable_bar-scroll="y" data-content="tree">...</div>
+   If missing, script falls back to the tree parent element.
+3. Tree links:
+   <a class="tree_item" href="...">...</a>
+
+Optional DOM:
+1. Active/current document marker:
+   <a class="tree_item" active="true">...</a>
+   Used only for fallback centering. If missing, script still restores saved
+   scroll, but skips active-item centering.
+2. Project namespace marker:
+   <div ... data-project-title="StrictDoc Documentation">...</div>
+   Used to namespace localStorage key by project title, so different projects
+   on the same origin do not overwrite each other's tree scroll.
+*/
+
+const TREE_ROOT_SELECTOR = "[js-project_tree_preserve_scroll]";
+const SCROLL_CONTAINER_SELECTOR = "[js-resizable_bar-scroll]";
+const TREE_ITEM_SELECTOR = ".tree_item[href]";
+const ACTIVE_ITEM_SELECTOR = ".tree_item[active='true']";
+const STORAGE_KEY_PREFIX = "strictdoc.project_tree.scroll_top";
+
+// Returns project tree root element, or null when the script should be inactive.
+function findTreeRoot() {
+  return document.querySelector(TREE_ROOT_SELECTOR);
+}
+
+// Finds the actual scroll container that owns tree scrollTop.
+function findScrollContainer(treeRoot) {
+  return (
+    treeRoot.closest(SCROLL_CONTAINER_SELECTOR) ||
+    treeRoot.parentElement ||
+    null
+  );
+}
+
+// Builds localStorage key with per-project namespace (by project title).
+function getStorageKey(treeRoot) {
+  const projectTitle = (treeRoot.dataset.projectTitle || "").trim();
+  const projectKey = projectTitle.length > 0 ? projectTitle : "default";
+  return `${STORAGE_KEY_PREFIX}:${projectKey}`;
+}
+
+// Reads persisted scrollTop and validates it as a finite number.
+function readSavedScrollTop(treeRoot) {
+  const value = localStorage.getItem(getStorageKey(treeRoot));
+  if (value === null) {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+// Persists current scrollTop for the current project namespace.
+function saveScrollTop(treeRoot, container) {
+  localStorage.setItem(getStorageKey(treeRoot), String(container.scrollTop));
+}
+
+// Keeps target scrollTop within valid container bounds.
+function clampScrollTop(container, value) {
+  const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+  return Math.max(0, Math.min(value, maxScrollTop));
+}
+
+// Checks whether item rectangle is fully visible in current container viewport.
+function isFullyVisibleInContainer(containerRect, itemRect) {
+  return (
+    itemRect.top >= containerRect.top &&
+    itemRect.bottom <= containerRect.bottom
+  );
+}
+
+// Safety fallback: center active item only when it is outside the visible area.
+function alignActiveItemToCenterIfNeeded(treeRoot, container) {
+  const activeItem = treeRoot.querySelector(ACTIVE_ITEM_SELECTOR);
+  if (!activeItem) {
+    return;
+  }
+
+  const containerRect = container.getBoundingClientRect();
+  const activeRect = activeItem.getBoundingClientRect();
+
+  if (isFullyVisibleInContainer(containerRect, activeRect)) {
+    return;
+  }
+
+  const activeCenter = activeRect.top + activeRect.height / 2;
+  const containerCenter = containerRect.top + containerRect.height / 2;
+  const delta = activeCenter - containerCenter;
+  const nextScrollTop = container.scrollTop + delta;
+
+  container.scrollTop = clampScrollTop(container, nextScrollTop);
+}
+
+// Restores persisted scroll, then applies active-item fallback correction.
+function restoreScrollTop() {
+  const treeRoot = findTreeRoot();
+  if (!treeRoot) {
+    return false;
+  }
+
+  const container = findScrollContainer(treeRoot);
+  if (!container) {
+    return false;
+  }
+
+  const savedScrollTop = readSavedScrollTop(treeRoot);
+  if (savedScrollTop !== null) {
+    container.scrollTop = clampScrollTop(container, savedScrollTop);
+  }
+  // Independent safety rule:
+  // if active item is outside current viewport, center it.
+  alignActiveItemToCenterIfNeeded(treeRoot, container);
+  // Persist resulting position (restored and/or centered) for next reload.
+  saveScrollTop(treeRoot, container);
+  return true;
+}
+
+// Subscribes to tree-link clicks and persists scroll state for navigation.
+function bindPersistence() {
+  const treeRoot = findTreeRoot();
+  if (!treeRoot) {
+    return false;
+  }
+
+  const container = findScrollContainer(treeRoot);
+  if (!container) {
+    return false;
+  }
+
+  treeRoot.addEventListener("click", function (event) {
+    const treeItem = event.target.closest(TREE_ITEM_SELECTOR);
+    if (!treeItem || !treeRoot.contains(treeItem)) {
+      return;
+    }
+    saveScrollTop(treeRoot, container);
+  });
+
+  return true;
+}
+
+// Retries init for a few frames because resizable_bar wrapper is attached on load.
+function initWithRetries(maxAttempts) {
+  let attempt = 0;
+
+  // Attempts restore/bind until tree and scroll container are both available.
+  function tryInit() {
+    attempt += 1;
+
+    const restored = restoreScrollTop();
+    const bound = bindPersistence();
+
+    if (restored && bound) {
+      return;
+    }
+
+    if (attempt < maxAttempts) {
+      requestAnimationFrame(tryInit);
+    }
+  }
+
+  tryInit();
+}
+
+window.addEventListener("load", function () {
+  // Wait a few frames in case resizable_bar.js wraps content asynchronously.
+  initWithRetries(20);
+});

--- a/strictdoc/export/html/templates/screens/document/_shared/project_tree.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/project_tree.jinja
@@ -1,6 +1,10 @@
 
 {%- if not view_object.is_empty_tree() -%}
-  <div class="tree">
+  <div
+    class="tree"
+    js-project_tree_preserve_scroll="tree"
+    data-project-title="{{ view_object.project_config.project_title|e }}"
+  >
     {% for folder_or_file in view_object.iterator_files_first() -%}
       {% if folder_or_file.is_folder() %}
         {% if view_object.should_display_folder(folder_or_file) %}
@@ -43,4 +47,3 @@
 {%- else -%}
   <span data-testid="document-tree-empty-text">🐛 The project has no documents yet.</span>
 {%- endif -%}
-

--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -16,6 +16,7 @@
 
   <script src="{{ view_object.render_static_url('resizable_bar.js') }}"></script>
   <script src="{{ view_object.render_static_url('collapsible_toc.js') }}"></script>
+  <script src="{{ view_object.render_static_url('project_tree_preserve_scroll.js') }}"></script>
   <script src="{{ view_object.render_static_url('toc_highlighting.js') }}"></script>
 
   <script src="{{ view_object.render_static_url('controllers/anchor_controller.js') }}"></script>

--- a/strictdoc/export/html/templates/screens/document/pdf/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/pdf/index.jinja
@@ -8,6 +8,7 @@
 {% block head_scripts %}
   <script src="{{ view_object.render_static_url('viewtype_menu.js') }}"></script>
   <script src="{{ view_object.render_static_url('resizable_bar.js') }}"></script>
+  <script src="{{ view_object.render_static_url('project_tree_preserve_scroll.js') }}"></script>
   <script src="{{ view_object.render_static_url('toc_highlighting.js') }}"></script>
 
   {%- if view_object.project_config.is_activated_mathjax() -%}

--- a/strictdoc/export/html/templates/screens/document/table/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/index.jinja
@@ -9,6 +9,7 @@
   <script src="{{ view_object.render_static_url('viewtype_menu.js') }}"></script>
   <script src="{{ view_object.render_static_url('resizable_bar.js') }}"></script>
   <script src="{{ view_object.render_static_url('collapsible_toc.js') }}"></script>
+  <script src="{{ view_object.render_static_url('project_tree_preserve_scroll.js') }}"></script>
   <script src="{{ view_object.render_static_url('toc_highlighting.js') }}"></script>
 
   {%- if view_object.project_config.is_activated_mathjax() -%}

--- a/strictdoc/export/html/templates/screens/document/traceability/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/traceability/index.jinja
@@ -14,6 +14,7 @@
   <script src="{{ view_object.render_static_url('viewtype_menu.js') }}"></script>
   <script src="{{ view_object.render_static_url('resizable_bar.js') }}"></script>
   <script src="{{ view_object.render_static_url('collapsible_toc.js') }}"></script>
+  <script src="{{ view_object.render_static_url('project_tree_preserve_scroll.js') }}"></script>
   <script src="{{ view_object.render_static_url('toc_highlighting.js') }}"></script>
 
   {%- if view_object.project_config.is_running_on_server and not view_object.standalone -%}

--- a/strictdoc/export/html/templates/screens/document/traceability_deep/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/traceability_deep/index.jinja
@@ -14,6 +14,7 @@
   <script src="{{ view_object.render_static_url('viewtype_menu.js') }}"></script>
   <script src="{{ view_object.render_static_url('resizable_bar.js') }}"></script>
   <script src="{{ view_object.render_static_url('collapsible_toc.js') }}"></script>
+  <script src="{{ view_object.render_static_url('project_tree_preserve_scroll.js') }}"></script>
   <script src="{{ view_object.render_static_url('toc_highlighting.js') }}"></script>
 
   {%- if view_object.project_config.is_running_on_server and not view_object.standalone -%}

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp01.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp01.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 1
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp02.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp02.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 2
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp03.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp03.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 3
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp04.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp04.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 4
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp05.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp05.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 5
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp06.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp06.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 6
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp07.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp07.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 7
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp08.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp08.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 8
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp09.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp09.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 9
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp10.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp10.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 10
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp100.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp100.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 100
+UID: DOC-100
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp11.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp11.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 11
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp12.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp12.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 12
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp13.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp13.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 13
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp14.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp14.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 14
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp15.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp15.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 15
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp16.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp16.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 16
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp17.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp17.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 17
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp18.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp18.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 18
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp19.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp19.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 19
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp20.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp20.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 20
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp21.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp21.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 21
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp22.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp22.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 22
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp23.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp23.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 23
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp24.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp24.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 24
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp25.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp25.sdoc
@@ -1,0 +1,27 @@
+[DOCUMENT]
+TITLE: Test document 25
+UID: DOC-25
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+[LINK: DOC-75]
+
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp26.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp26.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 26
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp27.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp27.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 27
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp28.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp28.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 28
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp29.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp29.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 29
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp30.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp30.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 30
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp31.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp31.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 31
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp32.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp32.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 32
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp33.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp33.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 33
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp34.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp34.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 34
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp35.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp35.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 35
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp36.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp36.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 36
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp37.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp37.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 37
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp38.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp38.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 38
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp39.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp39.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 39
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp40.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp40.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 40
+UID: DOC-40
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp41.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp41.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 41
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp42.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp42.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 42
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp43.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp43.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 43
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp44.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp44.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 44
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp45.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp45.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 45
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp46.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp46.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 46
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp47.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp47.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 47
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp48.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp48.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 48
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp49.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp49.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 49
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp50.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp50.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 50
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp51.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp51.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 51
+UID: DOC-51
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp52.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp52.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 52
+UID: DOC-52
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp53.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp53.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 53
+UID: DOC-53
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp54.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp54.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 54
+UID: DOC-54
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp55.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp55.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 55
+UID: DOC-55
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp56.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp56.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 56
+UID: DOC-56
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp57.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp57.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 57
+UID: DOC-57
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp58.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp58.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 58
+UID: DOC-58
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp59.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp59.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 59
+UID: DOC-59
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp60.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp60.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 60
+UID: DOC-60
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp61.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp61.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 61
+UID: DOC-61
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp62.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp62.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 62
+UID: DOC-62
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp63.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp63.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 63
+UID: DOC-63
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp64.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp64.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 64
+UID: DOC-64
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp65.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp65.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 65
+UID: DOC-65
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp66.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp66.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 66
+UID: DOC-66
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp67.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp67.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 67
+UID: DOC-67
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp68.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp68.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 68
+UID: DOC-68
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp69.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp69.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 69
+UID: DOC-69
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp70.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp70.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 70
+UID: DOC-70
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp71.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp71.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 71
+UID: DOC-71
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp72.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp72.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 72
+UID: DOC-72
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp73.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp73.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 73
+UID: DOC-73
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp74.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp74.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 74
+UID: DOC-74
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp75.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp75.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 75
+UID: DOC-75
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp76.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp76.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 76
+UID: DOC-76
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp77.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp77.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 77
+UID: DOC-77
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp78.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp78.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 78
+UID: DOC-78
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp79.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp79.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 79
+UID: DOC-79
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp80.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp80.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 80
+UID: DOC-80
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp81.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp81.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 81
+UID: DOC-81
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp82.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp82.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 82
+UID: DOC-82
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp83.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp83.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 83
+UID: DOC-83
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp84.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp84.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 84
+UID: DOC-84
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp85.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp85.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 85
+UID: DOC-85
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp86.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp86.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 86
+UID: DOC-86
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp87.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp87.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 87
+UID: DOC-87
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp88.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp88.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 88
+UID: DOC-88
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp89.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp89.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 89
+UID: DOC-89
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp90.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp90.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 90
+UID: DOC-90
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp91.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp91.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 91
+UID: DOC-91
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp92.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp92.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 92
+UID: DOC-92
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp93.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp93.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 93
+UID: DOC-93
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp94.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp94.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 94
+UID: DOC-94
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp95.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp95.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 95
+UID: DOC-95
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp96.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp96.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 96
+UID: DOC-96
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp97.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp97.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 97
+UID: DOC-97
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp98.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp98.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 98
+UID: DOC-98
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp99.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/expected_output/temp99.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 99
+UID: DOC-99
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp01.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp01.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 1
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp02.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp02.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 2
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp03.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp03.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 3
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp04.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp04.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 4
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp05.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp05.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 5
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp06.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp06.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 6
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp07.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp07.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 7
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp08.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp08.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 8
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp09.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp09.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 9
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp10.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp10.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 10
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp100.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp100.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 100
+UID: DOC-100
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp11.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp11.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 11
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp12.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp12.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 12
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp13.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp13.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 13
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp14.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp14.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 14
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp15.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp15.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 15
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp16.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp16.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 16
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp17.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp17.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 17
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp18.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp18.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 18
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp19.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp19.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 19
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp20.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp20.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 20
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp21.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp21.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 21
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp22.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp22.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 22
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp23.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp23.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 23
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp24.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp24.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 24
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp25.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp25.sdoc
@@ -1,0 +1,27 @@
+[DOCUMENT]
+TITLE: Test document 25
+UID: DOC-25
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+[LINK: DOC-75]
+
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp26.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp26.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 26
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp27.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp27.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 27
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp28.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp28.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 28
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp29.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp29.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 29
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp30.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp30.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 30
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp31.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp31.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 31
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp32.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp32.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 32
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp33.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp33.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 33
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp34.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp34.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 34
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp35.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp35.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 35
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp36.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp36.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 36
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp37.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp37.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 37
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp38.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp38.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 38
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp39.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp39.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 39
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp40.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp40.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 40
+UID: DOC-40
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp41.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp41.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 41
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp42.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp42.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 42
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp43.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp43.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 43
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp44.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp44.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 44
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp45.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp45.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 45
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp46.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp46.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 46
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp47.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp47.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 47
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp48.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp48.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 48
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp49.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp49.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 49
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp50.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp50.sdoc
@@ -1,0 +1,24 @@
+[DOCUMENT]
+TITLE: Test document 50
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp51.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp51.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 51
+UID: DOC-51
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp52.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp52.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 52
+UID: DOC-52
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp53.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp53.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 53
+UID: DOC-53
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp54.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp54.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 54
+UID: DOC-54
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp55.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp55.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 55
+UID: DOC-55
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp56.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp56.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 56
+UID: DOC-56
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp57.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp57.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 57
+UID: DOC-57
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp58.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp58.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 58
+UID: DOC-58
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp59.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp59.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 59
+UID: DOC-59
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp60.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp60.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 60
+UID: DOC-60
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp61.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp61.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 61
+UID: DOC-61
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp62.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp62.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 62
+UID: DOC-62
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp63.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp63.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 63
+UID: DOC-63
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp64.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp64.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 64
+UID: DOC-64
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp65.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp65.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 65
+UID: DOC-65
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp66.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp66.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 66
+UID: DOC-66
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp67.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp67.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 67
+UID: DOC-67
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp68.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp68.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 68
+UID: DOC-68
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp69.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp69.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 69
+UID: DOC-69
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp70.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp70.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 70
+UID: DOC-70
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp71.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp71.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 71
+UID: DOC-71
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp72.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp72.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 72
+UID: DOC-72
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp73.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp73.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 73
+UID: DOC-73
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp74.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp74.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 74
+UID: DOC-74
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp75.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp75.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 75
+UID: DOC-75
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp76.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp76.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 76
+UID: DOC-76
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp77.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp77.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 77
+UID: DOC-77
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp78.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp78.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 78
+UID: DOC-78
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp79.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp79.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 79
+UID: DOC-79
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp80.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp80.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 80
+UID: DOC-80
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp81.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp81.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 81
+UID: DOC-81
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp82.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp82.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 82
+UID: DOC-82
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp83.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp83.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 83
+UID: DOC-83
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp84.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp84.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 84
+UID: DOC-84
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp85.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp85.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 85
+UID: DOC-85
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp86.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp86.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 86
+UID: DOC-86
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp87.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp87.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 87
+UID: DOC-87
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp88.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp88.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 88
+UID: DOC-88
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp89.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp89.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 89
+UID: DOC-89
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp90.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp90.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 90
+UID: DOC-90
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp91.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp91.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 91
+UID: DOC-91
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp92.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp92.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 92
+UID: DOC-92
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp93.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp93.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 93
+UID: DOC-93
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp94.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp94.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 94
+UID: DOC-94
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp95.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp95.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 95
+UID: DOC-95
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp96.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp96.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 96
+UID: DOC-96
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp97.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp97.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 97
+UID: DOC-97
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp98.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp98.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 98
+UID: DOC-98
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/input/temp99.sdoc
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/input/temp99.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test document 99
+UID: DOC-99
+OPTIONS:
+  VIEW_STYLE: Plain
+
+[[SECTION]]
+TITLE: Section 1
+
+[TEXT]
+STATEMENT: >>>
+Vivamus consectetur mollis varius. Quisque posuere venenatis nulla, sit amet pulvinar metus vestibulum **sed**. Sed at libero nec justo leo.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+TITLE: Section 2
+
+[TEXT]
+STATEMENT: >>>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris. Maecenas congue ligula ac quam viverra nec consectetur ante hendrerit. Donec et mollis dolor.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/navigation/project_tree_preserve_scroll/test_case.py
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/test_case.py
@@ -1,0 +1,189 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_document = screen_project_index.do_click_on_first_document()
+            screen_document.assert_on_screen_document()
+
+            tree_scroll_selector = (
+                '[js-resizable_bar-scroll][data-content="tree"]'
+            )
+            baseline_scroll_top = 100
+
+            def get_tree_scroll_top():
+                return self.execute_script(
+                    f"""
+                    const el = document.querySelector('{tree_scroll_selector}');
+                    return el ? el.scrollTop : null;
+                    """
+                )
+
+            # Part 1:
+            # We set tree scrollTop to a deterministic synthetic value on purpose.
+            # This test validates StrictDoc's persistence mechanism itself
+            # (save on tree click + restore after reload), and should not depend
+            # on browser/driver auto-scrolling behavior before click.
+            self.execute_script(
+                f"""
+                const el = document.querySelector('{tree_scroll_selector}');
+                if (el) el.scrollTop = {baseline_scroll_top};
+                """
+            )
+
+            # Click target document 25 in tree.
+            self.click_xpath(
+                '(//a[@data-testid="tree-document-link"]'
+                '[contains(@href, "temp25.html")])[1]'
+            )
+
+            # Measure scroll at click-time position.
+            clicked_scroll_top_doc25 = get_tree_scroll_top()
+            assert clicked_scroll_top_doc25 is not None, (
+                "Tree scroll container not found after click on temp25."
+            )
+            print(  # noqa: T201
+                f"[telemetry] doc25 clicked_scroll_top: {clicked_scroll_top_doc25}"
+            )
+
+            # Move tree to top and verify.
+            self.execute_script(
+                f"""
+                const el = document.querySelector('{tree_scroll_selector}');
+                if (el) el.scrollTop = 0;
+                """
+            )
+            scroll_top_after_manual_reset = get_tree_scroll_top()
+            assert scroll_top_after_manual_reset == 0, (
+                f"Expected manual tree scroll reset to 0, got: {scroll_top_after_manual_reset}."
+            )
+            print(  # noqa: T201
+                f"[telemetry] after manual reset scroll_top: {scroll_top_after_manual_reset}"
+            )
+
+            # Reload page and verify restoration to click-time position of temp25.
+            self.refresh_page()
+            restored_scroll_top_doc25 = get_tree_scroll_top()
+            assert restored_scroll_top_doc25 is not None, (
+                "Tree scroll container not found after refresh on temp25."
+            )
+            print(  # noqa: T201
+                f"[telemetry] doc25 restored_scroll_top: {restored_scroll_top_doc25}"
+            )
+            assert (
+                abs(restored_scroll_top_doc25 - clicked_scroll_top_doc25) <= 3
+            ), (
+                "Expected tree scroll to be restored close to click-time value "
+                "for temp25. "
+                f"clicked={clicked_scroll_top_doc25}, "
+                f"restored={restored_scroll_top_doc25}."
+            )
+
+            # Part 2:
+            # Click regular content link (NOT tree link): DOC-75.
+            self.click_xpath('(//a[contains(@href, "temp75.html#DOC-75")])[1]')
+
+            # Fallback centering should bring active tree item (DOC-75) into
+            # a deep/centered area of the scroll container.
+            centered_scroll_top_doc75 = get_tree_scroll_top()
+            assert centered_scroll_top_doc75 is not None, (
+                "Tree scroll container not found after navigation to temp75."
+            )
+            print(  # noqa: T201
+                f"[telemetry] doc75 centered_scroll_top: {centered_scroll_top_doc75}"
+            )
+
+            telemetry_doc75 = self.execute_script(
+                f"""
+                const container = document.querySelector('{tree_scroll_selector}');
+                const active = document.querySelector(
+                  '[js-project_tree_preserve_scroll] .tree_item[active="true"]'
+                );
+                if (!container || !active) return null;
+
+                const c = container.getBoundingClientRect();
+                const a = active.getBoundingClientRect();
+
+                const containerCenter = c.top + c.height / 2;
+                const activeCenter = a.top + a.height / 2;
+
+                return {{
+                  scrollTop: container.scrollTop,
+                  fullyVisible: a.top >= c.top && a.bottom <= c.bottom,
+                  distanceToCenter: Math.abs(activeCenter - containerCenter),
+                  containerTop: c.top,
+                  containerBottom: c.bottom,
+                  containerHeight: c.height,
+                  activeTop: a.top,
+                  activeBottom: a.bottom,
+                  activeHeight: a.height,
+                  activeCenter,
+                  containerCenter,
+                }};
+                """
+            )
+            print(f"[telemetry] doc75 geometry: {telemetry_doc75}")  # noqa: T201
+
+            # For the chosen low baseline, DOC-75 should be outside viewport.
+            # Fallback-centering must then move scroll away from baseline and
+            # place active item close to the viewport center.
+            assert telemetry_doc75 is not None, (
+                "Expected DOC-75 telemetry to be available."
+            )
+            assert centered_scroll_top_doc75 > baseline_scroll_top + 200, (
+                "Expected fallback-centering to change tree scroll significantly. "
+                f"baseline={baseline_scroll_top}, got={centered_scroll_top_doc75}."
+            )
+            assert telemetry_doc75["distanceToCenter"] <= 60, (
+                "Expected active DOC-75 tree item to be near center after fallback. "
+                f"telemetry={telemetry_doc75}."
+            )
+
+            # Part 3:
+            # Centered position of DOC-75 must also be persisted.
+            self.execute_script(
+                f"""
+                const el = document.querySelector('{tree_scroll_selector}');
+                if (el) el.scrollTop = 0;
+                """
+            )
+            scroll_top_after_second_manual_reset = get_tree_scroll_top()
+            assert scroll_top_after_second_manual_reset == 0, (
+                "Expected manual tree scroll reset to 0 before final refresh, "
+                f"got: {scroll_top_after_second_manual_reset}."
+            )
+            print(  # noqa: T201
+                "[telemetry] after second manual reset scroll_top: "
+                f"{scroll_top_after_second_manual_reset}"
+            )
+
+            self.refresh_page()
+            restored_scroll_top_doc75 = get_tree_scroll_top()
+            assert restored_scroll_top_doc75 is not None, (
+                "Tree scroll container not found after final refresh on temp75."
+            )
+            print(  # noqa: T201
+                f"[telemetry] doc75 restored_scroll_top: {restored_scroll_top_doc75}"
+            )
+            assert (
+                abs(restored_scroll_top_doc75 - centered_scroll_top_doc75) <= 3
+            ), (
+                "Expected DOC-75 centered scroll to be persisted and restored. "
+                f"centered={centered_scroll_top_doc75}, "
+                f"restored={restored_scroll_top_doc75}."
+            )


### PR DESCRIPTION
This PR introduces persistent scroll behavior for the project tree on document screens and adds end-to-end coverage for both primary and fallback scenarios.

- Implemented save/restore flow for tree scroll:
  - restore on page load (if saved value exists),
  - save on tree-link click (navigation intent).
- Implemented fallback behavior:
  - if active tree item is outside visible tree viewport, scroll it to container center,
  - centered position is also saved, so subsequent reload keeps that centered state.
- Added per-project localStorage namespacing using `data-project-title`

Closes #2710