### PR TITLE
fix(templates): hide Relations and Comments tabs when not in grammar

### DIFF
--- a/strictdoc/export/html/templates/screens/document/document/frame_requirement_form.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/frame_requirement_form.jinja
@@ -78,6 +78,7 @@
 </sdoc-tab-content>
 
 {# Relations #}
+{% if form_object.relation_types %}
 <sdoc-tab-content id="Relations">
   {% set relation_row_context = namespace() %}
 
@@ -101,8 +102,10 @@
     >{% include "icons/ico16_add.svg" %} Add relation</a>
   </sdoc-form-row>
 </sdoc-tab-content>
+{% endif %}
 
 {# Comments #}
+{% if "COMMENT" in form_object.fields %}
 <sdoc-tab-content id="Comments">
   {% set comment_field_row_context = namespace() %}
 
@@ -135,5 +138,6 @@
     >{% include "icons/ico16_add.svg" %} Add comment</a>
   </sdoc-form-row>
 </sdoc-tab-content>
+{% endif %}
 
 {% endblock form_content %}

--- a/tests/end2end/helpers/form/form.py
+++ b/tests/end2end/helpers/form/form.py
@@ -78,6 +78,12 @@ class Form:  # pylint: disable=invalid-name
             by=By.XPATH,
         )
 
+    def assert_tab_not_present(self, tab_name: str = "") -> None:
+        assert isinstance(tab_name, str)
+        self.test_case.assert_element_not_present(
+            f"//*[@data-testid='form-tab-{tab_name}']"
+        )
+
     #
     # Work with fields containers.
     #

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/edit_text_node_form_has_no_comments_tab/document.sdoc
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/edit_text_node_form_has_no_comments_tab/document.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[TEXT]
+STATEMENT: >>>
+Text statement.
+<<<

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/edit_text_node_form_has_no_comments_tab/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/edit_text_node_form_has_no_comments_tab/test_case.py
@@ -1,0 +1,45 @@
+import os
+
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.helpers.screens.document.form_edit_requirement import (
+    Form_EditRequirement,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+path_to_this_test_file_folder = os.path.dirname(os.path.abspath(__file__))
+
+
+class Test(E2ECase):
+    def test(self):
+        with SDocTestServer(
+            input_path=path_to_this_test_file_folder
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+            screen_document.assert_text("Text statement.")
+
+            node = screen_document.get_node(1)
+            form_edit_node: Form_EditRequirement = (
+                node.do_open_form_edit_requirement()
+            )
+
+            form_edit_node.assert_on_form()
+
+            # Default TEXT grammar has no COMMENT field and no relations:
+            # neither tab should appear.
+            form_edit_node.assert_tab_not_present("Comments")
+            form_edit_node.assert_tab_not_present("Relations")
+
+            form_edit_node.do_form_cancel()

--- a/tests/end2end/screens/document/update_node/_SECTION/edit_section_form_has_no_relations_or_comments_tabs/document.sdoc
+++ b/tests/end2end/screens/document/update_node/_SECTION/edit_section_form_has_no_relations_or_comments_tabs/document.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[[SECTION]]
+TITLE: Section title
+
+[[/SECTION]]

--- a/tests/end2end/screens/document/update_node/_SECTION/edit_section_form_has_no_relations_or_comments_tabs/test_case.py
+++ b/tests/end2end/screens/document/update_node/_SECTION/edit_section_form_has_no_relations_or_comments_tabs/test_case.py
@@ -1,0 +1,44 @@
+import os
+
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.helpers.screens.document.form_edit_requirement import (
+    Form_EditRequirement,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+path_to_this_test_file_folder = os.path.dirname(os.path.abspath(__file__))
+
+
+class Test(E2ECase):
+    def test(self):
+        with SDocTestServer(
+            input_path=path_to_this_test_file_folder
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+
+            section = screen_document.get_node(1)
+            form_edit_section: Form_EditRequirement = (
+                section.do_open_form_edit_requirement()
+            )
+
+            form_edit_section.assert_on_form()
+
+            # SECTION grammar has no relations and no COMMENT field:
+            # neither tab should appear.
+            form_edit_section.assert_tab_not_present("Relations")
+            form_edit_section.assert_tab_not_present("Comments")
+
+            form_edit_section.do_form_cancel()


### PR DESCRIPTION
Form tabs "Relations" and "Comments" were unconditionally rendered for all node types, even when the node's grammar element did not define the corresponding fields or relations.

- Hide the "Relations" tab when `form_object.relation_types` is empty
- Hide the "Comments" tab when "`COMMENT`" is not in `form_object.fields`