### PR TITLE
feat(export/html): add nodes (rows) visibility filter to table view

### DIFF
--- a/strictdoc/export/html/_static/table_view.css
+++ b/strictdoc/export/html/_static/table_view.css
@@ -105,6 +105,20 @@
   text-transform: uppercase;
 }
 
+/* .collapsed and .expanded are classes inside SVG .icon_collapse */
+[aria-expanded="false"] .icon_collapse_expand .collapsed {
+  display: initial;
+}
+[aria-expanded="false"] .icon_collapse_expand .expanded {
+  display: none;
+}
+[aria-expanded="true"] .icon_collapse_expand .expanded {
+  display: initial;
+}
+[aria-expanded="true"] .icon_collapse_expand .collapsed {
+  display: none;
+}
+
 .table-toolbar__panel {
   position: absolute;
   top: 100%;
@@ -115,13 +129,12 @@
 
 .table-toolbar__panel-header {
   display: flex;
-  align-items: flex-start;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: space-between;
   padding-left: calc(var(--base-rhythm) * 0.5);
 }
 
 .table-toolbar__panel-title {
-  text-transform: uppercase;
   font-weight: bold;
 }
 

--- a/strictdoc/export/html/_static/table_view.css
+++ b/strictdoc/export/html/_static/table_view.css
@@ -89,8 +89,16 @@
   z-index: 10;
   width: fit-content;
   height: 0;
+  display: flex;
+  column-gap: var(--base-rhythm);
   padding-inline: calc(4 * var(--base-rhythm));
   background-color: var(--color-bg-main);
+}
+
+.table-toolbar__columns,
+.table-toolbar__rows {
+  position: relative;
+  height: fit-content;
 }
 
 .table-toolbar__btn {
@@ -99,8 +107,8 @@
 
 .table-toolbar__panel {
   position: absolute;
-  top: -2px;
-  left: calc(4 * var(--base-rhythm) + 2px);
+  top: 100%;
+  left: 0;
   z-index: 100;
   min-width: 180px;
 }
@@ -108,7 +116,7 @@
 .table-toolbar__panel-header {
   display: flex;
   align-items: flex-start;
-  justify-content: space-between;
+  justify-content: flex-end;
   padding-left: calc(var(--base-rhythm) * 0.5);
 }
 

--- a/strictdoc/export/html/_static/table_view.js
+++ b/strictdoc/export/html/_static/table_view.js
@@ -7,8 +7,22 @@
      * State I/O
      */
 
-    function getStorageKey() {
-        return STORAGE_KEY_PREFIX + ':' + location.pathname;
+    function storageKey(prefix) {
+        return prefix + ':' + location.pathname;
+    }
+
+    function readJson(key) {
+        try {
+            return JSON.parse(localStorage.getItem(key) || '[]');
+        } catch (_) {
+            return [];
+        }
+    }
+
+    function writeJson(key, value) {
+        try {
+            localStorage.setItem(key, JSON.stringify(value));
+        } catch (_) {}
     }
 
     // Returns array of hidden column names from URL, or null if param is absent.
@@ -18,20 +32,6 @@
         if (!params.has(URL_PARAM)) return null;
         const val = params.get(URL_PARAM);
         return val ? val.split('|').map(decodeURIComponent) : [];
-    }
-
-    function readFromStorage() {
-        try {
-            return JSON.parse(localStorage.getItem(getStorageKey()) || '[]');
-        } catch (_) {
-            return [];
-        }
-    }
-
-    function writeToStorage(hiddenNames) {
-        try {
-            localStorage.setItem(getStorageKey(), JSON.stringify(hiddenNames));
-        } catch (_) {}
     }
 
     function writeToURL(hiddenNames) {
@@ -52,30 +52,8 @@
     }
 
     function persistState(hiddenNames) {
-        writeToStorage(hiddenNames);
+        writeJson(storageKey(STORAGE_KEY_PREFIX), hiddenNames);
         writeToURL(hiddenNames);
-    }
-
-    /*
-     * Row-type state I/O (localStorage only, no URL param)
-     */
-
-    function getRowsStorageKey() {
-        return ROWS_STORAGE_KEY_PREFIX + ':' + location.pathname;
-    }
-
-    function readRowsFromStorage() {
-        try {
-            return JSON.parse(localStorage.getItem(getRowsStorageKey()) || '[]');
-        } catch (_) {
-            return [];
-        }
-    }
-
-    function writeRowsToStorage(hiddenTypes) {
-        try {
-            localStorage.setItem(getRowsStorageKey(), JSON.stringify(hiddenTypes));
-        } catch (_) {}
     }
 
     /*
@@ -90,10 +68,10 @@
     function resolveInitialHidden() {
         const fromURL = readFromURL();
         if (fromURL !== null) {
-            writeToStorage(fromURL);
+            writeJson(storageKey(STORAGE_KEY_PREFIX), fromURL);
             return fromURL;
         }
-        const fromStorage = readFromStorage();
+        const fromStorage = readJson(storageKey(STORAGE_KEY_PREFIX));
         writeToURL(fromStorage);
         return fromStorage;
     }
@@ -120,7 +98,7 @@
     }
 
     /*
-     * Columns panel
+     * Shared panel helpers
      */
 
     function updateBtnLabel(btn, items) {
@@ -128,6 +106,42 @@
         const activeLabel = btn.dataset.label || btn.dataset.defaultLabel;
         btn.textContent = hidden > 0 ? activeLabel + ' (' + hidden + ' hidden)' : btn.dataset.defaultLabel;
     }
+
+    function syncResetBtn(resetBtn, items) {
+        resetBtn.disabled = items.every(i => i.visible);
+    }
+
+    function openPanel(btn, panel) {
+        panel.hidden = false;
+        btn.setAttribute('aria-expanded', 'true');
+        panel.setAttribute('aria-hidden', 'false');
+    }
+
+    function closePanel(btn, panel) {
+        panel.hidden = true;
+        btn.setAttribute('aria-expanded', 'false');
+        panel.setAttribute('aria-hidden', 'true');
+    }
+
+    // panels registry — populated by each initXxxPanel() call
+    const _panels = [];
+
+    function closeAllPanels() {
+        _panels.forEach(({ btn, panel }) => closePanel(btn, panel));
+    }
+
+    function initPanelToggle(btn, panel) {
+        btn.addEventListener('click', e => {
+            e.stopPropagation();
+            const opening = panel.hidden;
+            closeAllPanels();
+            if (opening) openPanel(btn, panel);
+        });
+    }
+
+    /*
+     * Columns panel
+     */
 
     function initColumnsPanel(table, columns, onToggle) {
         const btn = document.querySelector('[data-testid="table-toolbar-columns-btn"]');
@@ -137,10 +151,6 @@
         btn.dataset.defaultLabel = btn.textContent.trim();
 
         _panels.push({ btn, panel });
-
-        function syncResetBtn() {
-            resetBtn.disabled = columns.every(c => c.visible);
-        }
 
         columns.forEach(col => {
             const item = document.createElement('li');
@@ -156,7 +166,7 @@
             checkbox.addEventListener('change', () => {
                 onToggle(col, checkbox.checked);
                 updateBtnLabel(btn, columns);
-                syncResetBtn();
+                syncResetBtn(resetBtn, columns);
             });
 
             label.appendChild(checkbox);
@@ -169,18 +179,13 @@
             columns.forEach(col => onToggle(col, true));
             list.querySelectorAll('input[type=checkbox]').forEach(cb => (cb.checked = true));
             updateBtnLabel(btn, columns);
-            syncResetBtn();
+            syncResetBtn(resetBtn, columns);
         });
 
-        btn.addEventListener('click', e => {
-            e.stopPropagation();
-            const opening = panel.hidden;
-            closeAllPanels();
-            if (opening) openPanel(btn, panel);
-        });
+        initPanelToggle(btn, panel);
 
         updateBtnLabel(btn, columns);
-        syncResetBtn();
+        syncResetBtn(resetBtn, columns);
     }
 
     /*
@@ -210,16 +215,13 @@
         });
 
         // Restore state from storage.
-        const hiddenTypes = new Set(readRowsFromStorage());
+        const rowsKey = storageKey(ROWS_STORAGE_KEY_PREFIX);
+        const hiddenTypes = new Set(readJson(rowsKey));
         seenTypes.forEach(type => {
             if (hiddenTypes.has(type)) setRowTypeVisibility(tbody, type, false);
         });
 
         const rowTypes = seenTypes.map(type => ({ type, visible: !hiddenTypes.has(type) }));
-
-        function syncResetBtn() {
-            resetBtn.disabled = rowTypes.every(r => r.visible);
-        }
 
         rowTypes.forEach(rowType => {
             const item = document.createElement('li');
@@ -235,9 +237,9 @@
             checkbox.addEventListener('change', () => {
                 rowType.visible = checkbox.checked;
                 setRowTypeVisibility(tbody, rowType.type, rowType.visible);
-                writeRowsToStorage(rowTypes.filter(r => !r.visible).map(r => r.type));
+                writeJson(rowsKey, rowTypes.filter(r => !r.visible).map(r => r.type));
                 updateBtnLabel(btn, rowTypes);
-                syncResetBtn();
+                syncResetBtn(resetBtn, rowTypes);
             });
 
             label.appendChild(checkbox);
@@ -252,43 +254,15 @@
                 setRowTypeVisibility(tbody, rowType.type, true);
             });
             list.querySelectorAll('input[type=checkbox]').forEach(cb => (cb.checked = true));
-            writeRowsToStorage([]);
+            writeJson(rowsKey, []);
             updateBtnLabel(btn, rowTypes);
-            syncResetBtn();
+            syncResetBtn(resetBtn, rowTypes);
         });
 
-        btn.addEventListener('click', e => {
-            e.stopPropagation();
-            const opening = panel.hidden;
-            closeAllPanels();
-            if (opening) openPanel(btn, panel);
-        });
+        initPanelToggle(btn, panel);
 
         updateBtnLabel(btn, rowTypes);
-        syncResetBtn();
-    }
-
-    /*
-     * Panel open/close helpers (shared between columns and rows panels)
-     */
-
-    function openPanel(btn, panel) {
-        panel.hidden = false;
-        btn.setAttribute('aria-expanded', 'true');
-        panel.setAttribute('aria-hidden', 'false');
-    }
-
-    function closePanel(btn, panel) {
-        panel.hidden = true;
-        btn.setAttribute('aria-expanded', 'false');
-        panel.setAttribute('aria-hidden', 'true');
-    }
-
-    // panels registry — populated by each initXxxPanel() call
-    const _panels = [];
-
-    function closeAllPanels() {
-        _panels.forEach(({ btn, panel }) => closePanel(btn, panel));
+        syncResetBtn(resetBtn, rowTypes);
     }
 
     /*
@@ -299,6 +273,7 @@
         const table = document.querySelector('.content-view-table');
         if (!table) return;
 
+        const toolbar = document.querySelector('[data-testid="table-toolbar"]');
         const headerCells = Array.from(table.querySelectorAll(':scope > thead > tr > .content-view-th'));
         const tbody = table.querySelector(':scope > tbody');
 
@@ -321,7 +296,6 @@
         initRowsPanel(tbody);
 
         document.addEventListener('click', e => {
-            const toolbar = document.querySelector('[data-testid="table-toolbar"]');
             if (toolbar && !toolbar.contains(e.target)) {
                 closeAllPanels();
             }

--- a/strictdoc/export/html/_static/table_view.js
+++ b/strictdoc/export/html/_static/table_view.js
@@ -97,56 +97,20 @@
     }
 
     /*
-     * Toolbar
+     * Columns panel
      */
 
-    function buildToolbar(table, columns, onToggle) {
-        const toolbar = document.createElement('div');
-        toolbar.className = 'table-toolbar';
-        toolbar.setAttribute('data-testid', 'table-toolbar');
+    function initColumnsPanel(table, columns, onToggle) {
+        const btn = document.querySelector('[data-testid="table-toolbar-columns-btn"]');
+        const panel = document.querySelector('[data-testid="table-toolbar-columns-panel"]');
+        const resetBtn = document.querySelector('[data-testid="table-toolbar-columns-reset"]');
+        const list = document.querySelector('[data-testid="table-toolbar-columns-list"]');
 
-        const btn = document.createElement('button');
-        btn.className = 'table-toolbar__btn action_button';
-        btn.setAttribute('aria-haspopup', 'true');
-        btn.setAttribute('aria-expanded', 'false');
-        btn.setAttribute('data-testid', 'table-toolbar-columns-btn');
+        _panels.push({ btn, panel });
 
-        const panel = document.createElement('div');
-        panel.className = 'table-toolbar__panel dropdown_menu';
-        panel.hidden = true;
-        panel.setAttribute('aria-hidden', 'true');
-        panel.setAttribute('role', 'dialog');
-        panel.setAttribute('aria-label', 'Column visibility');
-        panel.setAttribute('data-testid', 'table-toolbar-columns-panel');
-
-        const panelHeader = document.createElement('div');
-        panelHeader.className = 'table-toolbar__panel-header';
-
-        const panelTitle = document.createElement('span');
-        panelTitle.className = 'table-toolbar__panel-title';
-        panelTitle.textContent = 'Columns';
-
-        const resetBtn = document.createElement('button');
-        resetBtn.className = 'table-toolbar__reset compact action_button';
-        resetBtn.textContent = 'Show all';
-        resetBtn.setAttribute('data-testid', 'table-toolbar-columns-reset');
         function syncResetBtn() {
             resetBtn.disabled = columns.every(c => c.visible);
         }
-
-        resetBtn.addEventListener('click', () => {
-            columns.forEach(col => onToggle(col, true));
-            panel.querySelectorAll('input[type=checkbox]').forEach(cb => (cb.checked = true));
-            updateBtnLabel(btn, columns);
-            syncResetBtn();
-        });
-
-        panelHeader.appendChild(panelTitle);
-        panelHeader.appendChild(resetBtn);
-        panel.appendChild(panelHeader);
-
-        const list = document.createElement('ul');
-        list.className = 'table-toolbar__list';
 
         columns.forEach(col => {
             const item = document.createElement('li');
@@ -161,7 +125,7 @@
             checkbox.setAttribute('data-testid', 'col-checkbox-' + col.name);
             checkbox.addEventListener('change', () => {
                 onToggle(col, checkbox.checked);
-                updateBtnLabel(btn, columns);
+                updateColumnsBtnLabel(btn, columns);
                 syncResetBtn();
             });
 
@@ -171,35 +135,50 @@
             list.appendChild(item);
         });
 
-        panel.appendChild(list);
+        resetBtn.addEventListener('click', () => {
+            columns.forEach(col => onToggle(col, true));
+            list.querySelectorAll('input[type=checkbox]').forEach(cb => (cb.checked = true));
+            updateColumnsBtnLabel(btn, columns);
+            syncResetBtn();
+        });
 
         btn.addEventListener('click', e => {
             e.stopPropagation();
             const opening = panel.hidden;
-            panel.hidden = !opening;
-            btn.setAttribute('aria-expanded', String(opening));
-            panel.setAttribute('aria-hidden', String(!opening));
+            closeAllPanels();
+            if (opening) openPanel(btn, panel);
         });
 
-        document.addEventListener('click', e => {
-            if (!toolbar.contains(e.target)) {
-                panel.hidden = true;
-                btn.setAttribute('aria-expanded', 'false');
-                panel.setAttribute('aria-hidden', 'true');
-            }
-        });
-
-        toolbar.appendChild(btn);
-        toolbar.appendChild(panel);
-
-        updateBtnLabel(btn, columns);
+        updateColumnsBtnLabel(btn, columns);
         syncResetBtn();
-        return toolbar;
     }
 
-    function updateBtnLabel(btn, columns) {
+    function updateColumnsBtnLabel(btn, columns) {
         const hidden = columns.filter(c => !c.visible).length;
         btn.textContent = hidden > 0 ? 'Columns (' + hidden + ' hidden)' : 'Columns visibility';
+    }
+
+    /*
+     * Panel open/close helpers (shared between columns and rows panels)
+     */
+
+    function openPanel(btn, panel) {
+        panel.hidden = false;
+        btn.setAttribute('aria-expanded', 'true');
+        panel.setAttribute('aria-hidden', 'false');
+    }
+
+    function closePanel(btn, panel) {
+        panel.hidden = true;
+        btn.setAttribute('aria-expanded', 'false');
+        panel.setAttribute('aria-hidden', 'true');
+    }
+
+    // panels registry — populated by each initXxxPanel() call
+    const _panels = [];
+
+    function closeAllPanels() {
+        _panels.forEach(({ btn, panel }) => closePanel(btn, panel));
     }
 
     /*
@@ -228,8 +207,14 @@
             persistState(columns.filter(c => !c.visible).map(c => c.name));
         }
 
-        const toolbar = buildToolbar(table, columns, onToggle);
-        table.parentNode.insertBefore(toolbar, table);
+        initColumnsPanel(table, columns, onToggle);
+
+        document.addEventListener('click', e => {
+            const toolbar = document.querySelector('[data-testid="table-toolbar"]');
+            if (toolbar && !toolbar.contains(e.target)) {
+                closeAllPanels();
+            }
+        });
 
         headerCells.forEach((headerCell, index) => {
             headerCell.addEventListener('click', () => {

--- a/strictdoc/export/html/_static/table_view.js
+++ b/strictdoc/export/html/_static/table_view.js
@@ -104,7 +104,8 @@
     function updateBtnLabel(btn, items) {
         const hidden = items.filter(i => !i.visible).length;
         const activeLabel = btn.dataset.label || btn.dataset.defaultLabel;
-        btn.textContent = hidden > 0 ? activeLabel + ' (' + hidden + ' hidden)' : btn.dataset.defaultLabel;
+        const textEl = btn.querySelector('.table-toolbar__btn-text');
+        textEl.textContent = hidden > 0 ? activeLabel + ' (' + hidden + ' hidden)' : btn.dataset.defaultLabel;
     }
 
     function syncResetBtn(resetBtn, items) {
@@ -148,7 +149,7 @@
         const panel = document.querySelector('[data-testid="table-toolbar-columns-panel"]');
         const resetBtn = document.querySelector('[data-testid="table-toolbar-columns-reset"]');
         const list = document.querySelector('[data-testid="table-toolbar-columns-list"]');
-        btn.dataset.defaultLabel = btn.textContent.trim();
+        btn.dataset.defaultLabel = btn.querySelector('.table-toolbar__btn-text').textContent.trim();
 
         _panels.push({ btn, panel });
 
@@ -203,7 +204,7 @@
         const panel = document.querySelector('[data-testid="table-toolbar-rows-panel"]');
         const resetBtn = document.querySelector('[data-testid="table-toolbar-rows-reset"]');
         const list = document.querySelector('[data-testid="table-toolbar-rows-list"]');
-        btn.dataset.defaultLabel = btn.textContent.trim();
+        btn.dataset.defaultLabel = btn.querySelector('.table-toolbar__btn-text').textContent.trim();
 
         _panels.push({ btn, panel });
 

--- a/strictdoc/export/html/_static/table_view.js
+++ b/strictdoc/export/html/_static/table_view.js
@@ -123,11 +123,18 @@
      * Columns panel
      */
 
+    function updateBtnLabel(btn, items) {
+        const hidden = items.filter(i => !i.visible).length;
+        const activeLabel = btn.dataset.label || btn.dataset.defaultLabel;
+        btn.textContent = hidden > 0 ? activeLabel + ' (' + hidden + ' hidden)' : btn.dataset.defaultLabel;
+    }
+
     function initColumnsPanel(table, columns, onToggle) {
         const btn = document.querySelector('[data-testid="table-toolbar-columns-btn"]');
         const panel = document.querySelector('[data-testid="table-toolbar-columns-panel"]');
         const resetBtn = document.querySelector('[data-testid="table-toolbar-columns-reset"]');
         const list = document.querySelector('[data-testid="table-toolbar-columns-list"]');
+        btn.dataset.defaultLabel = btn.textContent.trim();
 
         _panels.push({ btn, panel });
 
@@ -148,7 +155,7 @@
             checkbox.setAttribute('data-testid', 'col-checkbox-' + col.name);
             checkbox.addEventListener('change', () => {
                 onToggle(col, checkbox.checked);
-                updateColumnsBtnLabel(btn, columns);
+                updateBtnLabel(btn, columns);
                 syncResetBtn();
             });
 
@@ -161,7 +168,7 @@
         resetBtn.addEventListener('click', () => {
             columns.forEach(col => onToggle(col, true));
             list.querySelectorAll('input[type=checkbox]').forEach(cb => (cb.checked = true));
-            updateColumnsBtnLabel(btn, columns);
+            updateBtnLabel(btn, columns);
             syncResetBtn();
         });
 
@@ -172,13 +179,8 @@
             if (opening) openPanel(btn, panel);
         });
 
-        updateColumnsBtnLabel(btn, columns);
+        updateBtnLabel(btn, columns);
         syncResetBtn();
-    }
-
-    function updateColumnsBtnLabel(btn, columns) {
-        const hidden = columns.filter(c => !c.visible).length;
-        btn.textContent = hidden > 0 ? 'Columns (' + hidden + ' hidden)' : 'Columns visibility';
     }
 
     /*
@@ -196,6 +198,7 @@
         const panel = document.querySelector('[data-testid="table-toolbar-rows-panel"]');
         const resetBtn = document.querySelector('[data-testid="table-toolbar-rows-reset"]');
         const list = document.querySelector('[data-testid="table-toolbar-rows-list"]');
+        btn.dataset.defaultLabel = btn.textContent.trim();
 
         _panels.push({ btn, panel });
 
@@ -218,11 +221,6 @@
             resetBtn.disabled = rowTypes.every(r => r.visible);
         }
 
-        function updateBtnLabel() {
-            const hidden = rowTypes.filter(r => !r.visible).length;
-            btn.textContent = hidden > 0 ? 'Row visibility (' + hidden + ' hidden)' : 'Row visibility';
-        }
-
         rowTypes.forEach(rowType => {
             const item = document.createElement('li');
             item.className = 'table-toolbar__item';
@@ -238,7 +236,7 @@
                 rowType.visible = checkbox.checked;
                 setRowTypeVisibility(tbody, rowType.type, rowType.visible);
                 writeRowsToStorage(rowTypes.filter(r => !r.visible).map(r => r.type));
-                updateBtnLabel();
+                updateBtnLabel(btn, rowTypes);
                 syncResetBtn();
             });
 
@@ -255,7 +253,7 @@
             });
             list.querySelectorAll('input[type=checkbox]').forEach(cb => (cb.checked = true));
             writeRowsToStorage([]);
-            updateBtnLabel();
+            updateBtnLabel(btn, rowTypes);
             syncResetBtn();
         });
 
@@ -266,7 +264,7 @@
             if (opening) openPanel(btn, panel);
         });
 
-        updateBtnLabel();
+        updateBtnLabel(btn, rowTypes);
         syncResetBtn();
     }
 

--- a/strictdoc/export/html/_static/table_view.js
+++ b/strictdoc/export/html/_static/table_view.js
@@ -1,5 +1,6 @@
 (function () {
     const STORAGE_KEY_PREFIX = 'strictdoc.table.hidden_cols';
+    const ROWS_STORAGE_KEY_PREFIX = 'strictdoc.table.hidden_rows';
     const URL_PARAM = 'hidden';
 
     /*
@@ -53,6 +54,28 @@
     function persistState(hiddenNames) {
         writeToStorage(hiddenNames);
         writeToURL(hiddenNames);
+    }
+
+    /*
+     * Row-type state I/O (localStorage only, no URL param)
+     */
+
+    function getRowsStorageKey() {
+        return ROWS_STORAGE_KEY_PREFIX + ':' + location.pathname;
+    }
+
+    function readRowsFromStorage() {
+        try {
+            return JSON.parse(localStorage.getItem(getRowsStorageKey()) || '[]');
+        } catch (_) {
+            return [];
+        }
+    }
+
+    function writeRowsToStorage(hiddenTypes) {
+        try {
+            localStorage.setItem(getRowsStorageKey(), JSON.stringify(hiddenTypes));
+        } catch (_) {}
     }
 
     /*
@@ -159,6 +182,95 @@
     }
 
     /*
+     * Row visibility
+     */
+
+    function setRowTypeVisibility(tbody, type, visible) {
+        tbody.querySelectorAll(':scope > tr[data-row-type="' + type + '"]').forEach(row => {
+            row.style.display = visible ? '' : 'none';
+        });
+    }
+
+    function initRowsPanel(tbody) {
+        const btn = document.querySelector('[data-testid="table-toolbar-rows-btn"]');
+        const panel = document.querySelector('[data-testid="table-toolbar-rows-panel"]');
+        const resetBtn = document.querySelector('[data-testid="table-toolbar-rows-reset"]');
+        const list = document.querySelector('[data-testid="table-toolbar-rows-list"]');
+
+        _panels.push({ btn, panel });
+
+        // Collect unique row types from the tbody, preserving first-seen order.
+        const seenTypes = [];
+        tbody.querySelectorAll(':scope > tr[data-row-type]').forEach(row => {
+            const t = row.dataset.rowType;
+            if (!seenTypes.includes(t)) seenTypes.push(t);
+        });
+
+        // Restore state from storage.
+        const hiddenTypes = new Set(readRowsFromStorage());
+        seenTypes.forEach(type => {
+            if (hiddenTypes.has(type)) setRowTypeVisibility(tbody, type, false);
+        });
+
+        const rowTypes = seenTypes.map(type => ({ type, visible: !hiddenTypes.has(type) }));
+
+        function syncResetBtn() {
+            resetBtn.disabled = rowTypes.every(r => r.visible);
+        }
+
+        function updateBtnLabel() {
+            const hidden = rowTypes.filter(r => !r.visible).length;
+            btn.textContent = hidden > 0 ? 'Row visibility (' + hidden + ' hidden)' : 'Row visibility';
+        }
+
+        rowTypes.forEach(rowType => {
+            const item = document.createElement('li');
+            item.className = 'table-toolbar__item';
+
+            const label = document.createElement('label');
+            label.className = 'table-toolbar__label';
+
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.checked = rowType.visible;
+            checkbox.setAttribute('data-testid', 'row-checkbox-' + rowType.type);
+            checkbox.addEventListener('change', () => {
+                rowType.visible = checkbox.checked;
+                setRowTypeVisibility(tbody, rowType.type, rowType.visible);
+                writeRowsToStorage(rowTypes.filter(r => !r.visible).map(r => r.type));
+                updateBtnLabel();
+                syncResetBtn();
+            });
+
+            label.appendChild(checkbox);
+            label.appendChild(document.createTextNode(' ' + rowType.type));
+            item.appendChild(label);
+            list.appendChild(item);
+        });
+
+        resetBtn.addEventListener('click', () => {
+            rowTypes.forEach(rowType => {
+                rowType.visible = true;
+                setRowTypeVisibility(tbody, rowType.type, true);
+            });
+            list.querySelectorAll('input[type=checkbox]').forEach(cb => (cb.checked = true));
+            writeRowsToStorage([]);
+            updateBtnLabel();
+            syncResetBtn();
+        });
+
+        btn.addEventListener('click', e => {
+            e.stopPropagation();
+            const opening = panel.hidden;
+            closeAllPanels();
+            if (opening) openPanel(btn, panel);
+        });
+
+        updateBtnLabel();
+        syncResetBtn();
+    }
+
+    /*
      * Panel open/close helpers (shared between columns and rows panels)
      */
 
@@ -208,6 +320,7 @@
         }
 
         initColumnsPanel(table, columns, onToggle);
+        initRowsPanel(tbody);
 
         document.addEventListener('click', e => {
             const toolbar = document.querySelector('[data-testid="table-toolbar"]');

--- a/strictdoc/export/html/templates/icons/ico16_dropdown_collapse.svg
+++ b/strictdoc/export/html/templates/icons/ico16_dropdown_collapse.svg
@@ -1,0 +1,12 @@
+<svg
+  class="svg_icon icon_collapse_expand"
+  viewBox="0 0 16 16"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <polyline class="collapsed" points="12 6 8 10 4 6"></polyline>
+  <line class="expanded" x1="4" y1="8" x2="12" y2="8"></line>
+</svg>

--- a/strictdoc/export/html/templates/screens/document/table/filter.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/filter.jinja
@@ -4,7 +4,9 @@
             aria-haspopup="true"
             aria-expanded="false"
             data-label="Columns"
-            data-testid="table-toolbar-columns-btn">Columns visibility</button>
+            data-testid="table-toolbar-columns-btn">
+            {%- include "icons/ico16_dropdown_collapse.svg" -%}
+            <span class="table-toolbar__btn-text">Columns</span></button>
     <div class="table-toolbar__panel dropdown_menu"
           hidden
           aria-hidden="true"
@@ -12,7 +14,7 @@
           aria-label="Column visibility"
           data-testid="table-toolbar-columns-panel">
       <div class="table-toolbar__panel-header">
-        {# <span class="table-toolbar__panel-title">Columns</span> #}
+        <span class="table-toolbar__panel-title">Visible:</span>
         <button class="table-toolbar__reset compact action_button"
                 data-testid="table-toolbar-columns-reset">Show all</button>
       </div>
@@ -23,7 +25,9 @@
     <button class="table-toolbar__btn action_button"
             aria-haspopup="true"
             aria-expanded="false"
-            data-testid="table-toolbar-rows-btn">Rows visibility</button>
+            data-testid="table-toolbar-rows-btn">
+            {%- include "icons/ico16_dropdown_collapse.svg" -%}
+            <span class="table-toolbar__btn-text">Nodes</span></button>
     <div class="table-toolbar__panel dropdown_menu"
           hidden
           aria-hidden="true"
@@ -31,7 +35,7 @@
           aria-label="Row visibility"
           data-testid="table-toolbar-rows-panel">
       <div class="table-toolbar__panel-header">
-        {# <span class="table-toolbar__panel-title">Row types</span> #}
+        <span class="table-toolbar__panel-title">Visible:</span>
         <button class="table-toolbar__reset compact action_button"
                 data-testid="table-toolbar-rows-reset">Show all</button>
       </div>

--- a/strictdoc/export/html/templates/screens/document/table/filter.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/filter.jinja
@@ -3,6 +3,7 @@
     <button class="table-toolbar__btn action_button"
             aria-haspopup="true"
             aria-expanded="false"
+            data-label="Columns"
             data-testid="table-toolbar-columns-btn">Columns visibility</button>
     <div class="table-toolbar__panel dropdown_menu"
           hidden

--- a/strictdoc/export/html/templates/screens/document/table/filter.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/filter.jinja
@@ -1,0 +1,40 @@
+<div class="table-toolbar" data-testid="table-toolbar">
+  <div class="table-toolbar__columns">
+    <button class="table-toolbar__btn action_button"
+            aria-haspopup="true"
+            aria-expanded="false"
+            data-testid="table-toolbar-columns-btn">Columns visibility</button>
+    <div class="table-toolbar__panel dropdown_menu"
+          hidden
+          aria-hidden="true"
+          role="dialog"
+          aria-label="Column visibility"
+          data-testid="table-toolbar-columns-panel">
+      <div class="table-toolbar__panel-header">
+        {# <span class="table-toolbar__panel-title">Columns</span> #}
+        <button class="table-toolbar__reset compact action_button"
+                data-testid="table-toolbar-columns-reset">Show all</button>
+      </div>
+      <ul class="table-toolbar__list" data-testid="table-toolbar-columns-list"></ul>
+    </div>
+  </div>
+  <div class="table-toolbar__rows">
+    <button class="table-toolbar__btn action_button"
+            aria-haspopup="true"
+            aria-expanded="false"
+            data-testid="table-toolbar-rows-btn">Rows visibility</button>
+    <div class="table-toolbar__panel dropdown_menu"
+          hidden
+          aria-hidden="true"
+          role="dialog"
+          aria-label="Row visibility"
+          data-testid="table-toolbar-rows-panel">
+      <div class="table-toolbar__panel-header">
+        {# <span class="table-toolbar__panel-title">Row types</span> #}
+        <button class="table-toolbar__reset compact action_button"
+                data-testid="table-toolbar-rows-reset">Show all</button>
+      </div>
+      <ul class="table-toolbar__list" data-testid="table-toolbar-rows-list"></ul>
+    </div>
+    </div>
+</div>

--- a/strictdoc/export/html/templates/screens/document/table/main.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/main.jinja
@@ -7,6 +7,42 @@
         {% include "components/node_field/document_meta/index.jinja" %}
 
         </sdoc-node>
+        <div class="table-toolbar" data-testid="table-toolbar">
+          <button class="table-toolbar__btn action_button"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                  data-testid="table-toolbar-columns-btn">Columns visibility</button>
+          <div class="table-toolbar__panel dropdown_menu"
+               hidden
+               aria-hidden="true"
+               role="dialog"
+               aria-label="Column visibility"
+               data-testid="table-toolbar-columns-panel">
+            <div class="table-toolbar__panel-header">
+              <span class="table-toolbar__panel-title">Columns</span>
+              <button class="table-toolbar__reset compact action_button"
+                      data-testid="table-toolbar-columns-reset">Show all</button>
+            </div>
+            <ul class="table-toolbar__list" data-testid="table-toolbar-columns-list"></ul>
+          </div>
+          <button class="table-toolbar__btn action_button"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                  data-testid="table-toolbar-rows-btn">Row visibility</button>
+          <div class="table-toolbar__panel dropdown_menu"
+               hidden
+               aria-hidden="true"
+               role="dialog"
+               aria-label="Row visibility"
+               data-testid="table-toolbar-rows-panel">
+            <div class="table-toolbar__panel-header">
+              <span class="table-toolbar__panel-title">Row types</span>
+              <button class="table-toolbar__reset compact action_button"
+                      data-testid="table-toolbar-rows-reset">Show all</button>
+            </div>
+            <ul class="table-toolbar__list" data-testid="table-toolbar-rows-list"></ul>
+          </div>
+        </div>
         <table class="content-view-table">
           <thead>
             <tr>

--- a/strictdoc/export/html/templates/screens/document/table/main.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/main.jinja
@@ -5,44 +5,10 @@
         <sdoc-node>
         {% include "components/node_field/document_title/index.jinja" %}
         {% include "components/node_field/document_meta/index.jinja" %}
-
         </sdoc-node>
-        <div class="table-toolbar" data-testid="table-toolbar">
-          <button class="table-toolbar__btn action_button"
-                  aria-haspopup="true"
-                  aria-expanded="false"
-                  data-testid="table-toolbar-columns-btn">Columns visibility</button>
-          <div class="table-toolbar__panel dropdown_menu"
-               hidden
-               aria-hidden="true"
-               role="dialog"
-               aria-label="Column visibility"
-               data-testid="table-toolbar-columns-panel">
-            <div class="table-toolbar__panel-header">
-              <span class="table-toolbar__panel-title">Columns</span>
-              <button class="table-toolbar__reset compact action_button"
-                      data-testid="table-toolbar-columns-reset">Show all</button>
-            </div>
-            <ul class="table-toolbar__list" data-testid="table-toolbar-columns-list"></ul>
-          </div>
-          <button class="table-toolbar__btn action_button"
-                  aria-haspopup="true"
-                  aria-expanded="false"
-                  data-testid="table-toolbar-rows-btn">Row visibility</button>
-          <div class="table-toolbar__panel dropdown_menu"
-               hidden
-               aria-hidden="true"
-               role="dialog"
-               aria-label="Row visibility"
-               data-testid="table-toolbar-rows-panel">
-            <div class="table-toolbar__panel-header">
-              <span class="table-toolbar__panel-title">Row types</span>
-              <button class="table-toolbar__reset compact action_button"
-                      data-testid="table-toolbar-rows-reset">Show all</button>
-            </div>
-            <ul class="table-toolbar__list" data-testid="table-toolbar-rows-list"></ul>
-          </div>
-        </div>
+
+        {% include "screens/document/table/filter.jinja" %}
+
         <table class="content-view-table">
           <thead>
             <tr>

--- a/strictdoc/export/html/templates/screens/document/table/main.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/main.jinja
@@ -64,7 +64,7 @@
           {%- for node, _ in view_object.document_content_iterator() %}
             {%- if node.is_requirement() %}
               {%- set requirement = node %}
-              <tr>
+              <tr data-row-type="{{ node.node_type }}">
                 <td class="content-view-td content-view-td-type">
                   {{ node.node_type }}
                 </td>
@@ -165,7 +165,7 @@
               </tr>
             {%- elif node.is_document() %}
               {%- set section = node %}
-              <tr>
+              <tr data-row-type="Section">
                 <td class="content-view-td content-view-td-type">Section</td>
                 <td class="content-view-td content-view-td-meta">{{ section.context.title_number_string }}</td>
                 {%- for meta_field_title in view_object.document.enumerate_table_meta_field_titles() -%}

--- a/tests/end2end/helpers/screens/table/screen_table.py
+++ b/tests/end2end/helpers/screens/table/screen_table.py
@@ -6,6 +6,9 @@ from tests.end2end.helpers.screens.screen import Screen
 _COLUMNS_BTN = '[data-testid="table-toolbar-columns-btn"]'
 _COLUMNS_PANEL = '[data-testid="table-toolbar-columns-panel"]'
 _COLUMNS_RESET = '[data-testid="table-toolbar-columns-reset"]'
+_ROWS_BTN = '[data-testid="table-toolbar-rows-btn"]'
+_ROWS_PANEL = '[data-testid="table-toolbar-rows-panel"]'
+_ROWS_RESET = '[data-testid="table-toolbar-rows-reset"]'
 
 
 class Screen_Table(Screen):  # pylint: disable=invalid-name
@@ -73,3 +76,59 @@ class Screen_Table(Screen):  # pylint: disable=invalid-name
     def do_close_panel_by_outside_click(self) -> None:
         self.test_case.click(".content-view-table")
         self.assert_toolbar_panel_closed()
+
+    #
+    # Row visibility toolbar
+    #
+
+    def assert_rows_toolbar_btn_label(self, label: str) -> None:
+        actual = self.test_case.execute_script(
+            f"return document.querySelector('{_ROWS_BTN}').textContent"
+        )
+        assert actual == label, (
+            f"Rows button label: expected {label!r}, got {actual!r}"
+        )
+
+    def assert_rows_toolbar_panel_open(self) -> None:
+        self.test_case.assert_element_visible(_ROWS_PANEL)
+
+    def assert_rows_toolbar_panel_closed(self) -> None:
+        self.test_case.assert_element_not_visible(_ROWS_PANEL)
+
+    def assert_rows_show_all_disabled(self) -> None:
+        disabled = self.test_case.execute_script(
+            f"return document.querySelector('{_ROWS_RESET}').disabled"
+        )
+        assert disabled, "Expected rows Show all button to be disabled"
+
+    def assert_rows_show_all_enabled(self) -> None:
+        disabled = self.test_case.execute_script(
+            f"return document.querySelector('{_ROWS_RESET}').disabled"
+        )
+        assert not disabled, "Expected rows Show all button to be enabled"
+
+    def assert_rows_of_type_visible(self, row_type: str) -> None:
+        rows = self.test_case.execute_script(
+            f"return Array.from(document.querySelectorAll("
+            f"'tr[data-row-type=\"{row_type}\"]')"
+            f").every(r => r.style.display !== 'none')"
+        )
+        assert rows, f"Expected rows of type {row_type!r} to be visible"
+
+    def assert_rows_of_type_hidden(self, row_type: str) -> None:
+        rows = self.test_case.execute_script(
+            f"return Array.from(document.querySelectorAll("
+            f"'tr[data-row-type=\"{row_type}\"]')"
+            f").every(r => r.style.display === 'none')"
+        )
+        assert rows, f"Expected rows of type {row_type!r} to be hidden"
+
+    def do_open_rows_toolbar_panel(self) -> None:
+        self.test_case.click(_ROWS_BTN)
+        self.assert_rows_toolbar_panel_open()
+
+    def do_toggle_row_type(self, row_type: str) -> None:
+        self.test_case.click(f'[data-testid="row-checkbox-{row_type}"]')
+
+    def do_click_rows_show_all(self) -> None:
+        self.test_case.click(_ROWS_RESET)

--- a/tests/end2end/helpers/screens/table/screen_table.py
+++ b/tests/end2end/helpers/screens/table/screen_table.py
@@ -4,9 +4,11 @@ from seleniumbase import BaseCase
 from tests.end2end.helpers.screens.screen import Screen
 
 _COLUMNS_BTN = '[data-testid="table-toolbar-columns-btn"]'
+_COLUMNS_BTN_TEXT = _COLUMNS_BTN + " .table-toolbar__btn-text"
 _COLUMNS_PANEL = '[data-testid="table-toolbar-columns-panel"]'
 _COLUMNS_RESET = '[data-testid="table-toolbar-columns-reset"]'
 _ROWS_BTN = '[data-testid="table-toolbar-rows-btn"]'
+_ROWS_BTN_TEXT = _ROWS_BTN + " .table-toolbar__btn-text"
 _ROWS_PANEL = '[data-testid="table-toolbar-rows-panel"]'
 _ROWS_RESET = '[data-testid="table-toolbar-rows-reset"]'
 
@@ -27,7 +29,7 @@ class Screen_Table(Screen):  # pylint: disable=invalid-name
 
     def assert_toolbar_btn_label(self, label: str) -> None:
         actual = self.test_case.execute_script(
-            f"return document.querySelector('{_COLUMNS_BTN}').textContent"
+            f"return document.querySelector('{_COLUMNS_BTN_TEXT}').textContent"
         )
         assert actual == label, (
             f"Button label: expected {label!r}, got {actual!r}"
@@ -83,7 +85,7 @@ class Screen_Table(Screen):  # pylint: disable=invalid-name
 
     def assert_rows_toolbar_btn_label(self, label: str) -> None:
         actual = self.test_case.execute_script(
-            f"return document.querySelector('{_ROWS_BTN}').textContent"
+            f"return document.querySelector('{_ROWS_BTN_TEXT}').textContent"
         )
         assert actual == label, (
             f"Rows button label: expected {label!r}, got {actual!r}"

--- a/tests/end2end/screens/table/view_table_document/view_table_document_column_visibility_toggle/test_case.py
+++ b/tests/end2end/screens/table/view_table_document/view_table_document_column_visibility_toggle/test_case.py
@@ -37,7 +37,7 @@ class Test(E2ECase):
             #
             # Initial state
             #
-            screen_table.assert_toolbar_btn_label("Columns visibility")
+            screen_table.assert_toolbar_btn_label("Columns")
             screen_table.assert_toolbar_panel_closed()
 
             # Open panel — Show all disabled, checkboxes present
@@ -76,7 +76,7 @@ class Test(E2ECase):
             screen_table.assert_column_header_visible("Type")
             screen_table.assert_column_header_visible("Statement")
             self.assert_url_not_contains("hidden=")
-            screen_table.assert_toolbar_btn_label("Columns visibility")
+            screen_table.assert_toolbar_btn_label("Columns")
             screen_table.assert_show_all_disabled()
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_state_persistence/expected_output/document.sdoc
+++ b/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_state_persistence/expected_output/document.sdoc
@@ -1,0 +1,11 @@
+[DOCUMENT]
+TITLE: Document
+
+[[SECTION]]
+TITLE: First section
+
+[REQUIREMENT]
+TITLE: First requirement
+STATEMENT: Statement of the first requirement.
+
+[[/SECTION]]

--- a/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_state_persistence/input/document.sdoc
+++ b/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_state_persistence/input/document.sdoc
@@ -1,0 +1,11 @@
+[DOCUMENT]
+TITLE: Document
+
+[[SECTION]]
+TITLE: First section
+
+[REQUIREMENT]
+TITLE: First requirement
+STATEMENT: Statement of the first requirement.
+
+[[/SECTION]]

--- a/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_state_persistence/test_case.py
+++ b/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_state_persistence/test_case.py
@@ -1,0 +1,42 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.viewtype_selector import ViewType_Selector
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+
+            screen_document = screen_project_index.do_click_on_first_document()
+            screen_document.assert_on_screen_document()
+
+            self.clear_local_storage()
+
+            viewtype_selector = ViewType_Selector(self)
+            screen_table = viewtype_selector.do_go_to_table()
+            screen_table.assert_on_screen_table()
+
+            # Hide "SECTION" rows via the panel — written to localStorage.
+            screen_table.do_open_rows_toolbar_panel()
+            screen_table.do_toggle_row_type("SECTION")
+            screen_table.assert_rows_of_type_hidden("SECTION")
+
+            # Reload the page — state must be restored from localStorage.
+            self.reload_page_without_query()
+            screen_table.assert_on_screen_table()
+            screen_table.assert_rows_of_type_hidden("SECTION")
+            screen_table.assert_rows_of_type_visible("REQUIREMENT")
+
+        assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_toggle/expected_output/document.sdoc
+++ b/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_toggle/expected_output/document.sdoc
@@ -1,0 +1,15 @@
+[DOCUMENT]
+TITLE: Document
+
+[[SECTION]]
+TITLE: First section
+
+[REQUIREMENT]
+TITLE: First requirement
+STATEMENT: Statement of the first requirement.
+
+[[/SECTION]]
+
+[REQUIREMENT]
+TITLE: Second requirement
+STATEMENT: Statement of the second requirement.

--- a/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_toggle/input/document.sdoc
+++ b/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_toggle/input/document.sdoc
@@ -1,0 +1,15 @@
+[DOCUMENT]
+TITLE: Document
+
+[[SECTION]]
+TITLE: First section
+
+[REQUIREMENT]
+TITLE: First requirement
+STATEMENT: Statement of the first requirement.
+
+[[/SECTION]]
+
+[REQUIREMENT]
+TITLE: Second requirement
+STATEMENT: Statement of the second requirement.

--- a/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_toggle/test_case.py
+++ b/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_toggle/test_case.py
@@ -33,7 +33,7 @@ class Test(E2ECase):
             #
             # Initial state
             #
-            screen_table.assert_rows_toolbar_btn_label("Rows visibility")
+            screen_table.assert_rows_toolbar_btn_label("Nodes")
             screen_table.assert_rows_toolbar_panel_closed()
 
             # Open rows panel — Show all disabled, both types present
@@ -48,7 +48,7 @@ class Test(E2ECase):
             screen_table.do_toggle_row_type("SECTION")
             screen_table.assert_rows_of_type_hidden("SECTION")
             screen_table.assert_rows_of_type_visible("REQUIREMENT")
-            screen_table.assert_rows_toolbar_btn_label("Rows visibility (1 hidden)")
+            screen_table.assert_rows_toolbar_btn_label("Nodes (1 hidden)")
             screen_table.assert_rows_show_all_enabled()
 
             #
@@ -56,7 +56,7 @@ class Test(E2ECase):
             #
             screen_table.do_toggle_row_type("REQUIREMENT")
             screen_table.assert_rows_of_type_hidden("REQUIREMENT")
-            screen_table.assert_rows_toolbar_btn_label("Rows visibility (2 hidden)")
+            screen_table.assert_rows_toolbar_btn_label("Nodes (2 hidden)")
 
             #
             # Show all
@@ -64,7 +64,7 @@ class Test(E2ECase):
             screen_table.do_click_rows_show_all()
             screen_table.assert_rows_of_type_visible("SECTION")
             screen_table.assert_rows_of_type_visible("REQUIREMENT")
-            screen_table.assert_rows_toolbar_btn_label("Rows visibility")
+            screen_table.assert_rows_toolbar_btn_label("Nodes")
             screen_table.assert_rows_show_all_disabled()
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_toggle/test_case.py
+++ b/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_toggle/test_case.py
@@ -1,0 +1,70 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.viewtype_selector import ViewType_Selector
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+            screen_document.assert_on_screen_document()
+
+            self.clear_local_storage()
+
+            viewtype_selector = ViewType_Selector(self)
+            screen_table = viewtype_selector.do_go_to_table()
+            screen_table.assert_on_screen_table()
+            screen_table.assert_not_empty_view()
+
+            #
+            # Initial state
+            #
+            screen_table.assert_rows_toolbar_btn_label("Row visibility")
+            screen_table.assert_rows_toolbar_panel_closed()
+
+            # Open rows panel — Show all disabled, both types present
+            screen_table.do_open_rows_toolbar_panel()
+            screen_table.assert_rows_show_all_disabled()
+            self.assert_element('[data-testid="row-checkbox-SECTION"]')
+            self.assert_element('[data-testid="row-checkbox-REQUIREMENT"]')
+
+            #
+            # Hide "SECTION" rows
+            #
+            screen_table.do_toggle_row_type("SECTION")
+            screen_table.assert_rows_of_type_hidden("SECTION")
+            screen_table.assert_rows_of_type_visible("REQUIREMENT")
+            screen_table.assert_rows_toolbar_btn_label("Row visibility (1 hidden)")
+            screen_table.assert_rows_show_all_enabled()
+
+            #
+            # Hide "REQUIREMENT" rows
+            #
+            screen_table.do_toggle_row_type("REQUIREMENT")
+            screen_table.assert_rows_of_type_hidden("REQUIREMENT")
+            screen_table.assert_rows_toolbar_btn_label("Row visibility (2 hidden)")
+
+            #
+            # Show all
+            #
+            screen_table.do_click_rows_show_all()
+            screen_table.assert_rows_of_type_visible("SECTION")
+            screen_table.assert_rows_of_type_visible("REQUIREMENT")
+            screen_table.assert_rows_toolbar_btn_label("Row visibility")
+            screen_table.assert_rows_show_all_disabled()
+
+        assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_toggle/test_case.py
+++ b/tests/end2end/screens/table/view_table_document/view_table_document_row_visibility_toggle/test_case.py
@@ -33,7 +33,7 @@ class Test(E2ECase):
             #
             # Initial state
             #
-            screen_table.assert_rows_toolbar_btn_label("Row visibility")
+            screen_table.assert_rows_toolbar_btn_label("Rows visibility")
             screen_table.assert_rows_toolbar_panel_closed()
 
             # Open rows panel — Show all disabled, both types present
@@ -48,7 +48,7 @@ class Test(E2ECase):
             screen_table.do_toggle_row_type("SECTION")
             screen_table.assert_rows_of_type_hidden("SECTION")
             screen_table.assert_rows_of_type_visible("REQUIREMENT")
-            screen_table.assert_rows_toolbar_btn_label("Row visibility (1 hidden)")
+            screen_table.assert_rows_toolbar_btn_label("Rows visibility (1 hidden)")
             screen_table.assert_rows_show_all_enabled()
 
             #
@@ -56,7 +56,7 @@ class Test(E2ECase):
             #
             screen_table.do_toggle_row_type("REQUIREMENT")
             screen_table.assert_rows_of_type_hidden("REQUIREMENT")
-            screen_table.assert_rows_toolbar_btn_label("Row visibility (2 hidden)")
+            screen_table.assert_rows_toolbar_btn_label("Rows visibility (2 hidden)")
 
             #
             # Show all
@@ -64,7 +64,7 @@ class Test(E2ECase):
             screen_table.do_click_rows_show_all()
             screen_table.assert_rows_of_type_visible("SECTION")
             screen_table.assert_rows_of_type_visible("REQUIREMENT")
-            screen_table.assert_rows_toolbar_btn_label("Row visibility")
+            screen_table.assert_rows_toolbar_btn_label("Rows visibility")
             screen_table.assert_rows_show_all_disabled()
 
         assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
- Row type filter ("Nodes"): added a second toolbar panel to the table view that filters rows by node type (REQUIREMENT, SECTION, TEXT, etc.). Types are discovered dynamically from the table. Filter state persists across page reloads via localStorage.
- Toolbar HTML moved to template partial - filter.jinja, instead of being generated in JavaScript.
- Icons added to toolbar buttons
- Small UX improvements
- JS refactoring

Related to #2808
