### PR TITLE
export/html: prevent double-clicks on action buttons

### DIFF
--- a/strictdoc/export/html/_static/action_button_guard.js
+++ b/strictdoc/export/html/_static/action_button_guard.js
@@ -1,0 +1,40 @@
+(function () {
+
+  // Lightweight UI behaviors for server-interactive pages.
+  //
+  // Requires Turbo (hotwired/turbo) to be loaded on the page.
+  // Turbo dispatches its lifecycle events as standard DOM CustomEvents on
+  // document, so no Turbo API is called directly — but without Turbo the
+  // reset listeners below never fire. This is safe because without Turbo
+  // form submissions trigger a full page reload, which resets the DOM anyway.
+  // In StrictDoc this file is only loaded inside the is_running_on_server
+  // block, alongside the Turbo script, so Turbo is always present.
+
+  // Prevent double-clicks on action buttons from sending repeated requests.
+  // Uses capture phase to intercept before Turbo sees the event.
+  document.addEventListener('click', function (event) {
+    const btn = event.target.closest('.action_button');
+    if (!btn) return;
+    if (!btn.matches('[data-turbo-method], [type="submit"]')) return;
+    if (btn.dataset.pending) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+    btn.dataset.pending = 'true';
+    btn.classList.add('pending');
+  }, true);
+
+  // Reset pending state when a request ends, so buttons in forms that
+  // remain open after an error response become clickable again.
+  function resetPending() {
+    document.querySelectorAll('.action_button.pending').forEach(function (btn) {
+      btn.classList.remove('pending');
+      delete btn.dataset.pending;
+    });
+  }
+
+  document.addEventListener('turbo:submit-end', resetPending);
+  document.addEventListener('turbo:frame-render', resetPending);
+
+})();

--- a/strictdoc/export/html/_static/element.css
+++ b/strictdoc/export/html/_static/element.css
@@ -146,6 +146,20 @@ a.action_button:hover {
   cursor: default;
 }
 
+.ico_submit_static { display: block; }
+.ico_submit_spinner { display: none; }
+
+.action_button.pending .ico_submit_static { display: none; }
+.action_button.pending .ico_submit_spinner {
+  display: block;
+  animation: ico-spin 0.7s linear infinite;
+  transform-origin: center;
+}
+
+@keyframes ico-spin {
+  to { transform: rotate(360deg); }
+}
+
 .action_button svg {
   /*
     action_button 1.5 column-gap

--- a/strictdoc/export/html/_static/element.css
+++ b/strictdoc/export/html/_static/element.css
@@ -139,6 +139,13 @@ a.action_button:hover {
   cursor: default;
 }
 
+.action_button.pending,
+.action_button.pending:hover {
+  pointer-events: none;
+  opacity: .6;
+  cursor: default;
+}
+
 .action_button svg {
   /*
     action_button 1.5 column-gap

--- a/strictdoc/export/html/templates/components/button/submit.jinja
+++ b/strictdoc/export/html/templates/components/button/submit.jinja
@@ -11,4 +11,4 @@
   type="submit"
   data-action-type="submit"
   data-testid="form-submit-action"
->{{ submit_name|default('Save') }}</button>
+>{% include "icons/ico16_submit_animated.svg" %}{{ submit_name|default('Save') }}</button>

--- a/strictdoc/export/html/templates/icons/ico16_submit_animated.svg
+++ b/strictdoc/export/html/templates/icons/ico16_submit_animated.svg
@@ -1,0 +1,12 @@
+<svg
+  class="svg_icon"
+  viewBox="0 0 16 16"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path class="ico_submit_static" d="M2.5,8.5 C2.5,8.5 3.5,9.5 6,12 C11,7 13.5,4.5 13.5,4.5" />
+  <circle class="ico_submit_spinner" cx="8" cy="8" r="5.5" stroke-dasharray="22 13" />
+</svg>

--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -38,6 +38,7 @@
   <script src="{{ view_object.render_static_url('controllers/modal_controller.js') }}"></script>
   <script src="{{ view_object.render_static_url('controllers/scroll_into_view_controller.js') }}"></script>
   <script src="{{ view_object.render_static_url('controllers/tabs_controller.js') }}"></script>
+  <script src="{{ view_object.render_static_url('action_button_guard.js') }}"></script>
   {%- endif -%}
 
   {%- if view_object.project_config.is_activated_mathjax() -%}

--- a/strictdoc/export/html/templates/screens/document/traceability/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/traceability/index.jinja
@@ -22,6 +22,7 @@
     import hotwiredTurbo from "{{ view_object.render_static_url('turbo.min.js') }}";
   </script>
   <script src="{{ view_object.render_static_url('controllers/modal_controller.js') }}"></script>
+  <script src="{{ view_object.render_static_url('action_button_guard.js') }}"></script>
   {%- endif -%}
 
   {%- if view_object.project_config.is_activated_mathjax() -%}

--- a/strictdoc/export/html/templates/screens/document/traceability_deep/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/traceability_deep/index.jinja
@@ -22,6 +22,7 @@
     import hotwiredTurbo from "{{ view_object.render_static_url('turbo.min.js')}}";
   </script>
   <script src="{{ view_object.render_static_url('controllers/modal_controller.js') }}"></script>
+  <script src="{{ view_object.render_static_url('action_button_guard.js') }}"></script>
   {%- endif -%}
 
   {%- if view_object.project_config.is_activated_mathjax() -%}

--- a/strictdoc/export/html/templates/screens/git/index.jinja
+++ b/strictdoc/export/html/templates/screens/git/index.jinja
@@ -17,6 +17,7 @@
     import hotwiredTurbo from "{{ view_object.render_static_url_with_prefix('turbo.min.js') }}";
   </script>
   <script src="{{ view_object.render_static_url('controllers/modal_controller.js') }}"></script>
+  <script src="{{ view_object.render_static_url('action_button_guard.js') }}"></script>
   {%- endif -%}
   <script src="{{ view_object.render_static_url('diff.js') }}"></script>
 {% endblock head_scripts %}

--- a/strictdoc/export/html/templates/screens/project_index/index.jinja
+++ b/strictdoc/export/html/templates/screens/project_index/index.jinja
@@ -36,6 +36,7 @@
   <script src="{{ view_object.render_static_url('dropdown_menu.js') }}"></script>
   <script src="{{ view_object.render_static_url('controllers/editable_field_controller.js') }}"></script>
   <script src="{{ view_object.render_static_url('controllers/modal_controller.js') }}"></script>
+  <script src="{{ view_object.render_static_url('action_button_guard.js') }}"></script>
 {%- endif -%}
 {% endblock head_scripts %}
 

--- a/strictdoc/export/html/templates/screens/search/index.jinja
+++ b/strictdoc/export/html/templates/screens/search/index.jinja
@@ -16,6 +16,7 @@
     import hotwiredTurbo from "{{ view_object.render_static_url_with_prefix('turbo.min.js') }}";
   </script>
   <script src="{{ view_object.render_static_url('controllers/modal_controller.js') }}"></script>
+  <script src="{{ view_object.render_static_url('action_button_guard.js') }}"></script>
   {%- endif -%}
 {% endblock head_scripts %}
 


### PR DESCRIPTION
- Add `action_button_guard.js` — intercepts clicks on action buttons in capture phase; blocks repeated clicks while a request is pending
- Reset pending state on `turbo:submit-end` and `turbo:frame-render` so buttons in forms with error responses become clickable again
- Load `action_button_guard.js` on all server-interactive screens which have turbo


- Add spinner animation to the Save button: checkmark icon is replaced by a rotating arc while pending:
<img width="645" height="352" alt="image" src="https://github.com/user-attachments/assets/70fb617c-fa03-4554-909e-a6b65adeb8f4" />

Closes #871