### PR TITLE
fix: gitignore now accepts escaped characters

### DIFF
--- a/strictdoc/helpers/path_filter.py
+++ b/strictdoc/helpers/path_filter.py
@@ -16,7 +16,7 @@ REGEX_MASK_VALIDATION = rf"[^(\\|\/)]{REGEX_DOUBLE_WILDCARD}"
 DISALLOWED_CHARACTERS = ("..", "{", "}", "?", "+", "!")
 
 # "~"" comes from Windows.
-ALLOWED_FIRST_CHARACTERS = ("*", "/", ".", "_", "~")
+ALLOWED_FIRST_CHARACTERS = ("*", "/", ".", "_", "~", "\\")
 
 
 def validate_mask(mask: str) -> None:


### PR DESCRIPTION
The filter was too restrictive, not accepting "\\" as a first character while it is an acceptable character for git ignore files. It has now been added to the list of allowed first characters.