### PR TITLE
test(backend/sdoc): add a test for a case when TITLE is the last field, and all fields are therefore singleline

### DIFF
--- a/strictdoc/backend/sdoc/models/grammar_element.py
+++ b/strictdoc/backend/sdoc/models/grammar_element.py
@@ -290,7 +290,8 @@ class GrammarElement:
         # DESCRIPTION, then the fields before it are treated as single-line, and
         # the fields starting from it and after it are treated as multiline.
         # 2) If there is no content field, use TITLE as a boundary between the
-        # single-line and multiline.
+        # single-line and multiline. Note that this also covers the case when
+        # the TITLE is the last field in which case there are no multiline fields.
         # 3) If there is no content field and no TITLE, treat all fields as
         # multiline by setting the multiline_field_index to -1, which is less
         # than any valid field index.

--- a/tests/unit/strictdoc/backend/sdoc/test_grammar_element.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_grammar_element.py
@@ -67,3 +67,61 @@ def test_grammar_element_boundary_between_single_and_multiline_fields():
     assert element.is_field_multiline("TYPE") is False
     assert element.is_field_multiline("CONTENT") is True
     assert element.is_field_multiline("NOTE") is True
+
+
+def test_grammar_element_boundary_between_single_and_multiline_fields_when_no_content_and_title_is_last():
+    fields = [
+        GrammarElementFieldString(
+            parent=None,
+            title="MID",
+            human_title=None,
+            required="False",
+        ),
+        GrammarElementFieldString(
+            parent=None,
+            title="UID",
+            human_title=None,
+            required="False",
+        ),
+        GrammarElementFieldString(
+            parent=None,
+            title="NAME",
+            human_title=None,
+            required="False",
+        ),
+        GrammarElementFieldString(
+            parent=None,
+            title="TYPE",
+            human_title=None,
+            required="False",
+        ),
+        GrammarElementFieldString(
+            parent=None,
+            title="NOTE",
+            human_title=None,
+            required="False",
+        ),
+        GrammarElementFieldString(
+            parent=None,
+            title="TITLE",
+            human_title=None,
+            required="False",
+        ),
+    ]
+
+    element = GrammarElement(
+        parent=None,
+        tag="DDITEM",
+        property_is_composite="",
+        property_prefix="",
+        property_view_style="",
+        fields=fields,
+        relations=[],
+    )
+
+    assert element.is_field_multiline("MID") is False
+    assert element.is_field_multiline("UID") is False
+    assert element.is_field_multiline("NAME") is False
+    assert element.is_field_multiline("TYPE") is False
+    assert element.is_field_multiline("NOTE") is False
+    assert element.is_field_multiline("TITLE") is False


### PR DESCRIPTION

This is a follow-up to #2752.