### PR TITLE
feat: improve server and about printed message banners

### DIFF
--- a/strictdoc/cli/main.py
+++ b/strictdoc/cli/main.py
@@ -21,7 +21,7 @@ from strictdoc.helpers.exception import (
     StrictDocChildProcessException,
 )
 from strictdoc.helpers.parallelizer import Parallelizer
-from strictdoc.helpers.timing import measure_performance
+from strictdoc.helpers.timing import SimpleNominalExit, measure_performance
 
 COMMAND_REGISTRY: Dict[str, Any] = {
     "about": AboutCommand,
@@ -77,6 +77,8 @@ def _main() -> None:
     exception_info: Optional[ExceptionInfo] = None
     try:
         parser.run(parallelizer)
+    except SimpleNominalExit:
+        raise
     except StrictDocChildProcessException as exception_info_:
         exception_info = exception_info_.exception_info
     except Exception as exception_:

--- a/strictdoc/commands/about_command.py
+++ b/strictdoc/commands/about_command.py
@@ -7,6 +7,7 @@ import argparse
 import strictdoc
 from strictdoc.cli.base_command import BaseCommand
 from strictdoc.helpers.parallelizer import Parallelizer
+from strictdoc.helpers.timing import SimpleNominalExit
 
 
 class AboutCommand(BaseCommand):
@@ -21,17 +22,26 @@ class AboutCommand(BaseCommand):
         self.args = args
 
     def run(self, parallelizer: Parallelizer) -> None:  # noqa: ARG002
-        print("=============")  # noqa: T201
-        print("= StrictDoc =")  # noqa: T201
-        print("=============")  # noqa: T201
-        print(  # noqa: T201
-            "Purpose: Software for writing technical requirements specifications."
+        width = 72
+        border = "═" * width
+
+        lines = [
+            f" {'StrictDoc'.center(width - 2)} ",
+            "",
+            " Purpose: Software for writing technical requirements specifications.",
+            "",
+            f" Version: {strictdoc.__version__}",
+            " Docs:    https://strictdoc.readthedocs.io/en/stable/",
+            " GitHub:  https://github.com/strictdoc-project/strictdoc",
+            " License: Apache 2",
+        ]
+
+        banner = (
+            f"╔{border}╗\n"
+            + "\n".join(f"║{line.ljust(width)}║" for line in lines)
+            + f"\n╚{border}╝"
         )
-        print(f"Version: {strictdoc.__version__}")  # noqa: T201
-        print(  # noqa: T201
-            "Docs:    https://strictdoc.readthedocs.io/en/stable/"
-        )
-        print(  # noqa: T201
-            "GitHub:  https://github.com/strictdoc-project/strictdoc"
-        )
-        print("License: Apache 2")  # noqa: T201
+
+        print(banner)  # noqa: T201
+
+        raise SimpleNominalExit

--- a/strictdoc/commands/version_command.py
+++ b/strictdoc/commands/version_command.py
@@ -7,6 +7,7 @@ import argparse
 import strictdoc
 from strictdoc.cli.base_command import BaseCommand
 from strictdoc.helpers.parallelizer import Parallelizer
+from strictdoc.helpers.timing import SimpleNominalExit
 
 
 class VersionCommand(BaseCommand):
@@ -22,3 +23,5 @@ class VersionCommand(BaseCommand):
 
     def run(self, parallelizer: Parallelizer) -> None:  # noqa: ARG002
         print(strictdoc.__version__)  # noqa: T201
+
+        raise SimpleNominalExit

--- a/strictdoc/helpers/timing.py
+++ b/strictdoc/helpers/timing.py
@@ -11,6 +11,18 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
+class SimpleNominalExit(Exception):
+    """
+    A custom exception used for situations when we don't want to print the final
+    performance result at the end of function execution.
+
+    The use case for this: StrictDoc's "about" and "version" commands that do
+    not need the performance result (total execution time) to be printed.
+    """
+
+    pass
+
+
 def timing_decorator(name: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
     def timing_internal(func: Callable[P, R]) -> Callable[P, R]:
         @wraps(func)
@@ -33,7 +45,11 @@ def timing_decorator(name: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
 @contextlib.contextmanager
 def measure_performance(title: str) -> Iterator[None]:
     time_start = time.time()
-    yield
+    try:
+        yield
+    except SimpleNominalExit:
+        return
+
     time_end = time.time()
 
     time_diff = time_end - time_start

--- a/strictdoc/server/app.py
+++ b/strictdoc/server/app.py
@@ -2,16 +2,18 @@
 @relation(SDOC-SRS-126, scope=file)
 """
 
+import logging
 import os
 import sys
 import time
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Generator
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
+from strictdoc import __version__
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.helpers.coverage import register_code_coverage_hook
 from strictdoc.helpers.pickle import pickle_load
@@ -29,8 +31,50 @@ else:
     O_TEMPORARY = 0
 
 
+LOGGER = logging.getLogger("uvicorn.error")
+
+
+def print_welcome_message(project_config: ProjectConfig) -> None:
+    strictdoc_version = f"StrictDoc Web Server v{__version__}"
+
+    host = (
+        project_config.server_host
+        if project_config.server_host.startswith("http")
+        else f"http://{project_config.server_host}"
+    )
+
+    url = f"{host}:{project_config.server_port}"
+
+    width = 72
+    border = "═" * width
+
+    lines = [
+        f" {strictdoc_version.center(width - 2)} ",
+        "",
+        f" Server URL: {url}",
+        "",
+        " Documentation: https://strictdoc.readthedocs.io/",
+        "",
+        " Share feedback or report issues:",
+        " https://github.com/strictdoc-project/strictdoc/issues",
+    ]
+
+    banner = (
+        "\n\n"
+        f"╔{border}╗\n"
+        + "\n".join(f"║{line.ljust(width)}║" for line in lines)
+        + f"\n╚{border}╝\n"
+    )
+
+    LOGGER.info(banner)
+
+
 def create_app(*, project_config: ProjectConfig) -> FastAPI:
-    app = FastAPI()
+    def lifespan(_: FastAPI) -> Generator[None, None, None]:
+        print_welcome_message(project_config)
+        yield
+
+    app = FastAPI(lifespan=lifespan)
 
     origins = [
         "http://localhost",

--- a/strictdoc/server/server.py
+++ b/strictdoc/server/server.py
@@ -10,7 +10,6 @@ from typing import List, Tuple
 
 import uvicorn
 
-from strictdoc import __version__
 from strictdoc.commands.server_config import ServerCommandConfig
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.helpers.pickle import pickle_dump
@@ -18,26 +17,9 @@ from strictdoc.server.config import SDocServerEnvVariable
 from strictdoc.server.reload_config import UvicornReloadConfig
 
 
-def print_warning_message() -> None:
-    strictdoc_version = "StrictDoc web server v" + __version__
-    print(  # noqa: T201
-        f"""
-*********************************************************
-* {strictdoc_version.center(53)} *
-*                                                       *
-* Share feedback and report issues on GitHub:           *
-* https://github.com/strictdoc-project/strictdoc/issues *
-*********************************************************
-""",
-        flush=True,
-    )
-
-
 def run_strictdoc_server(
     *, server_config: ServerCommandConfig, project_config: ProjectConfig
 ) -> None:
-    print_warning_message()
-
     with ExitStack() as stack:
         reload_config = UvicornReloadConfig.create(
             project_config, server_config

--- a/tests/integration/features/commands/about/01_print_about/test.itest
+++ b/tests/integration/features/commands/about/01_print_about/test.itest
@@ -4,6 +4,12 @@
 
 RUN: %strictdoc about | filecheck %s --dump-input=fail
 
-CHECK:= StrictDoc =
-CHECK:Purpose: Software for writing technical requirements specifications.
-CHECK:License: Apache 2
+CHECK:╔════════════════════════════════════════════════════════════════════════╗
+
+CHECK:║                               StrictDoc                                ║
+
+CHECK:║                                                                        ║
+
+CHECK:║ GitHub:  https://github.com/strictdoc-project/strictdoc                ║
+
+CHECK:╚════════════════════════════════════════════════════════════════════════╝


### PR DESCRIPTION
**WHAT:**

- Print the server banner at the very end of the server start procedure. This ensures that a user will always see it even if a project is large and contains many documents and source files.
- Also unify the message style of the `server` and `about` commands.

**WHY:** Improves the user experience for `server` and `about` commands.