### PR TITLE
fix(export/html): restore singleline_suffix support in contenteditable

### DIFF
--- a/strictdoc/export/html/templates/components/form/field/contenteditable/index.jinja
+++ b/strictdoc/export/html/templates/components/form/field/contenteditable/index.jinja
@@ -52,6 +52,9 @@
       mid="{{ mid }}"
     {% endif %}
     placeholder="{{ field_placeholder }}"
+    {%- if field_type == "singleline" and singleline_suffix is defined -%}
+      data-field-suffix="{{ singleline_suffix }}"
+    {%- endif -%}
     data-field-label="{{ field_label }}{%- if field_required -%}&nbsp;*{%- endif -%}"
     {%- if field_class_name is not none -%}
       class="{{ field_class_name }}"


### PR DESCRIPTION
This was overlooked in PR #2828.
See #2834
