### PR TITLE
fix(export/html): detach sticky ea-ads to avoid TOC overlap

### DIFF
--- a/strictdoc/export/html/_static/element.css
+++ b/strictdoc/export/html/_static/element.css
@@ -1188,12 +1188,24 @@ sdoc-menu-handler[aria-expanded="true"] svg {
 
 /* tree */
 
+.layout_tree-wrapper_with_ea {
+  /* contains .tree and #ethical-ad-placement */
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
 #ethical-ad-placement {
   /* ID by https://docs.readthedocs.com/platform/stable/advertising/ad-customization.html */
-  position: absolute;
-  bottom: 0;
   background-color: var(--color-bg-main);
   border-top: var(--base-border);
+  margin-top: calc(var(--base-rhythm) * 2);
+  margin-left: calc(var(--base-rhythm) * 2);
+}
+
+#ethical-ad-placement img {
+  display: none !important;
 }
 
 .tree {
@@ -1203,7 +1215,7 @@ sdoc-menu-handler[aria-expanded="true"] svg {
   align-items: flex-start;
   gap: var(--base-rhythm);
   margin-top: calc(var(--base-rhythm) * 2);
-  margin-bottom: calc(var(--base-rhythm) * 22);  /* more space for #ethical-ad-placement  */
+  margin-bottom: calc(var(--base-rhythm) * 8);
   padding-left: calc(var(--base-rhythm) * 2);
   padding-right: calc(var(--base-rhythm) * 2);
 }

--- a/strictdoc/export/html/templates/screens/document/_shared/project_tree.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/project_tree.jinja
@@ -1,4 +1,5 @@
 
+<div class="layout_tree-wrapper_with_ea">
 {%- if not view_object.is_empty_tree() -%}
   <div
     class="tree"
@@ -44,14 +45,12 @@
       {% endif %}
     {%- endfor -%}
   </div>
-
+{%- else -%}
+  <span>{# to push next span to the middle of .layout_tree-wrapper_with_ea #}</span>
+  <span data-testid="document-tree-empty-text">{# We're not supposed to be here. #}🐛 The project has no documents yet.</span>
+{%- endif -%}
   {#
     by https://docs.readthedocs.com/platform/stable/advertising/ad-customization.html
-
-    We consider that without documents it will not be published,
-    so we do not insert it together with [data-testid="document-tree-empty-text"] 🐛.
   #}
   <div id="ethical-ad-placement"></div>
-{%- else -%}
-  <span data-testid="document-tree-empty-text">🐛 The project has no documents yet.</span>
-{%- endif -%}
+</div>


### PR DESCRIPTION

Added a wrapper for the left sidebar that contains the ad block and keeps it at the bottom of the screen when the sidebar is not scrollable. If the TOC is long and the sidebar becomes scrollable, the ad block stays in the normal flow together with the TOC.

---

**Reason:**

It turns out they sometimes have ads that take up quite a lot of space. We’ll need to unpin them so they scroll with the page, and that way we won’t risk covering the TOC.

<img width="299" height="517" alt="image" src="https://github.com/user-attachments/assets/ecca11c0-1b93-4498-9fcf-954a69d72c9a" />
