### PR TITLE
feat(html2pdf): enable cross-document PDF links/anchors

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -46,6 +46,24 @@ This document maintains a record of all changes to StrictDoc since November 2023
 <<<
 
 [[SECTION]]
+MID: 6e6ac78ae4c44856a37ac492b23f8f7d
+TITLE: Unreleased
+
+[TEXT]
+MID: 58efd4f91ca54465be2238ba624af6cb
+STATEMENT: >>>
+This unreleased section contains the following enhancements:
+
+1\) The HTML2PDF export now supports cross-document PDF links and anchors for StrictDoc LINK references. Generated PDF documents can link to each other using relative paths, which improves navigation in supporting PDF viewers and avoids leaking absolute local file system paths into the exported files.
+
+2\) The right-panel Table of Contents in HTML output now starts collapsed by default. This makes large document outlines easier to scan and lets users expand only the sections they want to inspect.
+
+3\) The static HTML search result highlighting now escapes regex-special characters in user queries before building the highlight pattern. Searches that contain symbols such as ``(``, ``)``, ``+``, or ``*`` now behave as literal text searches instead of breaking the result rendering.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
 MID: 214e954aafa146dda04de0630c1a142e
 TITLE: 0.19.0 (2026-03-15)
 

--- a/docs/strictdoc_11_developer_guide.sdoc
+++ b/docs/strictdoc_11_developer_guide.sdoc
@@ -395,10 +395,12 @@ MID: e06a9159c4be4555acd67d77f445c968
 STATEMENT: >>>
 - Add to the release notes (``docs/strictdoc_04_release_notes.sdoc``) a high-level, human-readable summary of all work since the latest Git tag.
 - Summarize all changes under the top section called "Unreleased". If that section does not exist yet, create it. It is this section that will later be turned into the actual release notes.
-- Do not try to create a new version yourself. This is handled with another playbook (TBD).
+- The section shall start with ``This release contains the following enhancements:<full empty line break>``.
 - Follow the example of the existing Release Notes.
 - Do not summarize each and every commit. Only include the most important user-facing changes that are implemented with ``feat:`` and ``fix:`` commits. Don't consider commits with any other prefix.
 - Ignore the changelog file ``CHANGELOG.md`` completely. It is an outdated auto-generated file that is going to be removed in the future.
+- Do not try to create a new version yourself. This is handled with another playbook (TBD).
+- Do not modify any existing content from the previous releases.
 <<<
 
 [[/SECTION]]

--- a/docs/strictdoc_21_l2_high_level_requirements.sdoc
+++ b/docs/strictdoc_21_l2_high_level_requirements.sdoc
@@ -1114,6 +1114,18 @@ RELATIONS:
   VALUE: SDOC-SSS-96
 
 [REQUIREMENT]
+MID: 50eabada50be47a1938e55fc10814972
+UID: SDOC-SRS-203
+STATUS: Active
+TITLE: Cross-linking PDF documents from same project tree
+STATEMENT: >>>
+When exporting multiple HTML documents from a same project tree into PDF, StrictDoc shall preserve all cross-document linking in the output PDF documents.
+<<<
+RATIONALE: >>>
+This enables navigation between PDF documents within the same project tree, which can be useful for simplifying the review and tracing work performed by readers.
+<<<
+
+[REQUIREMENT]
 MID: 6cfcb21b3f1949f49d13af6b00d3d37a
 UID: SDOC-SRS-160
 STATUS: Active

--- a/docs/strictdoc_22_l3_low_level_requirements.sdoc
+++ b/docs/strictdoc_22_l3_low_level_requirements.sdoc
@@ -500,3 +500,61 @@ StrictDoc shall employ a well-maintained Markdown library with Python support.
 <<<
 
 [[/SECTION]]
+
+[[SECTION]]
+MID: 65cfed23d9bb404cad88dadc95feb0d1
+TITLE: HTML2PDF export
+
+[REQUIREMENT]
+MID: 95f0e0198d8446a38eb1c7fc0f409522
+UID: SDOC-LLR-203
+TITLE: Use of html2pdf4doc
+STATEMENT: >>>
+StrictDoc shall export HTML documents using html2pdf4doc library with the following document types supported already:
+
+- StrictDoc's main DOC document type/screen.
+<<<
+RATIONALE: >>>
+html2pdf4doc is part of the StrictDoc project that is developed by the core team. It allows printing PDF pages directly from StrictDoc HTML and gives the developers a full control over the printing mechanics.
+<<<
+
+[REQUIREMENT]
+MID: 335b11da872245c0bf09c82d5909db0e
+UID: SDOC-LLR-204
+STATUS: Active
+TITLE: Use of PyPDF for PDF postprocessing
+STATEMENT: >>>
+StrictDoc shall employ the PyPDF library for the following tasks:
+
+- Rewriting all StrictDoc's LINK/ANCHOR to documents of the same project tree into the PDF anchors.
+<<<
+RATIONALE: >>>
+The extra processing with PyPDF is needed because there are limitations of what developers can do when printing HTML to PDF with html2pdf4doc based on Google Chrome Driver.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-203
+
+[REQUIREMENT]
+MID: 272338e1e8f244eca573348660464b09
+UID: SDOC-LLR-205
+STATUS: Active
+TITLE: Cross-linking PDF documents from one project tree
+STATEMENT: >>>
+When exporting HTML documents to PDF, StrictDoc shall rewrite all LINK/ANCHOR to documents of the same project tree into the PDF document links/anchors according to the following rule:
+
+- The Chrome Driver resolves the relative links to other documents with full paths, e.g., ``file:///<full-path-to-another-SDoc-document>-PDF.html#<anchor>``.
+- The PDF postprocessing step shall convert these absolute ``file:///...` links to just relative paths: ``<relative-path-to-another-SDoc-document>.pdf`` without the leading slash character.
+- If one PDF is in a nested folder compared to another PDF, the link to this PDF anchor shall have relative ``../`` path components.
+<<<
+RATIONALE: >>>
+Allows a reader to navigate between PDF documents of the same project as requested by the parent requirement.
+<<<
+COMMENT: >>>
+The PDF cross-document linking is supported by the PDF format natively but is known to not work in all PDF viewers. For example, it is known to work well in Linux PDF viewers, but not macOS Preview viewer.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: SDOC-SRS-203
+
+[[/SECTION]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ dependencies = [
 
     # HTML2PDF dependencies
     "html2pdf4doc == 0.0.31",
+    "pypdf >= 6.5.0, == 6.*",
 
     # Robot Framework dependencies
     "robotframework >= 4.0.0",

--- a/strictdoc/export/html2pdf/html2pdf_generator.py
+++ b/strictdoc/export/html2pdf/html2pdf_generator.py
@@ -117,6 +117,7 @@ class HTML2PDFGenerator:
             pdf_print_driver.get_pdf_from_html(
                 project_config,
                 paths_to_print,
+                path_to_output_pdf_html_dir,
             )
         except TimeoutError:
             print("error: HTML2PDF: timeout error.")  # noqa: T201

--- a/strictdoc/export/html2pdf/pdf_postprocessor.py
+++ b/strictdoc/export/html2pdf/pdf_postprocessor.py
@@ -1,0 +1,159 @@
+"""
+@relation(SDOC-SRS-51, scope=file)
+"""
+
+import ntpath
+import os
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import unquote, urlsplit
+
+from pypdf import PdfWriter
+from pypdf.generic import (
+    DictionaryObject,
+    NameObject,
+    PdfObject,
+    TextStringObject,
+)
+
+
+class PDFPostprocessor:
+    @classmethod
+    def rewrite_cross_document_links(
+        cls,
+        *,
+        path_to_input_root: str,  # noqa: ARG003
+        paths_to_print: List[Tuple[str, str]],
+    ) -> None:
+        html_to_pdf_map: Dict[str, str] = {
+            urlsplit(
+                Path(path_to_html).resolve().as_uri()
+            ).path: os.path.abspath(path_to_pdf)
+            for path_to_html, path_to_pdf in paths_to_print
+        }
+        for _, path_to_pdf in paths_to_print:
+            cls._rewrite_cross_document_links_in_single_document(
+                html_to_pdf_map=html_to_pdf_map,
+                path_to_pdf=path_to_pdf,
+            )
+
+    @classmethod
+    def _rewrite_cross_document_links_in_single_document(
+        cls,
+        *,
+        html_to_pdf_map: Dict[str, str],
+        path_to_pdf: str,
+    ) -> None:
+        path_to_pdf = os.path.abspath(path_to_pdf)
+        path_to_pdf_dir = os.path.dirname(path_to_pdf)
+
+        writer = PdfWriter(clone_from=path_to_pdf)
+        modified = False
+
+        for page in writer.pages:
+            annotations = page.get("/Annots")
+            if annotations is None:
+                continue
+
+            for annotation_reference in annotations:
+                annotation = annotation_reference.get_object()
+                if not isinstance(annotation, DictionaryObject):
+                    continue
+                if annotation.get("/Subtype") != "/Link":
+                    continue
+
+                action = annotation.get("/A")
+                if not isinstance(action, DictionaryObject):
+                    continue
+                if action.get("/S") != "/URI":
+                    continue
+
+                uri = action.get("/URI")
+                if not isinstance(uri, str):
+                    continue
+
+                rewritten_action = cls._create_pdf_gotor_action(
+                    uri=uri,
+                    html_to_pdf_map=html_to_pdf_map,
+                    path_to_pdf_dir=path_to_pdf_dir,
+                )
+                if rewritten_action is None:
+                    continue
+
+                annotation[NameObject("/A")] = rewritten_action
+                modified = True
+
+        if not modified:
+            return
+
+        with NamedTemporaryFile(
+            mode="wb",
+            suffix=".pdf",
+            dir=path_to_pdf_dir,
+            delete=False,
+        ) as temp_file:
+            writer.write(temp_file)
+            temp_file_path = temp_file.name
+        os.replace(temp_file_path, path_to_pdf)
+
+    @staticmethod
+    def _create_pdf_gotor_action(
+        *,
+        uri: str,
+        html_to_pdf_map: Dict[str, str],
+        path_to_pdf_dir: str,
+    ) -> Optional[DictionaryObject]:
+        # ruff: noqa: ERA001
+        # urlsplit() produces an object of the following kind:
+        # SplitResult(
+        #     scheme='file',
+        #     netloc='',
+        #     path='<path-to-project>/output/html2pdf/html/<project-mount-folder>/<path-to-doc>-PDF.html',
+        #     query='',
+        #     fragment='ANCHOR'
+        # )
+        parsed_uri = urlsplit(uri)
+        if parsed_uri.scheme != "file":
+            return None
+
+        matching_pdf_abspath = html_to_pdf_map.get(parsed_uri.path)
+        if matching_pdf_abspath is None:
+            return None
+
+        matching_pdf_relpath = PDFPostprocessor._create_relative_pdf_path(
+            path_to_pdf=matching_pdf_abspath,
+            start_dir=path_to_pdf_dir,
+        )
+
+        action = DictionaryObject()
+        action[NameObject("/Type")] = NameObject("/Action")
+        action[NameObject("/S")] = NameObject("/GoToR")
+        action[NameObject("/F")] = TextStringObject(matching_pdf_relpath)
+
+        destination_name = unquote(parsed_uri.fragment)
+        if destination_name is not None and len(destination_name) > 0:
+            action[NameObject("/D")] = (
+                PDFPostprocessor._create_destination_object(destination_name)
+            )
+        return action
+
+    @staticmethod
+    def _create_destination_object(destination_name: str) -> PdfObject:
+        assert len(destination_name) > 0
+        if destination_name.startswith("/"):
+            return NameObject(destination_name)
+        return NameObject(f"/{destination_name}")
+
+    @staticmethod
+    def _create_relative_pdf_path(*, path_to_pdf: str, start_dir: str) -> str:
+        path_module = (
+            ntpath
+            if ntpath.splitdrive(path_to_pdf)[0]
+            or ntpath.splitdrive(start_dir)[0]
+            else os.path
+        )
+        relative_path = path_module.relpath(path_to_pdf, start=start_dir)
+        # assert is needed to satisfy the type checker.
+        assert isinstance(relative_path, str), relative_path
+        return relative_path.replace("\\", "/")

--- a/strictdoc/export/html2pdf/pdf_print_driver.py
+++ b/strictdoc/export/html2pdf/pdf_print_driver.py
@@ -9,6 +9,7 @@ from typing import List, Tuple
 from html2pdf4doc.main import HPDExitCode
 
 from strictdoc.core.project_config import ProjectConfig
+from strictdoc.export.html2pdf.pdf_postprocessor import PDFPostprocessor
 from strictdoc.helpers.timing import measure_performance
 
 
@@ -55,6 +56,7 @@ class PDFPrintDriver:
     def get_pdf_from_html(
         project_config: ProjectConfig,
         paths_to_print: List[Tuple[str, str]],
+        path_to_input_root: str,
     ) -> None:
         assert isinstance(paths_to_print, list), paths_to_print
         path_to_html2pdf4doc_cache = os.path.join(
@@ -93,6 +95,10 @@ class PDFPrintDriver:
                     cmd,
                     capture_output=False,
                     check=True,
+                )
+                PDFPostprocessor.rewrite_cross_document_links(
+                    path_to_input_root=path_to_input_root,
+                    paths_to_print=paths_to_print,
                 )
             except Exception as e_:
                 raise PDFPrintDriverException(e_) from e_

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -2352,6 +2352,7 @@ def create_main_router(
             pdf_print_driver.get_pdf_from_html(
                 project_config,
                 [(path_to_output_html, path_to_output_pdf)],
+                project_config.export_output_html_root,
             )
         except PDFPrintDriverException as e_:  # pragma: no cover
             cleanup_html2pdf_artifacts()

--- a/tests/integration/features/html2pdf/09_cross_document_links_relative_paths/index.sdoc
+++ b/tests/integration/features/html2pdf/09_cross_document_links_relative_paths/index.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: Parent document
+UID: INDEX-DOC
+
+[REQUIREMENT]
+UID: REQ-INDEX
+TITLE: Index requirement
+STATEMENT: >>>
+Link to the nested document: [LINK: TARGET-333]
+<<<

--- a/tests/integration/features/html2pdf/09_cross_document_links_relative_paths/nested/other.sdoc
+++ b/tests/integration/features/html2pdf/09_cross_document_links_relative_paths/nested/other.sdoc
@@ -1,0 +1,407 @@
+[DOCUMENT]
+TITLE: Nested document
+UID: OTHER-DOC
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+UID: REQ-OTHER
+TITLE: Other requirement
+STATEMENT: >>>
+Link to the parent document: [LINK: INDEX-DOC]
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+TITLE: Filler
+STATEMENT: >>>
+FILLER>.............................
+<<<
+
+[REQUIREMENT]
+UID: TARGET-333
+TITLE: FINAL LAST TARGET
+STATEMENT: >>>
+FILLER>.............................
+<<<

--- a/tests/integration/features/html2pdf/09_cross_document_links_relative_paths/strictdoc.toml
+++ b/tests/integration/features/html2pdf/09_cross_document_links_relative_paths/strictdoc.toml
@@ -1,0 +1,7 @@
+[project]
+
+cache_dir = "./Output/cache"
+
+features = [
+  "HTML2PDF",
+]

--- a/tests/integration/features/html2pdf/09_cross_document_links_relative_paths/test.itest
+++ b/tests/integration/features/html2pdf/09_cross_document_links_relative_paths/test.itest
@@ -1,0 +1,19 @@
+# @relation(SDOC-SRS-51, scope=file)
+
+REQUIRES: TEST_HTML2PDF
+
+RUN: %strictdoc export %S --formats=html2pdf --output-dir %T | filecheck %s --dump-input=fail
+CHECK: html2pdf4doc: JS logs from the print session
+
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/index-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/other-PDF.html
+RUN: %check_exists --file %T/html2pdf/pdf/index.pdf
+RUN: %check_exists --file %T/html2pdf/pdf/nested/other.pdf
+
+RUN: %cat %T/html2pdf/html/%THIS_TEST_FOLDER/index-PDF.html | filecheck %s --check-prefix CHECK-INDEX-HTML
+CHECK-INDEX-HTML: <p>Link to the nested document: <a href="../09_cross_document_links_relative_paths/nested/other-PDF.html#TARGET-333">🔗&nbsp;67. FINAL LAST TARGET</a></p>
+
+RUN: %cat %T/html2pdf/html/%THIS_TEST_FOLDER/nested/other-PDF.html | filecheck %s --check-prefix CHECK-OTHER-HTML
+CHECK-OTHER-HTML: <p>Link to the parent document: <a href="../../09_cross_document_links_relative_paths/index-PDF.html#INDEX-DOC">🔗&nbsp;Parent document</a></p>
+
+RUN: python %S/test_pdf.py

--- a/tests/integration/features/html2pdf/09_cross_document_links_relative_paths/test_pdf.py
+++ b/tests/integration/features/html2pdf/09_cross_document_links_relative_paths/test_pdf.py
@@ -1,0 +1,47 @@
+"""
+@relation(SDOC-SRS-51, scope=file)
+"""
+
+from pypdf import PdfReader
+
+
+def get_annotation_actions(path_to_pdf: str) -> list[dict]:
+    reader = PdfReader(path_to_pdf)
+
+    actions = []
+    for page in reader.pages:
+        annotations = page.get("/Annots")
+        if annotations is None:
+            continue
+        for annotation_reference in annotations:
+            annotation = annotation_reference.get_object()
+            action = annotation.get("/A")
+            if action is None:
+                continue
+            actions.append(dict(action))
+    return actions
+
+
+index_actions = get_annotation_actions(
+    "Output/html2pdf/pdf/index.pdf"
+)
+other_actions = get_annotation_actions(
+    "Output/html2pdf/pdf/nested/other.pdf"
+)
+
+assert any(
+    action.get("/S") == "/GoToR"
+    and action.get("/F") == "nested/other.pdf"
+    and action.get("/D") == "/TARGET-333"
+    for action in index_actions
+), index_actions
+
+assert any(
+    action.get("/S") == "/GoToR"
+    and action.get("/F") == "../index.pdf"
+    and action.get("/D") == "/INDEX-DOC"
+    for action in other_actions
+), other_actions
+
+assert all(action.get("/S") != "/URI" for action in index_actions), index_actions
+assert all(action.get("/S") != "/URI" for action in other_actions), other_actions

--- a/tests/unit/strictdoc/export/html2pdf/test_pdf_postprocessor.py
+++ b/tests/unit/strictdoc/export/html2pdf/test_pdf_postprocessor.py
@@ -1,0 +1,166 @@
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from pypdf import PdfReader, PdfWriter
+from pypdf.generic import (
+    ArrayObject,
+    DictionaryObject,
+    NameObject,
+    NumberObject,
+    TextStringObject,
+)
+
+from strictdoc.export.html2pdf.pdf_postprocessor import PDFPostprocessor
+
+
+def test_pdf_postprocessor_rewrites_export_local_file_uris(
+    tmp_path: Path,
+) -> None:
+    export_root = tmp_path / "Output" / "html2pdf"
+    html_root = export_root / "html"
+    pdf_root = export_root / "pdf"
+
+    source_html = html_root / "docs" / "source-PDF.html"
+    target_html = html_root / "docs" / "nested" / "other-PDF.html"
+    skipped_html = html_root / "docs" / "skipped-PDF.html"
+    external_html = tmp_path / "outside" / "outside-PDF.html"
+    source_pdf = pdf_root / "docs" / "source.pdf"
+    target_pdf = pdf_root / "docs" / "nested" / "other.pdf"
+
+    for path in (
+        source_html,
+        target_html,
+        skipped_html,
+        external_html,
+        source_pdf,
+        target_pdf,
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+    source_html.write_text("", encoding="utf8")
+    target_html.write_text("", encoding="utf8")
+    skipped_html.write_text("", encoding="utf8")
+    external_html.write_text("", encoding="utf8")
+
+    _create_pdf_with_link_annotations(
+        path_to_pdf=source_pdf,
+        uris=(
+            target_html.resolve().as_uri() + "#OTHER-DOC",
+            skipped_html.resolve().as_uri() + "#SKIPPED-DOC",
+            "https://example.com/strictdoc",
+            external_html.resolve().as_uri() + "#OUTSIDE-DOC",
+        ),
+    )
+    _create_pdf_with_link_annotations(
+        path_to_pdf=target_pdf,
+        uris=(source_html.resolve().as_uri() + "#SOURCE-DOC",),
+    )
+
+    PDFPostprocessor.rewrite_cross_document_links(
+        path_to_input_root=str(html_root),
+        paths_to_print=[
+            (str(source_html), str(source_pdf)),
+            (str(target_html), str(target_pdf)),
+        ],
+    )
+
+    actions = _read_pdf_annotation_actions(path_to_pdf=source_pdf)
+
+    assert actions[0]["/S"] == "/GoToR"
+    assert actions[0]["/F"] == "nested/other.pdf"
+    assert actions[0]["/D"] == "/OTHER-DOC"
+
+    assert actions[1]["/S"] == "/URI"
+    assert (
+        actions[1]["/URI"] == skipped_html.resolve().as_uri() + "#SKIPPED-DOC"
+    )
+
+    assert actions[2]["/S"] == "/URI"
+    assert actions[2]["/URI"] == "https://example.com/strictdoc"
+
+    assert actions[3]["/S"] == "/URI"
+    assert (
+        actions[3]["/URI"] == external_html.resolve().as_uri() + "#OUTSIDE-DOC"
+    )
+
+    backlink_actions = _read_pdf_annotation_actions(path_to_pdf=target_pdf)
+
+    assert backlink_actions[0]["/S"] == "/GoToR"
+    assert backlink_actions[0]["/F"] == "../source.pdf"
+    assert backlink_actions[0]["/D"] == "/SOURCE-DOC"
+
+
+def test_pdf_postprocessor_rewrites_windows_relative_paths_with_slashes() -> (
+    None
+):
+    html_uri = "file:///C:/project/Output/html2pdf/html/docs/source-PDF.html"
+
+    action = PDFPostprocessor._create_pdf_gotor_action(
+        uri=html_uri + "#SOURCE-DOC",
+        html_to_pdf_map={
+            urlsplit(html_uri).path: (
+                r"C:\project\Output\html2pdf\pdf\docs\source.pdf"
+            )
+        },
+        path_to_pdf_dir=r"C:\project\Output\html2pdf\pdf\docs\nested",
+    )
+
+    assert action is not None
+    assert action["/S"] == "/GoToR"
+    assert action["/F"] == "../source.pdf"
+    assert action["/D"] == "/SOURCE-DOC"
+
+
+def _create_pdf_with_link_annotations(
+    *, path_to_pdf: Path, uris: tuple[str, ...]
+) -> None:
+    writer = PdfWriter()
+    page = writer.add_blank_page(width=200, height=200)
+
+    annotations = ArrayObject()
+    for uri in uris:
+        annotation = DictionaryObject()
+        annotation[NameObject("/Type")] = NameObject("/Annot")
+        annotation[NameObject("/Subtype")] = NameObject("/Link")
+        annotation[NameObject("/Rect")] = ArrayObject(
+            [
+                NumberObject(0),
+                NumberObject(0),
+                NumberObject(10),
+                NumberObject(10),
+            ]
+        )
+        annotation[NameObject("/Border")] = ArrayObject(
+            [NumberObject(0), NumberObject(0), NumberObject(0)]
+        )
+
+        action = DictionaryObject()
+        action[NameObject("/Type")] = NameObject("/Action")
+        action[NameObject("/S")] = NameObject("/URI")
+        action[NameObject("/URI")] = TextStringObject(uri)
+
+        annotation[NameObject("/A")] = action
+        annotations.append(writer._add_object(annotation))
+
+    page[NameObject("/Annots")] = annotations
+
+    with path_to_pdf.open("wb") as output_file:
+        writer.write(output_file)
+
+
+def _read_pdf_annotation_actions(
+    *, path_to_pdf: Path
+) -> list[DictionaryObject]:
+    reader = PdfReader(path_to_pdf)
+    actions = []
+    for page in reader.pages:
+        annotations = page.get("/Annots")
+        if annotations is None:
+            continue
+        for annotation_reference in annotations:
+            annotation = annotation_reference.get_object()
+            action = annotation.get("/A")
+            if action is None:
+                continue
+            actions.append(action)
+    return actions


### PR DESCRIPTION
WHAT:

This change enables the HTML2PDF export feature to cross-link PDF documents
within the same project tree if they link to each other using StrictDoc's
LINK mechanism.

WHY:

This allows navigation between PDF documents in PDF viewers that support the
PDF cross-linking feature.

This also fixes the long-standing behavior of HTML2PDF, which always printed
local links resolved to their full paths, and these paths were hardcoded in the
final HTML.

This is how a user expressed the need:

The links should go to the correct locations in the exported PDFs. Preferably
using relative paths, so that the local file structure, which on Linux includes
the username, is not leaked :)

Closes #2741

HOW:

The underlying implementation is a little tricky:

We tried several approaches and failed to make html2pdf4doc and ChromeDriver
produce LINKs to other documents that actually work in at least some PDF viewers.

The only solution that seems to work — and this is what is implemented by this
commit — is to add an extra preprocessing step and manually fix up the relative
paths to other documents into PDF links/anchors using the PDF GoToR feature.

