### PR TITLE
fix(sdoc_source_code): skip erroneous function_definitions

### DIFF
--- a/strictdoc/backend/sdoc_source_code/reader_c.py
+++ b/strictdoc/backend/sdoc_source_code/reader_c.py
@@ -254,7 +254,7 @@ class SourceFileTraceabilityReader_C:
                         node_, "function_declarator", raise_on_error=True
                     )
                 except LookupError:
-                    # probably confused by macro, skip node to avoid processing random subtrees
+                    # Probably confused by macro, skip node to avoid processing random subtrees.
                     continue
                 # C++ reference declaration wrap the function declaration one time.
                 if function_declarator_node is None:

--- a/strictdoc/backend/sdoc_source_code/reader_c.py
+++ b/strictdoc/backend/sdoc_source_code/reader_c.py
@@ -249,9 +249,13 @@ class SourceFileTraceabilityReader_C:
             elif node_.type == "function_definition":
                 function_name = ""
 
-                function_declarator_node = ts_find_child_node_by_type(
-                    node_, "function_declarator"
-                )
+                try:
+                    function_declarator_node = ts_find_child_node_by_type(
+                        node_, "function_declarator", raise_on_error=True
+                    )
+                except LookupError:
+                    # probably confused by macro, skip node to avoid processing random subtrees
+                    continue
                 # C++ reference declaration wrap the function declaration one time.
                 if function_declarator_node is None:
                     # Example: Foo& Foo::operator+(const Foo& c) { return *this; }

--- a/strictdoc/backend/sdoc_source_code/tree_sitter_helpers.py
+++ b/strictdoc/backend/sdoc_source_code/tree_sitter_helpers.py
@@ -24,7 +24,9 @@ def traverse_tree(tree: Tree) -> Generator[Node, None, None]:
 
 
 def ts_find_child_node_by_type(
-    node: Node, node_type: Union[str, Tuple[str, ...], str]
+    node: Node,
+    node_type: Union[str, Tuple[str, ...], str],
+    raise_on_error: bool = False,
 ) -> Optional[Node]:
     node_types: Tuple[str, ...] = (
         node_type if isinstance(node_type, tuple) else (node_type,)
@@ -32,6 +34,8 @@ def ts_find_child_node_by_type(
     for child_ in node.children:
         if child_.type in node_types:
             return child_
+        elif raise_on_error and child_.type == "ERROR":
+            raise LookupError("stop search on error node")
     return None
 
 


### PR DESCRIPTION
WHAT: Ignore function_definitions where the declarer comes after a tree-sitter error node.

WHY: In such a situation the parser is already lost, and a declarer, if any, is random. Since this is sadly an expected case in non-preprocessed C-code due to macros, and since tree-sitter is good in recovering after errors, we should not simply error out, but skip the non-meaningful node.

Following Linux [kernel/softirq.c code](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/kernel/softirq.c#n125) revealed the bug:

```c
static DEFINE_PER_CPU(struct softirq_ctrl, softirq_ctrl) = {
 	.lock	= INIT_LOCAL_LOCK(softirq_ctrl.lock),
};
```

It produces a tree-sitter function_definition with nested error nodes. Worse, the spurious sub tree, which points to unrelated code far below, happens to drive reader_c into the 'identifier_node is None' branch and StrictDoc aborted with `NotImplementedError`.