### PR TITLE
feat(export/html): viewtype menu empty state indicators

### DIFF
--- a/strictdoc/export/html/_static/dropdown_menu.js
+++ b/strictdoc/export/html/_static/dropdown_menu.js
@@ -3,49 +3,66 @@
 // Content: element with that id + aria-hidden.
 
 (function () {
-window.addEventListener("load", () => {
-  const toggles = document.querySelectorAll("[data-dropdown-handler]");
-  const pairs = [];
-  toggles.forEach((toggle) => {
-    const contentId = toggle.getAttribute("aria-controls");
-    if (!contentId) return;
-    const content = document.getElementById(contentId);
-    if (!content) return;
-    pairs.push({ toggle, content });
-  });
-
-  pairs.forEach((pair) => {
-    const { toggle, content } = pair;
-
-    const show = () => {
-      pairs.forEach((p) => {
-        if (p === pair) return;
-        p.toggle.setAttribute("aria-expanded", false);
-        p.content.setAttribute("aria-hidden", true);
-      });
-      toggle.setAttribute("aria-expanded", true);
-      content.setAttribute("aria-hidden", false);
-    };
-
-    const hide = () => {
-      toggle.setAttribute("aria-expanded", false);
-      content.setAttribute("aria-hidden", true);
-    };
-
-    toggle.addEventListener("click", (event) => {
-      event.stopPropagation();
-      JSON.parse(toggle.getAttribute("aria-expanded")) ? hide() : show();
+  function initDropdowns() {
+    const toggles = document.querySelectorAll(
+      "[data-dropdown-handler]:not([data-dropdown-initialized])"
+    );
+    const pairs = [];
+    toggles.forEach((toggle) => {
+      const contentId = toggle.getAttribute("aria-controls");
+      if (!contentId) return;
+      const content = document.getElementById(contentId);
+      if (!content) return;
+      toggle.setAttribute("data-dropdown-initialized", "true");
+      pairs.push({ toggle, content });
     });
 
-    // Close when click/focus is outside both the toggle and the content.
-    const handleClosure = (event) => {
-      const target = event.target;
-      if (!toggle.contains(target) && !content.contains(target)) hide();
-    };
+    pairs.forEach((pair) => {
+      const { toggle, content } = pair;
 
-    window.addEventListener("click", handleClosure);
-    window.addEventListener("focusin", handleClosure);
+      const show = () => {
+        pairs.forEach((p) => {
+          if (p === pair) return;
+          p.toggle.setAttribute("aria-expanded", false);
+          p.content.setAttribute("aria-hidden", true);
+        });
+        toggle.setAttribute("aria-expanded", true);
+        content.setAttribute("aria-hidden", false);
+      };
+
+      const hide = () => {
+        toggle.setAttribute("aria-expanded", false);
+        content.setAttribute("aria-hidden", true);
+      };
+
+      toggle.addEventListener("click", (event) => {
+        event.stopPropagation();
+        JSON.parse(toggle.getAttribute("aria-expanded")) ? hide() : show();
+      });
+
+      // Close when click/focus is outside both the toggle and the content.
+      const handleClosure = (event) => {
+        const target = event.target;
+        if (!toggle.contains(target) && !content.contains(target)) hide();
+      };
+
+      window.addEventListener("click", handleClosure);
+      window.addEventListener("focusin", handleClosure);
+    });
+  }
+
+  // On initial page load, wire up all dropdowns found in the DOM.
+  window.addEventListener("load", () => {
+    initDropdowns();
+
+    // When a turbo-stream replaces the frame content, the old DOM nodes and
+    // their event listeners are gone. MutationObserver re-initializes any
+    // fresh toggle that appears — the :not([data-dropdown-initialized])
+    // selector makes it a no-op if nothing new arrived.
+    const frame = document.getElementById("frame-viewtype-menu");
+    if (frame) {
+      new MutationObserver(initDropdowns).observe(frame, { childList: true });
+    }
   });
 
-}, false);
 })();

--- a/strictdoc/export/html/_static/element.css
+++ b/strictdoc/export/html/_static/element.css
@@ -1041,6 +1041,12 @@ a.strictdoc__version:hover {
   cursor: default;
 }
 
+.dropdown_menu_item.empty {
+  color: var(--color-fg-secondary);
+  background-color: var(--color-bg-contrast);
+  cursor: default;
+}
+
 /*
  ** header-actions: reusable wrapper for header buttons + kebab dropdown
  */

--- a/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
@@ -129,6 +129,11 @@ class DocumentScreenViewObject:
             view_object=self,
         )
 
+        output += self.jinja_environment.render_template_as_markup(
+            "actions/document/_shared/stream_updated_viewtype_menu.jinja.html",
+            view_object=self,
+        )
+
         return output
 
     def render_updated_nodes_and_toc(
@@ -170,6 +175,18 @@ class DocumentScreenViewObject:
                 target="frame-toc",
             )
 
+            viewtype_menu_content = (
+                self.jinja_environment.render_template_as_markup(
+                    "screens/document/_shared/viewtype_menu.jinja",
+                    view_object=self,
+                )
+            )
+            output += render_turbo_stream(
+                content=viewtype_menu_content,
+                action="update",
+                target="frame-viewtype-menu",
+            )
+
         return output
 
     def render_update_document_content_with_moved_node(
@@ -194,6 +211,12 @@ class DocumentScreenViewObject:
             action="update",
             target="frame-toc",
         )
+
+        output += self.jinja_environment.render_template_as_markup(
+            "actions/document/_shared/stream_updated_viewtype_menu.jinja.html",
+            view_object=self,
+        )
+
         return output
 
     def render_document_version(self) -> Optional[str]:

--- a/strictdoc/export/html/templates/actions/document/_shared/stream_updated_viewtype_menu.jinja.html
+++ b/strictdoc/export/html/templates/actions/document/_shared/stream_updated_viewtype_menu.jinja.html
@@ -1,0 +1,5 @@
+<turbo-stream action="update" target="frame-viewtype-menu">
+  <template>
+    {% include "screens/document/_shared/viewtype_menu.jinja" %}
+  </template>
+</turbo-stream>

--- a/strictdoc/export/html/templates/screens/document/_shared/frame_viewtype_menu.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/frame_viewtype_menu.jinja
@@ -1,0 +1,6 @@
+<turbo-frame
+  id="frame-viewtype-menu"
+  style="display: contents"
+>
+  {% include "screens/document/_shared/viewtype_menu.jinja" %}
+</turbo-frame>

--- a/strictdoc/export/html/templates/screens/document/_shared/viewtype_menu.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/viewtype_menu.jinja
@@ -1,3 +1,14 @@
+{#
+  Empty-state flags: a view is "empty" if it would show the placeholder instead of content.
+  - Table and Traceability: no nodes at all in the document.
+  - Deep Traceability: uses has_any_requirements() which historically excluded sections,
+    but after a refactoring sections now appear in DTR as well.
+    TODO: revisit deeptrace_is_empty condition if the DTR output changes to exclude sections again.
+#}
+{%- set table_is_empty = not view_object.has_any_nodes() -%}
+{%- set trace_is_empty = not view_object.has_any_nodes() -%}
+{%- set deeptrace_is_empty = not view_object.document.has_any_requirements() -%}
+
 <div class="viewtype">
   <div
     id="viewtype_handler"
@@ -28,30 +39,30 @@
     <li>
       <a
         data-viewtype_link="table"
-        class="dropdown_menu_item"
-        title="Go to Table view"
+        class="dropdown_menu_item{% if table_is_empty %} empty{% endif %}"
+        title="{% if table_is_empty %}This page has no content{% else %}Go to Table view{% endif %}"
         href="{{ view_object.render_document_link(view_object.document, none, "TABLE") }}">
-      Table</a>
+      Table{% if table_is_empty %} (empty){% endif %}</a>
     </li>
     {%- endif -%}
     {%- if view_object.project_config.is_activated_trace_screen() -%}
     <li>
       <a
         data-viewtype_link="traceability"
-        class="dropdown_menu_item"
-        title="Go to Traceability view"
+        class="dropdown_menu_item{% if trace_is_empty %} empty{% endif %}"
+        title="{% if trace_is_empty %}This page has no content{% else %}Go to Traceability view{% endif %}"
         href="{{ view_object.render_document_link(view_object.document, none, "TRACE") }}">
-      Traceability</a>
+      Traceability{% if trace_is_empty %} (empty){% endif %}</a>
     </li>
     {%- endif -%}
     {%- if view_object.project_config.is_activated_deep_trace_screen() -%}
     <li>
       <a
         data-viewtype_link="deep_traceability"
-        class="dropdown_menu_item"
-        title="Go to Deep Traceability view"
+        class="dropdown_menu_item{% if deeptrace_is_empty %} empty{% endif %}"
+        title="{% if deeptrace_is_empty %}This page has no content{% else %}Go to Deep Traceability view{% endif %}"
         href="{{ view_object.render_document_link(view_object.document, none, "DEEPTRACE") }}">
-      Deep Traceability</a>
+      Deep Traceability{% if deeptrace_is_empty %} (empty){% endif %}</a>
     </li>
     {%- endif -%}
     {%- if view_object.project_config.is_activated_html2pdf() -%}

--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -122,7 +122,7 @@
 
 {%- set header_items = [
       "screens/document/_shared/frame_header_document_title.jinja",
-      "screens/document/_shared/viewtype_menu.jinja"
+      "screens/document/_shared/frame_viewtype_menu.jinja"
     ]
 -%}
 

--- a/strictdoc/export/html/templates/screens/document/pdf/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/pdf/index.jinja
@@ -59,7 +59,7 @@
 
 {%- set header_items = [
       "screens/document/_shared/frame_header_document_title.jinja",
-      "screens/document/_shared/viewtype_menu.jinja"
+      "screens/document/_shared/frame_viewtype_menu.jinja"
     ]
 -%}
 

--- a/strictdoc/export/html/templates/screens/document/table/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/index.jinja
@@ -49,7 +49,7 @@
   {%- with
       header__items=[
         "screens/document/_shared/frame_header_document_title.jinja",
-        "screens/document/_shared/viewtype_menu.jinja"
+        "screens/document/_shared/frame_viewtype_menu.jinja"
       ]
   -%}
     {% include "components/header/index.jinja" %}

--- a/strictdoc/export/html/templates/screens/document/traceability/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/traceability/index.jinja
@@ -59,7 +59,7 @@
   {%- with
       header__items=[
         "screens/document/_shared/frame_header_document_title.jinja",
-        "screens/document/_shared/viewtype_menu.jinja"
+        "screens/document/_shared/frame_viewtype_menu.jinja"
       ]
   -%}
     {% include "components/header/index.jinja" %}

--- a/strictdoc/export/html/templates/screens/document/traceability_deep/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/traceability_deep/index.jinja
@@ -59,7 +59,7 @@
   {%- with
       header__items=[
         "screens/document/_shared/frame_header_document_title.jinja",
-        "screens/document/_shared/viewtype_menu.jinja"
+        "screens/document/_shared/frame_viewtype_menu.jinja"
       ]
   -%}
     {% include "components/header/index.jinja" %}

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -1089,6 +1089,12 @@ def create_main_router(
             "actions/document/_shared/stream_updated_toc.jinja.html",
             view_object=view_object,
         )
+
+        output += env().render_template_as_markup(
+            "actions/document/_shared/stream_updated_viewtype_menu.jinja.html",
+            view_object=view_object,
+        )
+
         return HTMLResponse(
             content=output,
             status_code=200,

--- a/tests/end2end/helpers/components/viewtype_selector.py
+++ b/tests/end2end/helpers/components/viewtype_selector.py
@@ -83,6 +83,22 @@ class ViewType_Selector:  # pylint: disable=invalid-name
         )
         return Screen_Deep_Traceability(self.test_case)
 
+    # empty state assertions
+
+    def assert_menu_item_is_empty(self, viewtype_link: str) -> None:
+        self.test_case.assert_element(
+            f'//*[@data-viewtype_link="{viewtype_link}"]'
+            f'[contains(., "(empty)")]',
+            by=By.XPATH,
+        )
+
+    def assert_menu_item_is_not_empty(self, viewtype_link: str) -> None:
+        self.test_case.assert_element(
+            f'//*[@data-viewtype_link="{viewtype_link}"]'
+            f'[not(contains(., "(empty)"))]',
+            by=By.XPATH,
+        )
+
     def do_go_to_pdf_document(self) -> Screen_PDFDocument:
         self.do_click_viewtype_handler()
         self.assert_viewtype_menu_opened()

--- a/tests/end2end/navigation/viewtype_selector/viewtype_menu_empty_state/expected_output/document.sdoc
+++ b/tests/end2end/navigation/viewtype_selector/viewtype_menu_empty_state/expected_output/document.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Empty document
+
+[[SECTION]]
+TITLE: New section
+
+[[/SECTION]]

--- a/tests/end2end/navigation/viewtype_selector/viewtype_menu_empty_state/input/document.sdoc
+++ b/tests/end2end/navigation/viewtype_selector/viewtype_menu_empty_state/input/document.sdoc
@@ -1,0 +1,2 @@
+[DOCUMENT]
+TITLE: Empty document

--- a/tests/end2end/navigation/viewtype_selector/viewtype_menu_empty_state/test_case.py
+++ b/tests/end2end/navigation/viewtype_selector/viewtype_menu_empty_state/test_case.py
@@ -1,0 +1,59 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.viewtype_selector import (
+    ViewType_Selector,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Empty document")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Empty document")
+            screen_document.assert_empty_document()
+
+            viewtype_selector = ViewType_Selector(self)
+
+            # Open menu — all views should be marked as empty.
+            viewtype_selector.do_click_viewtype_handler()
+            viewtype_selector.assert_viewtype_menu_opened()
+            viewtype_selector.assert_menu_item_is_empty("table")
+            viewtype_selector.assert_menu_item_is_empty("traceability")
+            viewtype_selector.assert_menu_item_is_empty("deep_traceability")
+
+            # Close menu.
+            viewtype_selector.do_click_viewtype_handler()
+            viewtype_selector.assert_viewtype_menu_closed()
+
+            # Add a section to the document.
+            root_node = screen_document.get_root_node()
+            root_node_menu = root_node.do_open_node_menu()
+            form_edit_section = root_node_menu.do_node_add_element_first(
+                "SECTION"
+            )
+            form_edit_section.do_fill_in("TITLE", "New section")
+            form_edit_section.do_form_submit()
+
+            # Open menu — all views are no longer empty.
+            viewtype_selector.do_click_viewtype_handler()
+            viewtype_selector.assert_viewtype_menu_opened()
+            viewtype_selector.assert_menu_item_is_not_empty("table")
+            viewtype_selector.assert_menu_item_is_not_empty("traceability")
+            viewtype_selector.assert_menu_item_is_not_empty("deep_traceability")
+
+        assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
- Menu items (Table, Traceability, Deep Traceability) show `(empty)` when the corresponding view has no content
- But you can still click the link; the placeholders on the blank pages have been saved
- Menu is updated in real time via turbo-stream when nodes are added or removed on the Document screen
- Dropdown re-initialization fixed for turbo-stream-based DOM updates (MutationObserver)
- E2E test covering: empty → add section → non-empty transition

<img width="715" height="381" alt="image" src="https://github.com/user-attachments/assets/57175231-6c7c-43a1-9d41-78bcc50b71f0" />


Closes #1007
