### PR TITLE
feat(export/html): add container for Read the Docs ad placement

### DIFF
--- a/strictdoc/export/html/_static/element.css
+++ b/strictdoc/export/html/_static/element.css
@@ -1188,6 +1188,14 @@ sdoc-menu-handler[aria-expanded="true"] svg {
 
 /* tree */
 
+#ethical-ad-placement {
+  /* ID by https://docs.readthedocs.com/platform/stable/advertising/ad-customization.html */
+  position: absolute;
+  bottom: 0;
+  background-color: var(--color-bg-main);
+  border-top: var(--base-border);
+}
+
 .tree {
   display: flex;
   flex-direction: column;
@@ -1195,7 +1203,7 @@ sdoc-menu-handler[aria-expanded="true"] svg {
   align-items: flex-start;
   gap: var(--base-rhythm);
   margin-top: calc(var(--base-rhythm) * 2);
-  margin-bottom: calc(var(--base-rhythm) * 8);
+  margin-bottom: calc(var(--base-rhythm) * 22);  /* more space for #ethical-ad-placement  */
   padding-left: calc(var(--base-rhythm) * 2);
   padding-right: calc(var(--base-rhythm) * 2);
 }

--- a/strictdoc/export/html/_static/layout.css
+++ b/strictdoc/export/html/_static/layout.css
@@ -63,6 +63,14 @@
   min-width: 0;
 }
 
+.layout_main > [data-ea-publisher].loaded {
+  /*
+    DEV: We provide space in the sidebar.
+    Inserting it into the central container breaks the layout, so we suppress it here.
+  */
+  display: none !important;
+}
+
 /*  */
 
 .section-number {

--- a/strictdoc/export/html/templates/screens/document/_shared/project_tree.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/project_tree.jinja
@@ -44,6 +44,14 @@
       {% endif %}
     {%- endfor -%}
   </div>
+
+  {#
+    by https://docs.readthedocs.com/platform/stable/advertising/ad-customization.html
+
+    We consider that without documents it will not be published,
+    so we do not insert it together with [data-testid="document-tree-empty-text"] 🐛.
+  #}
+  <div id="ethical-ad-placement"></div>
 {%- else -%}
   <span data-testid="document-tree-empty-text">🐛 The project has no documents yet.</span>
 {%- endif -%}


### PR DESCRIPTION
Added to the left aside under TOC

<img width="488" height="689" alt="image" src="https://github.com/user-attachments/assets/31ef9cb8-5dd3-416d-a504-3a84355ea471" />
