### PR TITLE
feat(sdoc_source_code): Parse source nodes from robot Documentation

### DIFF
--- a/strictdoc/backend/sdoc_source_code/reader_registry.py
+++ b/strictdoc/backend/sdoc_source_code/reader_registry.py
@@ -43,7 +43,9 @@ class SourceCodeReaderRegistry:
         ):
             return SourceFileTraceabilityReader_C(custom_tags=source_node_tags)
         if path_to_file.endswith(".robot"):
-            return SourceFileTraceabilityReader_Robot()
+            return SourceFileTraceabilityReader_Robot(
+                custom_tags=source_node_tags
+            )
         if path_to_file.endswith(".rs"):
             return SourceFileTraceabilityReader_Rust(
                 custom_tags=source_node_tags

--- a/strictdoc/backend/sdoc_source_code/reader_robot.py
+++ b/strictdoc/backend/sdoc_source_code/reader_robot.py
@@ -2,7 +2,7 @@
 @relation(SDOC-SRS-142, SDOC-SRS-148, scope=file)
 """
 
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from robot.api.parsing import (
     Comment,
@@ -14,6 +14,7 @@ from robot.api.parsing import (
     Token,
     get_model,
 )
+from robot.parsing.model.statements import Statement
 
 from strictdoc.backend.sdoc_source_code.constants import FunctionAttribute
 from strictdoc.backend.sdoc_source_code.marker_parser import MarkerParser
@@ -29,6 +30,7 @@ from strictdoc.backend.sdoc_source_code.models.range_marker import (
 from strictdoc.backend.sdoc_source_code.models.source_file_info import (
     SourceFileTraceabilityInfo,
 )
+from strictdoc.backend.sdoc_source_code.models.source_node import SourceNode
 from strictdoc.backend.sdoc_source_code.parse_context import ParseContext
 from strictdoc.backend.sdoc_source_code.processors.general_language_marker_processors import (
     language_item_marker_processor,
@@ -56,10 +58,12 @@ class SdocRelationVisitor(ModelVisitor):  # type: ignore[misc]
         self,
         traceability_info: SourceFileTraceabilityInfo,
         parse_context: ParseContext,
+        custom_tags: Optional[set[str]] = None,
     ):
         super().__init__()
         self.traceability_info = traceability_info
         self.parse_context = parse_context
+        self.custom_tags = custom_tags
 
     def visit_Comment(self, node: Comment) -> None:
         """
@@ -84,7 +88,11 @@ class SdocRelationVisitor(ModelVisitor):  # type: ignore[misc]
         Create function and non-function Marker from TestCases.
         """
         trailing_empty_lines = 0
-        tc_markers = []
+        tc_markers: List[
+            Union[LanguageItemMarker, RangeMarker, LineMarker]
+        ] = []
+        tc_source_nodes: List[SourceNode] = []
+
         for stmt in node.body:
             if isinstance(stmt, EmptyLine):
                 # Trim trailing newlines from test case range.
@@ -92,20 +100,13 @@ class SdocRelationVisitor(ModelVisitor):  # type: ignore[misc]
             else:
                 trailing_empty_lines = 0
 
-            if isinstance(stmt, (Comment, Tags, Documentation)):
-                for token in filter(self._token_filter, stmt.tokens):
-                    source_node = MarkerParser.parse(
-                        input_string=token.value,
-                        line_start=token.lineno,
-                        line_end=token.lineno,
-                        # FIXME: Byte range is currently not used for Robot framework.
-                        comment_byte_range=None,
-                        filename=self.parse_context.filename,
-                        comment_line_start=token.lineno,
-                        entity_name=node.name,
-                        col_offset=token.col_offset,
-                    )
-                    tc_markers.extend(source_node.markers)
+            source_node = self._parse_stmt(
+                stmt, node.name, node.lineno, node.end_lineno
+            )
+            if source_node is not None:
+                tc_markers.extend(source_node.markers)
+                if isinstance(stmt, Documentation) and source_node.fields:
+                    tc_source_nodes.append(source_node)
 
         language_item_markers = []
         for marker_ in tc_markers:
@@ -134,39 +135,78 @@ class SdocRelationVisitor(ModelVisitor):  # type: ignore[misc]
             markers=language_item_markers,
             attributes={FunctionAttribute.DEFINITION},
         )
+        # Link source nodes (parsed from [Documentation] key: value fields)
+        # to the test case LanguageItem and register them in traceability_info.
+        for source_node in tc_source_nodes:
+            source_node.function = test_case
+        self.traceability_info.source_nodes.extend(tc_source_nodes)
         self.traceability_info.functions.append(test_case)
 
     def _visit_possibly_marked_node(
         self, node: Union[Comment, Documentation, Tags]
     ) -> None:
-        for token in filter(self._token_filter, node.tokens):
-            source_node = MarkerParser.parse(
-                input_string=token.value,
-                line_start=node.lineno,
-                line_end=node.lineno,
-                # FIXME: Byte range is currently not used for Robot framework.
+        source_node = self._parse_stmt(node, None, node.lineno, node.end_lineno)
+        if source_node is None:
+            return
+        for marker_ in source_node.markers:
+            if (
+                isinstance(marker_, LanguageItemMarker)
+                and marker_.scope is RangeMarkerType.FILE
+            ):
+                # Outside Test Cases only accept scope=file function markers
+                marker_.ng_range_line_begin = 1
+                marker_.ng_range_line_end = (
+                    self.parse_context.file_stats.lines_total
+                )
+                language_item_marker_processor(marker_, self.parse_context)
+                self.traceability_info.markers.append(marker_)
+            elif isinstance(marker_, RangeMarker):
+                range_marker_processor(marker_, self.parse_context)
+            elif isinstance(marker_, LineMarker):
+                line_marker_processor(marker_, self.parse_context)
+
+    def _parse_stmt(
+        self,
+        stmt: Statement,
+        entity_name: Optional[str],
+        line_start: int,
+        line_end: int,
+    ) -> Optional[SourceNode]:
+        if isinstance(stmt, Documentation):
+            # Documentation is expected to contain relation markers and source nodes.
+            # FIXME: No writeback support for source nodes, because
+            #   1) Robot parser doesn't track byte-offsets (lines/columns count characters, not bytes),
+            #   2) Line continuation format not handled by MarkerParser.
+            return MarkerParser.parse(
+                input_string=stmt.value,
+                line_start=line_start,
+                line_end=line_end,
                 comment_byte_range=None,
                 filename=self.parse_context.filename,
-                comment_line_start=node.lineno,
-                entity_name=None,
-                col_offset=token.col_offset,
+                comment_line_start=stmt.lineno,
+                entity_name=entity_name,
+                col_offset=stmt.col_offset,
+                custom_tags=self.custom_tags,
             )
-            for marker_ in source_node.markers:
-                if (
-                    isinstance(marker_, LanguageItemMarker)
-                    and marker_.scope is RangeMarkerType.FILE
-                ):
-                    # Outside Test Cases only accept scope=file function markers
-                    marker_.ng_range_line_begin = 1
-                    marker_.ng_range_line_end = (
-                        self.parse_context.file_stats.lines_total
-                    )
-                    language_item_marker_processor(marker_, self.parse_context)
-                    self.traceability_info.markers.append(marker_)
-                elif isinstance(marker_, RangeMarker):
-                    range_marker_processor(marker_, self.parse_context)
-                elif isinstance(marker_, LineMarker):
-                    line_marker_processor(marker_, self.parse_context)
+        elif isinstance(stmt, (Comment, Tags)):
+            # Expect relation markers but no source nodes in comments and tags to keep things simple.
+            source_nodes = SourceNode(
+                entity_name=entity_name, comment_byte_range=None
+            )
+            for token in filter(self._token_filter, stmt.tokens):
+                sn = MarkerParser.parse(
+                    input_string=token.value,
+                    line_start=token.lineno,
+                    line_end=token.lineno,
+                    comment_byte_range=None,
+                    filename=self.parse_context.filename,
+                    comment_line_start=token.lineno,
+                    entity_name=entity_name,
+                    col_offset=token.col_offset,
+                )
+                source_nodes.markers.extend(sn.markers)
+            return source_nodes
+        return None
 
     @staticmethod
     def _token_filter(token: Token) -> bool:
@@ -180,6 +220,9 @@ class SourceFileTraceabilityReader_Robot:
     def supported_elements() -> list[str]:
         return ["testcase"]
 
+    def __init__(self, custom_tags: Optional[set[str]] = None) -> None:
+        self.custom_tags: Optional[set[str]] = custom_tags
+
     def read(
         self, input_buffer: str, file_path: Optional[str] = None
     ) -> SourceFileTraceabilityInfo:
@@ -189,7 +232,9 @@ class SourceFileTraceabilityReader_Robot:
         file_stats = SourceFileStats.create(input_buffer)
         parse_context = ParseContext(file_path, file_stats)
         robotfw_model = get_model(input_buffer, data_only=False)
-        visitor = SdocRelationVisitor(traceability_info, parse_context)
+        visitor = SdocRelationVisitor(
+            traceability_info, parse_context, self.custom_tags
+        )
         visitor.visit(robotfw_model)
         source_file_traceability_info_processor(
             traceability_info, parse_context

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -237,6 +237,139 @@ class FileTraceabilityIndex:
                     ).append(function_)
 
         #
+        # STEP: Auto-generated SDocNodes from source file comments and register
+        #       their UIDs. This must happen before marker validation so that
+        #       source files can reference these UIDs via @relation.
+        #
+        documents_with_generated_content = set()
+
+        section_cache: Dict[str, Union[SDocDocumentIF, SDocNode]] = {}
+        source_nodes_config: List[SourceNodesEntry] = (
+            project_config.source_nodes
+        )
+        unused_source_node_paths = {
+            config_entry_.path for config_entry_ in source_nodes_config
+        }
+        for (
+            path_to_source_file_,
+            traceability_info_,
+        ) in self.map_paths_to_source_file_traceability_info.items():
+            if len(traceability_info_.source_nodes) == 0:
+                continue
+
+            if len(source_nodes_config) == 0:
+                continue
+
+            relevant_source_node_entry = (
+                project_config.get_relevant_source_nodes_entry(
+                    path_to_source_file_
+                )
+            )
+            if relevant_source_node_entry is not None:
+                unused_source_node_paths.discard(
+                    relevant_source_node_entry.path
+                )
+            else:
+                continue
+
+            document_uid = relevant_source_node_entry.uid
+            document = traceability_index.get_node_by_uid(document_uid)
+            documents_with_generated_content.add(document)
+            current_top_node = None
+
+            for source_node_ in traceability_info_.source_nodes:
+                if len(source_node_.fields) == 0:
+                    continue
+
+                assert source_node_.entity_name is not None
+                sdoc_node = None
+                sdoc_node_uid = source_node_.get_sdoc_field(
+                    "UID", relevant_source_node_entry
+                )
+                mid = source_node_.get_sdoc_field(
+                    "MID", relevant_source_node_entry
+                )
+
+                # First merge criterion: Merge if SDoc node with same MID exists.
+                if mid is not None:
+                    sdoc_node_mid = MID(mid)
+                    merge_candidate_sdoc_node = (
+                        traceability_index.get_node_by_mid_weak(sdoc_node_mid)
+                    )
+                    if isinstance(merge_candidate_sdoc_node, SDocNode):
+                        sdoc_node = merge_candidate_sdoc_node
+                        sdoc_node_uid = sdoc_node.reserved_uid
+
+                if sdoc_node is None:
+                    # If no UID from source code field or merge-by-MID, create UID by conventional scheme.
+                    if sdoc_node_uid is None:
+                        sdoc_node_uid = f"{document_uid}/{path_to_source_file_}/{source_node_.entity_name}"
+                    # Second merge criterion: Merge if SDoc node with same UID exists.
+                    tmp_sdoc_node = traceability_index.get_node_by_uid_weak(
+                        sdoc_node_uid
+                    )
+                    if isinstance(tmp_sdoc_node, SDocNode):
+                        sdoc_node = tmp_sdoc_node
+
+                assert sdoc_node_uid is not None
+                if sdoc_node is not None:
+                    sdoc_node = assert_cast(sdoc_node, SDocNode)
+                    self.merge_sdoc_node_with_source_node(
+                        relevant_source_node_entry,
+                        source_node_,
+                        sdoc_node,
+                        document,
+                    )
+                else:
+                    sdoc_node = self.create_sdoc_node_from_source_node(
+                        source_node_,
+                        relevant_source_node_entry,
+                        sdoc_node_uid,
+                        document,
+                    )
+                    sdoc_node_uid = assert_cast(sdoc_node.reserved_uid, str)
+                    if current_top_node is None:
+                        current_top_node, created_sections = (
+                            FileTraceabilityIndex.create_source_node_section(
+                                document,
+                                path_to_source_file_,
+                                section_cache,
+                            )
+                        )
+                        for created_section in created_sections:
+                            traceability_index.graph_database.create_link(
+                                link_type=GraphLinkType.MID_TO_NODE,
+                                lhs_node=created_section.reserved_mid,
+                                rhs_node=created_section,
+                            )
+                    current_top_node.section_contents.append(sdoc_node)
+
+                self.connect_source_node_function(
+                    source_node_, sdoc_node_uid, traceability_info_
+                )
+                self.connect_sdoc_node_with_file_path(
+                    sdoc_node, path_to_source_file_
+                )
+                self.connect_source_node_requirements(
+                    source_node_, sdoc_node, traceability_index
+                )
+
+        # Warn if source_node was not matched by any include_source_paths, it indicates misconfiguration
+        for unused_source_node_path in unused_source_node_paths:
+            print(  # noqa: T201
+                f"warning: source_node path {unused_source_node_path} doesn't match any source file. "
+                "Hint: Check include_source_paths."
+            )
+
+        # Iterate over all generated documents to calculate all node levels.
+        for document_ in documents_with_generated_content:
+            document_iterator = SDocDocumentIterator(document_)
+            for _, _ in document_iterator.all_content(
+                print_fragments=False,
+            ):
+                pass
+
+        #
         # STEP: Resolve requirements that have forward links.
         #       Some requirements can come from the SDoc documents generated
         #       on the fly from JUnit XML documents.
@@ -563,138 +696,6 @@ class FileTraceabilityIndex:
                             definition_function_trace_info.markers.append(
                                 language_item_marker
                             )
-
-        #
-        # STEP: Create auto-generated documents created from source file comments.
-        #       Register these documents with the main traceability index.
-        #
-        documents_with_generated_content = set()
-
-        section_cache: Dict[str, Union[SDocDocumentIF, SDocNode]] = {}
-        source_nodes_config: List[SourceNodesEntry] = (
-            project_config.source_nodes
-        )
-        unused_source_node_paths = {
-            config_entry_.path for config_entry_ in source_nodes_config
-        }
-        for (
-            path_to_source_file_,
-            traceability_info_,
-        ) in self.map_paths_to_source_file_traceability_info.items():
-            if len(traceability_info_.source_nodes) == 0:
-                continue
-
-            if len(source_nodes_config) == 0:
-                continue
-
-            relevant_source_node_entry = (
-                project_config.get_relevant_source_nodes_entry(
-                    path_to_source_file_
-                )
-            )
-            if relevant_source_node_entry is not None:
-                unused_source_node_paths.discard(
-                    relevant_source_node_entry.path
-                )
-            else:
-                continue
-
-            document_uid = relevant_source_node_entry.uid
-            document = traceability_index.get_node_by_uid(document_uid)
-            documents_with_generated_content.add(document)
-            current_top_node = None
-
-            for source_node_ in traceability_info_.source_nodes:
-                if len(source_node_.fields) == 0:
-                    continue
-
-                assert source_node_.entity_name is not None
-                sdoc_node = None
-                sdoc_node_uid = source_node_.get_sdoc_field(
-                    "UID", relevant_source_node_entry
-                )
-                mid = source_node_.get_sdoc_field(
-                    "MID", relevant_source_node_entry
-                )
-
-                # First merge criterion: Merge if SDoc node with same MID exists.
-                if mid is not None:
-                    sdoc_node_mid = MID(mid)
-                    merge_candidate_sdoc_node = (
-                        traceability_index.get_node_by_mid_weak(sdoc_node_mid)
-                    )
-                    if isinstance(merge_candidate_sdoc_node, SDocNode):
-                        sdoc_node = merge_candidate_sdoc_node
-                        sdoc_node_uid = sdoc_node.reserved_uid
-
-                if sdoc_node is None:
-                    # If no UID from source code field or merge-by-MID, create UID by conventional scheme.
-                    if sdoc_node_uid is None:
-                        sdoc_node_uid = f"{document_uid}/{path_to_source_file_}/{source_node_.entity_name}"
-                    # Second merge criterion: Merge if SDoc node with same UID exists.
-                    tmp_sdoc_node = traceability_index.get_node_by_uid_weak(
-                        sdoc_node_uid
-                    )
-                    if isinstance(tmp_sdoc_node, SDocNode):
-                        sdoc_node = tmp_sdoc_node
-
-                assert sdoc_node_uid is not None
-                if sdoc_node is not None:
-                    sdoc_node = assert_cast(sdoc_node, SDocNode)
-                    self.merge_sdoc_node_with_source_node(
-                        relevant_source_node_entry,
-                        source_node_,
-                        sdoc_node,
-                        document,
-                    )
-                else:
-                    sdoc_node = self.create_sdoc_node_from_source_node(
-                        source_node_,
-                        relevant_source_node_entry,
-                        sdoc_node_uid,
-                        document,
-                    )
-                    sdoc_node_uid = assert_cast(sdoc_node.reserved_uid, str)
-                    if current_top_node is None:
-                        current_top_node, created_sections = (
-                            FileTraceabilityIndex.create_source_node_section(
-                                document,
-                                path_to_source_file_,
-                                section_cache,
-                            )
-                        )
-                        for created_section in created_sections:
-                            traceability_index.graph_database.create_link(
-                                link_type=GraphLinkType.MID_TO_NODE,
-                                lhs_node=created_section.reserved_mid,
-                                rhs_node=created_section,
-                            )
-                    current_top_node.section_contents.append(sdoc_node)
-
-                self.connect_source_node_function(
-                    source_node_, sdoc_node_uid, traceability_info_
-                )
-                self.connect_sdoc_node_with_file_path(
-                    sdoc_node, path_to_source_file_
-                )
-                self.connect_source_node_requirements(
-                    source_node_, sdoc_node, traceability_index
-                )
-
-        # Warn if source_node was not matched by any include_source_paths, it indicates misconfiguration
-        for unused_source_node_path in unused_source_node_paths:
-            print(  # noqa: T201
-                f"warning: source_node path {unused_source_node_path} doesn't match any source file. "
-                "Hint: Check include_source_paths."
-            )
-
-        # Iterate over all generated documents to calculate all node levels.
-        for document_ in documents_with_generated_content:
-            document_iterator = SDocDocumentIterator(document_)
-            for _, _ in document_iterator.all_content(
-                print_fragments=False,
-            ):
-                pass
 
         #
         # STEP: Calculate requirements coverage by code. Sort nodes.

--- a/tests/integration/features/source_code_traceability/_language_parsers/robot/06_robot_source_nodes/input.sdoc
+++ b/tests/integration/features/source_code_traceability/_language_parsers/robot/06_robot_source_nodes/input.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[REQUIREMENT]
+UID: REQ-AUTH-001
+TITLE: UI Login
+STATEMENT: The system shall provide a dialog to authenticate users.
+
+[REQUIREMENT]
+UID: REQ-AUTH-002
+TITLE: UI Login
+STATEMENT: Login attempts with invalid credentials shall be rejected with error message and redirect to an empty login dialog.

--- a/tests/integration/features/source_code_traceability/_language_parsers/robot/06_robot_source_nodes/strictdoc_config.py
+++ b/tests/integration/features/source_code_traceability/_language_parsers/robot/06_robot_source_nodes/strictdoc_config.py
@@ -1,0 +1,24 @@
+from strictdoc.core.project_config import ProjectConfig, SourceNodesEntry
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=[
+            "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+        ],
+        source_nodes=[
+            SourceNodesEntry(
+                path="tests/",
+                uid="TEST_DOC",
+                node_type="TEST_SPEC",
+            )
+        ],
+        include_source_paths=[
+            "tests/",
+            "test_sessions/",
+        ],
+        exclude_doc_paths=[
+            "test_sessions/",
+        ],
+    )
+    return config

--- a/tests/integration/features/source_code_traceability/_language_parsers/robot/06_robot_source_nodes/test.itest
+++ b/tests/integration/features/source_code_traceability/_language_parsers/robot/06_robot_source_nodes/test.itest
@@ -1,0 +1,42 @@
+# @relation(SDOC-SRS-141, SDOC-SRS-148, scope=file)
+#
+# Source nodes from Robot Framework [Documentation] sections.
+#
+# StrictDoc parses key-value pairs from [Documentation] and generates source
+# nodes of type TEST_SPEC into testcases.sdoc. @relation markers in the
+# robot file link test case to requirements. @relation markers in the
+# markdown test report link test results to test cases.
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Hello world doc
+
+RUN: %check_exists --file "%T/html/_source_files/tests/file.robot.html"
+
+# Check testcases.sdoc contains generated source nodes with field values and
+# links back to the robot source file and the markdown test session report.
+RUN: %cat %T/html/%THIS_TEST_FOLDER/testcases.html | filecheck %s --check-prefix CHECK-SPEC
+CHECK-SPEC: TC-AUTH-001
+CHECK-SPEC: <a{{.*}}href="../_source_files/test_sessions/2026_05_28.md.html#TC-AUTH-001#9#10">
+CHECK-SPEC: test_sessions/2026_05_28.md, <i>lines: 9-10</i>
+CHECK-SPEC: TestExecution
+CHECK-SPEC: INTENTION:
+CHECK-SPEC: Verify that valid credentials grant access.
+CHECK-SPEC: EXPECTED_RESULTS:
+CHECK-SPEC: TC-AUTH-002
+CHECK-SPEC: <a{{.*}}href="../_source_files/test_sessions/2026_05_28.md.html#TC-AUTH-002#9#10">
+CHECK-SPEC: test_sessions/2026_05_28.md, <i>lines: 9-10</i>
+CHECK-SPEC: TestExecution
+CHECK-SPEC: INTENTION:
+CHECK-SPEC: Verify that login fails with wrong password
+CHECK-SPEC: EXPECTED_RESULTS:
+
+# Check requirements contain links to TestCase in robot DSL.
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --check-prefix CHECK-HTML
+CHECK-HTML: REQ-AUTH-001
+CHECK-HTML: TC-AUTH-001
+CHECK-HTML: <a{{.*}}href="../_source_files/tests/file.robot.html#REQ-AUTH-001#2#10">
+CHECK-HTML: tests/file.robot, <i>lines: 2-10</i>
+CHECK-HTML: REQ-AUTH-002
+CHECK-HTML: TC-AUTH-002
+CHECK-HTML: <a{{.*}}href="../_source_files/tests/file.robot.html#REQ-AUTH-002#12#20">
+CHECK-HTML: tests/file.robot, <i>lines: 12-20</i>

--- a/tests/integration/features/source_code_traceability/_language_parsers/robot/06_robot_source_nodes/test_sessions/2026_05_28.md
+++ b/tests/integration/features/source_code_traceability/_language_parsers/robot/06_robot_source_nodes/test_sessions/2026_05_28.md
@@ -1,0 +1,13 @@
+# Manual Test Session
+
+Date: 2026-05-28
+
+Reporter: Max Mustermann
+
+## Results
+
+<!--- @relation(TC-AUTH-001, TC-AUTH-002, scope=line, role=TestExecution) --->
+| Product Testcase ID(s) | Notes on test result                                                                                 | PASS/FAIL          |
+|------------------------|------------------------------------------------------------------------------------------------------|--------------------|
+| TC-AUTH-001            | - | PASS |
+| TC-AUTH-002            | - | PASS |

--- a/tests/integration/features/source_code_traceability/_language_parsers/robot/06_robot_source_nodes/testcases.sdoc
+++ b/tests/integration/features/source_code_traceability/_language_parsers/robot/06_robot_source_nodes/testcases.sdoc
@@ -1,0 +1,37 @@
+[DOCUMENT]
+TITLE: Test Specification
+UID: TEST_DOC
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: TEST_SPEC
+  PROPERTIES:
+    VIEW_STYLE: Narrative
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  - TITLE: INTENTION
+    TYPE: String
+    REQUIRED: False
+  - TITLE: EXPECTED_RESULTS
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File
+  - TYPE: File
+    ROLE: TestExecution

--- a/tests/integration/features/source_code_traceability/_language_parsers/robot/06_robot_source_nodes/tests/file.robot
+++ b/tests/integration/features/source_code_traceability/_language_parsers/robot/06_robot_source_nodes/tests/file.robot
@@ -1,0 +1,20 @@
+*** Test Cases ***
+Check Valid Login
+    [Documentation]    @relation(REQ-AUTH-001, scope=function)
+    ...    UID: TC-AUTH-001
+    ...    INTENTION: Verify that valid credentials grant access.
+    ...    EXPECTED_RESULTS: User is redirected to dashboard.
+    Precondition	System is commissioned
+
+    Do		Login to Web UI as "test", password "test".
+    Expect	Login is possible.
+
+Login With Invalid Credentials
+    [Documentation]    @relation(REQ-AUTH-002, scope=function)
+    ...    UID: TC-AUTH-002
+    ...    INTENTION: Verify that login fails with wrong password
+    ...    EXPECTED_RESULTS: Error message is shown, new login dialog appears.
+    Precondition	System is commissioned
+
+    Do		Login to Web UI with user "none", password "none"
+    Expect	Login is rejected.


### PR DESCRIPTION
What: The robot DSL has `[Documentation]` blocks. StrictDoc used to search relation markers there. Now we also search for key-value pairs there to auto-generate source nodes, as we already do for C/C++ and Rust.

Why: While working on a larger StrictDoc documentation the following use case appeared:
- Requirements are traced to robot test cases by means of relation markers in .robot files.
- Besides automated tests, .robot files also contain test descriptions for manual testing. Manual testers document and commit their results in markdown files (plain md, not the new convention StrictDoc md). The provided integration test demonstrates this scenario.
- The markdown files with results shall trace back to the test case definition. But since the robot test cases were only known as `LanguateItem`s (forward traceable), not as `SdocNode` (parent/child traceable), it was not possible to establish a link from markdown to test case.
- As a bonus, it is nice to have things like "test intention" and "expected result" in the rendered documentation, not only in robot  DSL.

The PR also contains refactoring for `validate_and_resolve` in 2d5a77098ce9ce68e0f16130f742f6c289ceb316. It's not strictly needed for the robot feature, but it's required to support the user scenario described above.

PS: I can split this into more PRs and tests if preferred, but probably won't get to it very soon.