### PR TITLE
fix(tests/end2end): End2EndTestSetup: skip __pycache__ directories when diffing in/out folders

### DIFF
--- a/tests/end2end/end2end_test_setup.py
+++ b/tests/end2end/end2end_test_setup.py
@@ -103,7 +103,11 @@ class End2EndTestSetup:
     def find_files(path_to_dir):
         assert os.path.isdir(path_to_dir), path_to_dir
         matches = []
-        for root, _, filenames in os.walk(path_to_dir, topdown=True):
+        for root, dirs, filenames in os.walk(path_to_dir, topdown=True):
+            # Skip __pycache__
+            # Example: strictdoc_config.py causes an entry in __pycache__ to be created.
+            if "__pycache__" in dirs:
+                dirs.remove("__pycache__")
             for filename in filenames:
                 relative_path = os.path.relpath(
                     os.path.join(root, filename), start=path_to_dir


### PR DESCRIPTION

WHY: Ensures that the test diffing works correctly and the __pycache__ folder does not get in the way.

HOW: Extracted from #2766.