### PR TITLE
feat(source_nodes): support [LINK] and [ANCHOR] in source node fields

### DIFF
--- a/strictdoc/backend/sdoc/models/node.py
+++ b/strictdoc/backend/sdoc/models/node.py
@@ -804,6 +804,16 @@ class SDocNode(SDocNodeIF):
         multiline = element.is_field_multiline(field_name)
         if multiline and isinstance(value, str):
             value = ensure_newline(value)
+        elif (
+            multiline
+            and isinstance(value, SDocNodeField)
+            and len(value.parts) > 0
+        ):
+            last_part = value.parts[-1]
+            if isinstance(last_part, str):
+                value.parts[-1] = ensure_newline(last_part)
+            elif isinstance(last_part, InlineLink):
+                value.parts.append("\n")
 
         if field_name in self.ordered_fields_lookup:
             if len(self.ordered_fields_lookup[field_name]) > form_field_index:

--- a/strictdoc/backend/sdoc/models/node.py
+++ b/strictdoc/backend/sdoc/models/node.py
@@ -94,6 +94,24 @@ class SDocNodeField:
             multiline__="multiline" if multiline else None,
         )
 
+    @staticmethod
+    def from_parts(
+        parent: Optional["SDocNode"],
+        field_name: str,
+        parts: List[Any],
+        multiline: bool,
+    ) -> "SDocNodeField":
+        sdoc_node_field = SDocNodeField(
+            parent=parent,
+            field_name=field_name,
+            parts=parts,
+            multiline__="multiline" if multiline else None,
+        )
+        for part in parts:
+            if isinstance(part, (InlineLink, Anchor)):
+                part.parent = sdoc_node_field
+        return sdoc_node_field
+
     def is_multiline(self) -> bool:
         return self.multiline
 

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -19,6 +19,7 @@ from strictdoc.backend.gcov.helpers import convert_function_name_to_gcovr_style
 from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.error_handling import StrictDocSemanticError
 from strictdoc.backend.sdoc.free_text_reader import SDFreeTextReader
+from strictdoc.backend.sdoc.models.anchor import Anchor
 from strictdoc.backend.sdoc.models.document_grammar import (
     DocumentGrammar,
 )
@@ -348,6 +349,21 @@ class FileTraceabilityIndex:
                                 rhs_node=created_section,
                             )
                     current_top_node.section_contents.append(sdoc_node)
+
+                # Register [ANCHOR]s from source node fields as linkable targets.
+                for node_field_ in sdoc_node.enumerate_fields():
+                    for part_ in node_field_.parts:
+                        if isinstance(part_, Anchor):
+                            traceability_index.graph_database.create_link(
+                                link_type=GraphLinkType.MID_TO_NODE,
+                                lhs_node=part_.mid,
+                                rhs_node=part_,
+                            )
+                            traceability_index.graph_database.create_link(
+                                link_type=GraphLinkType.UID_TO_NODE,
+                                lhs_node=part_.value,
+                                rhs_node=part_,
+                            )
 
                 self.connect_source_node_function(
                     source_node_, sdoc_node_uid, traceability_info_

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -18,6 +18,7 @@ from typing import (
 from strictdoc.backend.gcov.helpers import convert_function_name_to_gcovr_style
 from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.error_handling import StrictDocSemanticError
+from strictdoc.backend.sdoc.free_text_reader import SDFreeTextReader
 from strictdoc.backend.sdoc.models.document_grammar import (
     DocumentGrammar,
 )
@@ -1149,11 +1150,23 @@ class FileTraceabilityIndex:
     def set_sdoc_node_fields(
         sdoc_node: SDocNode, sdoc_node_fields: dict[str, str]
     ) -> None:
+        document = assert_cast(sdoc_node.get_document(), SDocDocumentIF)
+        grammar = assert_cast(document.grammar, DocumentGrammar)
+        element = grammar.elements_by_type[sdoc_node.node_type]
+
         for field_name, field_value in sdoc_node_fields.items():
+            multiline = element.is_field_multiline(field_name)
+            free_text_container = SDFreeTextReader.read(field_value)
+            sdoc_node_field = SDocNodeField.from_parts(
+                sdoc_node,
+                field_name=field_name,
+                parts=free_text_container.parts,
+                multiline=multiline,
+            )
             sdoc_node.set_field_value(
                 field_name=field_name,
                 form_field_index=0,
-                value=field_value,
+                value=sdoc_node_field,
             )
 
             # As we overwrite the field's content from the source code,

--- a/strictdoc/core/traceability_index.py
+++ b/strictdoc/core/traceability_index.py
@@ -71,6 +71,7 @@ class TraceabilityIndex:
             file_dependency_manager
         )
         self.node_filter: Optional[NodeFilter] = None
+        self.pending_inline_links: List[InlineLink] = []
 
         self.index_last_updated = datetime.datetime.today()
         self.contains_included_documents = False

--- a/strictdoc/core/traceability_index_builder.py
+++ b/strictdoc/core/traceability_index_builder.py
@@ -249,6 +249,24 @@ class TraceabilityIndexBuilder:
             traceability_index.document_tree.attach_source_tree(source_tree)
 
         #
+        # Resolve pending InlineLinks. This depends on UIDs and anchors from
+        # static documents, generated documents and source nodes.
+        #
+        for inline_link in traceability_index.pending_inline_links:
+            if not traceability_index.graph_database.has_any_link(
+                link_type=GraphLinkType.UID_TO_NODE,
+                lhs_node=inline_link.link,
+            ):
+                raise StrictDocException(
+                    "DocumentIndex: "
+                    "the inline link references an object with an UID "
+                    "that does not exist: "
+                    f"{inline_link.link}."
+                )
+            traceability_index.create_inline_link(inline_link)
+        traceability_index.pending_inline_links.clear()
+
+        #
         # Resolve all modification dates to support the incremental generation of
         # all artifacts.
         #
@@ -599,27 +617,10 @@ class TraceabilityIndexBuilder:
                     continue
 
                 requirement = assert_cast(node, SDocNode)
-
-                #
-                # At this point, we resolve LINKs, and the expectation is that
-                # all UIDs or ANCHORS (they also have UIDs) are registered at the
-                # previous pass.
-                #
                 for node_field_ in requirement.enumerate_fields():
                     for part in node_field_.parts:
                         if isinstance(part, InlineLink):
-                            if not graph_database.has_any_link(
-                                link_type=GraphLinkType.UID_TO_NODE,
-                                lhs_node=part.link,
-                            ):
-                                raise StrictDocException(
-                                    "DocumentIndex: "
-                                    "the inline link references an "
-                                    "object with an UID "
-                                    "that does not exist: "
-                                    f"{part.link}."
-                                )
-                            traceability_index.create_inline_link(part)
+                            traceability_index.pending_inline_links.append(part)
                 if requirement.reserved_uid is None:
                     continue
 

--- a/strictdoc/core/transforms/update_requirement.py
+++ b/strictdoc/core/transforms/update_requirement.py
@@ -568,14 +568,12 @@ class CreateOrUpdateNodeCommand:
                     map_form_to_requirement_fields[form_field]
                 )
                 requirement_field: Optional[SDocNodeField] = (
-                    SDocNodeField(
+                    SDocNodeField.from_parts(
                         node,
                         field_name=form_field_name,
                         parts=free_text_content.parts,
-                        multiline__="true"
-                        if form_field.field_type
-                        == RequirementFormFieldType.MULTILINE
-                        else None,
+                        multiline=form_field.field_type
+                        == RequirementFormFieldType.MULTILINE,
                     )
                     if free_text_content is not None
                     else None
@@ -585,11 +583,3 @@ class CreateOrUpdateNodeCommand:
                     form_field_index=form_field_index,
                     value=requirement_field,
                 )
-                if (
-                    requirement_field is not None
-                    and free_text_content is not None
-                ):
-                    for part_ in requirement_field.parts:
-                        if isinstance(part_, str):
-                            continue
-                        part_.parent = requirement_field

--- a/tests/integration/features/source_code_traceability/_source_nodes/04_link_and_anchor_in_fields/description.sdoc
+++ b/tests/integration/features/source_code_traceability/_source_nodes/04_link_and_anchor_in_fields/description.sdoc
@@ -1,0 +1,30 @@
+[DOCUMENT]
+TITLE: Test Specification
+UID: TEST_DOC
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: TEST_SPEC
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  - TITLE: INTENTION
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File

--- a/tests/integration/features/source_code_traceability/_source_nodes/04_link_and_anchor_in_fields/input.sdoc
+++ b/tests/integration/features/source_code_traceability/_source_nodes/04_link_and_anchor_in_fields/input.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: Requirements
+
+[REQUIREMENT]
+UID: REQ-1
+TITLE: First Requirement Title
+STATEMENT: The system shall do something.
+
+[REQUIREMENT]
+UID: REQ-2
+TITLE: Second Requirement Title
+STATEMENT: The system shall do something else.

--- a/tests/integration/features/source_code_traceability/_source_nodes/04_link_and_anchor_in_fields/strictdoc_config.py
+++ b/tests/integration/features/source_code_traceability/_source_nodes/04_link_and_anchor_in_fields/strictdoc_config.py
@@ -1,0 +1,20 @@
+from strictdoc.core.project_config import ProjectConfig, SourceNodesEntry
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=[
+            "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+        ],
+        source_nodes=[
+            SourceNodesEntry(
+                path="tests/",
+                uid="TEST_DOC",
+                node_type="TEST_SPEC",
+            )
+        ],
+        exclude_source_paths=[
+            "test.itest"
+        ],
+    )
+    return config

--- a/tests/integration/features/source_code_traceability/_source_nodes/04_link_and_anchor_in_fields/test.itest
+++ b/tests/integration/features/source_code_traceability/_source_nodes/04_link_and_anchor_in_fields/test.itest
@@ -1,0 +1,17 @@
+#
+# @relation(SDOC-SRS-141, scope=file)
+#
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
+
+CHECK: Published: Requirements
+
+RUN: %check_exists --file "%T/html/_source_files/tests/file.c.html"
+
+# The INTENTION field must render [LINK: ...] as a hyperlink, not as raw text.
+# Check for the fragment part of the URL.
+RUN: %cat %T/html/_source_files/tests/file.c.html | filecheck %s --check-prefix CHECK-SOURCE-FILE
+
+CHECK-SOURCE-FILE: <sdoc-node-field-label>INTENTION:</sdoc-node-field-label>
+CHECK-SOURCE-FILE: input.html#REQ-1{{.*}}input.html#REQ-2
+

--- a/tests/integration/features/source_code_traceability/_source_nodes/04_link_and_anchor_in_fields/tests/file.c
+++ b/tests/integration/features/source_code_traceability/_source_nodes/04_link_and_anchor_in_fields/tests/file.c
@@ -1,0 +1,6 @@
+/**
+ * @relation(REQ-1, scope=function)
+ *
+ * INTENTION: See [LINK: REQ-1] and [LINK: REQ-2] for the covered requirements.
+ */
+void test_case_with_links(void) {}

--- a/tests/integration/features/source_code_traceability/_source_nodes/05_anchor_in_source_node_field/description.sdoc
+++ b/tests/integration/features/source_code_traceability/_source_nodes/05_anchor_in_source_node_field/description.sdoc
@@ -1,0 +1,30 @@
+[DOCUMENT]
+TITLE: Test Specification
+UID: TEST_DOC
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: TEST_SPEC
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  - TITLE: INTENTION
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File

--- a/tests/integration/features/source_code_traceability/_source_nodes/05_anchor_in_source_node_field/input.sdoc
+++ b/tests/integration/features/source_code_traceability/_source_nodes/05_anchor_in_source_node_field/input.sdoc
@@ -1,0 +1,9 @@
+[DOCUMENT]
+TITLE: Requirements
+
+[REQUIREMENT]
+UID: REQ-1
+TITLE: First Requirement Title
+STATEMENT: >>>
+See [LINK: IMPL-1] for the core implementation.
+<<<

--- a/tests/integration/features/source_code_traceability/_source_nodes/05_anchor_in_source_node_field/strictdoc_config.py
+++ b/tests/integration/features/source_code_traceability/_source_nodes/05_anchor_in_source_node_field/strictdoc_config.py
@@ -1,0 +1,20 @@
+from strictdoc.core.project_config import ProjectConfig, SourceNodesEntry
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=[
+            "REQUIREMENT_TO_SOURCE_TRACEABILITY",
+        ],
+        source_nodes=[
+            SourceNodesEntry(
+                path="tests/",
+                uid="TEST_DOC",
+                node_type="TEST_SPEC",
+            )
+        ],
+        exclude_source_paths=[
+            "test.itest"
+        ],
+    )
+    return config

--- a/tests/integration/features/source_code_traceability/_source_nodes/05_anchor_in_source_node_field/test.itest
+++ b/tests/integration/features/source_code_traceability/_source_nodes/05_anchor_in_source_node_field/test.itest
@@ -1,0 +1,14 @@
+#
+# @relation(SDOC-SRS-141, scope=file)
+#
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s
+
+CHECK: Published: Requirements
+
+RUN: %check_exists --file "%T/html/05_anchor_in_source_node_field/input.html"
+
+# The STATEMENT field of the requirement must render [LINK: IMPL-1]
+# as a hyperlink pointing to the anchor in the source node's INTENTION field.
+RUN: %cat %T/html/05_anchor_in_source_node_field/input.html | filecheck %s --check-prefix CHECK-REQ
+CHECK-REQ: description.html#IMPL-1

--- a/tests/integration/features/source_code_traceability/_source_nodes/05_anchor_in_source_node_field/tests/file.c
+++ b/tests/integration/features/source_code_traceability/_source_nodes/05_anchor_in_source_node_field/tests/file.c
@@ -1,0 +1,10 @@
+/**
+ * @relation(REQ-1, scope=function)
+ *
+ * INTENTION:
+ * This function sets up the test environment and runs the test case.
+ *
+ * [ANCHOR: IMPL-1]
+ * The core algorithm validates the input and asserts the expected output.
+ */
+void test_case_with_anchor(void) {}


### PR DESCRIPTION
What: Support rendering `[LINK]` and `[ANCHOR]` that come from source nodes.

Why: Source nodes already render markup (like RST bullet lists, or code blocks). It's consistent and useful to also render StrictDoc native syntax.

For detailed What/Why/How see individual commit messages. Let me know if you prefer one PR per one commit.