### PR TITLE
feat(grammar): add reverse display names for relation roles

### DIFF
--- a/developer/tasks/20260610_add_reverse_role_name_support_feat_2755/task.md
+++ b/developer/tasks/20260610_add_reverse_role_name_support_feat_2755/task.md
@@ -1,0 +1,56 @@
+# Add REVERSE_ROLE as optional grammar metadata for Parent/Child relations
+
+## WHAT
+
+Implements proposed support for feature request #2755 by adding REVERSE_ROLE as optional grammar metadata for Parent/Child relations:
+
+Example:
+```
+RELATIONS:
+- TYPE: Parent
+  ROLE: Refines
+  REVERSE_ROLE: Refined by
+```
+
+## WHY
+
+Currently, the defined ROLE name is used for both the forward and backward directions of a relationship. While users can infer the meaning by checking if the relation is a "Parent" or "Child," it creates a mental hurdle. This feature allows the user to optionally define a name for the reverse role, to be presented when the relationship is viewed from the other direction.
+
+## HOW
+
+### Proposed behavior
+
+- ROLE remains the canonical relation identity.
+- REVERSE_ROLE is display-only metadata.
+- Node-level RELATIONS: stay unchanged.
+- Validation/filtering/querying still use (TYPE, ROLE).
+- The canonical traceability graph edge remains ROLE. REVERSE_ROLE is only resolved at display time.
+- When rendering the relation in the stored direction, StrictDoc shows ROLE.
+- When rendering the same relation from the opposite side, StrictDoc shows REVERSE_ROLE if configured.
+- If REVERSE_ROLE is not configured, rendering falls back to ROLE, preserving current behavior.
+- REVERSE_ROLE is rejected unless ROLE is also specified.
+
+### Implementation details
+- Extend the SDoc grammar parser for optional REVERSE_ROLE on Parent/Child grammar relations.
+- Add reverse_relation_role to grammar relation model classes.
+- Preserve REVERSE_ROLE in the SDoc writer so custom grammars round-trip correctly.
+- Add semantic validation for REVERSE_ROLE without ROLE.
+- Add traceability-index helpers that resolve the display label based on direction.
+- Update relation display in document relation links and diff/changelog views.
+- No support in the web grammar editor (at least not in the first PR).
+- Add user documentation for REVERSE_ROLE in the StrictDoc user guide.
+
+### Future work
+
+- Add support in the web grammar editor for creating/editing REVERSE_ROLE.
+- Decide whether REVERSE_ROLE should be supported for File relations.
+- Decide whether ReqIF/JSON/other exports should expose REVERSE_ROLE metadata or ignore it.
+- Review other visualizations, such as deep traceability / graph-oriented views, and add reverse role labels where those views render relation role text.
+
+### Verification
+
+- Parser/writer round-trip for REVERSE_ROLE
+- Parser support for REVERSE_ROLE in external .sgra grammar files.
+- Validation failure for REVERSE_ROLE without ROLE.
+- Display behavior for both Parent-defined and Child-defined relations.
+- Fallback behavior for both Parent-defined and Child-defined relations when REVERSE_ROLE is omitted.

--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -1540,6 +1540,8 @@ A requirement relation can be specialized with a role. The role must be register
       ROLE: Refines
 
 In this example REQ-1 is the parent of REQ-2 and REQ-2 refines REQ-1.
+
+The reverse name of a role, if needed, is configured in the grammar with ``REVERSE_ROLE``. It is not repeated in individual requirement relations. See [LINK: SECTION-UG-Relation-roles] for the grammar syntax.
 <<<
 
 [[/SECTION]]
@@ -2047,6 +2049,44 @@ StrictDoc's custom grammar support the configuration of relation roles. The Pare
         ROLE: Refines
 
 With this grammar, StrictDoc will only allow creating requirements that have Parent relations with the ``ROLE: Refines`` specified. Any other relations will trigger validation errors.
+
+Optionally, a role can define a reverse display name using ``REVERSE_ROLE``:
+
+.. code:: strictdoc
+
+    [DOCUMENT]
+    TITLE: Test Doc
+
+    [GRAMMAR]
+    ELEMENTS:
+    - TAG: REQUIREMENT
+      FIELDS:
+      - TITLE: UID
+        TYPE: String
+        REQUIRED: True
+      - TITLE: TITLE
+        TYPE: String
+        REQUIRED: True
+      RELATIONS:
+      - TYPE: Parent
+        ROLE: Refines
+        REVERSE_ROLE: Refined by
+
+    [REQUIREMENT]
+    UID: REQ-1
+    TITLE: Parent requirement
+
+    [REQUIREMENT]
+    UID: REQ-2
+    TITLE: Child requirement
+    RELATIONS:
+    - TYPE: Parent
+      VALUE: REQ-1
+      ROLE: Refines
+
+In this example, ``REQ-2`` has a Parent relation to ``REQ-1`` with ``ROLE: Refines``. When the relation is displayed from ``REQ-2`` to ``REQ-1``, StrictDoc shows ``Refines``. When the same relation is displayed from ``REQ-1`` back to ``REQ-2``, StrictDoc shows ``Refined by``.
+
+The ``REVERSE_ROLE`` field is only defined in the grammar. Individual requirement relations still specify only the canonical ``ROLE``. The ``REVERSE_ROLE`` field cannot be used without ``ROLE``. If ``REVERSE_ROLE`` is omitted, StrictDoc displays ``ROLE`` in both directions.
 
 .. note::
 

--- a/strictdoc/backend/sdoc/error_handling.py
+++ b/strictdoc/backend/sdoc/error_handling.py
@@ -405,6 +405,33 @@ ELEMENTS:
         )
 
     @staticmethod
+    def grammar_relation_reverse_role_without_role(
+        grammar_element: GrammarElement,
+        relation_type: str,
+        reverse_relation_role: str,
+        path_to_sdoc_file: str,
+    ) -> "StrictDocSemanticError":
+        return StrictDocSemanticError(
+            title=(
+                f"Grammar element '{grammar_element.tag}' defines "
+                f"REVERSE_ROLE without ROLE for relation type '{relation_type}'."
+            ),
+            hint=(
+                "REVERSE_ROLE can only be used for a specialized relation "
+                "that also defines ROLE."
+            ),
+            example=(
+                "RELATIONS:\n"
+                f"- TYPE: {relation_type}\n"
+                "  ROLE: Refines\n"
+                f"  REVERSE_ROLE: {reverse_relation_role}\n"
+            ),
+            line=grammar_element.ng_line_start,
+            col=grammar_element.ng_col_start,
+            filename=path_to_sdoc_file,
+        )
+
+    @staticmethod
     def view_references_nonexisting_grammar_element(
         document: SDocDocument,
         document_view: DocumentView,

--- a/strictdoc/backend/sdoc/grammar/grammar_grammar.py
+++ b/strictdoc/backend/sdoc/grammar/grammar_grammar.py
@@ -36,11 +36,13 @@ GrammarElementRelation[noskipws]:
 GrammarElementRelationParent[noskipws]:
   '  - TYPE: ' relation_type='Parent' '\n'
   ('    ROLE: ' relation_role=/.+/ '\n')?
+  ('    REVERSE_ROLE: ' reverse_relation_role=/.+/ '\n')?
 ;
 
 GrammarElementRelationChild[noskipws]:
   '  - TYPE: ' relation_type='Child' '\n'
   ('    ROLE: ' relation_role=/.+/ '\n')?
+  ('    REVERSE_ROLE: ' reverse_relation_role=/.+/ '\n')?
 ;
 
 GrammarElementRelationFile[noskipws]:

--- a/strictdoc/backend/sdoc/models/grammar_element.py
+++ b/strictdoc/backend/sdoc/models/grammar_element.py
@@ -145,7 +145,11 @@ GrammarElementFieldType = Union[
 @auto_described
 class GrammarElementRelationParent:  # noqa: PLW1641
     def __init__(
-        self, parent: Any, relation_type: str, relation_role: Optional[str]
+        self,
+        parent: Any,
+        relation_type: str,
+        relation_role: Optional[str],
+        reverse_relation_role: Optional[str] = None,
     ) -> None:
         assert relation_type == "Parent"
         self.parent: Any = parent
@@ -153,6 +157,12 @@ class GrammarElementRelationParent:  # noqa: PLW1641
         self.relation_role: Optional[str] = (
             relation_role
             if relation_role is not None and len(relation_role) > 0
+            else None
+        )
+        self.reverse_relation_role: Optional[str] = (
+            reverse_relation_role
+            if reverse_relation_role is not None
+            and len(reverse_relation_role) > 0
             else None
         )
         self.mid: MID = MID.create()
@@ -164,13 +174,18 @@ class GrammarElementRelationParent:  # noqa: PLW1641
             self.mid == other.mid
             and self.relation_type == other.relation_type
             and self.relation_role == other.relation_role
+            and self.reverse_relation_role == other.reverse_relation_role
         )
 
 
 @auto_described
 class GrammarElementRelationChild:
     def __init__(
-        self, parent: Any, relation_type: str, relation_role: Optional[str]
+        self,
+        parent: Any,
+        relation_type: str,
+        relation_role: Optional[str],
+        reverse_relation_role: Optional[str] = None,
     ):
         assert relation_type == "Child"
         self.parent: Any = parent
@@ -180,13 +195,23 @@ class GrammarElementRelationChild:
             if relation_role is not None and len(relation_role) > 0
             else None
         )
+        self.reverse_relation_role: Optional[str] = (
+            reverse_relation_role
+            if reverse_relation_role is not None
+            and len(reverse_relation_role) > 0
+            else None
+        )
         self.mid: MID = MID.create()
 
 
 @auto_described
 class GrammarElementRelationFile:
     def __init__(
-        self, parent: Any, relation_type: str, relation_role: Optional[str]
+        self,
+        parent: Any,
+        relation_type: str,
+        relation_role: Optional[str],
+        reverse_relation_role: Optional[str] = None,
     ):
         assert relation_type == "File"
         self.parent: Any = parent
@@ -194,6 +219,12 @@ class GrammarElementRelationFile:
         self.relation_role: Optional[str] = (
             relation_role
             if relation_role is not None and len(relation_role) > 0
+            else None
+        )
+        self.reverse_relation_role: Optional[str] = (
+            reverse_relation_role
+            if reverse_relation_role is not None
+            and len(reverse_relation_role) > 0
             else None
         )
         self.mid: MID = MID.create()
@@ -349,6 +380,7 @@ class GrammarElement:
                 parent=parent,
                 relation_type="Parent",
                 relation_role=None,
+                reverse_relation_role=None,
             ),
         ]
         if include_child:
@@ -357,6 +389,7 @@ class GrammarElement:
                     parent=parent,
                     relation_type="Child",
                     relation_role=None,
+                    reverse_relation_role=None,
                 )
             )
         relations.append(
@@ -364,6 +397,7 @@ class GrammarElement:
                 parent=parent,
                 relation_type="File",
                 relation_role=None,
+                reverse_relation_role=None,
             )
         )
         return relations
@@ -447,6 +481,18 @@ class GrammarElement:
             ):
                 return True
         return False
+
+    def get_relation_reverse_role(
+        self, relation_type: str, relation_role: Optional[str]
+    ) -> Optional[str]:
+        assert relation_role is None or len(relation_role) > 0
+        for relation_ in self.relations:
+            if (
+                relation_.relation_type == relation_type
+                and relation_.relation_role == relation_role
+            ):
+                return relation_.reverse_relation_role
+        return None
 
     def enumerate_table_meta_field_titles(self) -> Generator[str, None, None]:
         for field in self.fields:

--- a/strictdoc/backend/sdoc/validations/sdoc_validator.py
+++ b/strictdoc/backend/sdoc/validations/sdoc_validator.py
@@ -86,6 +86,18 @@ class SDocValidator:
                     path_to_grammar,
                 )
 
+        for relation_ in grammar_element.relations:
+            if (
+                relation_.reverse_relation_role is not None
+                and relation_.relation_role is None
+            ):
+                raise StrictDocSemanticError.grammar_relation_reverse_role_without_role(
+                    grammar_element=grammar_element,
+                    relation_type=relation_.relation_type,
+                    reverse_relation_role=relation_.reverse_relation_role,
+                    path_to_sdoc_file=path_to_grammar,
+                )
+
     @staticmethod
     def _validate_document_config(document: SDocDocument) -> None:
         document_config: DocumentConfig = document.config

--- a/strictdoc/backend/sdoc/writer.py
+++ b/strictdoc/backend/sdoc/writer.py
@@ -291,6 +291,11 @@ class SDWriter:
                             )
                             if element_relation.relation_role is not None:
                                 output += f"    ROLE: {element_relation.relation_role}\n"
+                            if (
+                                element_relation.reverse_relation_role
+                                is not None
+                            ):
+                                output += f"    REVERSE_ROLE: {element_relation.reverse_relation_role}\n"
 
         output += "\n"
 

--- a/strictdoc/core/traceability_index.py
+++ b/strictdoc/core/traceability_index.py
@@ -353,6 +353,104 @@ class TraceabilityIndex:
             )
         )
 
+    def get_display_role_for_parent_relation(
+        self,
+        node: SDocNode,
+        parent_node: SDocNode,
+        relation_role: Optional[str],
+    ) -> Optional[str]:
+        return self._get_display_role_for_relation(
+            node=node,
+            related_node=parent_node,
+            forward_relation_type="Parent",
+            reverse_relation_type="Child",
+            relation_role=relation_role,
+        )
+
+    def get_display_role_for_child_relation(
+        self,
+        node: SDocNode,
+        child_node: SDocNode,
+        relation_role: Optional[str],
+    ) -> Optional[str]:
+        return self._get_display_role_for_relation(
+            node=node,
+            related_node=child_node,
+            forward_relation_type="Child",
+            reverse_relation_type="Parent",
+            relation_role=relation_role,
+        )
+
+    def _get_display_role_for_relation(
+        self,
+        node: SDocNode,
+        related_node: SDocNode,
+        forward_relation_type: str,
+        reverse_relation_type: str,
+        relation_role: Optional[str],
+    ) -> Optional[str]:
+        if self._node_has_direct_relation(
+            source_node=node,
+            target_node=related_node,
+            relation_type=forward_relation_type,
+            relation_role=relation_role,
+        ):
+            return relation_role
+
+        if self._node_has_direct_relation(
+            source_node=related_node,
+            target_node=node,
+            relation_type=reverse_relation_type,
+            relation_role=relation_role,
+        ):
+            reverse_role = self._get_reverse_role_from_node_grammar(
+                node=related_node,
+                relation_type=reverse_relation_type,
+                relation_role=relation_role,
+            )
+            return reverse_role if reverse_role is not None else relation_role
+
+        return relation_role
+
+    @staticmethod
+    def _node_has_direct_relation(
+        source_node: SDocNode,
+        target_node: SDocNode,
+        relation_type: str,
+        relation_role: Optional[str],
+    ) -> bool:
+        for relation_ in source_node.relations:
+            if not isinstance(
+                relation_, (ParentReqReference, ChildReqReference)
+            ):
+                continue
+            if (
+                relation_.ref_type == relation_type
+                and relation_.ref_uid == target_node.reserved_uid
+                and relation_.role == relation_role
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _get_reverse_role_from_node_grammar(
+        node: SDocNode,
+        relation_type: str,
+        relation_role: Optional[str],
+    ) -> Optional[str]:
+        document = assert_optional_cast(node.get_document(), SDocDocument)
+        if document is None or document.grammar is None:
+            return None
+
+        grammar_element = document.grammar.elements_by_type.get(node.node_type)
+        if grammar_element is None:
+            return None
+
+        return grammar_element.get_relation_reverse_role(
+            relation_type=relation_type,
+            relation_role=relation_role,
+        )
+
     def get_children_requirements(
         self, requirement: SDocNode
     ) -> List[SDocNode]:

--- a/strictdoc/export/html/templates/components/node_field/links/index.jinja
+++ b/strictdoc/export/html/templates/components/node_field/links/index.jinja
@@ -1,17 +1,19 @@
 {# needs sdoc_entity, see README.txt #}
+  {%- set current_sdoc_entity = sdoc_entity -%}
   {%- if view_object.traceability_index.has_parent_requirements(sdoc_entity) %}
     <sdoc-node-field-label>RELATIONS (Parent):</sdoc-node-field-label>
     <sdoc-node-field data-field-label="parent relations">
       <ul class="requirement__link">
         {%- for sdoc_entity, relation_role_ in view_object.traceability_index.get_parent_relations_with_roles(sdoc_entity) %}
+        {%- set display_role_ = view_object.traceability_index.get_display_role_for_parent_relation(current_sdoc_entity, sdoc_entity, relation_role_) %}
         <li>
           <a data-turbo="false" class="requirement__link-parent" href="{{ view_object.render_node_link(sdoc_entity) }}">
             {%- if sdoc_entity.reserved_uid %}
             <span class="requirement__parent-uid">{{ sdoc_entity.reserved_uid }}</span>
             {%- endif %}
             {{ sdoc_entity.reserved_title if sdoc_entity.reserved_title else "" }}
-            {% if relation_role_ is not none %}
-              <span class="requirement__type-tag">({{ relation_role_ }})</span>
+            {% if display_role_ is not none %}
+              <span class="requirement__type-tag">({{ display_role_ }})</span>
             {% endif %}
           </a>
         </li>
@@ -25,14 +27,15 @@
     <sdoc-node-field data-field-label="child relations">
       <ul class="requirement__link">
         {%- for sdoc_entity, relation_role_ in view_object.traceability_index.get_child_relations_with_roles(sdoc_entity) %}
+        {%- set display_role_ = view_object.traceability_index.get_display_role_for_child_relation(current_sdoc_entity, sdoc_entity, relation_role_) %}
         <li>
           <a data-turbo="false" class="requirement__link-child" href="{{ view_object.render_node_link(sdoc_entity) }}">
             {%- if sdoc_entity.reserved_uid %}
             <span class="requirement__child-uid">{{ sdoc_entity.reserved_uid }}</span>
             {%- endif %}
             {{ sdoc_entity.reserved_title if sdoc_entity.reserved_title else "" }}
-            {% if relation_role_ is not none %}
-              <span class="requirement__type-tag">({{ relation_role_ }})</span>
+            {% if display_role_ is not none %}
+              <span class="requirement__type-tag">({{ display_role_ }})</span>
             {% endif %}
           </a>
         </li>

--- a/strictdoc/features/diff_and_changelog/templates/features/diff_and_changelog/fields/requirement_fields.jinja
+++ b/strictdoc/features/diff_and_changelog/templates/features/diff_and_changelog/fields/requirement_fields.jinja
@@ -38,6 +38,7 @@
 
   {%- if traceability_index.has_parent_requirements(requirement) %}
     {%- for parent_requirement_, relation_role_ in traceability_index.get_parent_relations_with_roles(requirement) %}
+      {%- set display_role_ = traceability_index.get_display_role_for_parent_relation(requirement, parent_requirement_, relation_role_) %}
       {# Relations are rendered one field at a time with its own label, not a group of fields: #}
       <div class="diff_node_field"
         {% if requirement_change is not none and not other_stats.contains_requirement_relations(requirement, parent_requirement_.reserved_uid, relation_role_) %}
@@ -52,8 +53,8 @@
 <b>{{ parent_requirement_.reserved_uid }}</b>{# Warning, we're inside a PRE and the line break here is significant: #}
 {{ parent_requirement_.reserved_title if parent_requirement_.reserved_title else "" }}
           {%- endif -%}
-          {%- if relation_role_ is not none -%}
-            <span class="requirement__type-tag">({{ relation_role_ }})</span>
+          {%- if display_role_ is not none -%}
+            <span class="requirement__type-tag">({{ display_role_ }})</span>
           {%- endif -%}
         </div>
       </div>
@@ -61,6 +62,7 @@
   {%- endif -%}
   {%- if traceability_index.has_children_requirements(requirement) %}
     {%- for child_requirement_, relation_role_ in traceability_index.get_child_relations_with_roles(requirement) %}
+      {%- set display_role_ = traceability_index.get_display_role_for_child_relation(requirement, child_requirement_, relation_role_) %}
       <div class="diff_node_field"
         {% if requirement_change is not none and not other_stats.contains_requirement_relations(requirement, child_requirement_.reserved_uid, relation_role_) %}
 modified="{{ side }}"
@@ -74,8 +76,8 @@ modified="{{ side }}"
 <b>{{ child_requirement_.reserved_uid }}</b>{# Warning, we're inside a PRE and the line break here is significant: #}
 {{ child_requirement_.reserved_title if child_requirement_.reserved_title else "" }}
           {%- endif -%}
-          {%- if relation_role_ is not none -%}
-            <span class="requirement__type-tag">({{ relation_role_ }})</span>
+          {%- if display_role_ is not none -%}
+            <span class="requirement__type-tag">({{ display_role_ }})</span>
           {%- endif -%}
         </div>
       </div>

--- a/tests/unit/helpers/document_builder.py
+++ b/tests/unit/helpers/document_builder.py
@@ -6,6 +6,10 @@ from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_config import DocumentConfig
 from strictdoc.backend.sdoc.models.document_grammar import DocumentGrammar
+from strictdoc.backend.sdoc.models.grammar_element import (
+    GrammarElementRelationChild,
+    GrammarElementRelationParent,
+)
 from strictdoc.backend.sdoc.models.node import SDocNode
 from strictdoc.backend.sdoc.models.object_factory import SDocObjectFactory
 from strictdoc.backend.sdoc.models.reference import (
@@ -62,6 +66,7 @@ class DocumentBuilder:
         source_requirement_id,
         target_requirement_id,
         role: Optional[str],
+        reverse_role: Optional[str] = None,
     ):
         assert relation_type in ("Parent", "Child")
         requirement: SDocNode = next(
@@ -79,6 +84,31 @@ class DocumentBuilder:
             )
         )
         requirement.relations.append(reference)
+
+        if role is not None:
+            grammar_element = self.document.grammar.elements_by_type[
+                requirement.node_type
+            ]
+            if not grammar_element.has_relation_type_role(
+                relation_type=relation_type,
+                relation_role=role,
+            ):
+                grammar_relation = (
+                    GrammarElementRelationParent(
+                        parent=grammar_element,
+                        relation_type=relation_type,
+                        relation_role=role,
+                        reverse_relation_role=reverse_role,
+                    )
+                    if relation_type == "Parent"
+                    else GrammarElementRelationChild(
+                        parent=grammar_element,
+                        relation_type=relation_type,
+                        relation_role=role,
+                        reverse_relation_role=reverse_role,
+                    )
+                )
+                grammar_element.relations.append(grammar_relation)
 
     def build(self):
         return self.document

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_grammar.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough_grammar.py
@@ -399,6 +399,46 @@ STATEMENT: This is a statement.
     assert input_sdoc == output
 
 
+def test_171_grammar_relations_with_reverse_role(default_project_config):
+    input_sdoc = """
+[DOCUMENT]
+TITLE: Test Doc
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: LOW_LEVEL_REQUIREMENT
+  FIELDS:
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+  RELATIONS:
+  - TYPE: Parent
+    ROLE: Refines
+    REVERSE_ROLE: Refined by
+  - TYPE: Child
+    ROLE: Verifies
+    REVERSE_ROLE: Verified by
+
+[LOW_LEVEL_REQUIREMENT]
+STATEMENT: This is a statement.
+""".lstrip()
+
+    reader = SDReader()
+
+    document = reader.read(input_sdoc)
+    assert isinstance(document, SDocDocument)
+
+    writer = SDWriter(default_project_config)
+    output = writer.write(document)
+
+    assert input_sdoc == output
+
+
 def test_180_additional_field_in_grammar():
     input_sdoc = """
 [DOCUMENT]

--- a/tests/unit/strictdoc/backend/sdoc/test_grammar_reader.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_grammar_reader.py
@@ -25,6 +25,44 @@ ELEMENTS:
     assert isinstance(grammar, DocumentGrammar)
 
 
+def test_grammar_from_file_supports_reverse_role():
+    input_sdoc = """
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+    ROLE: Refines
+    REVERSE_ROLE: Refined by
+  - TYPE: Child
+    ROLE: Verifies
+    REVERSE_ROLE: Verified by
+""".lstrip()
+
+    reader = SDocGrammarReader()
+
+    grammar = reader.read(input_sdoc)
+    assert isinstance(grammar, DocumentGrammar)
+    requirement = grammar.elements_by_type["REQUIREMENT"]
+
+    parent_relation = requirement.relations[0]
+    assert parent_relation.relation_type == "Parent"
+    assert parent_relation.relation_role == "Refines"
+    assert parent_relation.reverse_relation_role == "Refined by"
+
+    child_relation = requirement.relations[1]
+    assert child_relation.relation_type == "Child"
+    assert child_relation.relation_role == "Verifies"
+    assert child_relation.reverse_relation_role == "Verified by"
+
+
 def test_faulty_grammar():
     input_sdoc = """
 [GRAMMAR MISTAKE]

--- a/tests/unit/strictdoc/backend/sdoc/validations/test_requirement_validations.py
+++ b/tests/unit/strictdoc/backend/sdoc/validations/test_requirement_validations.py
@@ -7,6 +7,7 @@ from strictdoc.backend.sdoc.validations.sdoc_validator import (
     multi_choice_regex_match,
 )
 from strictdoc.core.document_iterator import SDocDocumentIterator
+from tests.unit.helpers.fake_document_meta import create_fake_document_meta
 
 
 def test_01_positive():
@@ -103,3 +104,41 @@ RELATIONS:
         "Requirement relation type/role is not registered: Parent / Refines."
     )
     assert exception.hint == "Problematic requirement: REQ-001."
+
+
+def test_22_validate_reverse_role_requires_role():
+    input_sdoc = """
+[DOCUMENT]
+TITLE: Test Doc
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+    REVERSE_ROLE: Refined by
+
+[REQUIREMENT]
+UID: REQ-001
+STATEMENT: This is a statement.
+""".lstrip()
+
+    reader = SDReader()
+    document = reader.read(input_sdoc)
+    document.meta = create_fake_document_meta()
+
+    with pytest.raises(StrictDocSemanticError) as exc_info:
+        SDocValidator.validate_document(document)
+
+    exception: StrictDocSemanticError = exc_info.value
+    assert exception.title == (
+        "Grammar element 'REQUIREMENT' defines REVERSE_ROLE without ROLE "
+        "for relation type 'Parent'."
+    )

--- a/tests/unit/strictdoc/core/test_traceability_index.py
+++ b/tests/unit/strictdoc/core/test_traceability_index.py
@@ -100,6 +100,156 @@ def test_valid_02_one_document_with_1req():
     assert requirement4_parents == [requirement3]
 
 
+def test_reverse_role_display_label_for_parent_relation():
+    document_builder = DocumentBuilder()
+    parent_requirement = document_builder.add_requirement("REQ-001")
+    child_requirement = document_builder.add_requirement("REQ-002")
+    document_builder.add_requirement_relation(
+        relation_type="Parent",
+        source_requirement_id="REQ-002",
+        target_requirement_id="REQ-001",
+        role="Refines",
+        reverse_role="Refined by",
+    )
+
+    document = document_builder.build()
+    document_tree = DocumentTree(
+        file_tree=[],
+        document_list=[document],
+        map_docs_by_paths={},
+        map_docs_by_rel_paths={},
+        map_grammars_by_filenames={},
+    )
+    traceability_index = TraceabilityIndexBuilder.create_from_document_tree(
+        document_tree, project_config=document_builder.project_config
+    )
+
+    assert (
+        traceability_index.get_display_role_for_parent_relation(
+            child_requirement, parent_requirement, "Refines"
+        )
+        == "Refines"
+    )
+    assert (
+        traceability_index.get_display_role_for_child_relation(
+            parent_requirement, child_requirement, "Refines"
+        )
+        == "Refined by"
+    )
+
+
+def test_reverse_role_display_label_for_child_relation():
+    document_builder = DocumentBuilder()
+    parent_requirement = document_builder.add_requirement("REQ-001")
+    child_requirement = document_builder.add_requirement("REQ-002")
+    document_builder.add_requirement_relation(
+        relation_type="Child",
+        source_requirement_id="REQ-001",
+        target_requirement_id="REQ-002",
+        role="Verifies",
+        reverse_role="Verified by",
+    )
+
+    document = document_builder.build()
+    document_tree = DocumentTree(
+        file_tree=[],
+        document_list=[document],
+        map_docs_by_paths={},
+        map_docs_by_rel_paths={},
+        map_grammars_by_filenames={},
+    )
+    traceability_index = TraceabilityIndexBuilder.create_from_document_tree(
+        document_tree, project_config=document_builder.project_config
+    )
+
+    assert (
+        traceability_index.get_display_role_for_child_relation(
+            parent_requirement, child_requirement, "Verifies"
+        )
+        == "Verifies"
+    )
+    assert (
+        traceability_index.get_display_role_for_parent_relation(
+            child_requirement, parent_requirement, "Verifies"
+        )
+        == "Verified by"
+    )
+
+
+def test_relation_display_label_falls_back_to_role_for_parent_relation():
+    document_builder = DocumentBuilder()
+    parent_requirement = document_builder.add_requirement("REQ-001")
+    child_requirement = document_builder.add_requirement("REQ-002")
+    document_builder.add_requirement_relation(
+        relation_type="Parent",
+        source_requirement_id="REQ-002",
+        target_requirement_id="REQ-001",
+        role="Refines",
+    )
+
+    document = document_builder.build()
+    document_tree = DocumentTree(
+        file_tree=[],
+        document_list=[document],
+        map_docs_by_paths={},
+        map_docs_by_rel_paths={},
+        map_grammars_by_filenames={},
+    )
+    traceability_index = TraceabilityIndexBuilder.create_from_document_tree(
+        document_tree, project_config=document_builder.project_config
+    )
+
+    assert (
+        traceability_index.get_display_role_for_parent_relation(
+            child_requirement, parent_requirement, "Refines"
+        )
+        == "Refines"
+    )
+    assert (
+        traceability_index.get_display_role_for_child_relation(
+            parent_requirement, child_requirement, "Refines"
+        )
+        == "Refines"
+    )
+
+
+def test_relation_display_label_falls_back_to_role_for_child_relation():
+    document_builder = DocumentBuilder()
+    parent_requirement = document_builder.add_requirement("REQ-001")
+    child_requirement = document_builder.add_requirement("REQ-002")
+    document_builder.add_requirement_relation(
+        relation_type="Child",
+        source_requirement_id="REQ-001",
+        target_requirement_id="REQ-002",
+        role="Verifies",
+    )
+
+    document = document_builder.build()
+    document_tree = DocumentTree(
+        file_tree=[],
+        document_list=[document],
+        map_docs_by_paths={},
+        map_docs_by_rel_paths={},
+        map_grammars_by_filenames={},
+    )
+    traceability_index = TraceabilityIndexBuilder.create_from_document_tree(
+        document_tree, project_config=document_builder.project_config
+    )
+
+    assert (
+        traceability_index.get_display_role_for_child_relation(
+            parent_requirement, child_requirement, "Verifies"
+        )
+        == "Verifies"
+    )
+    assert (
+        traceability_index.get_display_role_for_parent_relation(
+            child_requirement, parent_requirement, "Verifies"
+        )
+        == "Verifies"
+    )
+
+
 def test__adding_parent_link__01__two_requirements_in_one_document():
     document_builder = DocumentBuilder()
     requirement1 = document_builder.add_requirement("REQ-001")


### PR DESCRIPTION
Add optional REVERSE_ROLE metadata to Parent and Child grammar relations. ROLE remains the canonical relation identity used for validation, querying, filtering, and graph edges, while REVERSE_ROLE is used only as a display label when a relation is rendered from the opposite direction.

Implemented support includes:
- parsing REVERSE_ROLE in inline grammars and external .sgra grammar files
- preserving REVERSE_ROLE in the SDoc writer for parser/writer round trips
- rejecting REVERSE_ROLE unless ROLE is also specified
- storing reverse_relation_role on grammar relation model objects
- resolving relation display labels through the traceability index
- using reverse labels in document relation links and diff/changelog views
- falling back to ROLE when REVERSE_ROLE is omitted
- documenting REVERSE_ROLE usage in the user guide
- adding unit coverage for parser/writer behavior, validation, external .sgra parsing, Parent/Child display behavior, and fallback behavior

REVERSE_ROLE is intentionally not supported on requirement-level RELATIONS. Requirements continue to specify only TYPE, VALUE, and optional ROLE; the reverse name is defined once in the grammar.