### PR TITLE
refactor(sdoc): move .ng_level variable to SDocNodeContext

### DIFF
--- a/strictdoc/backend/reqif/p01_sdoc/reqif_to_sdoc_converter.py
+++ b/strictdoc/backend/reqif/p01_sdoc/reqif_to_sdoc_converter.py
@@ -543,7 +543,7 @@ class P01_ReqIFToSDocConverter:
             if grammar_element.property_is_composite
             else None,
         )
-        requirement.ng_level = level
+        requirement.context.ng_level = level
         requirement.ng_document_reference = document_reference
         requirement.ng_including_document_reference = DocumentReference()
 

--- a/strictdoc/backend/reqif/p01_sdoc/sdoc_to_reqif_converter.py
+++ b/strictdoc/backend/reqif/p01_sdoc/sdoc_to_reqif_converter.py
@@ -278,13 +278,15 @@ class P01_SDocToReqIFObjectConverter:
             node_stack: List[ReqIFSpecHierarchy] = [root_hierarchy]
 
             # FIXME: ReqIF must export complete documents including fragments.
-            for node_, _ in document_iterator.all_content(
+            for node_, node_context_ in document_iterator.all_content(
                 print_fragments=False
             ):
                 if not isinstance(node_, SDocNode):
                     continue
                 leaf_or_composite_node = assert_cast(node_, SDocNode)
-                while len(node_stack) > assert_cast(node_.ng_level, int):
+                while len(node_stack) > assert_cast(
+                    node_context_.get_level(), int
+                ):
                     node_stack.pop()
 
                 current_hierarchy = node_stack[-1]
@@ -305,7 +307,7 @@ class P01_SDocToReqIFObjectConverter:
                     spec_object=spec_object.identifier,
                     children=None,
                     ref_then_children_order=True,
-                    level=leaf_or_composite_node.ng_level,
+                    level=node_context_.get_level(),
                 )
                 current_hierarchy.add_child(hierarchy)
                 if leaf_or_composite_node.is_composite:

--- a/strictdoc/backend/sdoc/models/document.py
+++ b/strictdoc/backend/sdoc/models/document.py
@@ -25,19 +25,17 @@ from strictdoc.backend.sdoc.models.model import (
     SDocElementIF,
     SDocNodeIF,
 )
-from strictdoc.backend.sdoc.models.node import SDocNode, SDocNodeField
+from strictdoc.backend.sdoc.models.node import (
+    SDocNode,
+    SDocNodeContext,
+    SDocNodeField,
+)
 from strictdoc.core.document_meta import DocumentMeta
 from strictdoc.helpers.auto_described import auto_described
 from strictdoc.helpers.cast import assert_cast
 from strictdoc.helpers.mid import MID
 from strictdoc.helpers.ordered_set import OrderedSet
 from strictdoc.helpers.string import tokenize
-
-
-@auto_described
-class SDocDocumentContext:
-    def __init__(self) -> None:
-        self.title_number_string: Optional[str] = None
 
 
 @dataclass
@@ -82,8 +80,6 @@ class SDocDocument(SDocDocumentIF):
 
         self.fragments_from_files: List[SDocDocumentFromFileIF] = []
 
-        # FIXME: Is this used?
-        self.ng_level: int = 0
         self.ng_has_requirements = False
 
         self.meta: Optional[DocumentMeta] = None
@@ -91,7 +87,7 @@ class SDocDocument(SDocDocumentIF):
         self.reserved_mid: MID = MID(mid) if mid is not None else MID.create()
         self.mid_permanent: bool = mid is not None
         self.included_documents: List[SDocDocumentIF] = []
-        self.context: SDocDocumentContext = SDocDocumentContext()
+        self.context: SDocNodeContext = SDocNodeContext()
 
         self.ng_including_document_reference: Optional[DocumentReference] = None
         self.ng_including_document_from_file: Optional[

--- a/strictdoc/backend/sdoc/models/free_text.py
+++ b/strictdoc/backend/sdoc/models/free_text.py
@@ -5,7 +5,6 @@ class FreeTextContainer:
     def __init__(self, parts: List[Any]) -> None:
         assert isinstance(parts, list)
         self.parts = parts
-        self.ng_level = None
         self.ng_line_start: Optional[int] = None
         self.ng_line_end: Optional[int] = None
         self.ng_col_start: Optional[int] = None

--- a/strictdoc/backend/sdoc/models/node.py
+++ b/strictdoc/backend/sdoc/models/node.py
@@ -3,6 +3,7 @@
 """
 
 from collections import OrderedDict
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Generator, List, Optional, Tuple, Union
 
@@ -36,10 +37,10 @@ from strictdoc.helpers.mid import MID
 from strictdoc.helpers.string import ensure_newline
 
 
-@auto_described
+@dataclass
 class SDocNodeContext:
-    def __init__(self) -> None:
-        self.title_number_string: Optional[str] = None
+    title_number_string: Optional[str] = None
+    ng_level: int = 0
 
 
 class SDocNodeFieldOrigin(str, Enum):
@@ -181,7 +182,6 @@ class SDocNode(SDocNodeIF):
         self.ordered_fields_lookup: OrderedDict[str, List[SDocNodeField]] = (
             ordered_fields_lookup
         )
-        self.ng_level: Optional[int] = None
         self.ng_document_reference: Optional[DocumentReference] = None
         self.ng_including_document_reference: Optional[DocumentReference] = None
         self.ng_line_start: Optional[int] = None

--- a/strictdoc/core/document_iterator.py
+++ b/strictdoc/core/document_iterator.py
@@ -110,7 +110,7 @@ class SDocDocumentIterator:
             )
             if update_levels:
                 node.context.title_number_string = context.get_level_string()
-                node.ng_level = context.get_level()
+                node.context.ng_level = context.get_level()
 
             yield node, context
 
@@ -145,7 +145,7 @@ class SDocDocumentIterator:
                     node.context.title_number_string = (
                         context.get_level_string()
                     )
-                    node.ng_level = context.get_level()
+                    node.context.ng_level = context.get_level()
 
                 yield node, context
 

--- a/strictdoc/export/html/templates/components/node_field/section_h/index.jinja
+++ b/strictdoc/export/html/templates/components/node_field/section_h/index.jinja
@@ -4,8 +4,8 @@
 <sdoc-section-title
   data-level="{{ sdoc_entity.context.title_number_string }}"
 >
-  {%- set h_level = sdoc_entity.ng_level + 1
-      if sdoc_entity.ng_level < 6
+  {%- set h_level = sdoc_entity.context.ng_level + 1
+      if sdoc_entity.context.ng_level < 6
       else 6 -%}
 
   <h{{ h_level }}>

--- a/strictdoc/export/html/templates/components/node_field/section_h/pdf.jinja
+++ b/strictdoc/export/html/templates/components/node_field/section_h/pdf.jinja
@@ -4,8 +4,8 @@
 <sdoc-section-title
   data-level="{{ sdoc_entity.context.title_number_string }}"
 >
-  {%  set h_level = sdoc_entity.ng_level + 1
-      if sdoc_entity.ng_level < 6
+  {%  set h_level = sdoc_entity.context.ng_level + 1
+      if sdoc_entity.context.ng_level < 6
       else 6  %}
   <h{{ h_level }}
     id="{{ view_object.render_local_anchor(section) }}"

--- a/strictdoc/export/html/templates/components/node_field/title/index.jinja
+++ b/strictdoc/export/html/templates/components/node_field/title/index.jinja
@@ -12,8 +12,8 @@
         and node_view not in ['table', 'zebra', 'simple', 'inline']
     -%}
 
-    {%- set h_level = sdoc_entity.ng_level + 1
-        if sdoc_entity.ng_level < 6
+    {%- set h_level = sdoc_entity.context.ng_level + 1
+        if sdoc_entity.context.ng_level < 6
         else 6 -%}
 
     {% if title_has_h_level %}<h{{ h_level }}>{% endif %}

--- a/strictdoc/export/html/templates/screens/document/_shared/toc.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/toc.jinja
@@ -8,7 +8,7 @@
       data-last_moved_node_id="{{ last_moved_node_id.get_string_value() }}"
       {% endif -%}
     >
-    {%- for section, _ in view_object.table_of_contents() -%}
+    {%- for section, node_context_ in view_object.table_of_contents() -%}
       <li data-nodeid="{{ section.reserved_mid.get_string_value() }}">
         {%- if section.is_document() -%}
           {%- if not section.ng_has_requirements and view_object.is_deeptrace() -%}
@@ -18,7 +18,7 @@
               </span>{{ section.title }}
             </span>
           {#
-             The calculation below: "&nbsp;" * (section.ng_level * 2 - 1)
+             The calculation below: "&nbsp;" * (node_context_.get_level() * 2 - 1)
              is needed to accommodate for the case when a section or a
              requirement don't have a numeric level set (LEVEL: None).
              Empty spaces &nbsp; ensure the lines in the TOC are still aligned
@@ -32,7 +32,7 @@
               data-turbo="false"
             >
               <span class="section-number">
-                {{ section.context.title_number_string if section.context.title_number_string else "&nbsp;"|safe * (section.ng_level * 2 - 1) }}
+                {{ section.context.title_number_string if section.context.title_number_string else "&nbsp;"|safe * (node_context_.get_level() * 2 - 1) }}
               </span>{{- section.title -}}
               {# TODO #fragment #}
               {# {{ section.document_is_included() }} {{ section.get_parent_or_including_document().reserved_title }}/{{ section.get_document().reserved_title }} #}
@@ -46,7 +46,7 @@
           data-turbo="false"
         >
           <span class="section-number">
-            {{ section.context.title_number_string if section.context.title_number_string else "&nbsp;"|safe * (section.ng_level * 2 - 1) }}
+            {{ section.context.title_number_string if section.context.title_number_string else "&nbsp;"|safe * (node_context_.get_level() * 2 - 1) }}
           </span>
           {%- if section.reserved_title is not none -%}
             {{- section.reserved_title -}}
@@ -57,11 +57,11 @@
         {%- endif -%}
 
       {%- if not loop.last -%}
-        {%- if loop.nextitem[0].ng_level > section.ng_level -%}
+        {%- if loop.nextitem[1].get_level() > node_context_.get_level() -%}
           <ul>
-        {%- elif loop.nextitem[0].ng_level < section.ng_level -%}
+        {%- elif loop.nextitem[1].get_level() < node_context_.get_level() -%}
             </li>
-          {%- for x in range(0, section.ng_level - loop.nextitem[0].ng_level) -%}
+          {%- for x in range(0, node_context_.get_level() - loop.nextitem[1].get_level()) -%}
             </ul>
             </li>
           {%- endfor -%}
@@ -70,7 +70,7 @@
         {%- endif -%}
       {%- else -%}
         </li>
-        {%- for x in range(0, section.ng_level - 1) -%}
+        {%- for x in range(0, node_context_.get_level() - 1) -%}
             </ul>
             </li>
           {%- endfor -%}

--- a/strictdoc/export/html/templates/screens/document/pdf/toc.jinja
+++ b/strictdoc/export/html/templates/screens/document/pdf/toc.jinja
@@ -5,12 +5,12 @@
     <span class="pdf-toc-cell" style="text-align: center;font-weight: bold;">Table of contents</span>
     <span class="pdf-toc-cell"></span>
     </div>
-    {%- for item, _ in view_object.document_iterator.table_of_contents() -%}
+    {%- for item, node_context_ in view_object.document_iterator.table_of_contents() -%}
 
       <div class="pdf-toc-row" data-nodeid="{{ item.reserved_mid }}">
 
           <span class="pdf-toc-cell">
-            {{ item.context.title_number_string if item.context.title_number_string else "&nbsp;"|safe * (item.ng_level * 2 - 1) }}
+            {{ item.context.title_number_string if item.context.title_number_string else "&nbsp;"|safe * (node_context_.get_level() * 2 - 1) }}
           </span>
           <span dotted class="pdf-toc-cell">
             <a href="#{{ view_object.render_local_anchor(item) }}" data-turbo="false">

--- a/strictdoc/export/html/templates/screens/git/node/document.jinja
+++ b/strictdoc/export/html/templates/screens/git/node/document.jinja
@@ -11,7 +11,7 @@
       {%- include "components/badge/index.jinja" -%}
     {%- endwith -%}
     <span>
-      {{ document.context.title_number_string if document.context.title_number_string else "&nbsp;"|safe * (document.ng_level * 2 - 1) }}
+      {{ document.context.title_number_string if document.context.title_number_string else "&nbsp;"|safe * (document.context.ng_level * 2 - 1) }}
     </span>
     <span>{{ document.reserved_title }}</span>
     {%- if tab == "diff" -%}

--- a/strictdoc/export/html/templates/screens/git/node/requirement.jinja
+++ b/strictdoc/export/html/templates/screens/git/node/requirement.jinja
@@ -16,7 +16,7 @@
       {%- include "components/badge/index.jinja" -%}
     {%- endwith -%}
     <span>
-      {{ requirement.context.title_number_string if requirement.context.title_number_string else "&nbsp;"|safe * (requirement.ng_level * 2 - 1) }}
+      {{ requirement.context.title_number_string if requirement.context.title_number_string else "&nbsp;"|safe * (requirement.context.ng_level * 2 - 1) }}
     </span>
     {%- if requirement.reserved_title is not none -%}
       <span>

--- a/strictdoc/export/rst/templates/requirement.jinja.rst
+++ b/strictdoc/export/rst/templates/requirement.jinja.rst
@@ -4,7 +4,7 @@
 {% endif -%}
 
 {%- if requirement.reserved_title is not none -%}
-{{ _print_rst_header(requirement.reserved_title, requirement.ng_level) }}
+{{ _print_rst_header(requirement.reserved_title, requirement.context.ng_level) }}
 
 {% endif -%}
 

--- a/strictdoc/export/rst/writer.py
+++ b/strictdoc/export/rst/writer.py
@@ -33,16 +33,16 @@ class RSTWriter:
                 document.title, 0, reference_uid=document_uid
             )
 
-        for content_node, _ in document_iterator.all_content():
+        for content_node, node_context_ in document_iterator.all_content():
             if (
                 isinstance(content_node, SDocNode)
                 and content_node.node_type == "SECTION"
             ):
-                assert content_node.ng_level is not None
+                assert node_context_.get_level() is not None
                 assert content_node.reserved_title is not None
                 output += self._print_rst_header(
                     content_node.reserved_title,
-                    content_node.ng_level,
+                    node_context_.get_level(),
                     content_node.reserved_uid,
                 )
 


### PR DESCRIPTION
WHY: This is one more step for reducing the complexity of the core classes SDocNode and SDocDocument.