### PR TITLE
refactor(backend/sdoc): model: nest RESERVED_NON_META_FIELDS under its parent Enum object

### DIFF
--- a/strictdoc/backend/sdoc/models/grammar_element.py
+++ b/strictdoc/backend/sdoc/models/grammar_element.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 from strictdoc.backend.sdoc.models.model import (
-    RESERVED_NON_META_FIELDS,
     RequirementFieldName,
 )
 from strictdoc.helpers.auto_described import auto_described
@@ -420,7 +419,7 @@ class GrammarElement:
                 RequirementFieldName.STATEMENT,
             ):
                 break
-            if field.title in RESERVED_NON_META_FIELDS:
+            if field.title in RequirementFieldName.RESERVED_NON_META_FIELDS:
                 continue
             yield field.title
 
@@ -434,7 +433,7 @@ class GrammarElement:
                 RequirementFieldName.STATEMENT,
             ):
                 after_title_or_statement = True
-            if field.title in RESERVED_NON_META_FIELDS:
+            if field.title in RequirementFieldName.RESERVED_NON_META_FIELDS:
                 continue
             if not after_title_or_statement:
                 continue

--- a/strictdoc/backend/sdoc/models/model.py
+++ b/strictdoc/backend/sdoc/models/model.py
@@ -3,7 +3,7 @@
 """
 
 from abc import ABC, abstractmethod
-from typing import Generator, List, Optional, Union
+from typing import Final, Generator, List, Optional, Union
 
 from strictdoc.backend.sdoc.models.document_config import (
     DocumentConfig,
@@ -33,16 +33,17 @@ class RequirementFieldName:
     RATIONALE = "RATIONALE"
     COMMENT = "COMMENT"
 
-
-RESERVED_NON_META_FIELDS = [
-    RequirementFieldName.TITLE,
-    RequirementFieldName.STATEMENT,
-    RequirementFieldName.DESCRIPTION,
-    RequirementFieldName.CONTENT,
-    RequirementFieldName.COMMENT,
-    RequirementFieldName.RATIONALE,
-    RequirementFieldName.LEVEL,
-]
+    RESERVED_NON_META_FIELDS: Final[frozenset[str]] = frozenset(
+        (
+            TITLE,
+            STATEMENT,
+            DESCRIPTION,
+            CONTENT,
+            COMMENT,
+            RATIONALE,
+            LEVEL,
+        )
+    )
 
 
 class SDocNodeFieldIF(ABC):

--- a/strictdoc/backend/sdoc/models/node.py
+++ b/strictdoc/backend/sdoc/models/node.py
@@ -19,7 +19,6 @@ from strictdoc.backend.sdoc.models.grammar_element import (
 )
 from strictdoc.backend.sdoc.models.inline_link import InlineLink
 from strictdoc.backend.sdoc.models.model import (
-    RESERVED_NON_META_FIELDS,
     RequirementFieldName,
     SDocDocumentIF,
     SDocElementIF,
@@ -161,7 +160,10 @@ class SDocNode(SDocNodeIF):
 
         has_meta: bool = False
         for field in fields:
-            if field.field_name not in RESERVED_NON_META_FIELDS:
+            if (
+                field.field_name
+                not in RequirementFieldName.RESERVED_NON_META_FIELDS
+            ):
                 has_meta = True
             ordered_fields_lookup.setdefault(field.field_name, []).append(field)
 
@@ -566,7 +568,10 @@ class SDocNode(SDocNodeIF):
         ]
 
         for field in self.enumerate_fields():
-            if field.field_name in RESERVED_NON_META_FIELDS:
+            if (
+                field.field_name
+                in RequirementFieldName.RESERVED_NON_META_FIELDS
+            ):
                 continue
 
             is_single_line_field = not element.is_field_multiline(
@@ -790,7 +795,10 @@ class SDocNode(SDocNodeIF):
     def _update_has_meta(self) -> None:
         has_meta: bool = False
         for field in self.enumerate_fields():
-            if field.field_name not in RESERVED_NON_META_FIELDS:
+            if (
+                field.field_name
+                not in RequirementFieldName.RESERVED_NON_META_FIELDS
+            ):
                 has_meta = True
         self.has_meta = has_meta
 


### PR DESCRIPTION

WHY: This will help us to introduce similar constants under the same Enum and keep things consistent.