### PR TITLE
chore(spec): extract the Markdown/RST formatting rules to a dedicated spec

### DIFF
--- a/developer/tasks/20260614_document_line_width/task.md
+++ b/developer/tasks/20260614_document_line_width/task.md
@@ -16,28 +16,19 @@ Introduce `strictdoc format` command that acts like `black` or `ruff`, reading
 the input documents and outputting the line width-formatted content back
 (in-place editing for now).
 
+The formatting rules specification shall be followed as defined here:
+`spec/Formatting.md`.
+
 The minimal acceptable limit shall be `80`.
 
 The user manual shall be updated to reflect the new `format` command.
 
 The formatters for Markdown and RST shall be implemented in separate dedicated Python files. Rationale: Easier maintainance of two similar but different markups.
 
-The formatting shall not affect the long code blocks inside backticks of
-Markdown and `.. code::` sections of RST.
-
-The formatting shall treat the StrictDoc `[LINK: ]` and `[ANCHOR: ]` keywords
-as full words, never splitting them in parts.
-
-The formatting shall treat Markdown and RST links as full words. If such a link causes a given line to exceed its limit, the link shall be written as a single word on a separate line.
-
 Add a dedicated integration smoke test that runs the `format` against the
 StrictDoc documentation in `docs/` twice. This is to ensure that the
 formatting always works against StrictDoc's own documentation.
 
-Formatting shall both respect and modify the bullet or numbered lists in the following way:
-
-- Left indentation before the list keywords such as `- ` or `* ` must be always respected.
-- The lines starting 
 
 ## WHY
 
@@ -52,197 +43,3 @@ When running `format`, StrictDoc shall only build a traceability index for
 documents and avoid reading source files. This is to run the command faster
 because the source file information is not required for correct formatting
 of documents.
-
-### Extra spec items
-
-### General
-
-* The formatter wraps text lines to a configurable maximum width.
-* The default maximum width is 80 characters.
-* The formatter preserves the input document format:
-
-  * Markdown remains valid Markdown.
-  * reStructuredText remains valid reStructuredText.
-* The formatter does not alter the semantic content of the document.
-* The formatter preserves blank lines.
-* The formatter preserves indentation-sensitive document structure.
-
-### Markdown lists
-
-* The formatter preserves unordered Markdown list markers:
-
-  * `-`
-  * `*`
-  * `+`
-* The formatter preserves ordered Markdown list markers:
-
-  * `1.`
-  * `2.`
-  * `1)`
-  * Similar valid Markdown numbering styles.
-* The formatter preserves the indentation of nested Markdown lists.
-* Wrapped continuation lines align with the content of the list item rather than with the list marker.
-
-Example:
-
-```markdown
-- This is a long list item that wraps onto
-  the next line.
-```
-
-* The formatter does not renumber ordered lists.
-* The formatter preserves task list syntax such as:
-
-  * `- [ ]`
-  * `- [x]`
-* Wrapped continuation lines in task lists align with the content following the checkbox marker.
-
-### reStructuredText lists
-
-* The formatter preserves unordered list markers:
-
-  * `-`
-  * `*`
-  * `+`
-* The formatter preserves enumerated list markers:
-
-  * `1.`
-  * `A.`
-  * `a.`
-  * `I.`
-  * `i.`
-  * `#.`
-* The formatter preserves nested list indentation.
-* Wrapped continuation lines align with the list item content.
-* The formatter preserves definition lists.
-* The formatter preserves field lists such as:
-
-```rst
-:field: value
-```
-
-### Line wrapping
-
-* The formatter wraps prose without exceeding the configured width whenever possible.
-* The formatter does not split words.
-* The formatter treats Markdown inline links as atomic tokens.
-
-Example:
-
-```markdown
-[link text](https://example.com/very/long/url)
-```
-
-* The formatter treats reStructuredText inline links as atomic tokens.
-
-Example:
-
-```rst
-`link text <https://example.com/very/long/url>`_
-```
-
-* If a Markdown or reStructuredText link would cause a line to exceed the configured width, the entire link is moved to a separate line.
-* Exception: If the link is the first content of a list item, the formatter shall keep the link on the same line as the list marker, even if the resulting line exceeds the configured width.
-* The formatter may allow an individual atomic token to exceed the configured width if splitting it would invalidate syntax or alter semantics.
-* The formatter does not insert whitespace inside link syntax.
-* The formatter treats inline code spans as atomic tokens.
-* The formatter does not wrap inside Markdown autolinks or RST code blocks:
-
-```markdown
-<https://example.com>
-```
-
-* The formatter does not wrap inside bare URLs unless explicitly configured to do so.
-
-### List-specific wrapping rules
-
-* The formatter preserves the list marker and its associated content as a single logical list item.
-* Wrapped lines remain visually associated with their parent list item.
-* Nested list items preserve their relative indentation after wrapping.
-* A wrapped line must never be interpreted as a sibling list item when parsed by Markdown or reStructuredText.
-* Wrapping must not alter list nesting depth.
-* Wrapping must not convert a list item into a paragraph or vice versa.
-* A list item containing only a long link may be rendered as:
-
-```markdown
--
-  [very long link](...)
-```
-
-or
-
-```markdown
-- [very long link](...)
-```
-
-provided that the resulting syntax remains valid and unambiguous.
-
-* The formatter preserves blank lines that are semantically significant within list structures.
-
-### Blocks that must not be rewrapped
-
-* The formatter does not rewrap fenced Markdown code blocks.
-* The formatter does not rewrap indented Markdown code blocks.
-* The formatter does not rewrap reStructuredText literal blocks introduced by `::`.
-* The formatter does not rewrap reStructuredText code blocks introduced by directives such as:
-
-```rst
-.. code-block::
-```
-
-* The formatter does not rewrap tables unless table formatting support is explicitly enabled.
-* The formatter does not modify directive structure.
-
-### Inline markup preservation
-
-* The formatter preserves Markdown emphasis syntax:
-
-  * `*text*`
-  * `_text_`
-  * `**text**`
-  * `__text__`
-* The formatter preserves Markdown inline code syntax.
-* The formatter preserves Markdown image syntax.
-* The formatter preserves reStructuredText emphasis, strong emphasis, interpreted text, substitutions, and inline literals.
-* The formatter preserves reStructuredText reference syntax, including:
-
-  * `reference_`
-  * `anonymous__`
-  * `` `phrase reference`_ ``
-* The formatter preserves Markdown reference-style links.
-* The formatter preserves reStructuredText hyperlink targets.
-
-### Idempotency and stability
-
-* Formatting an already formatted document produces identical output.
-* Formatting is deterministic.
-* The formatter does not introduce trailing whitespace.
-* Final newline handling is configurable.
-
-### Error handling
-
-* When malformed Markdown or reStructuredText is encountered, the formatter avoids destructive transformations.
-* When syntax cannot be parsed with confidence, the formatter applies conservative formatting behavior.
-* Optional diagnostics may report formatting limitations and ambiguities.
-
-### Configuration
-
-* The maximum line width is configurable.
-* Markdown-specific behavior is configurable independently from reStructuredText-specific behavior.
-* Individual block types may be excluded from wrapping.
-* Existing manual line breaks may optionally be preserved.
-* List indentation normalization may optionally be enabled.
-
-### Testing
-
-* Tests cover flat Markdown unordered lists.
-* Tests cover nested Markdown unordered lists.
-* Tests cover Markdown ordered lists.
-* Tests cover Markdown task lists.
-* Tests cover flat reStructuredText bullet lists.
-* Tests cover nested reStructuredText bullet lists.
-* Tests cover reStructuredText enumerated lists.
-* Tests cover links that fit within the configured width.
-* Tests cover links that exceed the configured width.
-* Tests cover cases where a link must occupy its own line.
-* Tests verify that code blocks, literal blocks, directives, and tables are not corrupted by formatting.

--- a/spec/Formatting.md
+++ b/spec/Formatting.md
@@ -1,0 +1,232 @@
+# Formatting specification
+
+**Grammar**: Markdown.gra.md
+
+This specification defines the behavior of StrictDoc's text formatter for
+Markdown and reStructuredText (RST) content. The formatter wraps long lines to
+a configurable maximum width while preserving document structure and semantics.
+
+The formatter is implemented in two separate modules:
+`strictdoc/backend/rst/formatter.py` for RST content in SDoc TEXT nodes and
+`strictdoc/backend/markdown/formatter.py` for Markdown content in SDoc TEXT
+nodes and standalone `.md` files.
+
+## General behavior
+
+### Line width
+
+**MID**: f1e2d3c4b5a6f7e8d9c0b1a2f3e4d5c6 \
+**UID**: FMT-1
+
+**STATEMENT**: The formatter wraps text lines to a configurable maximum line
+width. The minimum acceptable line width is 80 characters.
+
+### Prose wrapping
+
+**MID**: a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7 \
+**UID**: FMT-2
+
+**STATEMENT**: The formatter wraps plain prose paragraphs so that no output
+line exceeds the configured line width. Paragraph boundaries (two or more
+consecutive blank lines) are preserved. The formatter does not split individual
+words.
+
+### Blank lines
+
+**MID**: b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8 \
+**UID**: FMT-3
+
+**STATEMENT**: The formatter preserves blank lines that separate paragraphs or
+list items. No blank lines are added or removed during formatting.
+
+### Idempotency
+
+**MID**: c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9 \
+**UID**: FMT-4
+
+**STATEMENT**: Formatting an already-formatted document produces identical
+output. Running the formatter twice on the same input produces the same result
+as running it once.
+
+### No semantic change
+
+**MID**: d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0 \
+**UID**: FMT-5
+
+**STATEMENT**: The formatter does not alter the semantic content of the
+document. It only changes line-break positions within wrappable prose.
+
+### Blocks that must not be rewrapped
+
+**MID**: e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1 \
+**UID**: FMT-6
+
+**STATEMENT**: The formatter preserves the following block types unchanged,
+regardless of line length:
+
+- Fenced code blocks (Markdown ` ``` ` or `~~~`, and analogous RST forms).
+- Indented blocks (any leading whitespace signals code, continuation, or a
+  blockquote and is left untouched).
+- reStructuredText directives (`.. name::`).
+- reStructuredText literal blocks introduced by `::`.
+- reStructuredText field lists (`:field: value`).
+- Tables (Markdown pipe tables and RST grid/simple tables).
+- Blockquotes (`>`).
+
+### Inline links as atomic tokens
+
+**MID**: f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2 \
+**UID**: FMT-7
+
+**STATEMENT**: The formatter treats inline links as atomic tokens that are
+never broken across lines:
+
+- Markdown inline links: `[text](url)`
+- reStructuredText hyperlinks: `` `text <url>`_ `` and `` `text <url>`__ ``
+
+If an atomic token would cause the current line to exceed the configured width,
+the entire token is moved to the next line as a single unit.
+
+The formatter may allow a single atomic token to exceed the configured width
+when no line-break position within the token exists.
+
+## Markdown formatting
+
+### Markdown list markers
+
+**MID**: 08b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3 \
+**UID**: FMT-MD-1
+
+**STATEMENT**: The formatter recognises and preserves the following unordered
+Markdown list markers: `-`, `*`, `+`. The following ordered list markers are
+also recognised: digit-based styles such as `1.`, `2.`, `1)`.
+
+Task list markers (`- [ ]`, `- [x]`, `- [X]`) are also recognised and
+preserved.
+
+### Markdown list continuation indentation
+
+**MID**: 19c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4 \
+**UID**: FMT-MD-2
+
+**STATEMENT**: When a Markdown list item is wrapped, continuation lines are
+indented to align with the content of the list item, not with the list marker.
+
+Example:
+
+```markdown
+- This is a long list item that wraps onto
+  the next line.
+```
+
+The continuation indent equals the total width of the leading whitespace plus
+the marker (including its trailing space). For a `- ` marker the indent is
+2 spaces; for a `1. ` marker it is 3 spaces; for a `- [ ] ` task marker it is
+6 spaces.
+
+### Markdown preserved blocks
+
+**MID**: 2ad1e2f3a4b5c6d7e8f9a0b1c2d3e4f5 \
+**UID**: FMT-MD-3
+
+**STATEMENT**: The formatter does not rewrap the following Markdown constructs:
+
+- ATX headings (lines starting with one to six `#` characters).
+- Fenced code blocks (content between ` ``` ` or `~~~` fence lines).
+- Indented code blocks (4 or more leading spaces).
+- Blockquotes (lines starting with `>`).
+- Pipe table rows and column-separator lines.
+- Thematic breaks (`---`, `===`, `***`).
+
+## reStructuredText formatting
+
+### RST list markers
+
+**MID**: 3be2f3a4b5c6d7e8f9a0b1c2d3e4f5a6 \
+**UID**: FMT-RST-1
+
+**STATEMENT**: The formatter recognises and preserves the following RST list
+markers:
+
+- Unordered: `-`, `*`, `+`.
+- Enumerated: arabic numerals (`1.`, `2.`), uppercase and lowercase letters
+  (`A.`, `a.`), uppercase and lowercase Roman numerals (`I.`, `i.`), and
+  auto-number (`#.`). Both period (`.`) and right-parenthesis (`)`) suffixes
+  are recognised.
+
+### RST list continuation indentation
+
+**MID**: 4cf3a4b5c6d7e8f9a0b1c2d3e4f5a6b7 \
+**UID**: FMT-RST-2
+
+**STATEMENT**: When an RST list item is wrapped, continuation lines are
+indented to align with the content of the list item, not with the list marker.
+
+Example:
+
+```rst
+- This is a long list item that wraps onto
+  the next line.
+
+1. A numbered item that wraps onto
+   the next line.
+```
+
+The continuation indent equals the total width of the leading whitespace plus
+the marker (including its trailing space).
+
+### RST preserved blocks
+
+**MID**: 5da4b5c6d7e8f9a0b1c2d3e4f5a6b7c8 \
+**UID**: FMT-RST-3
+
+**STATEMENT**: The formatter does not rewrap the following RST constructs:
+
+- Any line with leading whitespace (indented code, continuation lines, or
+  nested content).
+- RST directives (lines starting with `.. `).
+- RST literal block markers (`::` standalone or at line end).
+- RST field lists (lines starting with `:letter`).
+- RST table cells (`|`) and table borders (`+---`, `+===`).
+- Blockquotes (`>`).
+
+## StrictDoc-specific rules
+
+### LINK keyword as atomic token
+
+**MID**: 6eb5c6d7e8f9a0b1c2d3e4f5a6b7c8d9 \
+**UID**: FMT-SD-1
+
+**STATEMENT**: The formatter treats `[LINK: uid]` as an atomic token. The
+space between the colon and the UID is not a valid line-break position. If the
+keyword would cause the current line to exceed the configured width, the entire
+`[LINK: uid]` expression is moved to the next line as a single unit.
+
+### ANCHOR keyword as atomic token
+
+**MID**: 7fc6d7e8f9a0b1c2d3e4f5a6b7c8d9e0 \
+**UID**: FMT-SD-2
+
+**STATEMENT**: The formatter treats `[ANCHOR: uid]` as an atomic token with
+the same line-break rules as FMT-SD-1.
+
+### Link as first content of a list item
+
+**MID**: 80d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1 \
+**UID**: FMT-SD-3
+
+**STATEMENT**: If an inline link or a StrictDoc cross-reference keyword
+(`[LINK: uid]` or `[ANCHOR: uid]`) is the first content of a list item —
+immediately following the list marker with no preceding prose — the formatter
+keeps the token on the same line as the list marker, even if the resulting line
+exceeds the configured width.
+
+This rule applies to both Markdown and RST list items and takes precedence over
+FMT-7.
+
+Example (RST):
+
+```rst
+- `Very long link text <https://example.com/a/very/long/path/to/a/resource>`_
+  followed by more prose on the continuation line.
+```

--- a/strictdoc/backend/markdown/reader.py
+++ b/strictdoc/backend/markdown/reader.py
@@ -823,29 +823,7 @@ class SDMarkdownReader:
             else:
                 is_last_field = meta_line_index == meta_line_count
                 if not is_last_field:
-                    next_line_text = SDMarkdownReader._line_without_line_ending(
-                        meta_lines[meta_line_index]
-                    )
-                    next_field_match = (
-                        SDMarkdownReader.plain_field_pattern.match(
-                            next_line_text
-                        )
-                    )
-                    next_field_is_relations = (
-                        next_field_match is not None
-                        and next_field_match.group("name").upper()
-                        == "RELATIONS"
-                        and len(
-                            SDMarkdownReader._trim_single_space_prefix(
-                                next_field_match.group("value")
-                            )
-                        )
-                        == 0
-                    )
-                    if not value.endswith(" \\"):
-                        if not next_field_is_relations:
-                            return [], False
-                    else:
+                    if value.endswith(" \\"):
                         value = value[:-2]
                 elif value.endswith("\\"):
                     return [], False
@@ -943,8 +921,6 @@ class SDMarkdownReader:
                     continuation_lines: List[str] = []
                     while line_index < line_count:
                         candidate_line = body_lines[line_index]
-                        if SDMarkdownReader._is_empty_line(candidate_line):
-                            break
                         candidate_line_text = (
                             SDMarkdownReader._line_without_line_ending(
                                 candidate_line
@@ -959,6 +935,13 @@ class SDMarkdownReader:
                             break
                         continuation_lines.append(candidate_line)
                         line_index += 1
+                    while (
+                        continuation_lines
+                        and SDMarkdownReader._is_empty_line(
+                            continuation_lines[-1]
+                        )
+                    ):
+                        continuation_lines.pop()
                     if continuation_lines:
                         field_value = (
                             inline_value + "\n" + "".join(continuation_lines)

--- a/strictdoc/backend/markdown/writer.py
+++ b/strictdoc/backend/markdown/writer.py
@@ -353,6 +353,21 @@ class SDMarkdownWriter:
             )
         return "\n\n".join(output_blocks)
 
+    # Lines that start with a Markdown structural element — these cannot follow
+    # a field name on the same line, so they force the block format.
+    _MD_BLOCK_START_RE = re.compile(
+        r"^("
+        r"[-*+] "  # unordered list
+        r"|\d+[.)]\s"  # ordered list
+        r"|#{1,6} "  # ATX heading
+        r"|`{3}"  # fenced code block
+        r"|~{3}"  # fenced code block (tilde)
+        r"|>"  # blockquote
+        r"|\|"  # table cell
+        r"|\s"  # indented block
+        r")"
+    )
+
     @staticmethod
     def _serialize_single_content_field(
         field_name: str,
@@ -362,13 +377,11 @@ class SDMarkdownWriter:
         normalized_value = SDMarkdownWriter._to_lf(field_value).strip("\n")
         if line_width is not None:
             normalized_value = wrap_md_text(normalized_value, line_width)
-        if SDMarkdownWriter._is_multi_paragraph(normalized_value):
-            if len(normalized_value) > 0:
-                return f"**{field_name}**:\n\n{normalized_value}"
+        if len(normalized_value) == 0:
             return f"**{field_name}**:"
-        if len(normalized_value) > 0:
-            return f"**{field_name}**: {normalized_value}"
-        return f"**{field_name}**:"
+        if SDMarkdownWriter._MD_BLOCK_START_RE.match(normalized_value):
+            return f"**{field_name}**:\n\n{normalized_value}"
+        return f"**{field_name}**: {normalized_value}"
 
     @staticmethod
     def _meta_value_to_single_line(field_value: str) -> str:

--- a/tests/integration/features/markdown/03_consecutive_requirements/input.md
+++ b/tests/integration/features/markdown/03_consecutive_requirements/input.md
@@ -1,0 +1,30 @@
+# Markdown example
+
+Some intro
+
+## General behavior
+
+### Node #1
+
+**MID**: mid1 \
+**UID**: FMT-1
+
+**STATEMENT**: Lorem ipsum.
+
+### Node #2
+
+**MID**: mid2 \
+**UID**: FMT-2
+
+**STATEMENT**: The statement continues below after the colon:
+
+- Item 1.
+- Item 2.
+- Item 3.
+
+### Node #3
+
+**MID**: mid3 \
+**UID**: FMT-3
+
+**STATEMENT**: Lorem ipsum.

--- a/tests/integration/features/markdown/03_consecutive_requirements/test.itest
+++ b/tests/integration/features/markdown/03_consecutive_requirements/test.itest
@@ -1,0 +1,15 @@
+#
+# Verify that StrictDoc parses a requirement when it has a statement that has
+# two parts separated by a full empty line.
+#
+
+RUN: %strictdoc export %S --formats=html --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Markdown example
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-FILE
+
+CHECK-HTML-FILE: data-testid="node-requirement"
+CHECK-HTML-FILE: data-uid="FMT-2"
+CHECK-HTML-FILE: <sdoc-node-field-label>STATEMENT:</sdoc-node-field-label>
+CHECK-HTML-FILE: The statement continues below after the colon:
+CHECK-HTML-FILE: Item 1.


### PR DESCRIPTION

WHY: This makes the formatting rules more formal and maintainable long-term.