### PR TITLE
feat(project): add functionality to edit project title

### DIFF
--- a/strictdoc/commands/_shared.py
+++ b/strictdoc/commands/_shared.py
@@ -18,5 +18,9 @@ def add_config_argument(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--config",
         type=str,
-        help="Path to the StrictDoc TOML config file.",
+        help=(
+            "Path to the StrictDoc config file ("
+            "strictdoc_config.py preferred, strictdoc.toml legacy"
+            ")."
+        ),
     )

--- a/strictdoc/export/html/templates/actions/project_index/edit_project_title/stream_form_edit_project_title.jinja.html
+++ b/strictdoc/export/html/templates/actions/project_index/edit_project_title/stream_form_edit_project_title.jinja.html
@@ -1,0 +1,5 @@
+<turbo-stream action="update" target="modal">
+  <template>
+    {% include "screens/project_index/frame_form_edit_project_title.jinja.html" %}
+  </template>
+</turbo-stream>

--- a/strictdoc/export/html/templates/actions/project_index/edit_project_title/stream_save_project_title.jinja.html
+++ b/strictdoc/export/html/templates/actions/project_index/edit_project_title/stream_save_project_title.jinja.html
@@ -1,0 +1,14 @@
+<turbo-stream action="replace" target="header-project-name">
+  <template>
+    <div
+      class="header__project_name"
+      id="header-project-name"
+      title="{{ project_config.project_title }}"
+    >{{ project_config.project_title }}
+    </div>
+  </template>
+</turbo-stream>
+
+<turbo-stream action="update" target="modal">
+  <template></template>
+</turbo-stream>

--- a/strictdoc/export/html/templates/components/header/index.jinja
+++ b/strictdoc/export/html/templates/components/header/index.jinja
@@ -4,6 +4,7 @@
   {% include "icons/ico16_project.svg" %}
   <div
     class="header__project_name"
+    id="header-project-name"
     title="{{ view_object.project_config.project_title }}"
   >{{ view_object.project_config.project_title }}
   </div>

--- a/strictdoc/export/html/templates/screens/project_index/action_list.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/action_list.jinja
@@ -7,6 +7,15 @@
   role="menuitem"
 >{% include "icons/ico16_add.svg" %} Add document</a>
 
+<a
+  class="dropdown_menu_item"
+  href="/actions/project_index/edit_project_title_form"
+  data-turbo="true"
+  title="Edit project title"
+  data-testid="project-edit-title-action"
+  role="menuitem"
+>Edit project title</a>
+
 {%- if view_object.project_config.is_activated_reqif() -%}
 <a
   class="dropdown_menu_item"

--- a/strictdoc/export/html/templates/screens/project_index/frame_form_edit_project_title.jinja.html
+++ b/strictdoc/export/html/templates/screens/project_index/frame_form_edit_project_title.jinja.html
@@ -1,0 +1,35 @@
+{% extends "components/modal/form.jinja" %}
+{% set form = "sdoc_modal_form" %}
+{% block modal__context %}{% endblock modal__context %}
+{% block modal_form__header %}
+Edit project title
+{% endblock modal_form__header %}
+{% block modal_form__content %}
+  <form
+    id="{{ form }}"
+    action="/actions/project_index/save_project_title"
+    method="POST"
+    enctype="application/x-www-form-urlencoded"
+    data-turbo="true"
+  >
+    <sdoc-form-grid>
+      {%- with
+        field_class_name="",
+        field_input_name="project_title",
+        field_name="project title",
+        field_label="Project title",
+        field_value=(new_title if new_title is defined else project_config.project_title),
+        field_type="singleline",
+        field_required=true,
+        errors=error_object.get_errors("project_title")
+      -%}
+        {% include "components/form/field/text/index.jinja" %}
+      {%- endwith -%}
+    </sdoc-form-grid>
+  </form>
+{% endblock modal_form__content %}
+{% block modal_form__footer_submit %}
+  {%- with name="Save" -%}
+    {% include "components/button/submit.jinja" %}
+  {%- endwith -%}
+{% endblock modal_form__footer_submit %}

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -1225,6 +1225,176 @@ def create_main_router(
             },
         )
 
+    @read_router.get(
+        "/actions/project_index/edit_project_title_form",
+        response_class=Response,
+    )
+    def get_edit_project_title_form() -> Response:
+        error_object = ErrorObject()
+        output = env().render_template_as_markup(
+            "actions/project_index/edit_project_title/"
+            "stream_form_edit_project_title.jinja.html",
+            error_object=error_object,
+            project_config=project_config,
+        )
+        return HTMLResponse(
+            content=output,
+            headers={
+                "Content-Type": "text/vnd.turbo-stream.html",
+            },
+        )
+
+    @write_router.post(
+        "/actions/project_index/save_project_title", response_class=Response
+    )
+    def save_project_title(project_title: str = Form("")) -> Response:
+        error_object = ErrorObject()
+
+        new_title = project_title.strip() if project_title is not None else ""
+        if len(new_title) == 0:
+            error_object.add_error(
+                "project_title", "Project title must not be empty."
+            )
+
+        if error_object.any_errors():
+            output = env().render_template_as_markup(
+                "actions/project_index/edit_project_title/"
+                "stream_form_edit_project_title.jinja.html",
+                error_object=error_object,
+                project_config=project_config,
+                new_title=new_title,
+            )
+            return HTMLResponse(
+                content=output,
+                status_code=200,
+                headers={
+                    "Content-Type": "text/vnd.turbo-stream.html",
+                },
+            )
+
+        # Try to persist the new title into the project configuration when available.
+        project_root = project_config.get_project_root_path()
+        config_toml_path: Optional[str] = None
+        config_py_path: Optional[str] = None
+
+        if os.path.isdir(project_root):
+            # Prefer Python config when both exist.
+            candidate_py = os.path.join(project_root, "strictdoc_config.py")
+            candidate_toml = os.path.join(project_root, "strictdoc.toml")
+            if os.path.isfile(candidate_py):
+                config_py_path = candidate_py
+            elif os.path.isfile(candidate_toml):
+                config_toml_path = candidate_toml
+        else:
+            # project_root may point directly to a config file or to an
+            # input path next to the config files.
+            if project_root.endswith("strictdoc.toml"):
+                config_toml_path = project_root
+            elif project_root.endswith("strictdoc_config.py"):
+                config_py_path = project_root
+            else:
+                config_dir = os.path.dirname(project_root)
+                candidate_py = os.path.join(config_dir, "strictdoc_config.py")
+                candidate_toml = os.path.join(config_dir, "strictdoc.toml")
+                if os.path.isfile(candidate_py):
+                    config_py_path = candidate_py
+                elif os.path.isfile(candidate_toml):
+                    config_toml_path = candidate_toml
+
+        # strictdoc.toml is not supported anymore.
+        if config_toml_path is not None:
+            error_object = ErrorObject()
+
+            error_object.add_error(
+                "project_title",
+                "Renaming project title is not supported with TOML config files. Switch from strictdoc_config.toml to strictdoc_config.py and try again.",
+            )
+
+            output = env().render_template_as_markup(
+                "actions/project_index/edit_project_title/"
+                "stream_form_edit_project_title.jinja.html",
+                error_object=error_object,
+                project_config=project_config,
+                new_title=new_title,
+            )
+            return HTMLResponse(
+                content=output,
+                status_code=400,
+                headers={
+                    "Content-Type": "text/vnd.turbo-stream.html",
+                },
+            )
+
+        # Update strictdoc_config.py by editing its title using regex.
+        # The implementation is pretty hacky but should work for now.
+        if config_py_path is not None:
+            with open(config_py_path, encoding="utf8") as config_file:
+                config_text = config_file.read()
+
+            pattern = re.compile(
+                r"(project_title\s*=\s*)([\"'])(.*?)([\"'])",
+                re.DOTALL,
+            )
+
+            def _replace_title(match: re.Match[str]) -> str:
+                prefix = match.group(1)
+                quote = match.group(2)
+                escaped_title = new_title.replace(quote, "\\" + quote)
+                return f"{prefix}{quote}{escaped_title}{quote}"
+
+            new_text, count = pattern.subn(_replace_title, config_text, count=1)
+
+            if count > 0:
+                with open(config_py_path, "w", encoding="utf8") as config_file:
+                    config_file.write(new_text)
+            else:
+                error_object = ErrorObject()
+
+                error_object.add_error(
+                    "project_title",
+                    (
+                        "Renaming project title is not supported when a title is "
+                        "not already configured to a previous value in"
+                        "strictdoc_config.py."
+                    ),
+                )
+
+                output = env().render_template_as_markup(
+                    "actions/project_index/edit_project_title/"
+                    "stream_form_edit_project_title.jinja.html",
+                    error_object=error_object,
+                    project_config=project_config,
+                    new_title=new_title,
+                )
+                return HTMLResponse(
+                    content=output,
+                    status_code=400,
+                    headers={
+                        "Content-Type": "text/vnd.turbo-stream.html",
+                    },
+                )
+
+        # Update in-memory project configuration after successful validation
+        # of where the title can be stored on disk.
+        project_config.project_title = new_title
+
+        # This ensures that the cached project index HTML page is invalidated.
+        export_action.traceability_index.update_last_updated()
+
+        # Return Turbo Streams to update the header title and close the modal.
+        output = env().render_template_as_markup(
+            "actions/project_index/edit_project_title/"
+            "stream_save_project_title.jinja.html",
+            project_config=project_config,
+        )
+        return HTMLResponse(
+            content=output,
+            status_code=200,
+            headers={
+                "Content-Type": "text/vnd.turbo-stream.html",
+            },
+        )
+
     @write_router.post(
         "/actions/project_index/create_document", response_class=Response
     )

--- a/tests/end2end/helpers/screens/project_index/screen_project_index.py
+++ b/tests/end2end/helpers/screens/project_index/screen_project_index.py
@@ -17,6 +17,7 @@ from tests.end2end.helpers.screens.project_index.form_import_reqif import (
 from tests.end2end.helpers.screens.project_statistics.project_statistics import (
     Screen_ProjectStatistics,
 )
+from tests.end2end.helpers.screens.screen import Screen
 from tests.end2end.helpers.screens.search.search import Screen_Search
 from tests.end2end.helpers.screens.source_coverage.screen_source_coverage import (
     Screen_SourceCoverage,
@@ -27,7 +28,7 @@ from tests.end2end.helpers.screens.traceability_matrix.screen_requirements_cover
 from tests.end2end.helpers.screens.tree_map.tree_map import Screen_TreeMap
 
 
-class Screen_ProjectIndex:  # pylint: disable=invalid-name
+class Screen_ProjectIndex(Screen):  # pylint: disable=invalid-name
     def __init__(self, test_case: BaseCase) -> None:
         assert isinstance(test_case, BaseCase)
         self.test_case: BaseCase = test_case
@@ -227,6 +228,15 @@ class Screen_ProjectIndex:  # pylint: disable=invalid-name
 
     def do_export_reqif(self) -> None:
         self.actions_menu.do_click_action("tree-export-reqif-action")
+
+    def do_update_project_title(self, title: str) -> None:
+        self.actions_menu.do_click_action("project-edit-title-action")
+
+        input_xpath = "//*[@data-testid='form-field-project_title']"
+
+        self.test_case.type(input_xpath, title, by=By.XPATH)
+
+        self.test_case.click_xpath('//*[@data-testid="form-submit-action"]')
 
     # project_tree_controls
     # Show/Hide fragments

--- a/tests/end2end/helpers/screens/screen.py
+++ b/tests/end2end/helpers/screens/screen.py
@@ -10,7 +10,7 @@ from tests.end2end.helpers.components.node.section import Section
 from tests.end2end.helpers.components.toc import TOC
 
 
-class Screen:  # pylint: disable=invalid-name, too-many-public-methods
+class Screen:
     def __init__(self, test_case: BaseCase) -> None:
         assert isinstance(test_case, BaseCase)
         self.test_case: BaseCase = test_case

--- a/tests/end2end/screens/project_index/update_project_title_python_config/expected_output/Document_1.sdoc
+++ b/tests/end2end/screens/project_index/update_project_title_python_config/expected_output/Document_1.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[TEXT]
+STATEMENT: >>>
+Document 1 free text.
+<<<
+
+[[SECTION]]
+TITLE: Document 1 section
+
+[TEXT]
+STATEMENT: >>>
+Document 1 statement.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/screens/project_index/update_project_title_python_config/expected_output/Document_2.sdoc
+++ b/tests/end2end/screens/project_index/update_project_title_python_config/expected_output/Document_2.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Document 2
+
+[TEXT]
+STATEMENT: >>>
+Document 2 free text.
+<<<
+
+[[SECTION]]
+TITLE: Document 2 section
+
+[TEXT]
+STATEMENT: >>>
+Document 2 statement.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/screens/project_index/update_project_title_python_config/expected_output/strictdoc_config.py
+++ b/tests/end2end/screens/project_index/update_project_title_python_config/expected_output/strictdoc_config.py
@@ -1,0 +1,9 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_title="UPDATED TITLE",
+        project_features=[],
+    )
+    return config

--- a/tests/end2end/screens/project_index/update_project_title_python_config/input/Document_1.sdoc
+++ b/tests/end2end/screens/project_index/update_project_title_python_config/input/Document_1.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[TEXT]
+STATEMENT: >>>
+Document 1 free text.
+<<<
+
+[[SECTION]]
+TITLE: Document 1 section
+
+[TEXT]
+STATEMENT: >>>
+Document 1 statement.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/screens/project_index/update_project_title_python_config/input/Document_2.sdoc
+++ b/tests/end2end/screens/project_index/update_project_title_python_config/input/Document_2.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Document 2
+
+[TEXT]
+STATEMENT: >>>
+Document 2 free text.
+<<<
+
+[[SECTION]]
+TITLE: Document 2 section
+
+[TEXT]
+STATEMENT: >>>
+Document 2 statement.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/screens/project_index/update_project_title_python_config/input/strictdoc_config.py
+++ b/tests/end2end/screens/project_index/update_project_title_python_config/input/strictdoc_config.py
@@ -1,0 +1,9 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_title="StrictDoc Documentation",
+        project_features=[],
+    )
+    return config

--- a/tests/end2end/screens/project_index/update_project_title_python_config/test_case.py
+++ b/tests/end2end/screens/project_index/update_project_title_python_config/test_case.py
@@ -1,0 +1,43 @@
+"""
+@relation(SDOC-SRS-72, scope=file)
+"""
+
+import os
+import shutil
+
+from tests.end2end.conftest import DOWNLOADED_FILES_PATH
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+path_to_expected_downloaded_file = os.path.join(
+    DOWNLOADED_FILES_PATH, "export.reqif"
+)
+
+
+class Test(E2ECase):
+    def test(self):
+        shutil.rmtree(DOWNLOADED_FILES_PATH, ignore_errors=True)
+
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+
+            screen_project_index.do_update_project_title("UPDATED TITLE")
+
+            screen_project_index.assert_text("UPDATED TITLE")
+
+            self.refresh_page()
+
+            screen_project_index.assert_text("UPDATED TITLE")
+
+        assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/expected_output/Document_1.sdoc
+++ b/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/expected_output/Document_1.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[TEXT]
+STATEMENT: >>>
+Document 1 free text.
+<<<
+
+[[SECTION]]
+TITLE: Document 1 section
+
+[TEXT]
+STATEMENT: >>>
+Document 1 statement.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/expected_output/Document_2.sdoc
+++ b/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/expected_output/Document_2.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Document 2
+
+[TEXT]
+STATEMENT: >>>
+Document 2 free text.
+<<<
+
+[[SECTION]]
+TITLE: Document 2 section
+
+[TEXT]
+STATEMENT: >>>
+Document 2 statement.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/expected_output/strictdoc_config.py
+++ b/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/expected_output/strictdoc_config.py
@@ -1,0 +1,8 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=[],
+    )
+    return config

--- a/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/input/Document_1.sdoc
+++ b/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/input/Document_1.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[TEXT]
+STATEMENT: >>>
+Document 1 free text.
+<<<
+
+[[SECTION]]
+TITLE: Document 1 section
+
+[TEXT]
+STATEMENT: >>>
+Document 1 statement.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/input/Document_2.sdoc
+++ b/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/input/Document_2.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Document 2
+
+[TEXT]
+STATEMENT: >>>
+Document 2 free text.
+<<<
+
+[[SECTION]]
+TITLE: Document 2 section
+
+[TEXT]
+STATEMENT: >>>
+Document 2 statement.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/input/strictdoc_config.py
+++ b/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/input/strictdoc_config.py
@@ -1,0 +1,8 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=[],
+    )
+    return config

--- a/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/test_case.py
+++ b/tests/end2end/screens/project_index/update_project_title_python_config_disabled_for_config_without_title/test_case.py
@@ -1,0 +1,42 @@
+"""
+@relation(SDOC-SRS-72, scope=file)
+"""
+
+import os
+import shutil
+
+from tests.end2end.conftest import DOWNLOADED_FILES_PATH
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+path_to_expected_downloaded_file = os.path.join(
+    DOWNLOADED_FILES_PATH, "export.reqif"
+)
+
+
+class Test(E2ECase):
+    def test(self):
+        shutil.rmtree(DOWNLOADED_FILES_PATH, ignore_errors=True)
+
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+
+            screen_project_index.do_update_project_title("UPDATED TITLE")
+
+            screen_project_index.assert_text(
+                "Renaming project title is not supported when a title is not "
+                "already configured to a previous value instrictdoc_config.py."
+            )
+
+        assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/expected_output/Document_1.sdoc
+++ b/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/expected_output/Document_1.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[TEXT]
+STATEMENT: >>>
+Document 1 free text.
+<<<
+
+[[SECTION]]
+TITLE: Document 1 section
+
+[TEXT]
+STATEMENT: >>>
+Document 1 statement.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/expected_output/Document_2.sdoc
+++ b/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/expected_output/Document_2.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Document 2
+
+[TEXT]
+STATEMENT: >>>
+Document 2 free text.
+<<<
+
+[[SECTION]]
+TITLE: Document 2 section
+
+[TEXT]
+STATEMENT: >>>
+Document 2 statement.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/expected_output/strictdoc.toml
@@ -1,0 +1,5 @@
+[project]
+
+features = [
+  "REQIF",
+]

--- a/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/input/Document_1.sdoc
+++ b/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/input/Document_1.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[TEXT]
+STATEMENT: >>>
+Document 1 free text.
+<<<
+
+[[SECTION]]
+TITLE: Document 1 section
+
+[TEXT]
+STATEMENT: >>>
+Document 1 statement.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/input/Document_2.sdoc
+++ b/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/input/Document_2.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Document 2
+
+[TEXT]
+STATEMENT: >>>
+Document 2 free text.
+<<<
+
+[[SECTION]]
+TITLE: Document 2 section
+
+[TEXT]
+STATEMENT: >>>
+Document 2 statement.
+<<<
+
+[[/SECTION]]

--- a/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/input/strictdoc.toml
+++ b/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/input/strictdoc.toml
@@ -1,0 +1,5 @@
+[project]
+
+features = [
+  "REQIF",
+]

--- a/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/test_case.py
+++ b/tests/end2end/screens/project_index/update_project_title_toml_deprecated_config/test_case.py
@@ -1,0 +1,43 @@
+"""
+@relation(SDOC-SRS-72, scope=file)
+"""
+
+import os
+import shutil
+
+from tests.end2end.conftest import DOWNLOADED_FILES_PATH
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+path_to_expected_downloaded_file = os.path.join(
+    DOWNLOADED_FILES_PATH, "export.reqif"
+)
+
+
+class Test(E2ECase):
+    def test(self):
+        shutil.rmtree(DOWNLOADED_FILES_PATH, ignore_errors=True)
+
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+
+            screen_project_index.do_update_project_title("UPDATED TITLE")
+
+            screen_project_index.assert_text(
+                "Renaming project title is not supported with TOML config files. "
+                "Switch from strictdoc_config.toml to strictdoc_config.py "
+                "and try again."
+            )
+
+        assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
# feat: edit project title in web-UI

Hi everyone,
I’ve implemented another feature and wanted to share it with you as well 🙂
In the web UI, you can now edit the project title. The code is independent of the previous MR. If you find this useful, feel free to pull it in.
As always, I welcome your feedback—especially if you notice any improvements or alternative approaches.