### PR TITLE
 refactor(sdoc): change FileEntry from function/clazz to element/id

### DIFF
--- a/strictdoc/backend/sdoc/grammar/type_system.py
+++ b/strictdoc/backend/sdoc/grammar/type_system.py
@@ -48,10 +48,14 @@ FileReference[noskipws]:
 
 FileEntry[noskipws]:
   ('  FORMAT: ' g_file_format = FileEntryFormat '\n')?
-   '  VALUE: ' g_file_path = /.*$/ '\n'
+  ('  VALUE: ' g_deprecated_file_path = /.*$/ '\n')?
+  ('  PATH: ' g_file_path = /.*$/ '\n')?
+  ('  ELEMENT: ' element = /.*$/ '\n')?
+  ('  ID: ' id = /.*$/ '\n')?
   ('  LINE_RANGE: ' g_line_range = /.*$/ '\n')?
   ('  FUNCTION: ' function = /.*$/ '\n')?
   ('  CLASS: ' clazz = /.*$/ '\n')?
+  ('  HASH: ' hash = /.*$/ '\n')?
 ;
 
 FileEntryFormat[noskipws]:

--- a/strictdoc/backend/sdoc/models/document_grammar.py
+++ b/strictdoc/backend/sdoc/models/document_grammar.py
@@ -46,6 +46,7 @@ class DocumentGrammar(SDocGrammarIF):
     def create_default(
         parent: Optional[SDocDocumentIF],
         enable_mid: bool = False,
+        include_child_relation: bool = False,
     ) -> "DocumentGrammar":
         """
         @relation(SDOC-SRS-93, scope=function)
@@ -133,7 +134,8 @@ class DocumentGrammar(SDocGrammarIF):
         # @relation(SDOC-SRS-132, scope=range_end)
 
         requirement_element.relations = GrammarElement.create_default_relations(
-            requirement_element
+            requirement_element,
+            include_child=include_child_relation,
         )
 
         elements: List[GrammarElement] = []

--- a/strictdoc/backend/sdoc/models/grammar_element.py
+++ b/strictdoc/backend/sdoc/models/grammar_element.py
@@ -344,19 +344,31 @@ class GrammarElement:
     @staticmethod
     def create_default_relations(
         parent: "GrammarElement",
+        include_child: bool = False,
     ) -> List[GrammarElementRelationType]:
-        return [
+        relations: List[GrammarElementRelationType] = [
             GrammarElementRelationParent(
                 parent=parent,
                 relation_type="Parent",
                 relation_role=None,
             ),
+        ]
+        if include_child:
+            relations.append(
+                GrammarElementRelationChild(
+                    parent=parent,
+                    relation_type="Child",
+                    relation_role=None,
+                )
+            )
+        relations.append(
             GrammarElementRelationFile(
                 parent=parent,
                 relation_type="File",
                 relation_role=None,
-            ),
-        ]
+            )
+        )
+        return relations
 
     def is_field_multiline(self, field_name: str) -> bool:
         field_index = self.field_titles.index(field_name)

--- a/strictdoc/backend/sdoc/models/reference.py
+++ b/strictdoc/backend/sdoc/models/reference.py
@@ -2,7 +2,7 @@
 @relation(SDOC-SRS-31, SDOC-SRS-101, scope=file)
 """
 
-from typing import Any, Optional, Tuple
+from typing import Any, Optional, Tuple, Union
 
 from strictdoc.backend.sdoc.models.grammar_element import ReferenceType
 from strictdoc.helpers.auto_described import auto_described
@@ -17,26 +17,51 @@ class FileEntry:
         g_file_format: Optional[str],
         g_file_path: str,
         g_line_range: Optional[str],
-        function: Optional[str],
-        clazz: Optional[str],
+        g_deprecated_file_path: Optional[str] = None,
+        function: Optional[str] = None,
+        clazz: Optional[str] = None,
+        element: Optional[str] = None,
+        id: Optional[str] = None,  # noqa: A002
+        hash: Optional[str] = None,  # noqa: A002
     ):
         self.parent = parent
 
         # Default: FileEntryFormat.SOURCECODE  # noqa: ERA001
         self.g_file_format: Optional[str] = g_file_format
+        self.g_deprecated_file_path: Optional[str] = None
+
+        if (
+            g_deprecated_file_path is not None
+            and len(g_deprecated_file_path) > 0
+        ):
+            g_file_path = g_deprecated_file_path
+            self.g_deprecated_file_path = g_deprecated_file_path
 
         # TODO: Might be worth to prohibit the use of Windows paths altogether.
         self.g_file_path: str = g_file_path
         file_path_posix = g_file_path.replace("\\", "/")
         self.file_path_posix = file_path_posix
 
-        # The textX parser passes an empty string even if there is no LINE_RANGE
-        # provided in the SDoc source.
+        #
+        # For optional string fields:
+        # The textX parser passes an empty string even if there is no field
+        # present in the input. We want to convert such empty strings to None
+        # for better semantics and easier handling in the rest of the code.
+        #
         g_line_range = (
             g_line_range
             if g_line_range is not None and len(g_line_range) > 0
             else None
         )
+        self.deprecated_function = (
+            function if function is not None and len(function) > 0 else None
+        )
+        self.deprecated_clazz = (
+            clazz if clazz is not None and len(clazz) > 0 else None
+        )
+        _id = id if id is not None and len(id) > 0 else None
+        element = element if element is not None and len(element) > 0 else None
+        _hash = hash if hash is not None and len(hash) > 0 else None
 
         self.g_line_range: Optional[str] = g_line_range
         self.line_range: Optional[Tuple[int, int]] = None
@@ -48,14 +73,46 @@ class FileEntry:
                 int(range_components_str[1]),
             )
 
-        # The textX parser parses an optional element as an empty string. We
-        # make it to None ourselves.
-        self.function: Optional[str] = (
-            function if function is not None and len(function) > 0 else None
-        )
-        self.clazz: Optional[str] = (
-            clazz if clazz is not None and len(clazz) > 0 else None
-        )
+        if element is not None:
+            self.element: Optional[str] = element
+            self.id: Optional[str] = _id
+        elif self.deprecated_function is not None:
+            self.element = "function"
+            self.id = self.deprecated_function
+        elif self.deprecated_clazz is not None:
+            self.element = "class"
+            self.id = self.deprecated_clazz
+        else:
+            self.element = None
+            self.id = None
+
+        # Placeholder for drift-detection hash (no runtime functionality yet).
+        self.hash: Optional[str] = _hash
+
+    def __setattr__(self, name: str, value: Union[str, Any]) -> None:
+        # Ignore legacy function and clazz from textX post-init. The attributes are already converted to
+        # during __init__.
+        if name in ("function", "clazz"):
+            return
+        object.__setattr__(self, name, value)
+
+    def function(self) -> Optional[str]:
+        if self.deprecated_function is not None:
+            return self.deprecated_function
+
+        if self.element == "function":
+            return self.id
+
+        return None
+
+    def clazz(self) -> Optional[str]:
+        if self.deprecated_clazz is not None:
+            return self.deprecated_clazz
+
+        if self.element == "class":
+            return self.id
+
+        return None
 
 
 class FileEntryFormat:

--- a/strictdoc/backend/sdoc/writer.py
+++ b/strictdoc/backend/sdoc/writer.py
@@ -502,18 +502,44 @@ class SDWriter:
                     output += "  FORMAT: "
                     output += file_format
                     output += "\n"
-                output += "  VALUE: "
+
+                if ref.g_file_entry.g_deprecated_file_path is not None:
+                    output += "  VALUE: "
+                else:
+                    output += "  PATH: "
+
                 output += ref.get_posix_path()
                 output += "\n"
-                if ref.g_file_entry.line_range is not None:
+                if (
+                    ref.g_file_entry.deprecated_function is None
+                    and ref.g_file_entry.deprecated_clazz is None
+                    and ref.g_file_entry.element is not None
+                    and ref.g_file_entry.id is not None
+                ):
+                    output += "  ELEMENT: "
+                    output += ref.g_file_entry.element
+                    output += "\n"
+                    output += "  ID: "
+                    output += ref.g_file_entry.id
+                    output += "\n"
+                elif ref.g_file_entry.line_range is not None:
                     output += "  LINE_RANGE: "
                     output += str(ref.g_file_entry.line_range[0])
                     output += ", "
                     output += str(ref.g_file_entry.line_range[1])
                     output += "\n"
-                elif ref.g_file_entry.function is not None:
+                elif ref.g_file_entry.deprecated_function is not None:
                     output += "  FUNCTION: "
-                    output += str(ref.g_file_entry.function)
+                    output += str(ref.g_file_entry.deprecated_function)
+                    output += "\n"
+                elif ref.g_file_entry.deprecated_clazz is not None:
+                    output += "  CLASS: "
+                    output += str(ref.g_file_entry.deprecated_clazz)
+                    output += "\n"
+
+                if ref.g_file_entry.hash is not None:
+                    output += "  HASH: "
+                    output += str(ref.g_file_entry.hash)
                     output += "\n"
 
             elif isinstance(reference, ParentReqReference):

--- a/strictdoc/backend/sdoc_source_code/coverage_reports/gcov.py
+++ b/strictdoc/backend/sdoc_source_code/coverage_reports/gcov.py
@@ -212,8 +212,8 @@ class GCovJSONReader:
                             g_file_format=FileEntryFormat.SOURCECODE,
                             g_file_path=json_file_name,
                             g_line_range=None,
-                            function=json_function_name,
-                            clazz=None,
+                            element="function",
+                            id=json_function_name,
                         ),
                     )
                 )

--- a/strictdoc/backend/sdoc_source_code/test_reports/junit_xml_reader.py
+++ b/strictdoc/backend/sdoc_source_code/test_reports/junit_xml_reader.py
@@ -388,8 +388,8 @@ class JUnitXMLReader:
                                     g_file_format=FileEntryFormat.SOURCECODE,
                                     g_file_path=test_case_node_test_path,
                                     g_line_range=None,
-                                    function=test_case_node_test_function,
-                                    clazz=None,
+                                    element="function",
+                                    id=test_case_node_test_function,
                                 ),
                             )
                         )
@@ -402,8 +402,8 @@ class JUnitXMLReader:
                                     g_file_format=FileEntryFormat.SOURCECODE,
                                     g_file_path="#FORWARD#",
                                     g_line_range=None,
-                                    function=test_case_node_test_function,
-                                    clazz=None,
+                                    element="function",
+                                    id=test_case_node_test_function,
                                 ),
                             )
                         )

--- a/strictdoc/backend/sdoc_source_code/test_reports/robot_xml_reader.py
+++ b/strictdoc/backend/sdoc_source_code/test_reports/robot_xml_reader.py
@@ -172,8 +172,8 @@ class SdocVisitor(ResultVisitor):  # type: ignore[misc]
                         g_file_format=FileEntryFormat.SOURCECODE,
                         g_file_path="#FORWARD#",
                         g_line_range=None,
-                        function=test.name,
-                        clazz=None,
+                        element="function",
+                        id=test.name,
                     ),
                 )
             )

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -301,8 +301,8 @@ class FileTraceabilityIndex:
                         g_file_format=relation_.g_file_entry.g_file_format,
                         g_file_path=resolved_path_to_function_file,
                         g_line_range=None,
-                        function=test_function,
-                        clazz=None,
+                        element="function",
+                        id=test_function,
                     )
 
                     forward_requirement_.set_field_value(
@@ -360,25 +360,31 @@ class FileTraceabilityIndex:
                     forward_requirement_.reserved_uid, OrderedSet()
                 ).add(file_posix_path)
 
-                if file_reference.g_file_entry.function is not None:
+                if (
+                    file_reference.g_file_entry.element == "function"
+                    and file_reference.g_file_entry.id is not None
+                ):
                     one_file_function_name_to_reqs_uids = (
                         self.map_file_function_names_to_reqs_uids.setdefault(
                             file_posix_path, {}
                         )
                     )
                     one_file_function_name_to_reqs_uids.setdefault(
-                        file_reference.g_file_entry.function, []
+                        file_reference.g_file_entry.id, []
                     ).append(
                         (forward_requirement_.reserved_uid, relation_.role)
                     )
-                elif file_reference.g_file_entry.clazz is not None:
+                elif (
+                    file_reference.g_file_entry.element == "class"
+                    and file_reference.g_file_entry.id is not None
+                ):
                     one_file_class_name_to_reqs_uids = (
                         self.map_file_class_names_to_reqs_uids.setdefault(
                             file_posix_path, {}
                         )
                     )
                     one_file_class_name_to_reqs_uids.setdefault(
-                        file_reference.g_file_entry.clazz, []
+                        file_reference.g_file_entry.id, []
                     ).append(
                         (forward_requirement_.reserved_uid, relation_.role)
                     )

--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -547,8 +547,6 @@ class RequirementFormObject(ErrorObject):
                     g_file_format=FileEntryFormat.SOURCECODE,
                     g_file_path=reference_field.field_value,
                     g_line_range="",
-                    function=None,
-                    clazz=None,
                 )
                 references.append(
                     FileReference(

--- a/strictdoc/export/spdx/spdx_to_sdoc_converter.py
+++ b/strictdoc/export/spdx/spdx_to_sdoc_converter.py
@@ -284,8 +284,6 @@ class SPDXToSDocConverter:
                     g_file_format=None,
                     g_file_path=file.name,
                     g_line_range=None,
-                    function=None,
-                    clazz=None,
                 ),
             )
         ]
@@ -340,8 +338,6 @@ class SPDXToSDocConverter:
                     g_file_format=None,
                     g_file_path=spdx_file.name,
                     g_line_range=f"{snippet.line_range.begin}, {snippet.line_range.end - 1}",
-                    function=None,
-                    clazz=None,
                 ),
             )
         ]

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_relations.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_relations.py
@@ -124,6 +124,54 @@ RELATIONS:
   ROLE: TestDefinition
   VALUE: tools/testing/selftests/devmem/devmem.c
   FUNCTION: test_function
+- TYPE: File
+  ROLE: TestDefinition
+  VALUE: tools/testing/selftests/devmem/devmem.c
+  CLASS: FooClass
+""".lstrip()
+
+    reader = SDReader()
+
+    document = reader.read(input_sdoc)
+    assert isinstance(document, SDocDocument)
+
+    writer = SDWriter(default_project_config)
+    output = writer.write(document)
+
+    assert input_sdoc == output
+
+
+def test_004_file_relations_element_and_id(default_project_config):
+    input_sdoc = """
+[DOCUMENT]
+TITLE: Test Doc
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+  RELATIONS:
+  - TYPE: File
+
+[REQUIREMENT]
+STATEMENT: >>>
+This is a statement.
+<<<
+RELATIONS:
+- TYPE: File
+  ROLE: TestDefinition
+  PATH: tools/testing/selftests/devmem/devmem.c
+  ELEMENT: Function
+  ID: test_function
+  HASH: abc123
 """.lstrip()
 
     reader = SDReader()


### PR DESCRIPTION
WHAT: Refactor FileEntry. In the former model, a source code element was always either a function or a class. In the changed model, a source code element can be anything. It is therefore no longer reasonable to hardcode attributes function and clazz. Rather describe it as optional element string and mandatory id. This change only affects the inner representation. SDoc syntax still uses the old FUNCTION:/CLASS: fields for backwards compatibility.

WHY: There are multiple reasons for this change:
- We want to reference more element kinds, not only functions and classes (say macros, structs, enums in C). The kinds are language specific and shall be easily extensible for StrictDoc.
- Some languages like Rust have a single namespace for all elements. For example, if we say "file.c:foo" in C, there could be a struct foo and a function void foo() in the same file. In Rust, no such overload is allowed. In consequence, it is possible to infer the kind from the identifier.
- Prepare ground for upcoming markdown forward relations, that shall use the element/id form right from the start.