### PR TITLE
fix(sdoc_source_code): cargo-nextest: mark requirements satisfied, resolve nested/workspace tests, render full test source

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -4668,25 +4668,16 @@ test binary (the crate's unit tests, or one integration-test target). Each
   example ``tests::add_works`` or ``tests::nested::nested_module_test``).
 
 cargo-nextest does not record the source file or line number of each test in
-the JUnit XML, so traceability between a test result and a function in the
-source code is resolved by a forward lookup. For each test result StrictDoc
-builds a small list of candidate Rust canonical paths from the test's
-``classname`` and ``name`` and resolves to the first candidate that matches a
-function registered by the Rust source-code reader:
+the JUnit XML, so a test result is matched to a function by its Rust canonical
+path. The path is ``<classname>::<name>``, where ``classname`` is the crate's
+``[package]`` name, optionally followed by ``::<integration_test_name>``:
 
-- If ``classname`` contains ``::`` (the test belongs to an integration-test
-  binary), the file stem is taken from the part after the last ``::``, and the
-  candidate path is ``<stem>::<name>``. Example: classname
-  ``my_crate::integration``, name ``integration_add`` →
-  ``integration::integration_add``.
-- Otherwise the test belongs to the crate's own unit tests in ``src/lib.rs``
-  or ``src/main.rs``, so two candidates are tried in order: ``lib::<name>``
-  and ``main::<name>``. Example: classname ``my_crate``, name
-  ``tests::add_works`` → ``lib::tests::add_works`` then
-  ``main::tests::add_works``.
+- ``my_crate``, ``tests::add_works`` → ``my_crate::tests::add_works``;
+- ``my_crate::integration``, ``integration_add`` →
+  ``my_crate::integration::integration_add``.
 
-The same forward-lookup-with-candidates mechanism is used by the Google Test
-flavor.
+The Rust source-code reader registers each function under the same
+crate-qualified path.
 
 .. note::
 

--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -46,6 +46,25 @@ This document maintains a record of all changes to StrictDoc since November 2023
 <<<
 
 [[SECTION]]
+MID: b5181ae005fb1160e73e1fcd4cc972dd
+TITLE: Unreleased
+
+[TEXT]
+MID: 055660bc7cf09fbf5d00cf516111e80f
+STATEMENT: >>>
+This release contains the following enhancements:
+
+1\) cargo-nextest test results now link to the requirements their tests verify.
+A passing or failing test marks its requirement *IsSatisfiedBy* the result, and
+the result's rendered source includes the test's attributes and doc comment.
+Resolution is crate-qualified (the crate's ``[package]`` name plus the in-crate
+module path), so tests resolve in any module hierarchy, including integration-test
+binaries and multi-crate Cargo workspaces.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
 MID: 71592b7fb5c44af4a8b308b75fab9491
 TITLE: 0.23.1 (2026-06-05)
 

--- a/strictdoc/backend/sdoc_source_code/reader_rust.py
+++ b/strictdoc/backend/sdoc_source_code/reader_rust.py
@@ -3,9 +3,11 @@
 """
 
 from enum import IntEnum
-from pathlib import Path
-from typing import Optional, Union
+from functools import lru_cache
+from pathlib import Path, PurePath
+from typing import Optional, cast
 
+import toml
 import tree_sitter_rust as ts_rust
 from tree_sitter import Language, Node, Parser, Query, QueryCursor
 
@@ -18,10 +20,10 @@ from strictdoc.backend.sdoc_source_code.models.language_item_marker import (
 )
 from strictdoc.backend.sdoc_source_code.models.line_marker import LineMarker
 from strictdoc.backend.sdoc_source_code.models.range_marker import (
-    ForwardRangeMarker,
     RangeMarker,
 )
 from strictdoc.backend.sdoc_source_code.models.source_file_info import (
+    RelationMarkerType,
     SourceFileTraceabilityInfo,
 )
 from strictdoc.backend.sdoc_source_code.models.source_location import ByteRange
@@ -34,7 +36,10 @@ from strictdoc.backend.sdoc_source_code.processors.general_language_marker_proce
 )
 from strictdoc.helpers.cast import assert_cast
 from strictdoc.helpers.file_stats import SourceFileStats
-from strictdoc.helpers.file_system import file_open_read_bytes
+from strictdoc.helpers.file_system import (
+    file_open_read_bytes,
+    file_open_read_utf8,
+)
 
 # @relation(SDOC-LLR-177, SDOC-LLR-171, SDOC-LLR-173, scope=line)
 TS_QUERY = """
@@ -199,6 +204,87 @@ class RustTsQuery(IntEnum):
     IDENTIFIABLE_ITEM = 4
 
 
+@lru_cache(maxsize=None)
+def rust_crate_root_and_name(directory: str) -> Optional[tuple[str, str]]:
+    """
+    ``(crate_root, package_name)`` of the nearest ``Cargo.toml`` with a
+    ``[package]`` at or above ``directory``, or ``None`` if there is none.
+    ``lru_cache`` memoizes the result per directory, so the many files of one
+    crate cost a single manifest read.
+    """
+    for current in (Path(directory), *Path(directory).parents):
+        manifest = current / "Cargo.toml"
+        if not manifest.is_file():
+            continue
+        try:
+            with file_open_read_utf8(str(manifest)) as manifest_file:
+                package = toml.loads(manifest_file.read()).get("package")
+        except (OSError, toml.TomlDecodeError):
+            continue
+        if isinstance(package, dict):
+            name = package.get("name")
+            if isinstance(name, str):
+                return str(current), name
+    return None
+
+
+def rust_module_segments_within_crate(rel_parts: tuple[str, ...]) -> list[str]:
+    """
+    Module path of a source file *within its crate*, from the file's path
+    relative to the crate root split into ``rel_parts``. Applies Rust's
+    file<->module convention (the reader sees one file, so it cannot follow
+    ``mod`` declarations)::
+
+        src/lib.rs | src/main.rs   -> []                 (the crate root)
+        src/model.rs               -> ["model"]
+        src/model/mod.rs           -> ["model"]
+        src/a/b/c.rs               -> ["a", "b", "c"]
+        tests/it.rs                -> ["it"]             (integration target)
+        tests/it/helper.rs         -> ["it", "helper"]
+
+    The module path is taken from the file's location, so ``#[path = "..."]``
+    overrides and non-default ``[lib]`` / ``[[bin]]`` target paths are not
+    supported.
+    """
+
+    def module_name(file: str) -> str:
+        return file[:-3] if file.endswith(".rs") else file
+
+    if not rel_parts:
+        return []
+    target_dir, inner = rel_parts[0], list(rel_parts[1:])
+    if not inner:
+        stem = module_name(target_dir)
+        return [] if stem in ("lib", "main") else [stem]
+    *dirs, leaf = inner
+    stem = module_name(leaf)
+    if target_dir == "src" and not dirs and stem in ("lib", "main"):
+        return []
+    if stem in ("mod", "main"):
+        return dirs
+    return [*dirs, stem]
+
+
+def rust_canonical_crate_segments(full_path: Optional[str]) -> list[str]:
+    """
+    Canonical-path prefix shared by every item in a Rust file: the crate name
+    (the ``[package]`` of the nearest ``Cargo.toml``, or the file stem when
+    there is none) followed by the file's module path within the crate.
+    """
+    if not full_path:
+        return []
+    path = PurePath(full_path)
+    crate = rust_crate_root_and_name(str(path.parent))
+    if crate is None:
+        return [path.stem]
+    crate_root, crate_name = crate
+    try:
+        rel_parts = path.relative_to(crate_root).parts
+    except ValueError:
+        return [path.stem]
+    return [crate_name, *rust_module_segments_within_crate(rel_parts)]
+
+
 def comments_text_from_comment_nodes(comments: list[Node]) -> str:
     """
     Join multiple comment nodes into one multi-line string.
@@ -213,6 +299,36 @@ def comments_text_from_comment_nodes(comments: list[Node]) -> str:
             comment_part.text, bytes
         ).decode("utf-8")
     return comment_text
+
+
+def item_definition_line_begin(item: Node) -> int:
+    """
+    First 1-based line of ``item``'s definition, including the leading outer
+    attributes (``#[test]``, ``#[cfg(...)]``) and doc/line comments above it,
+    which tree-sitter models as siblings rather than part of the item node.
+    """
+    line_begin_0_based = item.start_point[0]
+    sibling = item.prev_sibling
+    while sibling is not None and sibling.type in (
+        "attribute_item",
+        "line_comment",
+        "block_comment",
+    ):
+        # A line comment node extends to the start of the following line, so its
+        # last line of content is its start row; attributes and block comments
+        # end where their end point is.
+        sibling_content_end = (
+            sibling.start_point[0]
+            if sibling.type == "line_comment"
+            else sibling.end_point[0]
+        )
+        # Stop once a blank line separates the sibling from the header: such a
+        # comment documents something else, not this definition.
+        if sibling_content_end != line_begin_0_based - 1:
+            break
+        line_begin_0_based = sibling.start_point[0]
+        sibling = sibling.prev_sibling
+    return line_begin_0_based + 1
 
 
 def special_description(item: Node, identifier_text: str) -> Optional[str]:
@@ -450,11 +566,7 @@ class ParserRun:
             default_scope="function",
         )
 
-        function_markers: list[
-            Union[
-                LanguageItemMarker, LineMarker, RangeMarker, ForwardRangeMarker
-            ]
-        ] = []
+        function_markers: list[LanguageItemMarker] = []
         for marker_ in source_node.markers:
             if isinstance(marker_, LanguageItemMarker) and (
                 language_item_marker_ := marker_
@@ -476,19 +588,22 @@ class ParserRun:
             parent=self.traceability_info,
             name=name,
             display_name=name,
-            line_begin=item.start_point[0] + 1,
+            line_begin=item_definition_line_begin(item),
             line_end=item.end_point[0] + 1,
             code_byte_range=ByteRange.create_from_ts_node(item),
             child_functions=[],
-            markers=[],
+            markers=function_markers,
             attributes={FunctionAttribute.DEFINITION},
         )
         if len(source_node.fields) > 0:
             source_node.function = new_function_for_rust_item
         self.traceability_info.source_nodes.append(source_node)
         self.traceability_info.functions.append(new_function_for_rust_item)
-        self.traceability_info.ng_map_names_to_markers[identifier_text] = (
-            function_markers
+        # list is invariant, so list[LanguageItemMarker] is not a
+        # list[RelationMarkerType] even though every element is one. The widen
+        # is sound; cast it for the map, which holds the wider type.
+        self.traceability_info.ng_map_names_to_markers[identifier_text] = cast(
+            list[RelationMarkerType], function_markers
         )
 
     def _process_normal_comment(self, comments: list[Node]) -> None:
@@ -547,7 +662,7 @@ class ParserRun:
             parent=self.traceability_info,
             name=name,
             display_name=name,
-            line_begin=item.start_point[0] + 1,
+            line_begin=item_definition_line_begin(item),
             line_end=max(item.end_point[0] + 1, item.start_point[0] + 2),
             code_byte_range=ByteRange.create_from_ts_node(item),
             child_functions=[],
@@ -602,7 +717,11 @@ class ParserRun:
                     name = assert_cast(name_node.text, bytes).decode("utf-8")
                     path_prefix_segments.append(name)
                 cursor = cursor.parent
-            path_prefix_segments.append(Path(self.parse_context.filename).stem)
+            path_prefix_segments.extend(
+                reversed(
+                    rust_canonical_crate_segments(self.parse_context.filename)
+                )
+            )
             path_prefix = "::".join(reversed(path_prefix_segments))
 
         # rust-lang.org: The canonical path is defined as a path prefix appended by the path segment the item itself

--- a/strictdoc/helpers/cargo_nextest.py
+++ b/strictdoc/helpers/cargo_nextest.py
@@ -5,26 +5,15 @@ def convert_nextest_test_to_rust_canonical_paths(
     classname: str, name: str
 ) -> List[str]:
     """
-    Map a cargo-nextest test identity to candidate Rust canonical paths, in
-    resolution order; the first one the source-code index knows about wins.
+    The Rust canonical path of a cargo-nextest test: ``classname::name``.
 
-    StrictDoc stores functions under ``<file_stem>::...`` while cargo-nextest
-    reports ``classname`` (the binary id) and ``name`` (the in-binary test
-    path) with no source file, so the stem is inferred:
-
-    - integration-test binary (``classname`` contains ``::``) → file stem is
-      the part after the last ``::``  → ``<stem>::<name>``;
-    - crate unit tests (no ``::``) → ``lib::<name>`` then ``main::<name>``.
-
-    See the cargo-nextest section of the user guide for the full rationale.
+    ``classname`` is the crate's ``[package]`` name (optionally ``::<binary>``
+    for an integration test); ``name`` is the in-binary test path. See the
+    cargo-nextest section of the user guide.
     """
     assert isinstance(classname, str)
     assert isinstance(name, str)
     assert len(classname) > 0
     assert len(name) > 0
 
-    if "::" in classname:
-        _, _, file_stem = classname.rpartition("::")
-        return [f"{file_stem}::{name}"]
-
-    return [f"lib::{name}", f"main::{name}"]
+    return [f"{classname}::{name}"]

--- a/tests/integration/features/test_reports/junit_xml/nextest/01_minimal_document/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/nextest/01_minimal_document/test.itest
@@ -11,5 +11,12 @@ RUN: %check_exists --file "%T/html/_source_files/src/lib.rs.html"
 RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.nextest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT: hello_world_crate::tests::add_works
 CHECK-TEST-REPORT: PASSED
-CHECK-TEST-REPORT: href="../../_source_files/src/lib.rs.html#hello_world_crate::tests::add_works#11#13"
-CHECK-TEST-REPORT: src/lib.rs, <i>lines: 11-13</i>, function lib::tests::add_works()
+CHECK-TEST-REPORT: href="../../_source_files/src/lib.rs.html#hello_world_crate::tests::add_works#9#13"
+CHECK-TEST-REPORT: src/lib.rs, <i>lines: 9-13</i>, function hello_world_crate::tests::add_works()
+
+# REQ-1 renders IsSatisfiedBy the nextest test result.
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/docs/input.html" | filecheck %s --check-prefix CHECK-REQ-DOC
+CHECK-REQ-DOC: RELATIONS (Child):
+CHECK-REQ-DOC: reports/tests_unit.nextest.junit.html#hello_world_crate-tests-add_works
+CHECK-REQ-DOC: hello_world_crate::tests::add_works
+CHECK-REQ-DOC: (IsSatisfiedBy)

--- a/tests/integration/features/test_reports/junit_xml/nextest/02_failed_test/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/nextest/02_failed_test/test.itest
@@ -11,5 +11,5 @@ RUN: %check_exists --file "%T/html/_source_files/src/lib.rs.html"
 RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.nextest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT: hello_world_crate::tests::add_fails
 CHECK-TEST-REPORT: FAILED
-CHECK-TEST-REPORT: href="../../_source_files/src/lib.rs.html#hello_world_crate::tests::add_fails#11#13"
-CHECK-TEST-REPORT: src/lib.rs, <i>lines: 11-13</i>, function lib::tests::add_fails()
+CHECK-TEST-REPORT: href="../../_source_files/src/lib.rs.html#hello_world_crate::tests::add_fails#9#13"
+CHECK-TEST-REPORT: src/lib.rs, <i>lines: 9-13</i>, function hello_world_crate::tests::add_fails()

--- a/tests/integration/features/test_reports/junit_xml/nextest/03_ignored_test/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/nextest/03_ignored_test/test.itest
@@ -17,5 +17,5 @@ RUN: %check_exists --file "%T/html/_source_files/src/lib.rs.html"
 RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.nextest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
 CHECK-TEST-REPORT: hello_world_crate::tests::add_works
 CHECK-TEST-REPORT: PASSED
-CHECK-TEST-REPORT: src/lib.rs, <i>lines: 11-13</i>, function lib::tests::add_works()
+CHECK-TEST-REPORT: src/lib.rs, <i>lines: 9-13</i>, function hello_world_crate::tests::add_works()
 CHECK-TEST-REPORT-NOT: always_ignored

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/.config/nextest.toml
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci.junit]
+path = "junit.xml"

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/.gitignore
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/Cargo.toml
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "widget_lib"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/docs/input.sdoc
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/docs/input.sdoc
@@ -1,0 +1,26 @@
+[DOCUMENT]
+TITLE: Module layouts
+
+[REQUIREMENT]
+UID: REQ-MODULE
+STATEMENT: A test in a module file (src/model.rs) satisfies this.
+
+[REQUIREMENT]
+UID: REQ-DEEP
+STATEMENT: A test in a deeply nested module (src/deep/inner.rs) satisfies this.
+
+[REQUIREMENT]
+UID: REQ-DUP-A
+STATEMENT: A test in src/dup.rs satisfies this.
+
+[REQUIREMENT]
+UID: REQ-DUP-B
+STATEMENT: A test in src/sub/dup.rs (same file stem and test name) satisfies this.
+
+[REQUIREMENT]
+UID: REQ-IT
+STATEMENT: An integration-test binary root (tests/it) satisfies this.
+
+[REQUIREMENT]
+UID: REQ-IT-SUB
+STATEMENT: An integration-test submodule (tests/it/helper.rs) satisfies this.

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/reports/tests_unit.nextest.junit.xml
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/reports/tests_unit.nextest.junit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="nextest-run" tests="6" failures="0" errors="0" uuid="00000000-0000-0000-0000-000000000000" timestamp="2025-03-10T10:30:39+00:00" time="0.000">
+    <testsuite name="widget_lib" tests="4" disabled="0" errors="0" failures="0">
+        <testcase name="deep::inner::tests::deep_works" classname="widget_lib" timestamp="2025-03-10T10:30:39+00:00" time="0.000">
+        </testcase>
+        <testcase name="sub::dup::tests::dup_works" classname="widget_lib" timestamp="2025-03-10T10:30:39+00:00" time="0.000">
+        </testcase>
+        <testcase name="dup::tests::dup_works" classname="widget_lib" timestamp="2025-03-10T10:30:39+00:00" time="0.000">
+        </testcase>
+        <testcase name="model::tests::model_works" classname="widget_lib" timestamp="2025-03-10T10:30:39+00:00" time="0.000">
+        </testcase>
+    </testsuite>
+    <testsuite name="widget_lib::it" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="helper::helper_works" classname="widget_lib::it" timestamp="2025-03-10T10:30:39+00:00" time="0.000">
+        </testcase>
+        <testcase name="it_works" classname="widget_lib::it" timestamp="2025-03-10T10:30:39+00:00" time="0.000">
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/deep/inner.rs
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/deep/inner.rs
@@ -1,0 +1,6 @@
+#[cfg(test)]
+mod tests {
+    /// @relation(REQ-DEEP, scope=function)
+    #[test]
+    fn deep_works() { assert_eq!(1, 1); }
+}

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/deep/mod.rs
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/deep/mod.rs
@@ -1,0 +1,1 @@
+pub mod inner;

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/dup.rs
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/dup.rs
@@ -1,0 +1,6 @@
+#[cfg(test)]
+mod tests {
+    /// @relation(REQ-DUP-A, scope=function)
+    #[test]
+    fn dup_works() { assert_eq!(1, 1); }
+}

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/lib.rs
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod model;
+pub mod deep;
+pub mod dup;
+pub mod sub;

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/model.rs
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/model.rs
@@ -1,0 +1,6 @@
+#[cfg(test)]
+mod tests {
+    /// @relation(REQ-MODULE, scope=function)
+    #[test]
+    fn model_works() { assert_eq!(1, 1); }
+}

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/sub/dup.rs
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/sub/dup.rs
@@ -1,0 +1,6 @@
+#[cfg(test)]
+mod tests {
+    /// @relation(REQ-DUP-B, scope=function)
+    #[test]
+    fn dup_works() { assert_eq!(1, 1); }
+}

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/sub/mod.rs
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/src/sub/mod.rs
@@ -1,0 +1,1 @@
+pub mod dup;

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/strictdoc.toml
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/strictdoc.toml
@@ -1,0 +1,5 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+]

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/test.itest
@@ -1,0 +1,27 @@
+# Tests in module files, a nested module, and an integration-test submodule;
+# the two `dup` tests share a file stem and test name. Each requirement renders
+# IsSatisfiedBy its test under the crate-qualified path.
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Module layouts
+
+# Each requirement renders IsSatisfiedBy its test, resolved crate-qualified.
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/docs/input.html" | filecheck %s --check-prefix CHECK-REQS
+CHECK-REQS: REQ-MODULE
+CHECK-REQS: widget_lib::model::tests::model_works
+CHECK-REQS: (IsSatisfiedBy)
+CHECK-REQS: REQ-DEEP
+CHECK-REQS: widget_lib::deep::inner::tests::deep_works
+CHECK-REQS: (IsSatisfiedBy)
+CHECK-REQS: REQ-DUP-A
+CHECK-REQS: widget_lib::dup::tests::dup_works
+CHECK-REQS: (IsSatisfiedBy)
+CHECK-REQS: REQ-DUP-B
+CHECK-REQS: widget_lib::sub::dup::tests::dup_works
+CHECK-REQS: (IsSatisfiedBy)
+CHECK-REQS: REQ-IT
+CHECK-REQS: widget_lib::it::it_works
+CHECK-REQS: (IsSatisfiedBy)
+CHECK-REQS: REQ-IT-SUB
+CHECK-REQS: widget_lib::it::helper::helper_works
+CHECK-REQS: (IsSatisfiedBy)

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/tests/it/helper.rs
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/tests/it/helper.rs
@@ -1,0 +1,3 @@
+/// @relation(REQ-IT-SUB, scope=function)
+#[test]
+fn helper_works() { assert_eq!(1, 1); }

--- a/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/tests/it/main.rs
+++ b/tests/integration/features/test_reports/junit_xml/nextest/04_module_layouts/tests/it/main.rs
@@ -1,0 +1,4 @@
+mod helper;
+/// @relation(REQ-IT, scope=function)
+#[test]
+fn it_works() { assert_eq!(1, 1); }

--- a/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/.config/nextest.toml
+++ b/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.ci.junit]
+path = "junit.xml"

--- a/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/.gitignore
+++ b/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/.gitignore
@@ -1,0 +1,2 @@
+/target
+/Cargo.lock

--- a/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/Cargo.toml
+++ b/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/Cargo.toml
@@ -1,0 +1,3 @@
+[workspace]
+resolver = "2"
+members = ["crates/alpha", "crates/beta"]

--- a/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/crates/alpha/Cargo.toml
+++ b/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/crates/alpha/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "alpha_crate"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"

--- a/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/crates/alpha/src/lib.rs
+++ b/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/crates/alpha/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod util;
+#[cfg(test)]
+mod tests {
+    /// @relation(REQ-ALPHA, scope=function)
+    #[test]
+    fn shared_test() { assert_eq!(1, 1); }
+}

--- a/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/crates/alpha/src/util/helper.rs
+++ b/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/crates/alpha/src/util/helper.rs
@@ -1,0 +1,6 @@
+#[cfg(test)]
+mod tests {
+    /// @relation(REQ-ALPHA-DEEP, scope=function)
+    #[test]
+    fn deep_test() { assert_eq!(1, 1); }
+}

--- a/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/crates/alpha/src/util/mod.rs
+++ b/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/crates/alpha/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod helper;

--- a/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/crates/beta/Cargo.toml
+++ b/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/crates/beta/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "beta_crate"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"

--- a/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/crates/beta/src/lib.rs
+++ b/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/crates/beta/src/lib.rs
@@ -1,0 +1,6 @@
+#[cfg(test)]
+mod tests {
+    /// @relation(REQ-BETA, scope=function)
+    #[test]
+    fn shared_test() { assert_eq!(1, 1); }
+}

--- a/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/docs/input.sdoc
+++ b/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/docs/input.sdoc
@@ -1,0 +1,14 @@
+[DOCUMENT]
+TITLE: Workspace
+
+[REQUIREMENT]
+UID: REQ-ALPHA
+STATEMENT: alpha_crate's tests::shared_test satisfies this.
+
+[REQUIREMENT]
+UID: REQ-ALPHA-DEEP
+STATEMENT: alpha_crate's nested util::helper test satisfies this.
+
+[REQUIREMENT]
+UID: REQ-BETA
+STATEMENT: beta_crate's tests::shared_test (same test name as alpha) satisfies this.

--- a/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/reports/tests_unit.nextest.junit.xml
+++ b/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/reports/tests_unit.nextest.junit.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="nextest-run" tests="3" failures="0" errors="0" uuid="00000000-0000-0000-0000-000000000000" timestamp="2025-03-10T10:30:39+00:00" time="0.000">
+    <testsuite name="beta_crate" tests="1" disabled="0" errors="0" failures="0">
+        <testcase name="tests::shared_test" classname="beta_crate" timestamp="2025-03-10T10:30:39+00:00" time="0.000">
+        </testcase>
+    </testsuite>
+    <testsuite name="alpha_crate" tests="2" disabled="0" errors="0" failures="0">
+        <testcase name="util::helper::tests::deep_test" classname="alpha_crate" timestamp="2025-03-10T10:30:39+00:00" time="0.000">
+        </testcase>
+        <testcase name="tests::shared_test" classname="alpha_crate" timestamp="2025-03-10T10:30:39+00:00" time="0.000">
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/strictdoc.toml
+++ b/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/strictdoc.toml
@@ -1,0 +1,5 @@
+[project]
+
+features = [
+  "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+]

--- a/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/nextest/05_workspace/test.itest
@@ -1,0 +1,17 @@
+# A Cargo workspace where alpha_crate and beta_crate each define
+# tests::shared_test. The crate name keeps them distinct, so each requirement is
+# IsSatisfiedBy its own crate's test.
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Workspace
+
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/docs/input.html" | filecheck %s --check-prefix CHECK-REQS
+CHECK-REQS: REQ-ALPHA
+CHECK-REQS: alpha_crate::tests::shared_test
+CHECK-REQS: (IsSatisfiedBy)
+CHECK-REQS: REQ-ALPHA-DEEP
+CHECK-REQS: alpha_crate::util::helper::tests::deep_test
+CHECK-REQS: (IsSatisfiedBy)
+CHECK-REQS: REQ-BETA
+CHECK-REQS: beta_crate::tests::shared_test
+CHECK-REQS: (IsSatisfiedBy)

--- a/tests/integration/features/test_reports/junit_xml/nextest/README.md
+++ b/tests/integration/features/test_reports/junit_xml/nextest/README.md
@@ -1,12 +1,14 @@
 # Regenerating the cargo-nextest JUnit XML fixtures
 
-Each `NN_*` directory here is a **self-contained Cargo crate** as well as a
-StrictDoc fixture: its `src/lib.rs` is the source under test, and
-`reports/tests_unit.nextest.junit.xml` is the JUnit report that cargo-nextest
-produces for that crate. Both the report (for fast test runs) and the setup
-that produces it (for reproducibility) are committed on purpose, so that the
-fixtures can be trusted *and* regenerated when a new cargo-nextest version
-changes the JUnit layout.
+Each `NN_*` directory here is a **self-contained Cargo project** (a single
+crate, or a workspace) as well as a StrictDoc fixture: its Rust sources are the
+source under test, and `reports/tests_unit.nextest.junit.xml` is the JUnit
+report that cargo-nextest produces for it. Both the report (for fast test runs)
+and the setup that produces it (for reproducibility) are committed on purpose,
+so that the fixtures can be trusted *and* regenerated when a new cargo-nextest
+version changes the JUnit layout. `04_module_layouts` and `05_workspace` cover
+the non-trivial test module layouts (nested modules, integration-test
+submodules, same-stem files, and same-named tests across workspace crates).
 
 ## How to regenerate
 

--- a/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_rust.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/readers/test_reader_rust.py
@@ -1,0 +1,269 @@
+"""
+@relation(SDOC-SRS-142, scope=file)
+"""
+
+from pathlib import Path
+
+from strictdoc.backend.sdoc_source_code.models.source_file_info import (
+    SourceFileTraceabilityInfo,
+)
+from strictdoc.backend.sdoc_source_code.reader_rust import (
+    SourceFileTraceabilityReader_Rust,
+    rust_canonical_crate_segments,
+    rust_crate_root_and_name,
+    rust_module_segments_within_crate,
+)
+
+
+def _read(source: bytes, file_path: str) -> SourceFileTraceabilityInfo:
+    return SourceFileTraceabilityReader_Rust().read(source, file_path=file_path)
+
+
+def _function_named(info: SourceFileTraceabilityInfo, name: str):
+    matches = [function for function in info.functions if function.name == name]
+    assert len(matches) == 1, (
+        f"expected exactly one function named {name!r}, got "
+        f"{[function.name for function in info.functions]}"
+    )
+    return matches[0]
+
+
+def _crate(root: Path, package_name: str) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "Cargo.toml").write_text(
+        f'[package]\nname = "{package_name}"\n'
+        'version = "0.1.0"\nedition = "2024"\n',
+        encoding="utf-8",
+    )
+    return root
+
+
+def _read_one(file_path: str, source_body: bytes, fn_name: str):
+    source = b"/// @relation(REQ-1, scope=function)\n" + source_body
+    info = _read(source, file_path=file_path)
+    return _function_named(info, fn_name)
+
+
+def test_module_segments_within_crate_mapping():
+    f = rust_module_segments_within_crate
+    assert f(()) == []
+    assert f(("src", "lib.rs")) == []
+    assert f(("src", "main.rs")) == []
+    assert f(("src", "model.rs")) == ["model"]
+    assert f(("src", "model", "mod.rs")) == ["model"]
+    assert f(("src", "a", "b", "c.rs")) == ["a", "b", "c"]
+    assert f(("src", "model", "tests.rs")) == ["model", "tests"]
+    assert f(("tests", "it.rs")) == ["it"]
+    assert f(("tests", "it", "helper.rs")) == ["it", "helper"]
+    assert f(("tests", "it", "main.rs")) == ["it"]
+
+
+def test_crate_root_and_name_finds_enclosing_package(tmp_path):
+    _crate(tmp_path, "my_crate")
+    found = rust_crate_root_and_name(str(tmp_path / "src"))
+    assert found == (str(tmp_path), "my_crate")
+
+
+def test_crate_root_and_name_keeps_hyphenated_package_name(tmp_path):
+    _crate(tmp_path, "weird-pkg-name")
+    found = rust_crate_root_and_name(str(tmp_path / "src"))
+    assert found == (str(tmp_path), "weird-pkg-name")
+
+
+def test_crate_root_and_name_skips_workspace_only_manifest(tmp_path):
+    (tmp_path / "Cargo.toml").write_text(
+        '[workspace]\nmembers = ["crates/foo"]\n', encoding="utf-8"
+    )
+    assert rust_crate_root_and_name(str(tmp_path / "src")) is None
+
+
+def test_crate_root_and_name_returns_none_without_manifest(tmp_path):
+    assert rust_crate_root_and_name(str(tmp_path / "src")) is None
+
+
+def test_canonical_segments_crate_qualified(tmp_path):
+    _crate(tmp_path, "my_crate")
+    assert rust_canonical_crate_segments(str(tmp_path / "src" / "lib.rs")) == [
+        "my_crate"
+    ]
+    assert rust_canonical_crate_segments(
+        str(tmp_path / "src" / "a" / "b" / "c.rs")
+    ) == ["my_crate", "a", "b", "c"]
+
+
+def test_canonical_segments_fall_back_to_stem_without_cargo(tmp_path):
+    flat = tmp_path / "forward_relations.rs"
+    assert rust_canonical_crate_segments(str(flat)) == ["forward_relations"]
+
+
+def test_canonical_segments_none_path():
+    assert rust_canonical_crate_segments(None) == []
+
+
+def test_empty_file():
+    info = _read(b"", file_path="src/lib.rs")
+    assert isinstance(info, SourceFileTraceabilityInfo)
+    assert len(info.markers) == 0
+
+
+def test_relation_marker_is_attached_to_function(tmp_path):
+    _crate(tmp_path, "my_crate")
+    source = b"""\
+/// @relation(REQ-1, scope=function)
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+"""
+    info = _read(source, file_path=str(tmp_path / "src" / "lib.rs"))
+    function = _function_named(info, "my_crate::add")
+    assert function.markers[0].reqs == ["REQ-1"]
+
+
+def test_function_range_folds_in_leading_attributes_and_doc_comment():
+    source = b"""\
+#[cfg(test)]
+mod tests {
+    /// @relation(REQ-1, scope=function)
+    #[test]
+    fn add_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}
+"""
+    info = _read(source, file_path="lib.rs")
+    # doc comment = 3, #[test] = 4, fn = 5, closing brace = 7.
+    fn = _function_named(info, "lib::tests::add_works")
+    assert fn.line_begin == 3
+    assert fn.line_end == 7
+    module = _function_named(info, "lib::tests")
+    assert module.line_begin == 1
+
+
+def test_canonical_path_crate_root_lib(tmp_path):
+    _crate(tmp_path, "my_crate")
+    fn = _read_one(
+        str(tmp_path / "src" / "lib.rs"), b"pub fn add() {}\n", "my_crate::add"
+    )
+    assert fn.markers[0].reqs == ["REQ-1"]
+
+
+def test_canonical_path_crate_root_main(tmp_path):
+    _crate(tmp_path, "my_crate")
+    _read_one(
+        str(tmp_path / "src" / "main.rs"),
+        b"pub fn helper() {}\n",
+        "my_crate::helper",
+    )
+
+
+def test_canonical_path_top_level_module_file(tmp_path):
+    _crate(tmp_path, "my_crate")
+    _read_one(
+        str(tmp_path / "src" / "model.rs"),
+        b"pub fn parse() {}\n",
+        "my_crate::model::parse",
+    )
+
+
+def test_canonical_path_nested_module_file(tmp_path):
+    _crate(tmp_path, "my_crate")
+    _read_one(
+        str(tmp_path / "src" / "a" / "b" / "c.rs"),
+        b"pub fn run() {}\n",
+        "my_crate::a::b::c::run",
+    )
+
+
+def test_canonical_path_mod_rs_uses_directory_name(tmp_path):
+    _crate(tmp_path, "my_crate")
+    _read_one(
+        str(tmp_path / "src" / "model" / "mod.rs"),
+        b"pub fn run() {}\n",
+        "my_crate::model::run",
+    )
+
+
+def test_canonical_path_submodule_file(tmp_path):
+    _crate(tmp_path, "my_crate")
+    _read_one(
+        str(tmp_path / "src" / "model" / "tests.rs"),
+        b"pub fn round_trips() {}\n",
+        "my_crate::model::tests::round_trips",
+    )
+
+
+def test_canonical_path_inline_mod_nesting(tmp_path):
+    _crate(tmp_path, "my_crate")
+    source = b"""\
+mod tests {
+    /// @relation(REQ-3, scope=function)
+    pub fn it_works() {}
+}
+"""
+    info = _read(source, file_path=str(tmp_path / "src" / "element_id.rs"))
+    fn = _function_named(info, "my_crate::element_id::tests::it_works")
+    assert fn.markers[0].reqs == ["REQ-3"]
+
+
+def test_canonical_path_integration_test_root(tmp_path):
+    _crate(tmp_path, "my_crate")
+    _read_one(
+        str(tmp_path / "tests" / "it.rs"),
+        b"fn it_runs() {}\n",
+        "my_crate::it::it_runs",
+    )
+
+
+def test_canonical_path_integration_test_submodule(tmp_path):
+    _crate(tmp_path, "my_crate")
+    _read_one(
+        str(tmp_path / "tests" / "it" / "helper.rs"),
+        b"fn helps() {}\n",
+        "my_crate::it::helper::helps",
+    )
+
+
+def test_canonical_path_non_cargo_flat_file_uses_stem(tmp_path):
+    fn = _read_one(
+        str(tmp_path / "forward_relations.rs"),
+        b"pub fn parse() {}\n",
+        "forward_relations::parse",
+    )
+    assert fn.markers[0].reqs == ["REQ-1"]
+
+
+def test_canonical_path_non_cargo_nested_modules(tmp_path):
+    source = b"""\
+mod foo_module {
+    mod foo {
+        /// @relation(REQ-2, scope=function)
+        pub fn bar() {}
+    }
+}
+"""
+    info = _read(source, file_path=str(tmp_path / "forward_relations.rs"))
+    fn = _function_named(info, "forward_relations::foo_module::foo::bar")
+    assert fn.markers[0].reqs == ["REQ-2"]
+
+
+def test_canonical_path_workspace_members_stay_distinct(tmp_path):
+    (tmp_path / "Cargo.toml").write_text(
+        '[workspace]\nmembers = ["crates/foo", "crates/bar"]\n',
+        encoding="utf-8",
+    )
+    _crate(tmp_path / "crates" / "foo", "foo-crate")
+    _crate(tmp_path / "crates" / "bar", "bar-crate")
+    body = b"""\
+mod tests {
+    /// @relation(REQ-1, scope=function)
+    pub fn common_test() {}
+}
+"""
+    foo = _read(
+        body, file_path=str(tmp_path / "crates" / "foo" / "src" / "lib.rs")
+    )
+    bar = _read(
+        body, file_path=str(tmp_path / "crates" / "bar" / "src" / "lib.rs")
+    )
+    _function_named(foo, "foo-crate::tests::common_test")
+    _function_named(bar, "bar-crate::tests::common_test")

--- a/tests/unit/strictdoc/helpers/test_cargo_nextest.py
+++ b/tests/unit/strictdoc/helpers/test_cargo_nextest.py
@@ -3,22 +3,28 @@ from strictdoc.helpers.cargo_nextest import (
 )
 
 
-def test_unit_test_in_library_yields_lib_and_main_candidates():
+def test_unit_test_is_qualified_by_crate_name():
     assert convert_nextest_test_to_rust_canonical_paths(
         "my_crate", "tests::add_works"
-    ) == ["lib::tests::add_works", "main::tests::add_works"]
+    ) == ["my_crate::tests::add_works"]
 
 
-def test_integration_test_uses_test_target_name_as_stem():
+def test_integration_test_keeps_package_and_binary_qualifier():
     assert convert_nextest_test_to_rust_canonical_paths(
         "my_crate::integration", "integration_add"
-    ) == ["integration::integration_add"]
+    ) == ["my_crate::integration::integration_add"]
 
 
 def test_nested_module_test_path_is_passed_through():
     assert convert_nextest_test_to_rust_canonical_paths(
         "my_crate", "tests::nested::nested_module_test"
-    ) == [
-        "lib::tests::nested::nested_module_test",
-        "main::tests::nested::nested_module_test",
-    ]
+    ) == ["my_crate::tests::nested::nested_module_test"]
+
+
+def test_workspace_members_with_same_test_name_stay_distinct():
+    assert convert_nextest_test_to_rust_canonical_paths(
+        "foo-crate", "tests::common_test"
+    ) == ["foo-crate::tests::common_test"]
+    assert convert_nextest_test_to_rust_canonical_paths(
+        "bar-crate", "tests::common_test"
+    ) == ["bar-crate::tests::common_test"]


### PR DESCRIPTION
# cargo-nextest: mark requirements satisfied, resolve nested/workspace tests, render full test source

The previously added cargo-nextest support (#2873) has 3 gaps this PR fixes:

1. Bind the requirement: *IsSatisfiedBy* is not populated correctly for nextest. `_process_doc_comment` built the function with `markers=[]`, discarding the `@relation` markers that `file_traceability_index.py:489` iterates to mark a requirement *IsSatisfiedBy* the result, so a resolved result left the requirement unmarked.
Fix: Attach the markers.
3. Resolve any module layout: The current approach does not detect nextest tests in most module paths and can produce name conflicts. `canonical_path` appended `Path(filename).stem`, which is not globally unique and matches what nextest reports only for `src/lib.rs` / `main.rs` (stem `lib`/`main`) and top-level integration targets. Tests in other module files didn't resolve, and two files sharing a stem (e.g. two workspace crates' `lib.rs`, both `lib::…`) collided.
Fix: Crate-qualified paths: the `[package]` name of the nearest `Cargo.toml` + the file's module path = nextest's `classname::name`. If no `Cargo.toml` is found, we use the file stem. This should resolve correctly for any module hierarchy, cargo workspaces and lose .rs files.
4. Render the full source: A function's range started at `fn` (tree-sitter models `#[test]` / `///` as preceding siblings), so a result's rendered source dropped the attribute and doc comment.
Fix: Extend the range over the leading attributes/comments.

## Tests
Added tests that should have caught these bugs:
- Reader unit tests over Cargo crates: deep modules, integration binaries, workspace distinctness, the non-Cargo stem fallback, and the range folding in leading attributes/docs.
- `01_minimal_document` asserts `REQ-1` renders *IsSatisfiedBy* the result.
- Two new fixtures with real cargo-nextest reports: `04_module_layouts` (module files, a nested module, an integration submodule, and same-stem/same-name tests resolving distinctly) and `05_workspace` (two crates' identical `tests::shared_test` kept distinct by crate name).

## Remarks
- As these three bugs are all related to nextest support I made it a single PR with a single commit, as preferred in the developer guidelines. I am happy to reorganize or adapt this change to make it fit better.