### PR TITLE
chore: remove legacy --filter-requirements option

### DIFF
--- a/strictdoc/backend/sdoc/models/node.py
+++ b/strictdoc/backend/sdoc/models/node.py
@@ -210,7 +210,7 @@ class SDocNode(SDocNodeIF):
             self.ng_resolved_custom_level = level
             self.custom_level = level
 
-        # This is always true, unless the node is filtered out with --filter-requirements.
+        # This is always true, unless the node is filtered out with --filter-nodes.
         self.ng_whitelisted: bool = True
 
         self.ng_has_requirements: bool = False

--- a/strictdoc/commands/export.py
+++ b/strictdoc/commands/export.py
@@ -140,13 +140,11 @@ class ExportCommand(BaseCommand):
                 "SPEC-OBJECT's IDENTIFIER and vice versa when exporting/importing."
             ),
         )
-        # FIXME: --filter-requirements will be removed in 2026.
         command_parser_export.add_argument(
             "--filter-nodes",
-            "--filter-requirements",
             dest="filter_nodes",
             type=str,
-            help="Filter which requirements will be exported.",
+            help="Filter which nodes will be exported.",
         )
         command_parser_export.add_argument(
             "--view",

--- a/tests/integration/features/html/--filter-nodes/01_basic_filter/test.itest
+++ b/tests/integration/features/html/--filter-nodes/01_basic_filter/test.itest
@@ -1,5 +1,3 @@
-RUN: %strictdoc export %S --output-dir %T --filter-requirements='("2" in node["TITLE"] or "4" in node["TITLE"])' | filecheck %s --dump-input=fail
-RUN: rm -rf %T/*
 RUN: %strictdoc export %S --output-dir %T --filter-nodes='("2" in node["TITLE"] or "4" in node["TITLE"])' | filecheck %s --dump-input=fail
 CHECK: Published: Hello world doc
 

--- a/tests/integration/features/sdoc/passthrough/20_filter_requirements/test.itest
+++ b/tests/integration/features/sdoc/passthrough/20_filter_requirements/test.itest
@@ -1,4 +1,4 @@
-RUN: %expect_exit 0 %strictdoc export %S/input.sdoc --formats=sdoc --output-dir=%T --filter-requirements '("2" in node["TITLE"] or "4" in node["TITLE"])' | filecheck %s --dump-input=fail
+RUN: %expect_exit 0 %strictdoc export %S/input.sdoc --formats=sdoc --output-dir=%T --filter-nodes '("2" in node["TITLE"] or "4" in node["TITLE"])' | filecheck %s --dump-input=fail
 CHECK: Reading SDOC: input.sdoc
 
 RUN: %diff %S/expected/output.sdoc %T/sdoc/input.sdoc

--- a/tests/integration/features/sdoc/passthrough/30_in_place_rewrite/test.itest
+++ b/tests/integration/features/sdoc/passthrough/30_in_place_rewrite/test.itest
@@ -1,4 +1,4 @@
 RUN: mkdir %T/sandbox
 RUN: cp %S/input.sdoc %T/sandbox/
-RUN: %expect_exit 0 %strictdoc export %T/sandbox/input.sdoc --formats=sdoc --output-dir=%T/sandbox --filter-requirements='"2" not in node["TITLE"]'
+RUN: %expect_exit 0 %strictdoc export %T/sandbox/input.sdoc --formats=sdoc --output-dir=%T/sandbox --filter-nodes='"2" not in node["TITLE"]'
 RUN: %diff %S/expected.sdoc %T/sandbox/sdoc/input.sdoc


### PR DESCRIPTION
WHY: This option is deprecated some time ago in favour of the `--filter-nodes` option.