### PR TITLE
feat(sdoc_source_code): add known function-like Linux macros

### DIFF
--- a/strictdoc/backend/sdoc_source_code/reader_c.py
+++ b/strictdoc/backend/sdoc_source_code/reader_c.py
@@ -42,11 +42,27 @@ from strictdoc.helpers.file_system import file_open_read_bytes
 KNOWN_FUNCTION_DEFINITION_MACROS: Final[frozenset[str]] = frozenset(
     (
         # Linux
+        "COMPAT_SYSCALL_DEFINE0",
+        "COMPAT_SYSCALL_DEFINE1",
+        "COMPAT_SYSCALL_DEFINE2",
+        "COMPAT_SYSCALL_DEFINE3",
+        "COMPAT_SYSCALL_DEFINE4",
+        "COMPAT_SYSCALL_DEFINE5",
+        "COMPAT_SYSCALL_DEFINE6",
+        "FIXTURE_SETUP",
+        "FIXTURE_TEARDOWN",
+        "SYSCALL_DEFINE0",
+        "SYSCALL_DEFINE1",
         "SYSCALL_DEFINE2",
-        # Google Test
+        "SYSCALL_DEFINE3",
+        "SYSCALL_DEFINE4",
+        "SYSCALL_DEFINE5",
+        "SYSCALL_DEFINE6",
+        # Google Test and Linux
         "TEST",
         "TEST_F",
         "TEST_P",
+        "TEST_F_SIGNAL",
         "TYPED_TEST",
         # Zephyr
         "ZTEST_USER",


### PR DESCRIPTION
WHAT: Let the C reader recognize problematic but wanted Linux macros that look like function declarers.

WHY: Linux is one of the code bases used to showcase and evolve StrictDoc. Some of their macros confuse our tree-sitter C parser, but still shall be usable in forward relations.