### PR TITLE
fix(export/html): pan_with_space.js and editable elements

### DIFF
--- a/strictdoc/export/html/_static/pan_with_space.js
+++ b/strictdoc/export/html/_static/pan_with_space.js
@@ -38,6 +38,12 @@ window.addEventListener('load', function () {
       if (e.key === ' ' || e.key === 'Spacebar') {
         // ' ' is standard, 'Spacebar' was used by IE9 and Firefox < 37
 
+        var tag = document.activeElement && document.activeElement.tagName;
+        var isEditable = tag === 'INPUT' || tag === 'TEXTAREA' || document.activeElement.isContentEditable;
+        if (isEditable) {
+          return;
+        }
+
         e.preventDefault();
         e.stopPropagation();
         state.spacePressed = true;
@@ -76,6 +82,11 @@ window.addEventListener('load', function () {
     document.addEventListener("keyup", function (e) {
       if (e.key === ' ' || e.key === 'Spacebar') {
         // ' ' is standard, 'Spacebar' was used by IE9 and Firefox < 37
+        var tag = document.activeElement && document.activeElement.tagName;
+        var isEditable = tag === 'INPUT' || tag === 'TEXTAREA' || document.activeElement.isContentEditable;
+        if (isEditable) {
+          return;
+        }
         e.preventDefault();
         e.stopPropagation();
         state.spacePressed = false;


### PR DESCRIPTION
do not intercept Space key when focus is in an editable element