### PR TITLE
test(sdoc_source_code): add unit test for UB on linux macro

### DIFF
--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_c.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_c.py
@@ -641,7 +641,17 @@ static void handle_softirqs()
 	if (pending) { }
 }
 """
+
     reader = SourceFileTraceabilityReader_C()
 
-    # must not raise NotImplementedError
-    assert reader.read(input_string, file_path="foo.cpp")
+    info: SourceFileTraceabilityInfo = reader.read(
+        input_string, file_path="foo.cpp"
+    )
+
+    assert isinstance(info, SourceFileTraceabilityInfo)
+    assert len(info.markers) == 0
+    assert len(info.functions) == 1
+    assert len(info.source_nodes) == 0
+
+    assert info.functions[0].name == "handle_softirqs()"
+    assert info.functions[0].display_name == "handle_softirqs"

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_c.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_c.py
@@ -617,3 +617,31 @@ SYSCALL_DEFINE2(clock_gettime, const clockid_t, which_clock,
 
     assert info.functions[0].name == expected_function_name
     assert info.functions[0].display_name == expected_function_name
+
+
+def test_103_error_recovery_linux_define_per_cpu_macro():
+    """
+    Ensure this snippet derived from Linux kernel/softirq.c doesn't drive the
+    C reader into NotImplementedError. DEFINE_PER_CPU expectedly confuses the
+    parser. The rest of the snippet is special context that triggered undefined
+    behavior manifesting as NotImplemented error in StrictDoc <= 0.22.0a1.
+    """
+    input_string = b"""\
+static DEFINE_PER_CPU(struct softirq_ctrl, softirq_ctrl) = {
+	.lock	= INIT_LOCAL_LOCK(softirq_ctrl.lock),
+};
+
+struct lockdep_map bh_lock_map = {
+	.name			= "local_bh",
+};
+
+static void handle_softirqs()
+{
+	foo("\\n", bar());
+	if (pending) { }
+}
+"""
+    reader = SourceFileTraceabilityReader_C()
+
+    # must not raise NotImplementedError
+    assert reader.read(input_string, file_path="foo.cpp")


### PR DESCRIPTION
This unit test provides a reproducer for the bug fixed with e3b1ec33e566 to demonstrate the issue and avoid regression.