### PR TITLE
fix(backend/sdoc_source_code): recognize Google Benchmark functions, print warning instead of NotImplementedError

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -46,6 +46,29 @@ This document maintains a record of all changes to StrictDoc since November 2023
 <<<
 
 [[SECTION]]
+MID: 71592b7fb5c44af4a8b308b75fab9491
+TITLE: 0.23.1 (2026-06-05)
+
+[TEXT]
+MID: 39d572931ce144479f3f3927234589c9
+STATEMENT: >>>
+This release contains the following enhancements:
+
+1\) Source code traceability for C/C++ now recognizes Google Benchmark
+fixture macros such as ``BENCHMARK_F`` and ``BENCHMARK_DEFINE_F``. StrictDoc
+can parse the nested function declarator shape produced by tree-sitter for
+these macros, and unsupported function declarators are now reported as
+warnings instead of aborting the whole export.
+
+2\) The web interface now handles empty relation form fields more gracefully.
+Saving a node discards empty relation rows instead of raising a validation
+error, while clearing an existing relation UID still produces a proper
+validation error.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
 MID: 0a1b2c3d4e5f60718293a4b5c6d7e8f9
 TITLE: 0.23.0 (2026-06-04)
 

--- a/strictdoc/__init__.py
+++ b/strictdoc/__init__.py
@@ -1,6 +1,6 @@
 from strictdoc.core.environment import SDocRuntimeEnvironment
 
-__version__ = "0.23.0"
+__version__ = "0.23.1"
 
 
 environment = SDocRuntimeEnvironment(__file__)

--- a/strictdoc/backend/sdoc_source_code/reader_c.py
+++ b/strictdoc/backend/sdoc_source_code/reader_c.py
@@ -58,6 +58,13 @@ KNOWN_FUNCTION_DEFINITION_MACROS: Final[frozenset[str]] = frozenset(
         "SYSCALL_DEFINE4",
         "SYSCALL_DEFINE5",
         "SYSCALL_DEFINE6",
+        # Google Benchmark
+        "BENCHMARK",
+        "BENCHMARK_F",
+        "BENCHMARK_DEFINE_F",
+        "BENCHMARK_TEMPLATE",
+        "BENCHMARK_TEMPLATE_F",
+        "BENCHMARK_TEMPLATE_DEFINE_F",
         # Google Test and Linux
         "TEST",
         "TEST_F",
@@ -296,7 +303,14 @@ class SourceFileTraceabilityReader_C:
                     function_declarator_node
                 )
                 if identifier_node is None:
-                    raise NotImplementedError(function_declarator_node)
+                    print(  # noqa: T201
+                        "warning: C/C++ source reader: skipping unsupported "
+                        "function declarator at "
+                        f"{parse_context.filename}:"
+                        f"{function_declarator_node.start_point[0] + 1}: "
+                        f"{function_declarator_node}"
+                    )
+                    continue
 
                 assert identifier_node.text is not None, node_.text
                 function_display_name = identifier_node.text.decode("utf8")
@@ -468,7 +482,19 @@ class SourceFileTraceabilityReader_C:
                 "qualified_identifier",
             ),
         )
-        return function_identifier_node
+        if function_identifier_node is not None:
+            return function_identifier_node
+
+        nested_function_declarator_node = ts_find_child_node_by_type(
+            function_declarator_node,
+            "function_declarator",
+        )
+        if nested_function_declarator_node is not None:
+            return SourceFileTraceabilityReader_C._get_function_name_node(
+                nested_function_declarator_node
+            )
+
+        return None
 
     @staticmethod
     def get_node_ns(node: Node) -> Sequence[str]:

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_cpp.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_cpp.py
@@ -315,3 +315,83 @@ Foo& Foo::operator+(const Foo& c) { return *this; }
     marker_1: LanguageItemMarker = info.markers[0]
     assert marker_1.ng_range_line_begin == 9
     assert marker_1.ng_range_line_end == 12
+
+
+def test_30_google_benchmark_f_macro_definition():
+    """
+    Ensure that Google Benchmark fixture macros parse without crashing.
+
+    https://github.com/strictdoc-project/strictdoc/issues/2882
+    """
+
+    input_string = b"""\
+#include <benchmark/benchmark.h>
+
+class TestBench : public benchmark::Fixture {};
+
+BENCHMARK_F(TestBench, initMatrix)(benchmark::State& st) {
+  for (auto _ : st) {
+    (void)_;
+  }
+}
+"""
+
+    reader = SourceFileTraceabilityReader_C()
+
+    info = reader.read(input_string, file_path="NOT_RELEVANT")
+
+    assert isinstance(info, SourceFileTraceabilityInfo)
+    assert len(info.functions) == 1
+    assert len(info.markers) == 0
+
+    function: LanguageItem = info.functions[0]
+    assert (
+        function.name
+        == "BENCHMARK_F(TestBench, initMatrix)(benchmark::State& st)"
+    )
+    assert (
+        function.display_name
+        == "BENCHMARK_F(TestBench, initMatrix)(benchmark::State& st)"
+    )
+    assert function.line_begin == 5
+    assert function.line_end == 9
+
+
+def test_31_google_benchmark_define_f_macro_definition():
+    """
+    Ensure that Google Benchmark fixture definition macros parse without crashing.
+
+    https://github.com/strictdoc-project/strictdoc/issues/2882
+    """
+
+    input_string = b"""\
+#include <benchmark/benchmark.h>
+
+class TestBench : public benchmark::Fixture {};
+
+BENCHMARK_DEFINE_F(TestBench, initMatrix)(benchmark::State& st) {
+  for (auto _ : st) {
+    (void)_;
+  }
+}
+"""
+
+    reader = SourceFileTraceabilityReader_C()
+
+    info = reader.read(input_string, file_path="NOT_RELEVANT")
+
+    assert isinstance(info, SourceFileTraceabilityInfo)
+    assert len(info.functions) == 1
+    assert len(info.markers) == 0
+
+    function: LanguageItem = info.functions[0]
+    assert (
+        function.name
+        == "BENCHMARK_DEFINE_F(TestBench, initMatrix)(benchmark::State& st)"
+    )
+    assert (
+        function.display_name
+        == "BENCHMARK_DEFINE_F(TestBench, initMatrix)(benchmark::State& st)"
+    )
+    assert function.line_begin == 5
+    assert function.line_end == 9


### PR DESCRIPTION
WHY: Fixes a bug report:

Closes #2882