### PR TITLE
chore(tasks): allow running end-to-end tests in non-headless mode

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -227,6 +227,7 @@ def test_end2end(
     parallelize=False,
     long_timeouts=False,
     headless=False,
+    headed=False,
     shard=None,
     test_path=None,
     coverage: bool = False,
@@ -276,7 +277,7 @@ def test_end2end(
 
     focus_argument = f"-k {focus}" if focus is not None else ""
     exit_first_argument = "--exitfirst" if exit_first else ""
-    headless_argument = "--headless2" if headless else ""
+    headless_argument = "--headless2" if headless and not headed else "--gui"
     test_command = f"""
             {coverage_command_or_none}
             pytest

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,14 @@ deps =
 pass_env=
     CHROMEWEBDRIVER
     STRICTDOC_CACHE_DIR
+    # Pass the desktop session through tox so headed Chrome can open
+    # end-to-end tests in a visible browser window on Ubuntu/Linux.
+    DBUS_SESSION_BUS_ADDRESS
+    DISPLAY
+    WAYLAND_DISPLAY
+    XAUTHORITY
+    XDG_RUNTIME_DIR
+    XDG_SESSION_TYPE
 commands =
     python developer/pip_install_strictdoc_deps.py
     {posargs}


### PR DESCRIPTION
WHY:

Without this change, Chrome Driver cannot start running Chrome in a non-headless mode.

HOW:

The important part is that Tox is now passing the right variables from the parent environment ($DISPLAY).