### PR TITLE
fix(export/html): Let document tables inherit context font size

### DIFF
--- a/strictdoc/export/html/_static/autogen.css
+++ b/strictdoc/export/html/_static/autogen.css
@@ -25,7 +25,6 @@ sdoc-autogen a:visited {
 sdoc-autogen table {
   border-collapse: collapse;
   margin: var(--base-padding) 0;
-  font-size: 1rem;
 
   /*** add scroll for wide tables */
   /* issue#1370 https://css-tricks.com/preventing-a-grid-blowout/ */


### PR DESCRIPTION
Closes #2803