### PR TITLE
fix(backend/markdown): ensure that the parsed document gets an included document reference

### DIFF
--- a/strictdoc/backend/markdown/reader.py
+++ b/strictdoc/backend/markdown/reader.py
@@ -134,6 +134,8 @@ class SDMarkdownReader:
         document_reference.set_document(document)
         including_document_reference = DocumentReference()
 
+        document.ng_including_document_reference = including_document_reference
+
         detected_meta_style = SDMarkdownReader._parse_document_root(
             root_heading=heading_nodes[0],
             document=document,

--- a/tests/integration/features/_integration_/markdown_and_html2pdf_bundle_document/input.markdown
+++ b/tests/integration/features/_integration_/markdown_and_html2pdf_bundle_document/input.markdown
@@ -1,0 +1,5 @@
+# Dummy Software Requirements Specification #1
+
+## Section #1
+
+**UID**: SEC-1

--- a/tests/integration/features/_integration_/markdown_and_html2pdf_bundle_document/strictdoc_config.py
+++ b/tests/integration/features/_integration_/markdown_and_html2pdf_bundle_document/strictdoc_config.py
@@ -1,0 +1,10 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=[
+            "HTML2PDF",
+        ],
+    )
+    return config

--- a/tests/integration/features/_integration_/markdown_and_html2pdf_bundle_document/test.itest
+++ b/tests/integration/features/_integration_/markdown_and_html2pdf_bundle_document/test.itest
@@ -1,0 +1,19 @@
+#
+# Verify that a Markdown-based document can printed as bundle document to PDF.
+#
+# @relation(SDOC-SRS-51, scope=file)
+#
+
+REQUIRES: TEST_HTML2PDF
+
+RUN: %strictdoc export %S --formats=html2pdf --generate-bundle-document --output-dir %T | filecheck %s --dump-input=fail
+CHECK: html2pdf4doc: JS logs from the print session
+
+RUN: %check_exists --file %T/html2pdf/html/bundle-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/input-PDF.html
+
+RUN: %cat %T/html2pdf/html/bundle-PDF.html | filecheck %s --check-prefix CHECK-DOC-HTML
+
+CHECK-DOC-HTML: Untitled Project
+
+RUN: python %S/test_pdf.py

--- a/tests/integration/features/_integration_/markdown_and_html2pdf_bundle_document/test_pdf.py
+++ b/tests/integration/features/_integration_/markdown_and_html2pdf_bundle_document/test_pdf.py
@@ -1,0 +1,5 @@
+from pypdf import PdfReader
+
+reader = PdfReader("Output/html2pdf/pdf/bundle.pdf")
+
+assert len(reader.pages) == 3, reader.pages


### PR DESCRIPTION


WHY: This is needed for correct handling of documents parsed from Markdown. Otherwise, some features can't be used, e.g., printing bundle documents to PDF.

Fixes #2757