### PR TITLE
feat(markdown): enable the automatic ENABLE_MID behavior if MID is present in grammar

### DIFF
--- a/developer/tasks/20260617_markdown_enable_mid/task.md
+++ b/developer/tasks/20260617_markdown_enable_mid/task.md
@@ -1,0 +1,52 @@
+# Implement ENABLE_MID in Markdown
+
+## WHAT
+
+Enable the `ENABLE_MID` behavior in Markdown similar how it is done by the SDoc machinery.
+
+Implement in the following way:
+
+- DO NOT introduce a document level `ENABLE_MID` option.
+- Instead, make the `ENABLE_MID` behavior be activated if a user grammar contains the MID field.
+
+## WHY
+
+- The `ENABLE_MID` feature is very important for many users. We want to have it enabled for Markdown.
+- At the same time, we would like to avoid adding a yet another document-level option to active it.
+
+The automatic recognition based on the grammar field should be enough to do the job.
+
+## HOW
+
+### Trigger condition
+
+ENABLE_MID behavior is activated when **all three** conditions are met:
+
+1. The document uses a custom (non-default) grammar (`document_grammar.is_default == False`).
+2. The grammar element (e.g. `REQUIREMENT`) declares a `MID` field in its `fields_map`.
+3. The node being written does not already have a `MID` field in its `ordered_fields_lookup`.
+
+The default Markdown grammar also carries a `MID` field (for backward compatibility), so guarding with `is_default` prevents MID injection into plain Markdown documents that do not reference any custom grammar.
+
+### Changes
+
+**`strictdoc/backend/markdown/writer.py` — `_serialize_node_fields`**
+
+Before iterating the node's own fields, check the trigger condition. If met, prepend `("MID", node.reserved_mid)` to `meta_fields`. This causes the auto-generated UUID to be written to the document on the next save, making it permanent on the subsequent read (because `SDocNode.__init__` sets `mid_permanent = True` whenever a MID value is present in the parsed fields).
+
+**`strictdoc/core/transforms/update_requirement.py`**
+
+When the web UI creates a new requirement node, `mid_permanent = True` is set if `document.config.enable_mid` is True (SDoc path) **or** if the grammar element has a `MID` field (Markdown custom grammar path).
+
+**`strictdoc/core/file_traceability_index.py`**
+
+Same extension: when a MID field is updated via the server merge path, `mid_permanent = True` is set if the grammar element has a `MID` field (in addition to the existing `enable_mid` check).
+
+### Tests
+
+Three new unit tests were added to
+`tests/unit/strictdoc/backend/markdown/test_markdown_grammar.py`:
+
+- `test_007` — writer auto-writes MID when grammar has MID but node has none.
+- `test_008` — writer preserves an existing MID (no duplicate injection).
+- `test_009` — writer does NOT inject MID when grammar has no MID field.

--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -1213,6 +1213,37 @@ With the command-line interface, the generation of ``MID`` can be initiated with
 .. note::
 
     StrictDoc provides the ENABLE_MID option on a per-document basis because this allows for the integration of MID-enabled documents alongside third-party documents where the MID feature may not be necessary or possible.
+
+**Markdown documents**
+
+For Markdown documents, the ``ENABLE_MID`` behavior is activated automatically — no document-level option is required. Instead, the presence of a ``MID`` field in a custom grammar element is the activation signal.
+
+When a ``.gra.md`` grammar file declares a ``MID`` field for an element type, the Markdown writer automatically inserts a machine identifier for every node of that type that does not already have one. On the next read, the persisted value is treated as permanent.
+
+Example grammar with MID declared:
+
+.. code-block:: markdown
+
+    # StrictDoc Markdown Grammar
+
+    ## Element: REQUIREMENT
+
+    ### Field: MID
+
+    **Type**: String
+    **Required**: False
+
+    ### Field: UID
+
+    **Type**: String
+    **Required**: False
+
+    ### Field: STATEMENT
+
+    **Type**: String
+    **Required**: False
+
+With this grammar attached (``**Grammar**: requirements.gra.md``), any ``REQUIREMENT`` node that does not yet have a ``**MID**`` field will receive one on the first write-back.
 <<<
 
 [[SECTION]]

--- a/spec/Markdown.md
+++ b/spec/Markdown.md
@@ -139,6 +139,21 @@ With a custom grammar, an H2–H6 heading becomes a REQUIREMENT node when the me
 
 Field validation against the grammar schema is deferred to a later build stage. The heading text is assigned to the `TITLE` field.
 
+### MID auto-generation
+
+**MID**: 00fc24ee2f5c44f08c1d7f543a3677b0 \
+**UID**: MD-24
+
+**STATEMENT**:
+
+When a custom grammar declares a `MID` field for an element type, the writer automatically inserts the node's auto-generated machine identifier into the output for any node of that type that does not already carry a `MID` field.
+
+This is the Markdown equivalent of SDoc's document-level `ENABLE_MID` option. The presence of the `MID` field in the custom grammar is the activation signal — no explicit document-level option is required.
+
+On the first write-back, every node without a `MID` receives a freshly generated UUID. On subsequent reads, the persisted value is loaded and the node's machine identifier is treated as permanent.
+
+This behavior applies only to custom (user-defined) grammars. The built-in default grammar also declares `MID` for the `REQUIREMENT` element, but the default grammar does not trigger auto-generation.
+
 ### Meta-field styles
 
 **MID**: 0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a \

--- a/strictdoc/backend/markdown/writer.py
+++ b/strictdoc/backend/markdown/writer.py
@@ -174,6 +174,20 @@ class SDMarkdownWriter:
                 node.node_type, None
             )
 
+        # If a custom (user-defined) grammar declares MID and the node doesn't
+        # have one, auto-write the reserved_mid so it becomes permanent on the
+        # next read. This is the Markdown equivalent of SDoc's ENABLE_MID.
+        # The default grammar also carries MID, so guard with is_default to
+        # avoid injecting MID into plain Markdown documents.
+        if (
+            document_grammar is not None
+            and not document_grammar.is_default
+            and element is not None
+            and "MID" in element.fields_map
+            and "MID" not in node.ordered_fields_lookup
+        ):
+            meta_fields.append(("MID", node.reserved_mid))
+
         for field in node.enumerate_fields():
             if field.field_name == "TITLE":
                 continue

--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -1260,7 +1260,16 @@ class FileTraceabilityIndex:
                 # I currently struggle to update the search index.
                 parent_document = sdoc_node.get_parent_or_including_document()
                 sdoc_node.reserved_mid = MID(sdoc_mid_field)
-                if parent_document.config.enable_mid:
+                assert parent_document.grammar is not None
+                node_grammar_element = (
+                    parent_document.grammar.elements_by_type.get(
+                        sdoc_node.node_type
+                    )
+                )
+                if parent_document.config.enable_mid or (
+                    node_grammar_element is not None
+                    and "MID" in node_grammar_element.fields_map
+                ):
                     sdoc_node.mid_permanent = True
 
         if not traceability_index.graph_database.has_link(

--- a/strictdoc/core/transforms/update_requirement.py
+++ b/strictdoc/core/transforms/update_requirement.py
@@ -314,13 +314,15 @@ class CreateOrUpdateNodeCommand:
                 parent=parent, node_type=form_object.element_type
             )
             requirement.reserved_mid = MID(form_object.requirement_mid)
-            if document.config.enable_mid:
-                requirement.mid_permanent = True
-
             assert document.grammar is not None
             grammar_element: GrammarElement = document.grammar.elements_by_type[
                 form_object.element_type
             ]
+            if (
+                document.config.enable_mid
+                or "MID" in grammar_element.fields_map
+            ):
+                requirement.mid_permanent = True
 
             requirement.is_composite = (
                 grammar_element.property_is_composite is True

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_grammar.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_grammar.py
@@ -211,3 +211,162 @@ def test_006_markdown_grammar_reader_rejects_unknown_field_type():
     with pytest.raises(StrictDocSemanticError) as exc_info:
         MarkdownGrammarReader.read(input_markdown)
     assert "unknown field Type" in exc_info.value.title
+
+
+def test_007_markdown_writer_auto_writes_mid_when_grammar_has_mid_field():
+    """
+    When a document's grammar declares a MID field and a node doesn't have
+    MID set in the file, the Markdown writer must auto-write the
+    reserved_mid value so that the MID becomes permanent on the next read.
+    """
+    grammar_markdown = """\
+# StrictDoc Markdown Grammar
+
+## Element: REQUIREMENT
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False
+"""
+    doc_markdown = """\
+# Document
+
+**Grammar**: `requirements.gra.md`
+
+## Requirement title
+
+**UID**: REQ-1
+
+**Statement**: System shall do X.
+"""
+
+    document = SDMarkdownReader.read(doc_markdown, file_path=None)
+    assert document.grammar is not None
+
+    # Simulate grammar resolution (normally done by TraceabilityIndexBuilder).
+    resolved_grammar = MarkdownGrammarReader.read(grammar_markdown)
+    resolved_grammar.import_from_file = "requirements.gra.md"
+    resolved_grammar.parent = document
+    document.grammar = resolved_grammar
+
+    output_markdown = SDMarkdownWriter.write(document)
+
+    # The writer must have inserted a MID field.
+    assert "**MID**:" in output_markdown
+    # UID must still be present.
+    assert "**UID**: REQ-1" in output_markdown
+
+
+def test_008_markdown_writer_preserves_existing_mid_when_grammar_has_mid_field():
+    """
+    When a document's grammar declares MID and a node already has a MID
+    value in the document, the writer must preserve the existing MID value
+    (no duplicate MID field).
+    """
+    grammar_markdown = """\
+# StrictDoc Markdown Grammar
+
+## Element: REQUIREMENT
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False
+"""
+    doc_markdown = """\
+# Document
+
+**Grammar**: `requirements.gra.md`
+
+## Requirement title
+
+**MID**: abc123 \\
+**UID**: REQ-1
+
+**Statement**: System shall do X.
+"""
+
+    document = SDMarkdownReader.read(doc_markdown, file_path=None)
+    assert document.grammar is not None
+
+    # Simulate grammar resolution.
+    resolved_grammar = MarkdownGrammarReader.read(grammar_markdown)
+    resolved_grammar.import_from_file = "requirements.gra.md"
+    resolved_grammar.parent = document
+    document.grammar = resolved_grammar
+
+    output_markdown = SDMarkdownWriter.write(document)
+
+    # The existing MID must be preserved.
+    assert "**MID**: abc123" in output_markdown
+    # No duplicate MID field: count occurrences.
+    assert output_markdown.count("**MID**") == 1
+    assert "**UID**: REQ-1" in output_markdown
+
+
+def test_009_markdown_writer_no_mid_when_grammar_has_no_mid_field():
+    """
+    When the grammar does not declare a MID field, the writer must not
+    inject any MID field into the output even though nodes carry a
+    reserved_mid internally.
+    """
+    grammar_markdown = """\
+# StrictDoc Markdown Grammar
+
+## Element: REQUIREMENT
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False
+"""
+    doc_markdown = """\
+# Document
+
+**Grammar**: `requirements.gra.md`
+
+## Requirement title
+
+**UID**: REQ-1
+
+**Statement**: System shall do X.
+"""
+
+    document = SDMarkdownReader.read(doc_markdown, file_path=None)
+
+    # Simulate grammar resolution.
+    resolved_grammar = MarkdownGrammarReader.read(grammar_markdown)
+    resolved_grammar.import_from_file = "requirements.gra.md"
+    resolved_grammar.parent = document
+    document.grammar = resolved_grammar
+
+    output_markdown = SDMarkdownWriter.write(document)
+
+    assert "**MID**" not in output_markdown
+    assert "**UID**: REQ-1" in output_markdown


### PR DESCRIPTION

WHAT: Enable ENABLE_MID behavior for Markdown.

WHY: Closes #2920

HOW: To simplify the Markdown handling, the ENABLE_MID behavior is enabled simply when a grammar element has an MID field. This should be a strong enough signal to StrictDoc that a user wants to have automatically generated MIDs.