### PR TITLE
fix(backend/markdown): ensure that Relations must not be separated from other meta with a newline character

### DIFF
--- a/strictdoc/backend/markdown/reader.py
+++ b/strictdoc/backend/markdown/reader.py
@@ -259,7 +259,9 @@ class SDMarkdownReader:
             root_body_lines_without_meta,
             root_meta_valid,
             root_meta_style,
-        ) = SDMarkdownReader._parse_meta_fields(root_body_lines)
+        ) = SDMarkdownReader._parse_meta_fields(
+            root_body_lines, file_path=file_path
+        )
 
         if root_meta_valid and len(root_meta_fields) > 0:
             root_field_names = list(
@@ -363,6 +365,7 @@ class SDMarkdownReader:
             parsed_node = SDMarkdownReader._parse_markdown_node(
                 heading_node.title,
                 heading_node.body,
+                file_path=file_path,
             )
 
             if parsed_node.valid_for_requirement:
@@ -607,7 +610,9 @@ class SDMarkdownReader:
                 empty_line_count = 0
 
     @staticmethod
-    def _parse_markdown_node(title: str, body: str) -> ParsedMarkdownNode:
+    def _parse_markdown_node(
+        title: str, body: str, file_path: Optional[str]
+    ) -> ParsedMarkdownNode:
         """
         Parse a heading's body text into a ParsedMarkdownNode.
 
@@ -622,9 +627,11 @@ class SDMarkdownReader:
             body_lines_without_meta,
             meta_is_valid,
             meta_style,
-        ) = SDMarkdownReader._parse_meta_fields(body_lines)
+        ) = SDMarkdownReader._parse_meta_fields(body_lines, file_path=file_path)
         content_fields, content_is_valid = (
-            SDMarkdownReader._parse_content_fields(body_lines_without_meta)
+            SDMarkdownReader._parse_content_fields(
+                body_lines_without_meta, file_path=file_path
+            )
         )
 
         parsed_fields = meta_fields + content_fields
@@ -670,6 +677,7 @@ class SDMarkdownReader:
     @staticmethod
     def _parse_meta_fields(
         body_lines: List[str],
+        file_path: Optional[str],
     ) -> Tuple[List[ParsedField], List[str], bool, Optional[str]]:
         """
         Extract the leading meta-field block from raw markdown content of a requirement.
@@ -722,6 +730,37 @@ class SDMarkdownReader:
         if next_line_index < len(
             body_lines
         ) and SDMarkdownReader._is_empty_line(body_lines[next_line_index]):
+            next_nonempty_line_index = next_line_index + 1
+            while next_nonempty_line_index < len(body_lines):
+                if not SDMarkdownReader._is_empty_line(
+                    body_lines[next_nonempty_line_index]
+                ):
+                    break
+                next_nonempty_line_index += 1
+            if next_nonempty_line_index < len(body_lines):
+                next_nonempty_line_text = (
+                    SDMarkdownReader._line_without_line_ending(
+                        body_lines[next_nonempty_line_index]
+                    )
+                )
+                next_field_match = SDMarkdownReader.plain_field_pattern.match(
+                    next_nonempty_line_text
+                )
+                if (
+                    next_field_match is not None
+                    and next_field_match.group("name").upper() == "RELATIONS"
+                ):
+                    raise StrictDocSemanticError(
+                        title=(
+                            "Markdown parsing error: Relations must directly "
+                            "follow requirement metadata without an empty line."
+                        ),
+                        hint=None,
+                        example="**UID**: REQ-1\n**Relations**:",
+                        line=1,
+                        col=1,
+                        filename=file_path,
+                    )
             next_line_index += 1
 
         return parsed_fields, body_lines[next_line_index:], True, meta_style
@@ -811,9 +850,32 @@ class SDMarkdownReader:
                     else:
                         is_last_field = meta_line_index == meta_line_count
                         if not is_last_field:
+                            next_line_text = (
+                                SDMarkdownReader._line_without_line_ending(
+                                    meta_lines[meta_line_index]
+                                )
+                            )
+                            next_field_match = (
+                                SDMarkdownReader.plain_field_pattern.match(
+                                    next_line_text
+                                )
+                            )
+                            next_field_is_relations = (
+                                next_field_match is not None
+                                and next_field_match.group("name").upper()
+                                == "RELATIONS"
+                                and len(
+                                    SDMarkdownReader._trim_single_space_prefix(
+                                        next_field_match.group("value")
+                                    )
+                                )
+                                == 0
+                            )
                             if not value.endswith(" \\"):
-                                return [], False
-                            value = value[:-2]
+                                if not next_field_is_relations:
+                                    return [], False
+                            else:
+                                value = value[:-2]
                         elif value.endswith("\\"):
                             return [], False
                 elif meta_style == "two_spaces":
@@ -864,6 +926,7 @@ class SDMarkdownReader:
     @staticmethod
     def _parse_content_fields(
         body_lines: List[str],
+        file_path: Optional[str],
     ) -> Tuple[List[ParsedField], bool]:
         """
         Parse content fields and freeform STATEMENT prose from the post-meta body lines.
@@ -885,6 +948,44 @@ class SDMarkdownReader:
         while line_index < line_count:
             line = body_lines[line_index]
             if SDMarkdownReader._is_empty_line(line):
+                next_nonempty_line_index = line_index + 1
+                while next_nonempty_line_index < line_count:
+                    if not SDMarkdownReader._is_empty_line(
+                        body_lines[next_nonempty_line_index]
+                    ):
+                        break
+                    next_nonempty_line_index += 1
+                if (
+                    len(parsed_fields) > 0
+                    and parsed_fields[-1].name
+                    in SDMarkdownReader.requirement_meta_fields
+                    and next_nonempty_line_index < line_count
+                ):
+                    next_line_text = SDMarkdownReader._line_without_line_ending(
+                        body_lines[next_nonempty_line_index]
+                    )
+                    next_field_match = (
+                        SDMarkdownReader.plain_field_pattern.match(
+                            next_line_text
+                        )
+                    )
+                    if (
+                        next_field_match is not None
+                        and next_field_match.group("name").upper()
+                        == "RELATIONS"
+                    ):
+                        raise StrictDocSemanticError(
+                            title=(
+                                "Markdown parsing error: Relations must "
+                                "directly follow requirement metadata without "
+                                "an empty line."
+                            ),
+                            hint=None,
+                            example="**UID**: REQ-1\n**Relations**:",
+                            line=1,
+                            col=1,
+                            filename=file_path,
+                        )
                 line_index += 1
                 continue
 

--- a/strictdoc/backend/markdown/writer.py
+++ b/strictdoc/backend/markdown/writer.py
@@ -193,7 +193,13 @@ class SDMarkdownWriter:
                 SDMarkdownWriter._serialize_meta_fields(meta_fields, meta_style)
             )
         if relations_block is not None:
-            field_blocks.append(f"**Relations**:\n{relations_block}")
+            relations_field_block = f"**Relations**:\n{relations_block}"
+            if len(meta_fields) > 0:
+                field_blocks[-1] = (
+                    f"{field_blocks[-1]}\n{relations_field_block}"
+                )
+            else:
+                field_blocks.append(relations_field_block)
         if len(content_fields) > 0:
             field_blocks.append(
                 SDMarkdownWriter._serialize_content_fields(content_fields)
@@ -209,8 +215,8 @@ class SDMarkdownWriter:
         Serialize all relations to a multiline dict-list block.
 
         Returns the block *value* (the bullet list), or None when there are no
-        relations.  The caller appends ("Relations", <value>) to meta_fields so
-        that the existing meta-field serializer emits the **Relations**: header.
+        relations. The caller emits the **Relations** header directly after the
+        metadata block, without an empty line.
         """
         if len(node.relations) == 0:
             return None

--- a/tests/integration/features/markdown/05_relations/input.md
+++ b/tests/integration/features/markdown/05_relations/input.md
@@ -15,7 +15,6 @@ Parent requirement shall do B.
 ## Child requirement
 
 **UID**: REQ-3
-
 **RELATIONS**:
 - **Type**: Parent
   **ID**: REQ-1

--- a/tests/integration/features/markdown/07_relations_all_types/input.md
+++ b/tests/integration/features/markdown/07_relations_all_types/input.md
@@ -9,7 +9,6 @@ Parent requirement statement.
 ## Child requirement
 
 **UID**: REQ-CHILD
-
 **RELATIONS**:
 - **Type**: Parent
   **ID**: REQ-PARENT
@@ -19,7 +18,6 @@ Child requirement statement.
 ## Parent with child relation
 
 **UID**: REQ-PARENT-EXPLICIT-CHILD
-
 **RELATIONS**:
 - **Type**: Child
   **ID**: REQ-CHILD
@@ -29,7 +27,6 @@ Parent with explicit child relation.
 ## File relation C function
 
 **UID**: REQ-FILE-C
-
 **RELATIONS**:
 - **Type**: File
   **Path**: file.c
@@ -41,7 +38,6 @@ File relation to C function.
 ## File relation Python class
 
 **UID**: REQ-FILE-PY
-
 **RELATIONS**:
 - **Type**: File
   **Path**: file.py
@@ -53,7 +49,6 @@ File relation to Python class.
 ## File relation Rust no element
 
 **UID**: REQ-FILE-RUST
-
 **RELATIONS**:
 - **Type**: File
   **Path**: file.rs
@@ -64,7 +59,6 @@ File relation to Rust function without element annotation.
 ## File relation line range
 
 **UID**: REQ-FILE-LINE-RANGE
-
 **RELATIONS**:
 - **Type**: File
   **Path**: file.c
@@ -75,7 +69,6 @@ File relation to a line range.
 ## Requirement with multiple relations
 
 **UID**: REQ-MULTI
-
 **RELATIONS**:
 - **Type**: Parent
   **ID**: REQ-PARENT

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
@@ -116,7 +116,6 @@ def test_008_markdown_reader_raises_error_on_missing_relation_type_key():
 ## Requirement
 
 **UID**: REQ-1
-
 **Relations**:
 - **ID**: `REQ-0`
 
@@ -136,7 +135,6 @@ def test_009_markdown_reader_raises_error_on_unknown_relation_type():
 ## Requirement
 
 **UID**: REQ-1
-
 **Relations**:
 - **Type**: `Unknown` \\
   **ID**: `REQ-0`
@@ -157,7 +155,6 @@ def test_010_markdown_reader_raises_error_on_missing_id_key():
 ## Requirement
 
 **UID**: REQ-1
-
 **Relations**:
 - **Type**: `Parent`
 
@@ -177,7 +174,6 @@ def test_011_markdown_reader_raises_error_on_unknown_key_in_relation():
 ## Requirement
 
 **UID**: REQ-1
-
 **Relations**:
 - **Type**: `Parent` \\
   **ID**: `REQ-0` \\
@@ -235,3 +231,27 @@ System shall do X.
     assert requirement.node_type == "REQUIREMENT"
     assert requirement.reserved_statement is not None
     assert "**BAD.NAME**: value" in requirement.reserved_statement
+
+
+def test_014_rejects_blank_line_between_meta_and_relations():
+    input_markdown = """\
+# Document title
+
+## Requirement
+
+**UID**: REQ-3
+
+**Relations**:
+- **Type**: `Parent` \\
+  **ID**: `REQ-1`
+- **Type**: `Child` \\
+  **ID**: `REQ-4` \\
+  **Role**: `Refines`
+
+Requirement shall do B.
+"""
+
+    reader = SDMarkdownReader()
+    with pytest.raises(StrictDocSemanticError) as exc_info:
+        reader.read(input_markdown, file_path=None)
+    assert "Relations must directly follow" in exc_info.value.title

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_roundtrip.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_roundtrip.py
@@ -451,14 +451,13 @@ System shall do X.
     )
 
 
-def test_015_roundtrip_relation_with_role():
+def test_015b_roundtrip_relation_with_role():
     input_markdown = """\
 # Document title
 
 ## Requirement
 
 **UID**: REQ-3
-
 **Relations**:
 - **Type**: `Parent` \\
   **ID**: `REQ-1`
@@ -474,7 +473,6 @@ Requirement shall do B.
 ## Requirement
 
 **UID**: REQ-3
-
 **Relations**:
 - **Type**: `Parent` \\
   **ID**: `REQ-1`
@@ -501,7 +499,6 @@ Parent requirement statement.
 ## Child requirement
 
 **UID**: REQ-CHILD
-
 **RELATIONS**:
 - **Type**: Parent
   **ID**: REQ-PARENT
@@ -511,7 +508,6 @@ Child requirement statement.
 ## Parent with child relation
 
 **UID**: REQ-PARENT-EXPLICIT-CHILD
-
 **RELATIONS**:
 - **Type**: Child
   **ID**: REQ-CHILD
@@ -521,7 +517,6 @@ Parent with explicit child relation.
 ## File relation C function
 
 **UID**: REQ-FILE-C
-
 **RELATIONS**:
 - **Type**: File
   **Path**: file.c
@@ -533,7 +528,6 @@ File relation to C function.
 ## File relation Python class
 
 **UID**: REQ-FILE-PY
-
 **RELATIONS**:
 - **Type**: File
   **Path**: file.py
@@ -545,7 +539,6 @@ File relation to Python class.
 ## File relation Rust no element
 
 **UID**: REQ-FILE-RUST
-
 **RELATIONS**:
 - **Type**: File
   **Path**: file.rs
@@ -556,7 +549,6 @@ File relation to Rust function without element annotation.
 ## File relation line range
 
 **UID**: REQ-FILE-LINE-RANGE
-
 **RELATIONS**:
 - **Type**: File
   **Path**: file.c
@@ -567,7 +559,6 @@ File relation to a line range.
 ## Requirement with multiple relations
 
 **UID**: REQ-MULTI
-
 **RELATIONS**:
 - **Type**: Parent
   **ID**: REQ-PARENT
@@ -591,7 +582,6 @@ Multiple relations of different types.
 ## Child requirement
 
 **UID**: REQ-CHILD
-
 **Relations**:
 - **Type**: `Parent` \\
   **ID**: `REQ-PARENT`
@@ -601,7 +591,6 @@ Multiple relations of different types.
 ## Parent with child relation
 
 **UID**: REQ-PARENT-EXPLICIT-CHILD
-
 **Relations**:
 - **Type**: `Child` \\
   **ID**: `REQ-CHILD`
@@ -611,7 +600,6 @@ Multiple relations of different types.
 ## File relation C function
 
 **UID**: REQ-FILE-C
-
 **Relations**:
 - **Type**: `File` \\
   **Path**: `file.c` \\
@@ -623,7 +611,6 @@ Multiple relations of different types.
 ## File relation Python class
 
 **UID**: REQ-FILE-PY
-
 **Relations**:
 - **Type**: `File` \\
   **Path**: `file.py` \\
@@ -635,7 +622,6 @@ Multiple relations of different types.
 ## File relation Rust no element
 
 **UID**: REQ-FILE-RUST
-
 **Relations**:
 - **Type**: `File` \\
   **Path**: `file.rs` \\
@@ -646,7 +632,6 @@ Multiple relations of different types.
 ## File relation line range
 
 **UID**: REQ-FILE-LINE-RANGE
-
 **Relations**:
 - **Type**: `File` \\
   **Path**: `file.c` \\
@@ -657,7 +642,6 @@ Multiple relations of different types.
 ## Requirement with multiple relations
 
 **UID**: REQ-MULTI
-
 **Relations**:
 - **Type**: `Parent` \\
   **ID**: `REQ-PARENT`
@@ -739,7 +723,6 @@ RELATIONS:
 ## Child requirement
 
 **UID**: REQ-3
-
 **Relations**:
 - **Type**: `Parent` \\
   **ID**: `REQ-1`
@@ -769,7 +752,6 @@ RELATIONS:
 ## Parent requirement
 
 **UID**: REQ-1
-
 **Relations**:
 - **Type**: `Child` \\
   **ID**: `REQ-2` \\


### PR DESCRIPTION


WHY: We are still evolving the Markdown specification. This is one step to ensure the consistency of the spec.