### PR TITLE
feat(backend/sdoc): establish a more robust rule for defining single vs multiline fields

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -1577,7 +1577,9 @@ In the default and most common use case, single-line fields are used for meta-in
 
 Single-line fields are parsed as plain text, not as RST. To render RST or to have ``[LINK: ...]`` recognized as HTML, the field must be multiline.
 
-By convention, each node contains one primary multiline ``STATEMENT`` field (or an equivalent). All fields before this main statement field should be single-line fields storing meta-information, and all fields after the statement field should typically be multiline content.
+By convention, each node contains one primary multiline field: ``STATEMENT``, ``CONTENT`` or ``DESCRIPTION``. All fields before the primary multiline field should be single-line fields that store meta-information, and all fields after the primary multiline field should typically be multiline content.
+
+A fallback to this rule applies when a node does not have a content field, in which case the ``TITLE`` field serves as a boundary between single-line and multiline fields. If a node has neither a content field nor a ``TITLE`` field, all fields are treated as multiline.
 
 There is an ongoing discussion on GitHub about formalizing the single-line and multiline convention in the SDoc format: https://github.com/strictdoc-project/strictdoc/discussions/2221. User feedback is welcome.
 <<<

--- a/strictdoc/backend/sdoc/models/grammar_element.py
+++ b/strictdoc/backend/sdoc/models/grammar_element.py
@@ -284,13 +284,25 @@ class GrammarElement:
             statement_field or description_field or content_field or ("", -1)
         )
 
-        # Use TITLE as a boundary between the single-line and multiline, if
-        # TITLE exists. For nodes without a TITLE, use the content field, e.g.,
-        # STATEMENT or DESCRIPTION.
-        try:
-            multiline_field_index = self.get_field_titles().index("TITLE") + 1
-        except ValueError:
+        # The following rule governs which fields are treated as single-line and
+        # which are treated as multiline:
+        # 1) If a node has a content field, e.g., STATEMENT, CONTENT or
+        # DESCRIPTION, then the fields before it are treated as single-line, and
+        # the fields starting from it and after it are treated as multiline.
+        # 2) If there is no content field, use TITLE as a boundary between the
+        # single-line and multiline.
+        # 3) If there is no content field and no TITLE, treat all fields as
+        # multiline by setting the multiline_field_index to -1, which is less
+        # than any valid field index.
+        if self.content_field[1] != -1:
             multiline_field_index = self.content_field[1]
+        else:
+            try:
+                multiline_field_index = (
+                    self.get_field_titles().index("TITLE") + 1
+                )
+            except ValueError:
+                multiline_field_index = -1
         self._multiline_field_index: int = multiline_field_index
 
         self.mid: MID = MID.create()

--- a/tests/unit/strictdoc/backend/sdoc/test_grammar_element.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_grammar_element.py
@@ -1,0 +1,69 @@
+from strictdoc.backend.sdoc.models.document_grammar import (
+    GrammarElement,
+    GrammarElementFieldString,
+)
+
+
+def test_grammar_element_boundary_between_single_and_multiline_fields():
+    fields = [
+        GrammarElementFieldString(
+            parent=None,
+            title="MID",
+            human_title=None,
+            required="False",
+        ),
+        GrammarElementFieldString(
+            parent=None,
+            title="UID",
+            human_title=None,
+            required="False",
+        ),
+        GrammarElementFieldString(
+            parent=None,
+            title="TITLE",
+            human_title=None,
+            required="False",
+        ),
+        GrammarElementFieldString(
+            parent=None,
+            title="NAME",
+            human_title=None,
+            required="False",
+        ),
+        GrammarElementFieldString(
+            parent=None,
+            title="TYPE",
+            human_title=None,
+            required="False",
+        ),
+        GrammarElementFieldString(
+            parent=None,
+            title="CONTENT",
+            human_title=None,
+            required="False",
+        ),
+        GrammarElementFieldString(
+            parent=None,
+            title="NOTE",
+            human_title=None,
+            required="False",
+        ),
+    ]
+
+    element = GrammarElement(
+        parent=None,
+        tag="DDITEM",
+        property_is_composite="",
+        property_prefix="",
+        property_view_style="",
+        fields=fields,
+        relations=[],
+    )
+
+    assert element.is_field_multiline("MID") is False
+    assert element.is_field_multiline("UID") is False
+    assert element.is_field_multiline("TITLE") is False
+    assert element.is_field_multiline("NAME") is False
+    assert element.is_field_multiline("TYPE") is False
+    assert element.is_field_multiline("CONTENT") is True
+    assert element.is_field_multiline("NOTE") is True


### PR DESCRIPTION

WHAT:

Introduce a more robust rule for distinguishing single-line vs multiline fields, prioritizing grammars that define an explicit content field (one of: STATEMENT, CONTENT, or DESCRIPTION).

New precedence is `Primary field → TITLE → Fallback`:

- If a primary multiline field exists, use it as the boundary.
- Else if TITLE exists, use it as the boundary.
- Else, treat all fields as multiline.

Previously, the precedence was `TITLE → Primary field → Fallback`, which led to less consistent behavior in some cases.

WHY:

The previous TITLE-first rule caused confusion and did not align well with the intended semantics or documentation. Prioritizing explicit content fields provides a more intuitive and predictable model.

Closes #2744