### PR TITLE
Correct multiline SingleChoice, MultipleChoice, and Tag validation and update tests

### DIFF
--- a/strictdoc/backend/sdoc/validations/sdoc_validator.py
+++ b/strictdoc/backend/sdoc/validations/sdoc_validator.py
@@ -305,7 +305,10 @@ class SDocValidator:
         requirement_field_text_value = requirement_field.get_text_value()
 
         if isinstance(grammar_field, GrammarElementFieldSingleChoice):
-            if requirement_field_text_value not in grammar_field.options:
+            if (
+                requirement_field_text_value.strip()
+                not in grammar_field.options
+            ):
                 raise StrictDocSemanticError.invalid_choice_field(
                     node=requirement,
                     document_grammar=document_grammar,
@@ -314,7 +317,9 @@ class SDocValidator:
                 )
 
         elif isinstance(grammar_field, GrammarElementFieldMultipleChoice):
-            if not multi_choice_regex_match(requirement_field_text_value):
+            if not multi_choice_regex_match(
+                requirement_field_text_value.strip()
+            ):
                 raise StrictDocSemanticError.not_comma_separated_choices(
                     node=requirement,
                     requirement_field=requirement_field,
@@ -322,10 +327,10 @@ class SDocValidator:
                 )
 
             requirement_field_value_components = (
-                requirement_field_text_value.split(", ")
+                requirement_field_text_value.strip().split(", ")
             )
             for component in requirement_field_value_components:
-                if component not in grammar_field.options:
+                if component.strip() not in grammar_field.options:
                     raise StrictDocSemanticError.invalid_multiple_choice_field(
                         node=requirement,
                         document_grammar=document_grammar,
@@ -334,7 +339,9 @@ class SDocValidator:
                     )
 
         elif isinstance(grammar_field, GrammarElementFieldTag):
-            if not multi_choice_regex_match(requirement_field_text_value):
+            if not multi_choice_regex_match(
+                requirement_field_text_value.strip()
+            ):
                 raise StrictDocSemanticError.not_comma_separated_tag_field(
                     node=requirement,
                     requirement_field=requirement_field,

--- a/tests/integration/features/sdoc/document_grammar/type_system/multiple_single_choice/validation/03_valid_multiline_value/input.sdoc
+++ b/tests/integration/features/sdoc/document_grammar/type_system/multiple_single_choice/validation/03_valid_multiline_value/input.sdoc
@@ -1,0 +1,19 @@
+[DOCUMENT]
+TITLE: Test document
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: CHOICE_FIELD
+    TYPE: MultipleChoice(A, B, C, D)
+    REQUIRED: True
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+
+[REQUIREMENT]
+CHOICE_FIELD: >>>
+A, B
+<<<
+STATEMENT: This requirement has a valid multiline MultipleChoice field.

--- a/tests/integration/features/sdoc/document_grammar/type_system/multiple_single_choice/validation/03_valid_multiline_value/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/type_system/multiple_single_choice/validation/03_valid_multiline_value/test.itest
@@ -1,0 +1,6 @@
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Test document
+
+RUN: %cat %T/html/03_valid_multiline_value/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+CHECK-HTML:CHOICE_FIELD
+CHECK-HTML:A, B

--- a/tests/integration/features/sdoc/document_grammar/type_system/single_choice/validation/02_valid_multiline_value/input.sdoc
+++ b/tests/integration/features/sdoc/document_grammar/type_system/single_choice/validation/02_valid_multiline_value/input.sdoc
@@ -1,0 +1,19 @@
+[DOCUMENT]
+TITLE: Test document
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: CHOICE_FIELD
+    TYPE: SingleChoice(A, B, C, D)
+    REQUIRED: True
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+
+[REQUIREMENT]
+CHOICE_FIELD: >>>
+C
+<<<
+STATEMENT: This requirement has a valid multiline SingleChoice field.

--- a/tests/integration/features/sdoc/document_grammar/type_system/single_choice/validation/02_valid_multiline_value/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/type_system/single_choice/validation/02_valid_multiline_value/test.itest
@@ -1,0 +1,6 @@
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Test document
+
+RUN: %cat %T/html/02_valid_multiline_value/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+CHECK-HTML:CHOICE_FIELD
+CHECK-HTML:C

--- a/tests/integration/features/sdoc/document_grammar/type_system/tag/validation/02_valid_multiline_value/input.sdoc
+++ b/tests/integration/features/sdoc/document_grammar/type_system/tag/validation/02_valid_multiline_value/input.sdoc
@@ -1,0 +1,19 @@
+[DOCUMENT]
+TITLE: Test document
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: TAGS
+    TYPE: Tag
+    REQUIRED: True
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+
+[REQUIREMENT]
+TAGS: >>>
+TAG1, TAG2
+<<<
+STATEMENT: This requirement has valid multiline Tag fields.

--- a/tests/integration/features/sdoc/document_grammar/type_system/tag/validation/02_valid_multiline_value/test.itest
+++ b/tests/integration/features/sdoc/document_grammar/type_system/tag/validation/02_valid_multiline_value/test.itest
@@ -1,0 +1,6 @@
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Test document
+
+RUN: %cat %T/html/02_valid_multiline_value/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+CHECK-HTML:TAGS
+CHECK-HTML:TAG1, TAG2


### PR DESCRIPTION
Fixes https://github.com/strictdoc-project/strictdoc/issues/2760 and https://github.com/strictdoc-project/strictdoc/issues/2758 by stripping newlines before checks in sdoc_validator.py, adds tests for multiline entries of SingleChoice, MultipleChoice and Tag