### PR TITLE
feat(backend/sdoc_source_code): recognize and allow forward linking to selected C macros as functions

### DIFF
--- a/docs/strictdoc_22_l3_low_level_requirements.sdoc
+++ b/docs/strictdoc_22_l3_low_level_requirements.sdoc
@@ -964,4 +964,72 @@ RELATIONS:
 
 [[/SECTION]]
 
+[[SECTION]]
+MID: deab09f3aa374b46a639c504267c60f9
+TITLE: C
+
+[REQUIREMENT]
+MID: 5d49af5c74794e7ab0a77fe99576243c
+UID: SDOC-LLR-206
+TITLE: Macro definitions
+STATEMENT: >>>
+StrictDoc's C reader shall recognize the special macro definitions as function definitions:
+
+Special macro definitions:
+
+1) The following Zephyr test macro:
+
+.. code:: c
+
+    ZTEST_USER(semaphore, test_sem_take_multiple) {
+
+    }
+
+shall be recognized as a function with a title ``ZTEST_USER(semaphore, test_sem_take_multiple)``.
+
+2) The following Linux syscall macro:
+
+.. code:: c
+
+    SYSCALL_DEFINE2(clock_gettime, const clockid_t, which_clock,
+                    struct __kernel_timespec __user *, tp)
+    {
+        // ...
+        return error;
+    }
+
+shall be recognized as a function with a title ``SYSCALL_DEFINE2(clock_gettime, const clockid_t, which_clock, struct __kernel_timespec __user *, tp)`` with all newlines character replaced with a space character each but all content and punctuation preserved otherwise.
+<<<
+
+[REQUIREMENT]
+MID: a06d47fd0998421a867a9de4376fdfee
+UID: SDOC-LLR-207
+STATUS: Active
+TITLE: Forward links to macro definitions using regexes
+STATEMENT: >>>
+StrictDoc shall allow linking SDoc nodes to C macro definitions using regexes as follows:
+
+1) The forward link:
+
+.. code:: strictdoc
+
+    [REQUIREMENT]
+    UID: ...
+    STATEMENT: ...
+    RELATIONS:
+    - TYPE: File
+      VALUE: tests/kernel/semaphore/semaphore/src/main.c
+      FUNCTION: /ZTEST_USER.*semaphore.*test_k_sem_correct_count_limit/
+
+shall match the following C source code macro definition:
+
+.. code:: c
+
+    ZTEST_USER(semaphore, test_sem_take_multiple) {
+      // Some code
+    }
+<<<
+
+[[/SECTION]]
+
 [[/SECTION]]

--- a/strictdoc/backend/sdoc_source_code/reader_c.py
+++ b/strictdoc/backend/sdoc_source_code/reader_c.py
@@ -2,7 +2,7 @@
 @relation(SDOC-SRS-142, SDOC-SRS-146, scope=file)
 """
 
-from typing import List, Optional, Sequence
+from typing import Final, List, Optional, Sequence
 
 import tree_sitter_cpp
 from tree_sitter import Language, Node, Parser
@@ -38,6 +38,20 @@ from strictdoc.backend.sdoc_source_code.tree_sitter_helpers import (
 from strictdoc.helpers.cast import assert_cast
 from strictdoc.helpers.file_stats import SourceFileStats
 from strictdoc.helpers.file_system import file_open_read_bytes
+
+KNOWN_FUNCTION_DEFINITION_MACROS: Final[frozenset[str]] = frozenset(
+    (
+        # Linux
+        "SYSCALL_DEFINE2",
+        # Google Test
+        "TEST",
+        "TEST_F",
+        "TEST_P",
+        "TYPED_TEST",
+        # Zephyr
+        "ZTEST_USER",
+    )
+)
 
 
 class SourceFileTraceabilityReader_C:
@@ -267,10 +281,19 @@ class SourceFileTraceabilityReader_C:
                 # Remove extra trailing spaces, newlines etc added by code-formatting or linters
                 function_name = " ".join(function_name.split())
                 parent_names = self.get_node_ns(node_)
-                # FIXME: Special hack for Google Test macros TEST, TEST_F, TEST_P.
-                if function_name.startswith("TEST") or function_name.startswith(
-                    "TYPED_TEST"
-                ):
+
+                # The first if branch handles a special case where selected
+                # macros are actually function definitions. Typical examples of
+                # such functions:
+                # 1) Google Test TEST(...)
+                # 2) Zephyr RTOS ZTEST_USER(...)
+                # 3) Linux SYSCALL2_DEFINE etc.
+                if function_display_name in KNOWN_FUNCTION_DEFINITION_MACROS:
+                    # Make the display name to include the entire macro/function
+                    # signature.
+                    # Example of this case:
+                    # function_name: ZTEST_USER(semaphore, test_k_sem_correct_count_limit)  # noqa: ERA001
+                    # function_display_name (before assignment): ZTEST_USER
                     function_display_name = function_name
                 elif len(parent_names) > 0:
                     function_name = (

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -1,7 +1,8 @@
 """
-@relation(SDOC-SRS-28, SDOC-SRS-33, scope=file)
+@relation(SDOC-SRS-28, SDOC-SRS-33, SDOC-LLR-207, scope=file)
 """
 
+import re
 from copy import copy
 from typing import (
     TYPE_CHECKING,
@@ -718,11 +719,37 @@ class FileTraceabilityIndex:
     def get_req_uids_by_function_name(
         self, rel_path_posix: str, name: str
     ) -> Optional[List[Tuple[str, Optional[str]]]]:
-        if rel_path_posix in self.map_file_function_names_to_reqs_uids:
-            return self.map_file_function_names_to_reqs_uids[
-                rel_path_posix
-            ].get(name, None)
-        return None
+        if rel_path_posix not in self.map_file_function_names_to_reqs_uids:
+            return None
+
+        function_names_to_reqs_uids = self.map_file_function_names_to_reqs_uids[
+            rel_path_posix
+        ]
+
+        matching_req_uids: List[Tuple[str, Optional[str]]] = []
+        exact_matching_req_uids = function_names_to_reqs_uids.get(name, None)
+        if exact_matching_req_uids is not None:
+            matching_req_uids.extend(exact_matching_req_uids)
+
+        for function_name_, req_uids_ in function_names_to_reqs_uids.items():
+            if not FileTraceabilityIndex.is_regex_function_name(function_name_):
+                continue
+
+            regex_pattern = function_name_[1:-1]
+            try:
+                if re.search(regex_pattern, name) is not None:
+                    matching_req_uids.extend(req_uids_)
+            except re.error as exception:
+                raise StrictDocException(
+                    "Invalid regular expression in FUNCTION relation "
+                    f"{function_name_}: {exception}."
+                ) from exception
+
+        return matching_req_uids if len(matching_req_uids) > 0 else None
+
+    @staticmethod
+    def is_regex_function_name(name: str) -> bool:
+        return len(name) >= 2 and name[0] == "/" and name[-1] == "/"
 
     def get_req_uids_by_class_name(
         self, rel_path_posix: str, name: str

--- a/tests/integration/features/source_code_traceability/_language_parsers/c/11_c_forward_function_regex/file.c
+++ b/tests/integration/features/source_code_traceability/_language_parsers/c/11_c_forward_function_regex/file.c
@@ -1,0 +1,4 @@
+ZTEST_USER(semaphore, test_k_sem_correct_count_limit)
+{
+  // Some code here...
+}

--- a/tests/integration/features/source_code_traceability/_language_parsers/c/11_c_forward_function_regex/input.sdoc
+++ b/tests/integration/features/source_code_traceability/_language_parsers/c/11_c_forward_function_regex/input.sdoc
@@ -1,0 +1,11 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ-1
+TITLE: Requirement Title
+STATEMENT: Requirement Statement
+RELATIONS:
+- TYPE: File
+  VALUE: file.c
+  FUNCTION: /ZTEST_USER.*semaphore.*test_k_sem_correct_count_limit/

--- a/tests/integration/features/source_code_traceability/_language_parsers/c/11_c_forward_function_regex/strictdoc.toml
+++ b/tests/integration/features/source_code_traceability/_language_parsers/c/11_c_forward_function_regex/strictdoc.toml
@@ -1,0 +1,11 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+  "SOURCE_FILE_LANGUAGE_PARSERS",
+  "PROJECT_STATISTICS_SCREEN"
+]
+
+exclude_source_paths = [
+  "test.itest",
+]

--- a/tests/integration/features/source_code_traceability/_language_parsers/c/11_c_forward_function_regex/test.itest
+++ b/tests/integration/features/source_code_traceability/_language_parsers/c/11_c_forward_function_regex/test.itest
@@ -1,0 +1,15 @@
+# @relation(SDOC-LLR-207, scope=file)
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%T/html/_source_files/file.c.html"
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+CHECK-HTML: <a{{.*}}href="../_source_files/file.c.html#REQ-1#1#4">
+CHECK-HTML: function ZTEST_USER(semaphore, test_k_sem_correct_count_limit)()
+
+RUN: %cat %T/html/_source_files/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+CHECK-SOURCE-FILE: <b>[ 1-4 ]</b>
+CHECK-SOURCE-FILE: file.c, function ZTEST_USER(semaphore, test_k_sem_correct_count_limit)()
+CHECK-SOURCE-FILE: 1 - 4 | function ZTEST_USER(semaphore, test_k_sem_correct_count_limit)()

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_c.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_c.py
@@ -463,3 +463,157 @@ int add(int a,
     assert len(info.source_nodes) == 0
 
     assert info.functions[0].name == "add(int a, int b)"
+
+
+def test_100_known_c_macro_zephyr_test():
+    """
+    Ensure that Zephyr's function-like test macro is recognized as a
+    function with its full macro invocation as the display name.
+    """
+
+    input_string = b"""\
+ZTEST_USER(semaphore, test_k_sem_correct_count_limit)
+{
+  // Some code here...
+}
+"""
+    reader = SourceFileTraceabilityReader_C()
+
+    info: SourceFileTraceabilityInfo = reader.read(
+        input_string, file_path="foo.cpp"
+    )
+
+    assert isinstance(info, SourceFileTraceabilityInfo)
+    assert len(info.markers) == 0
+    assert len(info.functions) == 1
+    assert len(info.source_nodes) == 0
+
+    assert (
+        info.functions[0].name
+        == "ZTEST_USER(semaphore, test_k_sem_correct_count_limit)"
+    )
+    assert (
+        info.functions[0].display_name
+        == "ZTEST_USER(semaphore, test_k_sem_correct_count_limit)"
+    )
+
+
+def test_101_known_c_macro_zephyr_test_with_comment():
+    """
+    Ensure that Zephyr's function-like test macro is recognized as a
+    function with its full macro invocation as the display name.
+    """
+
+    input_string = b"""\
+/*
+ * Copyright (c) 2016, 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+/**
+ * @brief Test the max value a semaphore can be given and taken
+ * @details
+ * - Reset an initialized semaphore's count to zero.
+ * - Give the semaphore by a thread and verify the semaphore's count is
+ *   as expected.
+ * - Verify the max count a semaphore can reach.
+ * - Take the semaphore by a thread and verify the semaphore's count is
+ *   as expected.
+ * - Verify the max times a semaphore can be taken.
+ * @ingroup kernel_semaphore_tests
+ * @see k_sem_count_get(), k_sem_give()
+ */
+ZTEST_USER(semaphore, test_k_sem_correct_count_limit)
+{
+
+	/* reset an initialized semaphore's count to zero */
+	k_sem_reset(&simple_sem);
+	expect_k_sem_count_get(&simple_sem, 0U, "k_sem_reset failed: %u != %u");
+
+	/* Give the semaphore by a thread and verify the semaphore's
+	 * count is as expected
+	 */
+	for (int i = 1; i <= SEM_MAX_VAL; i++) {
+		k_sem_give(&simple_sem);
+		expect_k_sem_count_get_nomsg(&simple_sem, i);
+	}
+
+	/* Verify the max count a semaphore can reach
+	 * continue to run k_sem_give,
+	 * the count of simple_sem will not increase anymore
+	 */
+	for (int i = 0; i < 5; i++) {
+		k_sem_give(&simple_sem);
+		expect_k_sem_count_get_nomsg(&simple_sem, SEM_MAX_VAL);
+	}
+
+	/* Take the semaphore by a thread and verify the semaphore's
+	 * count is as expected
+	 */
+	for (int i = SEM_MAX_VAL - 1; i >= 0; i--) {
+		expect_k_sem_take_nomsg(&simple_sem, K_NO_WAIT, 0);
+		expect_k_sem_count_get_nomsg(&simple_sem, i);
+	}
+
+	/* Verify the max times a semaphore can be taken
+	 * continue to run k_sem_take, simple_sem can not be taken and
+	 * it's count will be zero
+	 */
+	for (int i = 0; i < 5; i++) {
+		expect_k_sem_take_nomsg(&simple_sem, K_NO_WAIT, -EBUSY);
+
+		expect_k_sem_count_get_nomsg(&simple_sem, 0U);
+	}
+}
+"""
+    reader = SourceFileTraceabilityReader_C()
+
+    info: SourceFileTraceabilityInfo = reader.read(
+        input_string, file_path="foo.cpp"
+    )
+
+    assert isinstance(info, SourceFileTraceabilityInfo)
+    assert len(info.markers) == 0
+    assert len(info.functions) == 1
+    assert len(info.source_nodes) == 1
+
+    assert (
+        info.functions[0].name
+        == "ZTEST_USER(semaphore, test_k_sem_correct_count_limit)"
+    )
+    assert (
+        info.functions[0].display_name
+        == "ZTEST_USER(semaphore, test_k_sem_correct_count_limit)"
+    )
+
+
+def test_102_known_c_macro_linux_syscall_define():
+    input_string = b"""\
+SYSCALL_DEFINE2(clock_gettime, const clockid_t, which_clock,
+                struct __kernel_timespec __user *, tp)
+{
+    // ...
+    return error;
+}
+"""
+    reader = SourceFileTraceabilityReader_C()
+
+    info: SourceFileTraceabilityInfo = reader.read(
+        input_string, file_path="foo.cpp"
+    )
+
+    assert isinstance(info, SourceFileTraceabilityInfo)
+    assert len(info.markers) == 0
+    assert len(info.functions) == 1
+    assert len(info.source_nodes) == 0
+
+    expected_function_name = (
+        "SYSCALL_DEFINE2(clock_gettime, "
+        "const clockid_t, which_clock, struct __kernel_timespec __user *, tp"
+        ")"
+    )
+
+    assert info.functions[0].name == expected_function_name
+    assert info.functions[0].display_name == expected_function_name


### PR DESCRIPTION
**WHAT**: This change enables tracing to C macros from/to requirements captured in SDoc or (later) Markdown.

**WHY**: Some projects, e.g., Zephyr or Linux Kernel, use macro-based C functions extensively. This change adds the necessary initial support.