### PR TITLE
fix(backend/markdown): render InlineLink anchors instead of escaping them

### DIFF
--- a/strictdoc/backend/markdown/markdown_to_html_fragment_writer.py
+++ b/strictdoc/backend/markdown/markdown_to_html_fragment_writer.py
@@ -12,7 +12,7 @@ from markdown_it.token import Token
 from markdown_it.utils import EnvType, OptionsDict
 from markupsafe import Markup
 
-_MARKDOWN_PARSER = MarkdownIt("default")
+_MARKDOWN_PARSER = MarkdownIt("default", {"html": True})
 _MARKDOWN_RENDERER = cast(RendererHTML, _MARKDOWN_PARSER.renderer)
 _FenceRenderer = Callable[[Sequence[Token], int, OptionsDict, EnvType], str]
 _MARKDOWN_RENDERER_RULES = cast(

--- a/tests/unit/strictdoc/export/markdown/test_markdown_to_html_fragment_writer.py
+++ b/tests/unit/strictdoc/export/markdown/test_markdown_to_html_fragment_writer.py
@@ -63,3 +63,14 @@ def test_06_writes_regular_fence_as_code_block():
     assert html_output == (
         '<pre><code class="language-python">print(1)\n</code></pre>\n'
     )
+
+
+def test_07_renders_anchor_link_as_raw_html_not_escaped():
+    markdown_input = MarkdownToHtmlFragmentWriter.write_anchor_link(
+        "Title",
+        "foo.bar",
+    )
+
+    html_output = MarkdownToHtmlFragmentWriter.write(markdown_input)
+
+    assert html_output == '<p><a href="foo.bar">🔗\u00a0Title</a></p>\n'


### PR DESCRIPTION
Fixes #2884.

In Markdown documents, an InlineLink (`[LINK: ...]`) was rendered as escaped text instead of a clickable link, both in the server and the HTML export. The Markdown fragment writer builds its parser from the markdown-it "default" preset, which sets `"html": False`, so the `<a>` anchor produced by `write_anchor_link()` got escaped on the way out.

This enables `"html": True` on the parser so the anchor passes through. I think this best matches how the RST writer already handles the same case, where it passes its `<a>` anchor through using the custom `"rawhtml"` role.

I also considered emitting a native Markdown link (`[title](href)`) from `write_anchor_link()` instead. That works too, but it needs extra escaping of the title and href and diverges from the RST approach, so I went with the parser option since it stays closest to the existing RST solution.

Added a unit test next to the existing fragment writer tests that asserts the anchor renders as raw HTML rather than escaped text.