### PR TITLE
feat(gcov): improve handling of C++ namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.virtualenv
 /.vscode/
 /build/
+/developer/tasks/**/Context.md
 /dist/
 /reports/
 /Output/

--- a/developer/tasks/20260604_gcov_cpp_namespaces_issue_2717/task.md
+++ b/developer/tasks/20260604_gcov_cpp_namespaces_issue_2717/task.md
@@ -1,0 +1,75 @@
+# GCOV/gcovr: C++ namespaces and function-name matching
+
+## WHAT
+
+- Improve GCOV/gcovr interoperability for C++ namespaced member functions.
+- Resolve the two issues pointed out by the user:
+  - GCOV report links used a file path/hash that did not exist.
+  - gcovr C++ function names did not match the names extracted by StrictDoc's C/C++ reader.
+- Follow the Dev Guide.
+- Always add tests.
+
+## WHY
+
+GCOV support in StrictDoc is still rudimentary as of June 2026.
+
+We received a bug report where a user is trying to use GCOV/gcovr against a C++ program that is larger than a trivial Hello World:
+
+https://github.com/strictdoc-project/strictdoc/issues/2717
+
+They summarize the issues as follows:
+
+> Currently the link in the coverage report uses a filename/path which does not exist. Additionally, when running this on C++ code the function names provided by gcov do not match the function names detected by treesitter (in the reader_c.py).
+
+## HOW
+
+### Implementation details
+
+- Fixed GCOV JSON reader function-name handling for C++.
+  - gcovr can emit both `name` and `demangled_name`.
+  - StrictDoc now prefers `demangled_name` and falls back to `name`.
+
+- Fixed GCOV HTML detail links.
+  - The link hash now uses the actual source file path from the gcovr JSON report.
+  - This removed the previous hardcoded `src/main.c` behavior.
+  - gcovr file paths are normalized in the GCOV reader before StrictDoc uses
+    them for UIDs, file references, and gcov HTML detail links.
+  - On Windows, absolute gcovr paths are relativized against
+    `project_config.source_root_path`, so StrictDoc uses the same
+    project-relative POSIX paths as the source-file index.
+
+- Added gcovr-style C++ function-name matching.
+  - StrictDoc/tree-sitter names such as:
+    - `test::Adder::add(const int& a, const int& b)`
+  - can now match gcovr names such as:
+    - `test::Adder::add(int const&, int const&)`
+  - `FileTraceabilityIndex.get_function_matching_names()` now tries:
+    - display name,
+    - full parser name,
+    - gcovr-style canonical name.
+
+- Added `strictdoc/backend/gcov/helpers.py`.
+  - Contains GCOV-specific C++ name canonicalization helpers.
+  - Internal helper functions are private and documented with examples.
+
+- Added regression tests.
+  - Unit tests for GCOV/gcovr C++ name conversion.
+  - Unit tests for GCOV JSON `demangled_name` precedence.
+  - Unit tests for real source-file hash links.
+  - Unit tests for Windows-style and Windows-absolute gcovr source paths.
+  - Integration test:
+    - `tests/integration/features/code_coverage_gcov/02_cpp_namespace_gcovr_issue_2717`
+
+- Adjusted the integration test to avoid Windows-fragile global source coverage table assumptions.
+  - The stronger assertion is now on the generated `functions.cpp` source-file page, scoped to the file under test.
+
+### Verification
+
+- Focused unit tests:
+  - `tests/unit/strictdoc/core/test_file_traceability_index.py`
+  - `tests/unit/strictdoc/backend/gcov/test_helpers.py`
+  - `tests/unit/strictdoc/backend/sdoc_source_code/coverage_reports/test_gcov.py`
+- Integration tests:
+  - `invoke ti --focus code_coverage_gcov`
+- Lint:
+  - `ruff check` on changed Python files.

--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -60,6 +60,13 @@ the result's rendered source includes the test's attributes and doc comment.
 Resolution is crate-qualified (the crate's ``[package]`` name plus the in-crate
 module path), so tests resolve in any module hierarchy, including integration-test
 binaries and multi-crate Cargo workspaces.
+
+2\) GCOV/gcovr coverage reports now handle C++ namespaced member functions more
+reliably. StrictDoc accepts gcovr ``demangled_name`` entries and matches
+gcovr-style function names such as ``test::Adder::add(int const&, int const&)``
+to the names extracted by StrictDoc's C/C++ reader. GCOV report detail links now
+use normalized source paths, keeping coverage anchors and gcovr HTML links
+stable across Linux and Windows.
 <<<
 
 [[/SECTION]]

--- a/strictdoc/backend/gcov/helpers.py
+++ b/strictdoc/backend/gcov/helpers.py
@@ -1,0 +1,119 @@
+import re
+from typing import List, Optional
+
+
+def normalize_gcovr_file_path(
+    path: str, *, source_root_path: Optional[str] = None
+) -> str:
+    normalized_path = path.replace("\\", "/")
+    if normalized_path.startswith("./"):
+        normalized_path = normalized_path[2:]
+
+    if source_root_path is None:
+        return normalized_path
+
+    normalized_source_root = source_root_path.replace("\\", "/").rstrip("/")
+    normalized_path_lower = normalized_path.lower()
+    normalized_source_root_lower = normalized_source_root.lower()
+    if normalized_path_lower.startswith(normalized_source_root_lower + "/"):
+        return normalized_path[len(normalized_source_root) + 1 :]
+    return normalized_path
+
+
+def convert_function_name_to_gcovr_style(name: str) -> str:
+    """
+    Convert a StrictDoc C++ function name to gcovr's demangled spelling.
+
+    Examples:
+    - "test::Adder::add(const int& a, const int& b)"
+      -> "test::Adder::add(int const&, int const&)"
+    - "test::Multiplier::multiply(int a, const int& b)"
+      -> "test::Multiplier::multiply(int, int const&)"
+    """
+    opening_bracket = name.rfind("(")
+    if opening_bracket == -1 or not name.endswith(")"):
+        return name
+
+    function_name = name[:opening_bracket]
+    parameter_list = name[opening_bracket + 1 : -1]
+    if parameter_list.strip() == "":
+        return name
+
+    parameters = _split_function_parameters(parameter_list)
+    canonical_parameters = [
+        _convert_function_parameter_to_gcovr_style(parameter_)
+        for parameter_ in parameters
+    ]
+    return f"{function_name}({', '.join(canonical_parameters)})"
+
+
+def _split_function_parameters(parameter_list: str) -> List[str]:
+    """
+    Split a C++ function parameter list on top-level commas.
+
+    Nested template and function-call commas are preserved.
+
+    Examples:
+    - "int a, const int& b" -> ["int a", "const int& b"]
+    - "Map<Key, Value> map, int count" -> ["Map<Key, Value> map", "int count"]
+    """
+    parameters: List[str] = []
+    current_parameter: List[str] = []
+    nested_angle_brackets = 0
+    nested_round_brackets = 0
+    nested_square_brackets = 0
+
+    for character_ in parameter_list:
+        if character_ == "," and (
+            nested_angle_brackets == 0
+            and nested_round_brackets == 0
+            and nested_square_brackets == 0
+        ):
+            parameters.append("".join(current_parameter).strip())
+            current_parameter = []
+            continue
+
+        current_parameter.append(character_)
+        if character_ == "<":
+            nested_angle_brackets += 1
+        elif character_ == ">" and nested_angle_brackets > 0:
+            nested_angle_brackets -= 1
+        elif character_ == "(":
+            nested_round_brackets += 1
+        elif character_ == ")" and nested_round_brackets > 0:
+            nested_round_brackets -= 1
+        elif character_ == "[":
+            nested_square_brackets += 1
+        elif character_ == "]" and nested_square_brackets > 0:
+            nested_square_brackets -= 1
+
+    parameters.append("".join(current_parameter).strip())
+    return parameters
+
+
+def _convert_function_parameter_to_gcovr_style(parameter: str) -> str:
+    """
+    Convert one StrictDoc/tree-sitter C++ parameter to gcovr's spelling.
+
+    The conversion removes the parameter name, normalizes pointer/reference
+    spacing, and moves a leading const qualifier behind the base type.
+
+    Examples:
+    - "const int& a" -> "int const&"
+    - "int a" -> "int"
+    """
+    parameter = re.sub(r"\s+", " ", parameter.strip())
+    parameter = re.sub(r"\s*=\s*.*$", "", parameter)
+    parameter = re.sub(r"\s+[A-Za-z_][A-Za-z0-9_]*$", "", parameter)
+    parameter = re.sub(r"\s*([*&])\s*", r"\1", parameter)
+
+    if parameter.startswith("const "):
+        parameter = parameter[len("const ") :]
+        if parameter.endswith("&"):
+            parameter = f"{parameter[:-1]} const&"
+        elif parameter.endswith("*"):
+            parameter = f"{parameter[:-1]} const*"
+        else:
+            parameter = f"{parameter} const"
+
+    return parameter

--- a/strictdoc/backend/gcov/reader.py
+++ b/strictdoc/backend/gcov/reader.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Type
 
+from strictdoc.backend.gcov.helpers import normalize_gcovr_file_path
 from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_grammar import DocumentGrammar
@@ -50,7 +51,7 @@ class GCovJSONReader:
         cls: Type["GCovJSONReader"],
         content: str,
         doc_file: File,  # noqa: ARG003
-        project_config: ProjectConfig,  # noqa: ARG003
+        project_config: ProjectConfig,
     ) -> SDocDocument:
         if len(content) == 0:
             raise RuntimeError("Document is empty")
@@ -79,11 +80,19 @@ class GCovJSONReader:
         Parse individual <testcase> elements.
         """
 
+        source_root_path = (
+            project_config.source_root_path
+            if project_config is not None
+            else None
+        )
+
         json_files = json_content["files"]
         for json_file_ in json_files:
             stats = GCovStatsObject()
 
-            json_file_name = json_file_["file"]
+            json_file_name = normalize_gcovr_file_path(
+                json_file_["file"], source_root_path=source_root_path
+            )
 
             file_section = SDocNode.create_section(
                 parent=document,
@@ -128,7 +137,10 @@ class GCovJSONReader:
             file_section.section_contents.append(non_covered_functions_section)
 
             for json_function_ in json_file_["functions"]:
-                json_function_name = json_function_["name"]
+                json_function_name = json_function_.get(
+                    "demangled_name", json_function_.get("name")
+                )
+                assert json_function_name is not None, json_function_
                 is_function_covered = json_function_["execution_count"] > 0
                 stats.add_function(is_function_covered)
 
@@ -169,9 +181,9 @@ class GCovJSONReader:
                     ),
                 )
 
-                path = "src/main.c"
-                gcov_path_hash = hashlib.md5(path.encode("utf-8")).hexdigest()
-                # FIXME: Resolve the relative path from a project config.
+                gcov_path_hash = hashlib.md5(
+                    json_file_name.encode("utf-8")
+                ).hexdigest()
                 link = (
                     "../../../../"  # noqa: ISC003
                     + "coverage."

--- a/strictdoc/core/file_system/document_finder.py
+++ b/strictdoc/core/file_system/document_finder.py
@@ -7,15 +7,15 @@ import sys
 from functools import partial
 from typing import Dict, List, Tuple, Union
 
+from strictdoc.backend.gcov.reader import (
+    GCovJSONReader,
+)
 from strictdoc.backend.markdown.reader import SDMarkdownReader
 from strictdoc.backend.reqif.reqif_reader import ReqIFReader
 from strictdoc.backend.sdoc.grammar_reader import SDocGrammarReader
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_grammar import DocumentGrammar
 from strictdoc.backend.sdoc.reader import SDReader
-from strictdoc.backend.sdoc_source_code.coverage_reports.gcov import (
-    GCovJSONReader,
-)
 from strictdoc.backend.sdoc_source_code.test_reports.junit_xml_reader import (
     JUnitXMLReader,
 )

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -15,6 +15,7 @@ from typing import (
     Union,
 )
 
+from strictdoc.backend.gcov.helpers import convert_function_name_to_gcovr_style
 from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.error_handling import StrictDocSemanticError
 from strictdoc.backend.sdoc.models.document_grammar import (
@@ -607,12 +608,10 @@ class FileTraceabilityIndex:
             ] = trace_info_
 
             for function_ in trace_info_.functions:
-                # FIXME: Using display_name, not name. A separate exercise is
-                #        to disambiguate forward links to C++ overloaded functions.
                 if (
-                    reqs_uids := self.get_req_uids_by_function_name(
+                    reqs_uids := self.get_req_uids_by_function_names(
                         source_file.in_doctree_source_file_rel_path_posix,
-                        function_.display_name,
+                        self.get_function_matching_names(function_),
                     )
                 ) is not None:
                     self.create_traceability_info_shared_markers_for_function(
@@ -788,6 +787,34 @@ class FileTraceabilityIndex:
                 ) from exception
 
         return matching_req_uids if len(matching_req_uids) > 0 else None
+
+    def get_req_uids_by_function_names(
+        self, rel_path_posix: str, names: List[str]
+    ) -> Optional[List[Tuple[str, Optional[str]]]]:
+        matching_req_uids: List[Tuple[str, Optional[str]]] = []
+        seen_req_uids: Set[Tuple[str, Optional[str]]] = set()
+
+        for name_ in names:
+            reqs_uids = self.get_req_uids_by_function_name(
+                rel_path_posix, name_
+            )
+            if reqs_uids is None:
+                continue
+            for req_uid_ in reqs_uids:
+                if req_uid_ in seen_req_uids:
+                    continue
+                seen_req_uids.add(req_uid_)
+                matching_req_uids.append(req_uid_)
+
+        return matching_req_uids if len(matching_req_uids) > 0 else None
+
+    @staticmethod
+    def get_function_matching_names(function: LanguageItem) -> List[str]:
+        names = [function.display_name, function.name]
+        gcovr_name = convert_function_name_to_gcovr_style(function.name)
+        if gcovr_name not in names:
+            names.append(gcovr_name)
+        return names
 
     @staticmethod
     def is_regex_function_name(name: str) -> bool:

--- a/tests/integration/features/code_coverage_gcov/02_cpp_namespace_gcovr_issue_2717/src/functions.cpp
+++ b/tests/integration/features/code_coverage_gcov/02_cpp_namespace_gcovr_issue_2717/src/functions.cpp
@@ -1,0 +1,13 @@
+#include "functions.h"
+
+namespace test {
+
+int Adder::add(const int& a, const int& b) {
+  return a + b;
+}
+
+int Multiplier::multiply(int a, const int& b) {
+  return a * b;
+}
+
+}

--- a/tests/integration/features/code_coverage_gcov/02_cpp_namespace_gcovr_issue_2717/src/functions.h
+++ b/tests/integration/features/code_coverage_gcov/02_cpp_namespace_gcovr_issue_2717/src/functions.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace test {
+
+class Adder {
+public:
+  int add(const int& a, const int& b);
+};
+
+class Multiplier {
+public:
+  int multiply(int a, const int& b);
+};
+
+}

--- a/tests/integration/features/code_coverage_gcov/02_cpp_namespace_gcovr_issue_2717/src/main.cpp
+++ b/tests/integration/features/code_coverage_gcov/02_cpp_namespace_gcovr_issue_2717/src/main.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+
+#include "functions.h"
+
+int main() {
+  test::Adder adder;
+  test::Multiplier multiplier;
+
+  std::cout << adder.add(2, 3) << "\n";
+  std::cout << multiplier.multiply(4, 5) << "\n";
+
+  return 0;
+}

--- a/tests/integration/features/code_coverage_gcov/02_cpp_namespace_gcovr_issue_2717/strictdoc.toml
+++ b/tests/integration/features/code_coverage_gcov/02_cpp_namespace_gcovr_issue_2717/strictdoc.toml
@@ -1,0 +1,5 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+]

--- a/tests/integration/features/code_coverage_gcov/02_cpp_namespace_gcovr_issue_2717/test.itest
+++ b/tests/integration/features/code_coverage_gcov/02_cpp_namespace_gcovr_issue_2717/test.itest
@@ -1,0 +1,30 @@
+#
+# @relation(SDOC-SRS-144, scope=file)
+#
+
+RUN: cd %T && g++ --coverage -g -O0 -o main %S/src/main.cpp %S/src/functions.cpp
+
+RUN: cd %T && ./main | filecheck %s --check-prefix CHECK-CPP
+CHECK-CPP: 5
+CHECK-CPP: 20
+
+RUN: cd %T && gcovr --object-directory ./ --root %S --html --html-details -o coverage.html
+RUN: cd %T && gcovr --object-directory ./ --root %S --json --json-pretty -o coverage.gcov.json
+RUN: cd %T && mkdir docs/ && cp coverage.gcov.json docs/
+RUN: cp %S/strictdoc.toml %T/docs/
+RUN: cp -r %S/src %T/docs/
+RUN: cd %T/docs && %strictdoc export . | filecheck %s --dump-input=fail
+
+CHECK: Published: Code coverage report
+
+RUN: %cat %T/docs/output/html/source_coverage.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-COVERAGE
+CHECK-SOURCE-COVERAGE: src/functions.cpp
+
+RUN: %cat %T/docs/output/html/_source_files/src/functions.cpp.html | filecheck %s --dump-input=fail --check-prefix CHECK-SOURCE-FILE
+CHECK-SOURCE-FILE: href="../../docs/coverage.gcov.html#GCOV-src-functions-cpp-test-Adder-add-int-const-int-const"
+CHECK-SOURCE-FILE: href="../../docs/coverage.gcov.html#GCOV-src-functions-cpp-test-Multiplier-multiply-int-int-const"
+CHECK-SOURCE-FILE: 5 - 7 | function test::Adder::add()
+CHECK-SOURCE-FILE: 9 - 11 | function test::Multiplier::multiply()
+
+RUN: %cat %T/docs/output/html/docs/coverage.gcov.html | filecheck %s --dump-input=fail --check-prefix CHECK-GCOV-REPORT
+CHECK-GCOV-REPORT: coverage.functions.cpp.c5e71015e270864c89a8b6e26afb227b.html

--- a/tests/unit/strictdoc/backend/gcov/test_helpers.py
+++ b/tests/unit/strictdoc/backend/gcov/test_helpers.py
@@ -1,0 +1,35 @@
+from strictdoc.backend.gcov.helpers import (
+    convert_function_name_to_gcovr_style,
+    normalize_gcovr_file_path,
+)
+
+
+def test_normalize_gcovr_file_path():
+    assert normalize_gcovr_file_path("src\\functions.cpp") == (
+        "src/functions.cpp"
+    )
+    assert normalize_gcovr_file_path("src/functions.cpp") == (
+        "src/functions.cpp"
+    )
+    assert (
+        normalize_gcovr_file_path(
+            "D:\\a\\strictdoc\\strictdoc\\docs\\src\\functions.cpp",
+            source_root_path="D:\\a\\strictdoc\\strictdoc\\docs",
+        )
+        == "src/functions.cpp"
+    )
+
+
+def test_convert_function_name_to_gcovr_style():
+    assert (
+        convert_function_name_to_gcovr_style(
+            "test::Adder::add(const int& a, const int& b)"
+        )
+        == "test::Adder::add(int const&, int const&)"
+    )
+    assert (
+        convert_function_name_to_gcovr_style(
+            "test::Multiplier::multiply(int a, const int& b)"
+        )
+        == "test::Multiplier::multiply(int, int const&)"
+    )

--- a/tests/unit/strictdoc/backend/sdoc_source_code/coverage_reports/test_gcov.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/coverage_reports/test_gcov.py
@@ -1,0 +1,147 @@
+import hashlib
+from types import SimpleNamespace
+
+from strictdoc.backend.gcov.reader import (
+    GCovJSONReader,
+)
+
+
+def test_gcov_html_link_uses_actual_source_file_path_for_hash():
+    document = GCovJSONReader.read_from_string(
+        """
+        {
+          "files": [
+            {
+              "file": "src/functions.cpp",
+              "functions": [
+                {
+                  "demangled_name": "test::Adder::add(int const&, int const&)",
+                  "execution_count": 1
+                }
+              ]
+            }
+          ]
+        }
+        """,
+        doc_file=None,  # type: ignore[arg-type]
+        project_config=None,  # type: ignore[arg-type]
+    )
+
+    source_path_hash = hashlib.md5(b"src/functions.cpp").hexdigest()
+    testcase_node = (
+        document.section_contents[1].section_contents[1].section_contents[0]
+    )
+    statement = testcase_node.get_field_by_name("STATEMENT").parts[0]
+
+    assert f"coverage.functions.cpp. {source_path_hash}.html" in statement
+
+
+def test_gcov_report_normalizes_windows_source_file_path():
+    document = GCovJSONReader.read_from_string(
+        """
+        {
+          "files": [
+            {
+              "file": "src\\\\functions.cpp",
+              "functions": [
+                {
+                  "demangled_name": "test::Adder::add(int const&, int const&)",
+                  "execution_count": 1
+                }
+              ]
+            }
+          ]
+        }
+        """,
+        doc_file=None,  # type: ignore[arg-type]
+        project_config=None,  # type: ignore[arg-type]
+    )
+
+    source_path_hash = hashlib.md5(b"src/functions.cpp").hexdigest()
+    testcase_node = (
+        document.section_contents[1].section_contents[1].section_contents[0]
+    )
+    statement = testcase_node.get_field_by_name("STATEMENT").parts[0]
+    uid = testcase_node.reserved_uid
+    file_reference = testcase_node.relations[0]
+
+    assert uid == (
+        "GCOV:src/functions.cpp:test::Adder::add(int const&, int const&)"
+    )
+    assert file_reference.g_file_entry.g_file_path == "src/functions.cpp"
+    assert f"coverage.functions.cpp. {source_path_hash}.html" in statement
+
+
+def test_gcov_report_relativizes_windows_absolute_source_file_path():
+    document = GCovJSONReader.read_from_string(
+        """
+        {
+          "files": [
+            {
+              "file": "D:\\\\a\\\\strictdoc\\\\strictdoc\\\\docs\\\\src\\\\functions.cpp",
+              "functions": [
+                {
+                  "demangled_name": "test::Adder::add(int const&, int const&)",
+                  "execution_count": 1
+                }
+              ]
+            }
+          ]
+        }
+        """,
+        doc_file=None,  # type: ignore[arg-type]
+        project_config=SimpleNamespace(
+            source_root_path="D:\\a\\strictdoc\\strictdoc\\docs"
+        ),  # type: ignore[arg-type]
+    )
+
+    source_path_hash = hashlib.md5(b"src/functions.cpp").hexdigest()
+    testcase_node = (
+        document.section_contents[1].section_contents[1].section_contents[0]
+    )
+    statement = testcase_node.get_field_by_name("STATEMENT").parts[0]
+    uid = testcase_node.reserved_uid
+    file_reference = testcase_node.relations[0]
+
+    assert uid == (
+        "GCOV:src/functions.cpp:test::Adder::add(int const&, int const&)"
+    )
+    assert file_reference.g_file_entry.g_file_path == "src/functions.cpp"
+    assert f"coverage.functions.cpp. {source_path_hash}.html" in statement
+
+
+def test_gcov_report_prefers_demangled_name_over_name():
+    document = GCovJSONReader.read_from_string(
+        """
+        {
+          "files": [
+            {
+              "file": "src/functions.cpp",
+              "functions": [
+                {
+                  "name": "_ZN4test5Adder3addERKiS2_",
+                  "demangled_name": "test::Adder::add(int const&, int const&)",
+                  "execution_count": 1
+                }
+              ]
+            }
+          ]
+        }
+        """,
+        doc_file=None,  # type: ignore[arg-type]
+        project_config=None,  # type: ignore[arg-type]
+    )
+
+    testcase_node = (
+        document.section_contents[1].section_contents[1].section_contents[0]
+    )
+
+    assert testcase_node.reserved_uid == (
+        "GCOV:src/functions.cpp:test::Adder::add(int const&, int const&)"
+    )
+    assert testcase_node.get_field_by_name("TITLE").parts[0] == (
+        "test::Adder::add(int const&, int const&)"
+    )
+    assert testcase_node.relations[0].g_file_entry.id == (
+        "test::Adder::add(int const&, int const&)"
+    )

--- a/tests/unit/strictdoc/core/test_file_traceability_index.py
+++ b/tests/unit/strictdoc/core/test_file_traceability_index.py
@@ -1,0 +1,49 @@
+from strictdoc.backend.sdoc_source_code.reader_c import (
+    SourceFileTraceabilityReader_C,
+)
+from strictdoc.core.file_traceability_index import FileTraceabilityIndex
+
+
+def test_get_req_uids_by_function_names_matches_gcovr_name():
+    file_traceability_index = FileTraceabilityIndex()
+    file_traceability_index.map_file_function_names_to_reqs_uids[
+        "functions.cpp"
+    ] = {
+        "test::Adder::add(int const&, int const&)": [
+            (
+                "GCOV:functions.cpp:test::Adder::add(int const&, int const&)",
+                None,
+            )
+        ]
+    }
+
+    assert file_traceability_index.get_req_uids_by_function_names(
+        "functions.cpp",
+        [
+            "test::Adder::add",
+            "test::Adder::add(const int& a, const int& b)",
+            "test::Adder::add(int const&, int const&)",
+        ],
+    ) == [("GCOV:functions.cpp:test::Adder::add(int const&, int const&)", None)]
+
+
+def test_get_function_matching_names_includes_gcovr_style_cpp_name():
+    source_file_traceability_info = SourceFileTraceabilityReader_C().read(
+        b"""\
+namespace test {
+
+int Adder::add(const int& a, const int& b) {
+  return a + b;
+}
+}
+""",
+        file_path="functions.cpp",
+    )
+
+    assert FileTraceabilityIndex.get_function_matching_names(
+        source_file_traceability_info.functions[0]
+    ) == [
+        "test::Adder::add",
+        "test::Adder::add(const int& a, const int& b)",
+        "test::Adder::add(int const&, int const&)",
+    ]


### PR DESCRIPTION
WHY: Closes a user bug report where it was highlighted that the handling of C++ namespaces was insufficient.

Closes #2717