### PR TITLE
fix(html): remove spurious backtick from write_anchor_link

### DIFF
--- a/strictdoc/export/html/renderers/html_fragment_writer.py
+++ b/strictdoc/export/html/renderers/html_fragment_writer.py
@@ -8,4 +8,4 @@ class HTMLFragmentWriter:
 
     @staticmethod
     def write_anchor_link(title: str, href: str) -> str:
-        return f'<a href="{href}">🔗&nbsp;{title}</a>`'
+        return f'<a href="{href}">🔗&nbsp;{title}</a>'

--- a/strictdoc/export/html/renderers/text_to_html_writer.py
+++ b/strictdoc/export/html/renderers/text_to_html_writer.py
@@ -8,4 +8,4 @@ class TextToHtmlWriter:
 
     @staticmethod
     def write_anchor_link(title: str, href: str) -> str:
-        return f'<a href="{href}">🔗&nbsp;{title}</a>`'
+        return f'<a href="{href}">🔗&nbsp;{title}</a>'

--- a/tests/unit/strictdoc/export/html/renderers/test_html_fragment_writer.py
+++ b/tests/unit/strictdoc/export/html/renderers/test_html_fragment_writer.py
@@ -1,0 +1,13 @@
+from strictdoc.export.html.renderers.html_fragment_writer import (
+    HTMLFragmentWriter,
+)
+
+
+def test_write_anchor_link():
+    result = HTMLFragmentWriter.write_anchor_link(
+        "REQ-001", "../requirements/REQ-001.html#REQ-001"
+    )
+    assert (
+        result
+        == '<a href="../requirements/REQ-001.html#REQ-001">🔗&nbsp;REQ-001</a>'
+    )

--- a/tests/unit/strictdoc/export/html/renderers/test_text_to_html_fragment_writer.py
+++ b/tests/unit/strictdoc/export/html/renderers/test_text_to_html_fragment_writer.py
@@ -1,6 +1,16 @@
 from strictdoc.export.html.renderers.text_to_html_writer import TextToHtmlWriter
 
 
+def test_write_anchor_link():
+    result = TextToHtmlWriter.write_anchor_link(
+        "REQ-001", "../requirements/REQ-001.html#REQ-001"
+    )
+    assert (
+        result
+        == '<a href="../requirements/REQ-001.html#REQ-001">🔗&nbsp;REQ-001</a>'
+    )
+
+
 def test_01_escapes_html_tags():
     text_input = """
 <a href="url">link</a>


### PR DESCRIPTION
Why: HTMLFragmentWriter and TextToHtmlWriter produced a trailing backtick in the HTML generated for rendered `[LINK:]`s. It was not visible in browsers, but is wrong anyway.

What: Remove the spurious backtick.