### PR TITLE
fix(server): use absolute paths on 404 page

### DIFF
--- a/strictdoc/export/html/generators/view_objects/server_error_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/server_error_view_object.py
@@ -57,7 +57,8 @@ class ServerErrorViewObject:
         return self.link_renderer.render_static_url_with_prefix(url)
 
     def render_url(self, url: str) -> str:
-        return self.link_renderer.render_url(url)
+        # Error pages can appear at any URL depth, so use absolute paths.
+        return "/" + url
 
     def render_static_url_with_prefix(self, url: str) -> str:
         return self.link_renderer.render_static_url_with_prefix(url)

--- a/strictdoc/export/html/templates/_shared/nav.jinja.html
+++ b/strictdoc/export/html/templates/_shared/nav.jinja.html
@@ -6,7 +6,9 @@
     data-link="index"
     class="nav_button"
     href="{{ view_object.render_url('index.html') }}"
-    title="Project index">
+    title="Project index"
+    data-testid="project-tree-link-project-index"
+  >
     {% include "icons/ico16_index.svg" %}
   </a>
 

--- a/strictdoc/export/html/templates/error/index.jinja
+++ b/strictdoc/export/html/templates/error/index.jinja
@@ -40,7 +40,7 @@
       {% include "icons/ico100_broken_file.svg" %}
       <h1>{{ view_object.get_error_title() }}</h1>
       <p>{{ view_object.get_error_text() }}</p>
-      <a href="{{ view_object.render_url('index.html') }}">Go to home page</a>
+      <a href="{{ view_object.render_url('index.html') }}" data-testid="error-home-page-link">Go to home page</a>
     </sdoc-main-placeholder>
   </div>
 {% endblock main_content %}

--- a/tests/end2end/helpers/screens/error_page/screen_error_page.py
+++ b/tests/end2end/helpers/screens/error_page/screen_error_page.py
@@ -20,3 +20,11 @@ class Screen_ErrorPage(Screen):
             f'//*[@data-testid="error-{error_code}"]',
             by=By.XPATH,
         )
+
+    def do_click_home_page_link(self) -> None:
+        self.test_case.click_xpath('//*[@data-testid="error-home-page-link"]')
+
+    def do_click_nav_project_index_link(self) -> None:
+        self.test_case.click_xpath(
+            '//a[@data-testid="project-tree-link-project-index"]'
+        )

--- a/tests/end2end/screens/error_page/view_error_page/test_case.py
+++ b/tests/end2end/screens/error_page/view_error_page/test_case.py
@@ -1,5 +1,7 @@
 import os
 
+from selenium.webdriver.common.by import By
+
 from tests.end2end.e2e_case import E2ECase
 from tests.end2end.helpers.screens.error_page.screen_error_page import (
     Screen_ErrorPage,
@@ -38,3 +40,49 @@ class Test(E2ECase):
             screen = Screen_ErrorPage(self)
             screen.assert_on_screen()
             screen.assert_error_code(404)
+
+    def test_04_home_page_link_navigates_to_project_index(self):
+        with SDocTestServer(
+            input_path=path_to_this_test_file_folder
+        ) as test_server:
+            # Use a nested URL to ensure the relative-path bug is exercised:
+            # without the fix, "index.html" would resolve to
+            # "/nested/path/index.html" instead of "/index.html".
+            self.open(
+                test_server.get_host_and_port()
+                + "/nested/path/nonexistent-page.html"
+            )
+            screen_error = Screen_ErrorPage(self)
+            screen_error.assert_on_screen()
+            screen_error.assert_error_code(404)
+            screen_error.do_click_home_page_link()
+
+            # Skip assert_no_js_errors(): the browser log still contains the
+            # expected 404 network error from the page we just navigated away from.
+            self.assert_element(
+                '//body[@data-viewtype="document-tree"]', by=By.XPATH
+            )
+            self.wait_for_ready_state_complete()
+
+    def test_05_nav_project_index_link_navigates_to_project_index(self):
+        with SDocTestServer(
+            input_path=path_to_this_test_file_folder
+        ) as test_server:
+            # Use a nested URL to ensure the relative-path bug is exercised:
+            # without the fix, "index.html" would resolve to
+            # "/nested/path/index.html" instead of "/index.html".
+            self.open(
+                test_server.get_host_and_port()
+                + "/nested/path/nonexistent-page.html"
+            )
+            screen_error = Screen_ErrorPage(self)
+            screen_error.assert_on_screen()
+            screen_error.assert_error_code(404)
+            screen_error.do_click_nav_project_index_link()
+
+            # Skip assert_no_js_errors(): the browser log still contains the
+            # expected 404 network error from the page we just navigated away from.
+            self.assert_element(
+                '//body[@data-viewtype="document-tree"]', by=By.XPATH
+            )
+            self.wait_for_ready_state_complete()


### PR DESCRIPTION
ServerErrorViewObject used root_path="" in LinkRenderer, so all rendered URLs were relative — at nested paths like /strictdoc/docs/test/ they resolved against the current path instead of the root
Fixed by returning "/" + url in ServerErrorViewObject.render_url()
Added e2e tests: clicking "Go to home page" and the nav project index button from a nested 404 page both land on the project index