### PR TITLE
fix(server, UI): validate Markdown document fields as Markdown in web UI

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -81,6 +81,11 @@ editable element.
 The ``manage auto-uid`` command now resolves source root paths correctly when
 test report paths are present, and asset copying now handles Windows paths
 consistently with Linux paths.
+
+7\) Editing a node in a Markdown document through the web interface no longer
+fails when a field contains valid Markdown such as a pipe table. The edit-time
+field validation now uses the writer that matches the document's markup,
+instead of always validating the content as RST.
 <<<
 
 [[/SECTION]]

--- a/strictdoc/core/transforms/update_requirement.py
+++ b/strictdoc/core/transforms/update_requirement.py
@@ -9,9 +9,13 @@ from typing import Dict, List, Optional, Set, Tuple, Union
 
 from textx import TextXSyntaxError
 
+from strictdoc.backend.markdown.markdown_to_html_fragment_writer import (
+    MarkdownToHtmlFragmentWriter,
+)
 from strictdoc.backend.rst.rst_to_html_fragment_writer import (
     RstToHtmlFragmentWriter,
 )
+from strictdoc.backend.sdoc.constants import SDocMarkup
 from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.error_handling import get_textx_syntax_error_message
 from strictdoc.backend.sdoc.free_text_reader import SDFreeTextReader
@@ -115,16 +119,32 @@ class CreateOrUpdateNodeCommand:
             for field_ in field_bucket_:
                 if field_.field_type != RequirementFormFieldType.MULTILINE:
                     continue
-                (
-                    parsed_html,
-                    rst_error,
-                ) = RstToHtmlFragmentWriter(
-                    project_config=self.project_config,
-                    context_document=self.context_document,
-                ).write_with_validation(field_.field_value)
+                # Validate the field content using the writer that matches the
+                # document's markup (RST by default, Markdown for Markdown
+                # documents).
+                markup = (
+                    self.context_document.config.markup
+                    if self.context_document is not None
+                    else None
+                )
+                if markup == SDocMarkup.MARKDOWN:
+                    (
+                        parsed_html,
+                        markup_error,
+                    ) = MarkdownToHtmlFragmentWriter.write_with_validation(
+                        field_.field_value
+                    )
+                else:
+                    (
+                        parsed_html,
+                        markup_error,
+                    ) = RstToHtmlFragmentWriter(
+                        project_config=self.project_config,
+                        context_document=self.context_document,
+                    ).write_with_validation(field_.field_value)
                 if parsed_html is None:
-                    assert rst_error is not None
-                    form_object.add_error(field_.field_name, rst_error)
+                    assert markup_error is not None
+                    form_object.add_error(field_.field_name, markup_error)
                 else:
                     try:
                         free_text_container: Optional[FreeTextContainer] = (

--- a/strictdoc/core/transforms/update_requirement.py
+++ b/strictdoc/core/transforms/update_requirement.py
@@ -90,13 +90,11 @@ class CreateOrUpdateNodeCommand:
         *,
         form_object: RequirementFormObject,
         node_info: Union[CreateNodeInfo, UpdateNodeInfo],
-        context_document: SDocDocument,
         traceability_index: TraceabilityIndex,
         project_config: ProjectConfig,
     ) -> None:
         self.form_object: RequirementFormObject = form_object
         self.node_info: Union[CreateNodeInfo, UpdateNodeInfo] = node_info
-        self.context_document: SDocDocument = context_document
         self.traceability_index: TraceabilityIndex = traceability_index
         self.project_config: ProjectConfig = project_config
 
@@ -109,6 +107,18 @@ class CreateOrUpdateNodeCommand:
         )
 
         traceability_index: TraceabilityIndex = self.traceability_index
+
+        if node_to_update_or_none is not None:
+            node_document = assert_cast(
+                node_to_update_or_none.get_document(), SDocDocument
+            )
+        else:
+            node_document = assert_cast(
+                traceability_index.get_node_by_mid(
+                    MID(form_object.document_mid)
+                ),
+                SDocDocument,
+            )
 
         map_form_to_requirement_fields: Dict[
             RequirementFormField, Optional[FreeTextContainer]
@@ -123,8 +133,8 @@ class CreateOrUpdateNodeCommand:
                 # document's markup (RST by default, Markdown for Markdown
                 # documents).
                 markup = (
-                    self.context_document.config.markup
-                    if self.context_document is not None
+                    node_document.config.markup
+                    if node_document is not None
                     else None
                 )
                 if markup == SDocMarkup.MARKDOWN:
@@ -140,7 +150,7 @@ class CreateOrUpdateNodeCommand:
                         markup_error,
                     ) = RstToHtmlFragmentWriter(
                         project_config=self.project_config,
-                        context_document=self.context_document,
+                        context_document=node_document,
                     ).write_with_validation(field_.field_value)
                 if parsed_html is None:
                     assert markup_error is not None

--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -8,9 +8,13 @@ from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 
 from starlette.datastructures import FormData
 
+from strictdoc.backend.markdown.markdown_to_html_fragment_writer import (
+    MarkdownToHtmlFragmentWriter,
+)
 from strictdoc.backend.rst.rst_to_html_fragment_writer import (
     RstToHtmlFragmentWriter,
 )
+from strictdoc.backend.sdoc.constants import SDocMarkup
 from strictdoc.backend.sdoc.errors.document_tree_error import DocumentTreeError
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_grammar import (
@@ -733,18 +737,33 @@ class RequirementFormObject(ErrorObject):
                         else grammar_element_field_.title
                     )
 
-                    # If field not empty, validate its RST syntax.
+                    # If field not empty, validate its markup syntax using the
+                    # writer that matches the document's markup (RST by
+                    # default, Markdown for Markdown documents).
                     if len(field_value) > 0:
-                        (
-                            parsed_html,
-                            rst_error,
-                        ) = RstToHtmlFragmentWriter(
-                            project_config=config,
-                            context_document=context_document,
-                        ).write_with_validation(field_value)
+                        markup = (
+                            context_document.config.markup
+                            if context_document is not None
+                            else None
+                        )
+                        if markup == SDocMarkup.MARKDOWN:
+                            (
+                                parsed_html,
+                                markup_error,
+                            ) = MarkdownToHtmlFragmentWriter.write_with_validation(
+                                field_value
+                            )
+                        else:
+                            (
+                                parsed_html,
+                                markup_error,
+                            ) = RstToHtmlFragmentWriter(
+                                project_config=config,
+                                context_document=context_document,
+                            ).write_with_validation(field_value)
                         if parsed_html is None:
-                            assert rst_error is not None
-                            self.add_error(error_key, rst_error)
+                            assert markup_error is not None
+                            self.add_error(error_key, markup_error)
                     # If field is empty, check if required and validate for emptiness.
                     else:
                         if grammar_element_field_.required:

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -573,7 +573,7 @@ def create_main_router(
         document: SDocDocument = (
             export_action.traceability_index.get_node_by_mid(MID(document_mid))
         )
-        context_document: SDocDocument = (
+        editing_context_document: SDocDocument = (
             export_action.traceability_index.get_node_by_mid(
                 MID(context_document_mid)
             )
@@ -613,7 +613,6 @@ def create_main_router(
                     requirement_mid=requirement_mid,
                     reference_mid=reference_mid,
                 ),
-                context_document=context_document,
                 traceability_index=export_action.traceability_index,
                 project_config=project_config,
             )
@@ -657,8 +656,8 @@ def create_main_router(
 
         # Saving new content to .SDoc files.
         write_document_to_file(document)
-        if document != context_document:
-            write_document_to_file(context_document)
+        if document != editing_context_document:
+            write_document_to_file(editing_context_document)
 
         # Exporting the updated document to HTML. Note that this happens after
         # the traceability index last update marker has been updated. This way
@@ -685,7 +684,7 @@ def create_main_router(
 
         view_object = DocumentScreenViewObject(
             document_type=DocumentType.DOCUMENT,
-            document=context_document,
+            document=editing_context_document,
             traceability_index=export_action.traceability_index,
             project_config=project_config,
             link_renderer=link_renderer,
@@ -857,12 +856,6 @@ def create_main_router(
         )
         existing_revision = revisions[form_object.requirement_mid]
 
-        context_document: SDocDocument = (
-            export_action.traceability_index.get_node_by_mid(
-                MID(form_object.context_document_mid)
-            )
-        )
-
         form_object.validate(
             traceability_index=export_action.traceability_index,
             context_document=document,
@@ -877,7 +870,6 @@ def create_main_router(
             update_command = CreateOrUpdateNodeCommand(
                 form_object=form_object,
                 node_info=UpdateNodeInfo(node_to_update=requirement),
-                context_document=context_document,
                 traceability_index=export_action.traceability_index,
                 project_config=project_config,
             )

--- a/tests/unit/strictdoc/core/transforms/test_update_requirement.py
+++ b/tests/unit/strictdoc/core/transforms/test_update_requirement.py
@@ -3,6 +3,7 @@
 """
 
 from strictdoc.backend.sdoc.constants import SDocMarkup
+from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.models.grammar_element import (
     GrammarElementRelationChild,
     GrammarElementRelationParent,
@@ -79,7 +80,6 @@ def test_01_single_document_add_first_parent_relation_with_no_role():
     update_command = CreateOrUpdateNodeCommand(
         form_object=form_object,
         node_info=UpdateNodeInfo(requirement2),
-        context_document=document_1,
         traceability_index=traceability_index,
         project_config=ProjectConfig.default_config(),
     )
@@ -148,7 +148,6 @@ def test_02_single_document_add_second_parent_relation_with_role():
     update_command = CreateOrUpdateNodeCommand(
         form_object=form_object,
         node_info=UpdateNodeInfo(requirement2),
-        context_document=document_1,
         traceability_index=traceability_index,
         project_config=ProjectConfig.default_config(),
     )
@@ -241,7 +240,6 @@ def test_20_single_document_add_second_child_relation_with_role():
     update_command = CreateOrUpdateNodeCommand(
         form_object=form_object,
         node_info=UpdateNodeInfo(requirement2),
-        context_document=document_1,
         traceability_index=traceability_index,
         project_config=ProjectConfig.default_config(),
     )
@@ -327,7 +325,6 @@ def test_25_single_document_remove_child_relation():
     update_command = CreateOrUpdateNodeCommand(
         form_object=form_object,
         node_info=UpdateNodeInfo(requirement2),
-        context_document=document_1,
         traceability_index=traceability_index,
         project_config=ProjectConfig.default_config(),
     )
@@ -409,7 +406,6 @@ def test_26_two_documents_remove_child_relation():
     update_command = CreateOrUpdateNodeCommand(
         form_object=form_object,
         node_info=UpdateNodeInfo(requirement2),
-        context_document=document_1,
         traceability_index=traceability_index,
         project_config=ProjectConfig.default_config(),
     )
@@ -460,7 +456,60 @@ def test_30_markdown_document_updates_field_with_markdown_table():
     update_command = CreateOrUpdateNodeCommand(
         form_object=form_object,
         node_info=UpdateNodeInfo(requirement),
-        context_document=document_1,
+        traceability_index=traceability_index,
+        project_config=ProjectConfig.default_config(),
+    )
+    result = update_command.perform()
+
+    assert result is not None
+    assert not form_object.any_errors()
+    assert requirement.reserved_statement == MARKDOWN_TABLE
+
+
+def test_31_included_markdown_document_uses_own_markup_when_updated_from_parent():
+    parent_document_builder = DocumentBuilder(uid="PARENT")
+    parent_document = parent_document_builder.build()
+    parent_document.config.markup = SDocMarkup.RST
+
+    included_document_builder = DocumentBuilder(uid="INCLUDED")
+    requirement = included_document_builder.add_requirement("REQ-001")
+    included_document = included_document_builder.build()
+    included_document.config.markup = SDocMarkup.MARKDOWN
+
+    included_document.ng_including_document_reference = DocumentReference()
+    included_document.ng_including_document_reference.set_document(
+        parent_document
+    )
+    parent_document.included_documents.append(included_document)
+
+    document_tree = DocumentTree(
+        file_tree=[],
+        document_list=[parent_document, included_document],
+        map_docs_by_paths={},
+        map_docs_by_rel_paths={},
+        map_grammars_by_filenames={},
+    )
+    traceability_index: TraceabilityIndex = (
+        TraceabilityIndexBuilder.create_from_document_tree(
+            document_tree,
+            project_config=included_document_builder.project_config,
+        )
+    )
+    traceability_index.document_tree = document_tree
+
+    form_object: RequirementFormObject = (
+        RequirementFormObject.create_from_requirement(
+            requirement=requirement,
+            revision=0,
+            context_document_mid=parent_document.reserved_mid,
+        )
+    )
+    for field in form_object.fields["STATEMENT"]:
+        field.field_value = MARKDOWN_TABLE
+
+    update_command = CreateOrUpdateNodeCommand(
+        form_object=form_object,
+        node_info=UpdateNodeInfo(requirement),
         traceability_index=traceability_index,
         project_config=ProjectConfig.default_config(),
     )

--- a/tests/unit/strictdoc/core/transforms/test_update_requirement.py
+++ b/tests/unit/strictdoc/core/transforms/test_update_requirement.py
@@ -2,6 +2,7 @@
 @relation(SDOC-SRS-55, scope=file)
 """
 
+from strictdoc.backend.sdoc.constants import SDocMarkup
 from strictdoc.backend.sdoc.models.grammar_element import (
     GrammarElementRelationChild,
     GrammarElementRelationParent,
@@ -20,6 +21,13 @@ from strictdoc.export.html.form_objects.requirement_form_object import (
 )
 from strictdoc.helpers.mid import MID
 from tests.unit.helpers.document_builder import DocumentBuilder
+
+MARKDOWN_TABLE = (
+    "|   | Action | Verify |\n"
+    "|---|--------|--------|\n"
+    "| 1 | Do the thing | |\n"
+    "| 2 | Do another thing | |\n"
+)
 
 
 def test_01_single_document_add_first_parent_relation_with_no_role():
@@ -416,3 +424,48 @@ def test_26_two_documents_remove_child_relation():
         traceability_index.get_child_relations_with_roles(requirement2)
     )
     assert requirement2_children == []
+
+
+def test_30_markdown_document_updates_field_with_markdown_table():
+    document_builder = DocumentBuilder()
+    requirement = document_builder.add_requirement("REQ-001")
+
+    document_1 = document_builder.build()
+    document_1.config.markup = SDocMarkup.MARKDOWN
+
+    document_tree = DocumentTree(
+        file_tree=[],
+        document_list=[document_1],
+        map_docs_by_paths={},
+        map_docs_by_rel_paths={},
+        map_grammars_by_filenames={},
+    )
+    traceability_index: TraceabilityIndex = (
+        TraceabilityIndexBuilder.create_from_document_tree(
+            document_tree, project_config=document_builder.project_config
+        )
+    )
+    traceability_index.document_tree = document_tree
+
+    form_object: RequirementFormObject = (
+        RequirementFormObject.create_from_requirement(
+            requirement=requirement,
+            revision=0,
+            context_document_mid=document_1.reserved_mid,
+        )
+    )
+    for field in form_object.fields["STATEMENT"]:
+        field.field_value = MARKDOWN_TABLE
+
+    update_command = CreateOrUpdateNodeCommand(
+        form_object=form_object,
+        node_info=UpdateNodeInfo(requirement),
+        context_document=document_1,
+        traceability_index=traceability_index,
+        project_config=ProjectConfig.default_config(),
+    )
+    result = update_command.perform()
+
+    assert result is not None
+    assert not form_object.any_errors()
+    assert requirement.reserved_statement == MARKDOWN_TABLE

--- a/tests/unit/strictdoc/export/html/form_objects/test_requirement_form_object_markup_validation.py
+++ b/tests/unit/strictdoc/export/html/form_objects/test_requirement_form_object_markup_validation.py
@@ -1,0 +1,105 @@
+"""
+@relation(SDOC-SRS-55, scope=file)
+"""
+
+from strictdoc.backend.sdoc.constants import SDocMarkup
+from strictdoc.core.document_tree import DocumentTree
+from strictdoc.core.project_config import ProjectConfig
+from strictdoc.core.traceability_index import TraceabilityIndex
+from strictdoc.core.traceability_index_builder import TraceabilityIndexBuilder
+from strictdoc.export.html.form_objects.requirement_form_object import (
+    RequirementFormObject,
+)
+from tests.unit.helpers.document_builder import DocumentBuilder
+
+# A Markdown pipe table. It is valid Markdown but not valid RST: the separator
+# row "|---|...|" is not a valid line-block continuation of the header row,
+# which docutils reports as "Line block ends without a blank line".
+MARKDOWN_TABLE = (
+    "|   | Action | Verify |\n"
+    "|---|--------|--------|\n"
+    "| 1 | Do the thing | |\n"
+    "| 2 | Do another thing | |\n"
+)
+
+
+def _build_index_with_single_requirement():
+    document_builder = DocumentBuilder()
+    requirement = document_builder.add_requirement("REQ-001")
+    document = document_builder.build()
+
+    document_tree = DocumentTree(
+        file_tree=[],
+        document_list=[document],
+        map_docs_by_paths={},
+        map_docs_by_rel_paths={},
+        map_grammars_by_filenames={},
+    )
+    traceability_index: TraceabilityIndex = (
+        TraceabilityIndexBuilder.create_from_document_tree(
+            document_tree, project_config=document_builder.project_config
+        )
+    )
+    traceability_index.document_tree = document_tree
+    return traceability_index, document, requirement
+
+
+def _make_form_object_with_statement(requirement, document, statement_value):
+    form_object: RequirementFormObject = (
+        RequirementFormObject.create_from_requirement(
+            requirement=requirement,
+            revision=0,
+            context_document_mid=document.reserved_mid,
+        )
+    )
+    for field in form_object.fields["STATEMENT"]:
+        field.field_value = statement_value
+    return form_object
+
+
+def test_markdown_document_validates_field_as_markdown():
+    """
+    In a Markdown document, a field containing a Markdown table validates
+    without errors.
+    """
+    traceability_index, document, requirement = (
+        _build_index_with_single_requirement()
+    )
+    document.config.markup = SDocMarkup.MARKDOWN
+
+    form_object = _make_form_object_with_statement(
+        requirement, document, MARKDOWN_TABLE
+    )
+    form_object.validate(
+        traceability_index=traceability_index,
+        context_document=document,
+        config=ProjectConfig.default_config(),
+        existing_revision=0,
+    )
+
+    assert not form_object.any_errors()
+    assert form_object.get_errors("STATEMENT") == []
+
+
+def test_rst_document_validates_field_as_rst():
+    """
+    In an RST document, a field is validated as RST. The pipe table is not
+    valid RST, so validation reports an error against the field.
+    """
+    traceability_index, document, requirement = (
+        _build_index_with_single_requirement()
+    )
+    document.config.markup = SDocMarkup.RST
+
+    form_object = _make_form_object_with_statement(
+        requirement, document, MARKDOWN_TABLE
+    )
+    form_object.validate(
+        traceability_index=traceability_index,
+        context_document=document,
+        config=ProjectConfig.default_config(),
+        existing_revision=0,
+    )
+
+    assert form_object.any_errors()
+    assert len(form_object.get_errors("STATEMENT")) > 0


### PR DESCRIPTION
When editing a node in a Markdown document through the web interface, the field content was always validated as RST, regardless of the document markup. Valid Markdown such as a pipe table was rejected, so the edit could not be saved even though the same content rendered correctly.

The edit-time field validation now selects the fragment writer based on the document's markup (Markdown for Markdown documents, RST otherwise), mirroring the logic already used by MarkupRenderer for rendering. The fix is applied to both validation sites: the requirement form object's validate() and the create/update node transform.