### PR TITLE
fix(markdown): fix writing field names back to Markdown under custom grammar

### DIFF
--- a/strictdoc/backend/markdown/writer.py
+++ b/strictdoc/backend/markdown/writer.py
@@ -307,6 +307,15 @@ class SDMarkdownWriter:
         if document is None or document.grammar is None:
             return field_name
         grammar = assert_cast(document.grammar, DocumentGrammar)
+        # For imported (custom) grammars, always write the field key name so
+        # that the reader can recover it via .upper(). Human titles in custom
+        # grammars are arbitrary strings (e.g. "Example Human Title" for key
+        # "DERIVED_RATIONALE") and do not round-trip through the reader's
+        # name.upper() normalisation. For the built-in default grammar the
+        # human title is always a simple capitalisation variant of the key
+        # (e.g. "Statement" for "STATEMENT"), so .upper() recovers it safely.
+        if grammar.import_from_file is not None:
+            return field_name
         element = grammar.elements_by_type.get(node.node_type, None)
         if element is None:
             return field_name

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_grammar.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_grammar.py
@@ -137,7 +137,66 @@ def test_004_markdown_grammar_custom_grammar_relaxes_uid_and_statement_requireme
     assert "NAME" in field_names
 
 
-def test_005_markdown_grammar_reader_rejects_unknown_field_type():
+def test_005_markdown_grammar_writer_uses_field_key_not_human_title_for_custom_grammar():
+    """
+    Regression test for https://github.com/strictdoc-project/strictdoc/issues/2918.
+
+    When a document has a custom (imported) grammar whose fields carry a
+    Human Title, the writer must serialise each field using the grammar key
+    name (e.g. DERIVED_RATIONALE), not the human-readable title
+    (e.g. "Example Human Title").  The reader canonicalises field names with
+    .upper(), so writing the human title produces an unrecoverable key on
+    the next parse.
+    """
+    grammar_markdown = """\
+# StrictDoc Markdown Grammar
+
+## Element: REQUIREMENT
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: DERIVED_RATIONALE
+
+**Type**: String
+**Human Title**: Example Human Title
+**Required**: False
+
+### Relations
+
+#### Relation: Parent
+"""
+    doc_markdown = """\
+# Document
+
+**Grammar**: `requirements.gra.md`
+
+## Requirement title
+
+**UID**: REQ-1
+**DERIVED_RATIONALE**: Some rationale text.
+"""
+
+    document = SDMarkdownReader.read(doc_markdown, file_path=None)
+    assert document.grammar is not None
+    assert document.grammar.import_from_file == "requirements.gra.md"
+
+    # Simulate grammar resolution (normally done by TraceabilityIndexBuilder).
+    resolved_grammar = MarkdownGrammarReader.read(grammar_markdown)
+    resolved_grammar.import_from_file = "requirements.gra.md"
+    resolved_grammar.parent = document
+    document.grammar = resolved_grammar
+
+    output_markdown = SDMarkdownWriter.write(document)
+
+    # The field key name must appear on disk, not the human title.
+    assert "**DERIVED_RATIONALE**" in output_markdown
+    assert "Example Human Title" not in output_markdown
+
+
+def test_006_markdown_grammar_reader_rejects_unknown_field_type():
     input_markdown = """\
 # StrictDoc Markdown Grammar
 


### PR DESCRIPTION

WHAT: Fix the issue related to incorrect handling of human titles vs original titles as they are stored in Markdown files.

As reported by a user:

```
**MID**: 12345 \
**UID**: REQ-5 \
**DERIVED**: No \
**Example Human Title**: Bug example string in the field with the Human Title that will get written to disc instead of the ### FIELD: KEY_NAME \
**SAFETY**: No \
**SECURITY**: No

**STATEMENT**: Bug example statement.
```

WHY: Closes #2918