### PR TITLE
fix(backend/sdoc): enumerate field titles across all grammar elements without duplicates

### DIFF
--- a/strictdoc/backend/sdoc/models/document.py
+++ b/strictdoc/backend/sdoc/models/document.py
@@ -259,18 +259,24 @@ class SDocDocument(SDocDocumentIF):
     def enumerate_meta_field_titles(self) -> Generator[str, None, None]:
         assert self.grammar is not None
         assert self.grammar.elements is not None
-        # FIXME: currently only enumerating a single element ([0])
-        yield from self.grammar.elements[0].enumerate_meta_field_titles()
+        seen: Set[str] = set()
+        for element in self.grammar.elements:
+            for title in element.enumerate_meta_field_titles():
+                if title not in seen:
+                    seen.add(title)
+                    yield title
 
     def enumerate_custom_content_field_titles(
         self,
     ) -> Generator[str, None, None]:
         assert self.grammar is not None
         assert self.grammar.elements is not None
-        # FIXME: currently only enumerating a single element ([0])
-        yield from self.grammar.elements[
-            0
-        ].enumerate_custom_content_field_titles()
+        seen: Set[str] = set()
+        for element in self.grammar.elements:
+            for title in element.enumerate_custom_content_field_titles():
+                if title not in seen:
+                    seen.add(title)
+                    yield title
 
     def get_grammar_element_field_for(
         self, element_type: str, field_name: str

--- a/tests/unit/strictdoc/backend/sdoc/models/test_document_enumerate_field_titles.py
+++ b/tests/unit/strictdoc/backend/sdoc/models/test_document_enumerate_field_titles.py
@@ -1,0 +1,132 @@
+from strictdoc.backend.sdoc.models.document import SDocDocument
+from strictdoc.backend.sdoc.models.document_grammar import (
+    DocumentGrammar,
+    GrammarElement,
+    GrammarElementFieldString,
+)
+
+
+def _make_field(title):
+    return GrammarElementFieldString(
+        parent=None,
+        title=title,
+        human_title=None,
+        required="False",
+    )
+
+
+def _make_element(tag, field_titles):
+    return GrammarElement(
+        parent=None,
+        tag=tag,
+        property_is_composite="",
+        property_prefix="",
+        property_view_style="",
+        fields=[_make_field(title_) for title_ in field_titles],
+        relations=[],
+    )
+
+
+def _make_document_with_elements(elements):
+    document = SDocDocument(
+        mid=None,
+        title="Test",
+        config=None,
+        view=None,
+        grammar=None,
+        section_contents=[],
+    )
+    grammar = DocumentGrammar(
+        parent=document,
+        elements=elements,
+    )
+    document.grammar = grammar
+    return document
+
+
+def test_enumerate_meta_field_titles_single_element():
+    element = _make_element(
+        "REQUIREMENT",
+        ["UID", "SEVERITY", "TITLE", "STATEMENT"],
+    )
+    document = _make_document_with_elements([element])
+
+    result = list(document.enumerate_meta_field_titles())
+
+    assert result == ["UID", "SEVERITY"]
+
+
+def test_enumerate_meta_field_titles_multiple_elements_no_duplicates():
+    element_a = _make_element(
+        "REQUIREMENT",
+        ["UID", "SEVERITY", "TITLE", "STATEMENT"],
+    )
+    element_b = _make_element(
+        "CUSTOM",
+        ["UID", "PRIORITY", "TITLE", "STATEMENT"],
+    )
+    document = _make_document_with_elements([element_a, element_b])
+
+    result = list(document.enumerate_meta_field_titles())
+
+    assert result == ["UID", "SEVERITY", "PRIORITY"]
+
+
+def test_enumerate_meta_field_titles_multiple_elements_with_common_fields():
+    element_a = _make_element(
+        "REQUIREMENT",
+        ["UID", "SEVERITY", "TITLE", "STATEMENT"],
+    )
+    element_b = _make_element(
+        "CUSTOM",
+        ["UID", "SEVERITY", "PRIORITY", "TITLE", "STATEMENT"],
+    )
+    document = _make_document_with_elements([element_a, element_b])
+
+    result = list(document.enumerate_meta_field_titles())
+
+    assert result == ["UID", "SEVERITY", "PRIORITY"]
+
+
+def test_enumerate_custom_content_field_titles_single_element():
+    element = _make_element(
+        "REQUIREMENT",
+        ["UID", "TITLE", "STATEMENT", "NOTE"],
+    )
+    document = _make_document_with_elements([element])
+
+    result = list(document.enumerate_custom_content_field_titles())
+
+    assert result == ["NOTE"]
+
+
+def test_enumerate_custom_content_field_titles_multiple_elements_no_duplicates():
+    element_a = _make_element(
+        "REQUIREMENT",
+        ["UID", "TITLE", "STATEMENT", "NOTE"],
+    )
+    element_b = _make_element(
+        "CUSTOM",
+        ["UID", "TITLE", "STATEMENT", "IMPACT"],
+    )
+    document = _make_document_with_elements([element_a, element_b])
+
+    result = list(document.enumerate_custom_content_field_titles())
+
+    assert result == ["NOTE", "IMPACT"]
+
+
+def test_enumerate_custom_content_field_titles_multiple_elements_with_common_fields():
+    element_a = _make_element(
+        "REQUIREMENT",
+        ["UID", "TITLE", "STATEMENT", "NOTE"],
+    )
+    element_b = _make_element(
+        "CUSTOM",
+        ["UID", "TITLE", "STATEMENT", "NOTE", "IMPACT"],
+    )
+    document = _make_document_with_elements([element_a, element_b])
+
+    result = list(document.enumerate_custom_content_field_titles())
+
+    assert result == ["NOTE", "IMPACT"]


### PR DESCRIPTION
WHY:
When a document grammar defines multiple element types (e.g., `SECTION`, `REQUIREMENT`, `CUSTOM`, ...), each with its own custom fields, the table view only displayed columns from the first grammar element. Any fields unique to other element types were silently missing from the table header and rows, making the table view incomplete and misleading for documents with multi-element grammars.