### PR TITLE
fix(create_document): strip leading slash from path input and show allowed paths hint

### DIFF
--- a/strictdoc/export/html/_static/form.css
+++ b/strictdoc/export/html/_static/form.css
@@ -557,6 +557,12 @@ sdoc-form-error + sdoc-form-field-group {
   border-color: var(--color-danger);
 }
 
+sdoc-form-hint {
+  display: block;
+  color: var(--color-fg-secondary);
+  font-size: var(--font-size-sm);
+  margin-top: var(--base-padding);
+}
 
 sdoc-form-field-group[errors]::before, /* Grammar -> label for group of fields */
 sdoc-contenteditable[errors]::before, /* inside contenteditable errors block does not affected */

--- a/strictdoc/export/html/templates/screens/project_index/frame_form_new_document.jinja.html
+++ b/strictdoc/export/html/templates/screens/project_index/frame_form_new_document.jinja.html
@@ -49,6 +49,14 @@ Add new document
           -%}
             {%- include "components/form/field/contenteditable/index.jinja" %}
           {%- endwith -%}
+          {%- if include_doc_paths -%}
+          <sdoc-form-hint>
+            ☞ Path must start with one of:
+            {% for path in include_doc_paths -%}
+              <code>{{ path }}</code>{% if not loop.last %}, {% endif %}
+            {%- endfor -%}
+          </sdoc-form-hint>
+          {%- endif -%}
         </sdoc-form-row-main>
         <sdoc-form-row-aside></sdoc-form-row-aside>
       </sdoc-form-row>

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -1416,7 +1416,7 @@ def create_main_router(
                 "document_path", "Document path must not be empty."
             )
         else:
-            document_path = document_path.strip()
+            document_path = document_path.strip().lstrip("/")
             if not is_safe_alphanumeric_string(document_path):
                 error_object.add_error(
                     "document_path",

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -1217,6 +1217,7 @@ def create_main_router(
             error_object=ErrorObject(),
             document_title="",
             document_path="",
+            include_doc_paths=project_config.include_doc_paths,
         )
         return HTMLResponse(
             content=output,
@@ -1464,6 +1465,7 @@ def create_main_router(
                 document_path=document_path
                 if document_path is not None
                 else "",
+                include_doc_paths=project_config.include_doc_paths,
             )
             return HTMLResponse(
                 content=output,

--- a/tests/end2end/screens/project_index/create_document/_validation/create_document_validate_document_path_with_bad_chars/test_case.py
+++ b/tests/end2end/screens/project_index/create_document/_validation/create_document_validate_document_path_with_bad_chars/test_case.py
@@ -36,10 +36,3 @@ class Test(E2ECase):
                 "Document path must be relative and only contain slashes, "
                 "alphanumeric characters, and underscore symbols."
             )
-
-            form_add_document.do_fill_in_path("/test1.sdoc")
-            form_add_document.do_form_submit_and_catch_error(
-                "Document path must be relative and only contain slashes, "
-                "alphanumeric characters, and underscore symbols."
-            )
-            self.assert_text("/test1.sdoc")

--- a/tests/end2end/screens/project_index/create_document/create_document_normal_flow/expected_output/docs/document3.sdoc
+++ b/tests/end2end/screens/project_index/create_document/create_document_normal_flow/expected_output/docs/document3.sdoc
@@ -1,0 +1,2 @@
+[DOCUMENT]
+TITLE: Document 3

--- a/tests/end2end/screens/project_index/create_document/create_document_normal_flow/test_case.py
+++ b/tests/end2end/screens/project_index/create_document/create_document_normal_flow/test_case.py
@@ -42,6 +42,14 @@ class Test(E2ECase):
             form_add_document.do_fill_in_path("docs/document2")
             form_add_document.do_form_submit()
 
-            screen_project_index.assert_contains_document("Document 2")
+            # Add file with a leading slash — slash must be stripped silently
+            form_add_document: Form_AddDocument = (
+                screen_project_index.do_open_modal_form_add_document()
+            )
+            form_add_document.do_fill_in_title("Document 3")
+            form_add_document.do_fill_in_path("/docs/document3")
+            form_add_document.do_form_submit()
+
+            screen_project_index.assert_contains_document("Document 3")
 
         assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
**Problem**

When creating a new document, the `include_doc_paths` config uses leading slashes (e.g. `/docs/`). Users naturally typed `/docs/file`, which triggered two validation errors - the format check rejected the leading slash, and the filter mismatch error repeated the same slashed paths, creating a confusing loop.

**Changes**

1. Strip leading slash silently (`main_router.py`)
Both `/docs/file` and `docs/file` are now accepted. The leading slash is removed before validation.

2. Show allowed paths hint in the form:
<img width="629" height="393" alt="image" src="https://github.com/user-attachments/assets/dd0c9910-a0ae-4ce0-a07f-148110f221db" />

When `include_doc_paths` is configured, a hint appears below the path field showing the allowed directories as they are written in the config (with leading slash), so the user sees what to type without guessing.

3. Update tests

- Remove case where /test1.sdoc was expected to fail.
- Add case: /docs/document3 (with leading slash) creates a document successfully.


Closes #2834