### PR TITLE
fix(forms): discard empty relation fields on save

### DIFF
--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -297,6 +297,9 @@ class RequirementFormObject(ErrorObject):
 
             relation_value = relation_dict["value"].strip()
 
+            if len(relation_value) == 0 and relation_type != "File":
+                continue
+
             form_ref_fields.append(
                 RequirementReferenceFormField(
                     field_mid=relation_mid,

--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -170,6 +170,10 @@ class RequirementReferenceFormField:
         field_type: FieldType,
         field_value: str,
         field_role: Optional[str],
+        # True for relation rows added client-side (never saved to the document).
+        # False (default) for rows that were already saved and loaded into the form.
+        # Used to distinguish "silently discard if empty" vs. "raise error if empty".
+        is_new: bool = False,
     ) -> None:
         assert isinstance(field_mid, str), field_mid
         assert isinstance(field_value, str), field_value
@@ -179,6 +183,7 @@ class RequirementReferenceFormField:
         self.field_role: str = (
             field_role if field_role is not None and len(field_role) > 0 else ""
         )
+        self.is_new: bool = is_new
         self.validation_messages: List[str] = []
 
     def get_input_field_name(self) -> str:
@@ -189,6 +194,9 @@ class RequirementReferenceFormField:
 
     def get_type_field_name(self) -> str:
         return f"requirement[relations][{self.field_mid}][typerole]"
+
+    def get_is_new_field_name(self) -> str:
+        return f"requirement[relations][{self.field_mid}][is_new]"
 
 
 @auto_described
@@ -298,7 +306,13 @@ class RequirementFormObject(ErrorObject):
             relation_value = relation_dict["value"].strip()
 
             if len(relation_value) == 0 and relation_type != "File":
-                continue
+                # is_new distinguishes two empty-UID cases:
+                # - True: user added a row but left it blank → silently discard.
+                # - False: user cleared the UID of an existing saved relation
+                #          → keep the field so validate() can raise the error.
+                is_new_relation = relation_dict.get("is_new", "false") == "true"
+                if is_new_relation:
+                    continue
 
             form_ref_fields.append(
                 RequirementReferenceFormField(

--- a/strictdoc/export/html/templates/components/form/row/row_with_relation.jinja
+++ b/strictdoc/export/html/templates/components/form/row/row_with_relation.jinja
@@ -23,6 +23,15 @@
 
 {% block row_content scoped %}
 
+{# Hidden field: tells the server whether this relation row is newly added (true)
+   or was already saved in the document (false).
+   New rows with a blank UID are silently discarded on save; existing rows with a
+   blank UID trigger a "Relation UID must not be empty" validation error. #}
+<input type="hidden"
+  name="{{ relation_row_context.field.get_is_new_field_name() }}"
+  value="{{ 'true' if relation_row_context.field.is_new else 'false' }}"
+/>
+
 <sdoc-form-field-group
   data-field-label="Node relation"
   {% if form_object.errors|length -%}

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -1804,6 +1804,8 @@ def create_main_router(
                 field_type=RequirementReferenceFormField.FieldType.PARENT,
                 field_value="",
                 field_role="",
+                # Mark as new so that an empty UID is silently discarded on save.
+                is_new=True,
             ),
             relation_types=grammar_element_relations,
         )

--- a/tests/end2end/helpers/screens/document/form_edit_requirement.py
+++ b/tests/end2end/helpers/screens/document/form_edit_requirement.py
@@ -86,6 +86,12 @@ class Form_EditRequirement(Form):  # pylint: disable=invalid-name
         # TODO: update with mid
         super().do_delete_field("form-field-relation", field_order)
 
+    def do_clear_relation_uid(self, field_order: int = 1) -> None:
+        # Clears the UID input of a relation row that already exists in the document.
+        # Used to verify Case 2: clearing the UID of a saved relation raises a
+        # validation error instead of silently discarding the relation.
+        super().do_clear_field("relation-uid", field_order)
+
     def do_fill_in_field_relation(self, mid: MID, field_value: str) -> None:
         assert isinstance(mid, MID)
         assert isinstance(field_value, str)

--- a/tests/end2end/screens/document/_cross_cutting/RELATIONS/update_node/_validations/update_requirement_parent_uid_must_not_be_empty/expected_output/document.sdoc
+++ b/tests/end2end/screens/document/_cross_cutting/RELATIONS/update_node/_validations/update_requirement_parent_uid_must_not_be_empty/expected_output/document.sdoc
@@ -10,3 +10,10 @@ Requirement statement.
 RATIONALE: >>>
 Requirement rationale.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: REQ-002
+
+[REQUIREMENT]
+UID: REQ-002
+TITLE: Parent requirement

--- a/tests/end2end/screens/document/_cross_cutting/RELATIONS/update_node/_validations/update_requirement_parent_uid_must_not_be_empty/input/document.sdoc
+++ b/tests/end2end/screens/document/_cross_cutting/RELATIONS/update_node/_validations/update_requirement_parent_uid_must_not_be_empty/input/document.sdoc
@@ -10,3 +10,10 @@ Requirement statement.
 RATIONALE: >>>
 Requirement rationale.
 <<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: REQ-002
+
+[REQUIREMENT]
+UID: REQ-002
+TITLE: Parent requirement

--- a/tests/end2end/screens/document/_cross_cutting/RELATIONS/update_node/_validations/update_requirement_parent_uid_must_not_be_empty/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/RELATIONS/update_node/_validations/update_requirement_parent_uid_must_not_be_empty/test_case.py
@@ -32,16 +32,32 @@ class Test(E2ECase):
             screen_document.assert_on_screen_document()
             screen_document.assert_header_document_title("Document 1")
 
-            # Open form and add 1 field:
             requirement = screen_document.get_node()
+
+            #
+            # Case 1: Adding a new empty relation field — form saves successfully,
+            # the empty relation is silently skipped (not saved).
+            # The existing PARENT: REQ-002 relation is preserved.
+            #
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )
             form_edit_requirement.do_open_tab("Relations")
             form_edit_requirement.do_form_add_field_relation()
+            form_edit_requirement.do_form_submit()
 
-            form_edit_requirement.do_form_submit_and_catch_error(
-                "Requirement relation UID must not be empty."
-            )
+            #
+            # Case 2: Clearing the UID of an existing relation (without deleting
+            # the field) — an error must be raised.
+            #
+            # TODO: Implement this case after implementing the form field clearing action.
+            #
+            # ruff: noqa: ERA001
+            # form_edit_requirement = requirement.do_open_form_edit_requirement()
+            # form_edit_requirement.do_open_tab("Relations")
+            # form_edit_requirement.do_clear_field("relation-uid", 1)
+            # form_edit_requirement.do_form_submit_and_catch_error(
+            #     "Requirement relation UID must not be empty."
+            # )
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/_cross_cutting/RELATIONS/update_node/_validations/update_requirement_parent_uid_must_not_be_empty/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/RELATIONS/update_node/_validations/update_requirement_parent_uid_must_not_be_empty/test_case.py
@@ -47,17 +47,16 @@ class Test(E2ECase):
             form_edit_requirement.do_form_submit()
 
             #
-            # Case 2: Clearing the UID of an existing relation (without deleting
-            # the field) — an error must be raised.
+            # Case 2: Clearing the UID of an existing saved relation (without
+            # deleting the row) must raise a validation error.
+            # This is distinct from Case 1: the row already exists in the document,
+            # so a blank UID is treated as a mistake, not an intent to remove.
             #
-            # TODO: Implement this case after implementing the form field clearing action.
-            #
-            # ruff: noqa: ERA001
-            # form_edit_requirement = requirement.do_open_form_edit_requirement()
-            # form_edit_requirement.do_open_tab("Relations")
-            # form_edit_requirement.do_clear_field("relation-uid", 1)
-            # form_edit_requirement.do_form_submit_and_catch_error(
-            #     "Requirement relation UID must not be empty."
-            # )
+            form_edit_requirement = requirement.do_open_form_edit_requirement()
+            form_edit_requirement.do_open_tab("Relations")
+            form_edit_requirement.do_clear_relation_uid(1)
+            form_edit_requirement.do_form_submit_and_catch_error(
+                "Requirement relation UID must not be empty."
+            )
 
         assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
Discards empty relation fields on save instead of raising a validation error.
If the user adds a relation row but leaves the UID blank, it is simply discarded on save.

This replaces the previous behavior where any empty relation UID triggered a hard validation error - which was too strict for the common case of opening a form, adding a relation row, and then deciding not to fill it in.

**There are two cases in which the connection UID may be empty:**

- New row, blank UID (user added a relation row but did not fill it in) → silently discarded on save.
- Existing relation, cleared UID (user opened the form, cleared the UID of an already-saved relation, and submitted) → validation error: "Requirement relation UID must not be empty."

The distinction is implemented via an `is_new` hidden field rendered into each relation row.
New rows (added client-side via "Add relation") carry `is_new=true`; rows loaded from the saved document carry `is_new=false`.
The server uses this flag in create_from_request to decide whether to discard the empty field silently or pass it through to the existing validation logic.