### PR TITLE
feat(export/html): Add CSS styles for code blocks with line numbers

### DIFF
--- a/strictdoc/export/html/_static/pygments.css
+++ b/strictdoc/export/html/_static/pygments.css
@@ -17,9 +17,17 @@ The actual lines produced do not have any "linenos" but:
 ...
 
 NOTE: These styles are coupled to the RST Writer settings, see RstToHtmlFragmentWriter.
-
-FIXME: A ticket to improve the styles: https://github.com/strictdoc-project/strictdoc/issues/2611.
 **/
+
+.code .ln { /* Line number */
+   position: relative;
+   left: -12px;
+   padding: 4px;
+   margin-right: 4px;
+   color: #cacdd1;
+   border-right: 1px solid var(--color-border);
+   user-select: none;
+}
 
 .code .hll { background-color: #ffffcc }
 .code { background: #f8f8f8; }


### PR DESCRIPTION
Closes #2611

Example:

<img width="686" height="385" alt="image" src="https://github.com/user-attachments/assets/02221cc9-121c-4930-8a03-87d05ad13910" />
