### PR TITLE
Preserve current viewtype when navigating via aside project tree

### DIFF
--- a/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
@@ -276,6 +276,15 @@ class DocumentScreenViewObject:
             document, context_document, DocumentType(document_type_string)
         )
 
+    def render_current_view_document_link(self, document: SDocDocument) -> str:
+        assert isinstance(document, SDocDocument), document
+        assert document.meta is not None
+        assert self.document.meta is not None
+        return document.meta.get_html_link(
+            self.document_type,
+            self.document.meta.level,
+        )
+
     @staticmethod
     def render_standalone_document_link(document: SDocDocument) -> str:
         assert document.meta is not None

--- a/strictdoc/export/html/templates/screens/document/_shared/project_tree.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/project_tree.jinja
@@ -23,7 +23,7 @@
         {%- set document_ = view_object.get_document_by_path(folder_or_file.full_path) %}
         {% if not document_.document_is_included() %}
         <a
-          href="{{ view_object.document.meta.get_root_path_prefix() }}/{{ document_.meta.get_html_doc_link() }}"
+          href="{{ view_object.render_current_view_document_link(document_) }}"
           class="tree_item"
           {% if view_object.document == document_ %}
           active="true"

--- a/strictdoc/export/html/templates/screens/document/_shared/project_tree_child_documents.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/project_tree_child_documents.jinja
@@ -8,7 +8,7 @@
       active="true"
       {% endif %}
       data-testid="tree-document-fragment-link"
-      href="{{ view_object.document.meta.get_root_path_prefix() }}/{{ child_document_.meta.get_html_doc_link() }}"
+      href="{{ view_object.render_current_view_document_link(child_document_) }}"
     >
       {# TODO #fragment #}
       {%- include "_res/svg_ico16_fragment_draft.jinja" -%}

--- a/tests/end2end/navigation/project_tree_preserve_scroll/test_case.py
+++ b/tests/end2end/navigation/project_tree_preserve_scroll/test_case.py
@@ -96,7 +96,10 @@ class Test(E2ECase):
 
             # Part 2:
             # Click regular content link (NOT tree link): DOC-75.
-            self.click_xpath('(//a[contains(@href, "temp75.html#DOC-75")])[1]')
+            self.click_xpath(
+                '//sdoc-node[@data-testid="node-requirement"]'
+                '//a[contains(@href, "temp75.html#DOC-75")]'
+            )
 
             # Fallback centering should bring active tree item (DOC-75) into
             # a deep/centered area of the scroll container.

--- a/tests/end2end/navigation/viewtype_persistence_across_documents/expected_output/document_1.sdoc
+++ b/tests/end2end/navigation/viewtype_persistence_across_documents/expected_output/document_1.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Document 1 title
+
+[TEXT]
+STATEMENT: >>>
+Document 1 text.
+<<<

--- a/tests/end2end/navigation/viewtype_persistence_across_documents/expected_output/document_2.sdoc
+++ b/tests/end2end/navigation/viewtype_persistence_across_documents/expected_output/document_2.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Document 2 title
+
+[TEXT]
+STATEMENT: >>>
+Document 2 text.
+<<<

--- a/tests/end2end/navigation/viewtype_persistence_across_documents/input/document_1.sdoc
+++ b/tests/end2end/navigation/viewtype_persistence_across_documents/input/document_1.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Document 1 title
+
+[TEXT]
+STATEMENT: >>>
+Document 1 text.
+<<<

--- a/tests/end2end/navigation/viewtype_persistence_across_documents/input/document_2.sdoc
+++ b/tests/end2end/navigation/viewtype_persistence_across_documents/input/document_2.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Document 2 title
+
+[TEXT]
+STATEMENT: >>>
+Document 2 text.
+<<<

--- a/tests/end2end/navigation/viewtype_persistence_across_documents/test_case.py
+++ b/tests/end2end/navigation/viewtype_persistence_across_documents/test_case.py
@@ -1,0 +1,47 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.viewtype_selector import (
+    ViewType_Selector,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.helpers.screens.table.screen_table import Screen_Table
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1 title")
+            screen_project_index.assert_contains_document("Document 2 title")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1 title")
+
+            viewtype_selector = ViewType_Selector(self)
+            screen_table = viewtype_selector.do_go_to_table()
+
+            screen_table.assert_on_screen_table()
+            screen_table.assert_header_document_title("Document 1 title")
+
+            self.click_xpath('(//*[@data-testid="tree-document-link"])[2]')
+
+            screen_table_second_document = Screen_Table(self)
+            screen_table_second_document.assert_on_screen_table()
+            screen_table_second_document.assert_header_document_title(
+                "Document 2 title"
+            )
+
+        assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION

This PR updates aside project tree navigation in document screens so that the currently selected **view type** (DOCUMENT, TABLE, TRACE, DEEPTRACE, PDF) is preserved when switching between documents.

The "aside project tree" previously used plain document links based on `get_html_doc_link()`, which always navigated to the default "_document_" view. As a result, switching to another document from the tree reset the selected view. 

Changes
- add a dedicated helper for building plain target-document page links that preserve the current `document_type`
- update aside project tree links to use that helper instead of plain default-document links
- add end-to-end coverage for viewtype persistence across documents
- refine the existing project tree scroll preservation test so it targets the inline content link explicitly

Result
- navigating to another document from the aside project tree now preserves the active viewtype 
- aside tree links remain regular document page links ( `render_current_view_document_link()` )
- viewtype menu links continue to use anchor-aware document links ( `render_document_link()` )

----

**Note**

The current viewtype menu uses render_document_link(), which generates anchor-aware document links. This helper was introduced earlier in the context of bundled HTML/PDF rendering and appears to have been designed for document-as-anchor navigation, although today it is only used by the viewtype menu.

To implement viewtype persistence across documents, reusing that helper directly for aside project tree links turned out to be incorrect: it can produce anchor-based links in included-document contexts, while the tree is expected to navigate between document pages.

The task is therefore resolved by separating the two link-generation cases:

viewtype menu keeps using the existing anchor-aware helper
aside project tree uses a new helper that builds plain page links for the current document_type

As a result, the selected view now persists when navigating between documents via the aside tree. At the same time, **links generated by the viewtype menu and by the aside tree are no longer identical**: menu links are anchor-aware, while tree links are plain page links. This does not block the feature, **but it creates a small UX inconsistency that may be worth revisiting later.**



