### PR TITLE
fix(grammar): make sdoc textX grammar CRLF aware

### DIFF
--- a/strictdoc/backend/sdoc/grammar/grammar.py
+++ b/strictdoc/backend/sdoc/grammar/grammar.py
@@ -7,7 +7,7 @@
 REGEX_UID = r"([\w]+[\w()\-\/.: ]*)"
 REGEX_FIELD_NAME = r"[A-Z]+[A-Za-z0-9_\-]*"
 
-NEGATIVE_MULTILINE_STRING_START = "(?!>>>\n)"
+NEGATIVE_MULTILINE_STRING_START = "(?!>>>\r?\n)"
 NEGATIVE_MULTILINE_STRING_END = "(?!^<<<)"
 NEGATIVE_RELATIONS = "(?!^RELATIONS)"
 NEGATIVE_UID = "(?!^UID)"
@@ -20,7 +20,7 @@ TextPart[noskipws]:
 ;
 
 SingleLineTextPart[noskipws]:
-  (Anchor | InlineLink | /{NEGATIVE_MULTILINE_STRING_START}\S.*/)
+  (Anchor | InlineLink | /{NEGATIVE_MULTILINE_STRING_START}\S[^\r\n]*/)
 ;
 
 NormalString[noskipws]:
@@ -34,18 +34,18 @@ InlineLink[noskipws]:
 Anchor[noskipws]:
   /^\[ANCHOR: /
   value = /{REGEX_UID}/ (', ' title = /\w+[\s\w+]*/)?
-  /\](\Z|\n)/
+  /\](\Z|\r?\n)/
 ;
 
 // According to the Strict Grammar Rule #3, both SingleLineString and
 // MultiLineString can never be empty strings.
 // Both must eventualy start with a non-space character.
 SingleLineString:
-  /{NEGATIVE_MULTILINE_STRING_START}\S.*$/
+  /{NEGATIVE_MULTILINE_STRING_START}\S[^\r\n]*/
 ;
 
 MultiLineString[noskipws]:
-  />>>\n/-
+  />>>\r?\n/-
     parts*=TextPart
   /^<<</-
 ;
@@ -221,7 +221,7 @@ SDocNodeField[noskipws]:
         (
           ' '
           (
-            multiline__ = />>>\n/
+            multiline__ = />>>\r?\n/
             parts+=TextPart
             /^<<</
           )

--- a/strictdoc/backend/sdoc/grammar/grammar_builder.py
+++ b/strictdoc/backend/sdoc/grammar/grammar_builder.py
@@ -16,7 +16,7 @@ from strictdoc.backend.sdoc.grammar.type_system import (
 class SDocGrammarBuilder:
     @staticmethod
     def _prep_grammar(grammar: str) -> str:
-        return grammar.replace("'\\n'", "'\n'")
+        return grammar.replace("'\\n'", "/\\r?\\n/")
 
     @staticmethod
     def create_grammar() -> str:

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
@@ -1213,3 +1213,42 @@ Multiline status is not allowed.
         "The node field STATUS is a reserved field and can only be written as "
         "a single-line, not multiline, field."
     )
+
+
+def test_crlf_single_line_field():
+    input_sdoc = (
+        "[DOCUMENT]\r\n"
+        "TITLE: Test Doc\r\n"
+        "\r\n"
+        "[REQUIREMENT]\r\n"
+        "STATEMENT: Test statement.\r\n"
+    )
+
+    reader = SDReader()
+
+    document = reader.read(input_sdoc)
+    assert isinstance(document, SDocDocument)
+    assert document.title == "Test Doc"
+    node = document.section_contents[0]
+    assert isinstance(node, SDocNode)
+    assert node.reserved_statement == "Test statement."
+
+
+def test_crlf_multiline_field():
+    input_sdoc = (
+        "[DOCUMENT]\r\n"
+        "TITLE: Test Doc\r\n"
+        "\r\n"
+        "[REQUIREMENT]\r\n"
+        "STATEMENT: >>>\r\n"
+        "Multiline content.\r\n"
+        "<<<\r\n"
+    )
+
+    reader = SDReader()
+
+    document = reader.read(input_sdoc)
+    assert isinstance(document, SDocDocument)
+    node = document.section_contents[0]
+    assert isinstance(node, SDocNode)
+    assert node.reserved_statement == "Multiline content.\r\n"

--- a/tests/unit/strictdoc/backend/sdoc/test_free_text_reader.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_free_text_reader.py
@@ -17,7 +17,7 @@ Modified statement.
     with pytest.raises(TextXSyntaxError) as exc_info:
         reader.read(free_text_input)
     assert """\
-None:3:13: Expected ', ' or '\\](\\Z|\\n)' => 'NCHOR: AD1*]!!!GARBAG'\
+None:3:13: Expected ', ' or '\\](\\Z|\\r?\\n)' => 'NCHOR: AD1*]!!!GARBAG'\
 """ == str(exc_info.value)
 
 
@@ -124,6 +124,25 @@ Hello world
     assert document.parts[1].value == "AD1"
     assert document.parts[2] == "\n"
     assert document.parts[3].value == "AD2"
+
+
+def test_015_anchor_lf_line_ending():
+    free_text_input = "Section free text.\n\n[ANCHOR: AD1]\n"
+
+    reader = SDFreeTextReader()
+    free_text_container = reader.read(free_text_input)
+    assert free_text_container.parts[0] == "Section free text.\n\n"
+    assert isinstance(free_text_container.parts[1], Anchor)
+    assert free_text_container.parts[1].value == "AD1"
+
+
+def test_016_anchor_crlf_line_ending():
+    free_text_input = "Section free text.\r\n\r\n[ANCHOR: AD1]\r\n"
+
+    reader = SDFreeTextReader()
+    free_text_container = reader.read(free_text_input)
+    assert isinstance(free_text_container.parts[1], Anchor)
+    assert free_text_container.parts[1].value == "AD1"
 
 
 def test_020_link():


### PR DESCRIPTION
What: Let the sdoc textX grammar recognize both `\n` and `\r\n` as line endings.

Why: The grammar made an implicit assumption that it would only ever see input that has been normalized by Python's text mode read, which converts `\r\n` to `\n`. This assumption should go away because:
- it is implicit and therefore fragile,
- there are code paths that do not go through Python text mode read, e.g. when feeding strings to SDFreeTextReader that come from source node fields extracted by tree-sitter as done in #2917, which reads raw bytes.
- the textX grammar should be reusable outside StrictDoc, e.g. for syntax highlighters, where there is also no normalization guarantee.

How: For symbols that are delimited by line break, match `\r?\n` as line break, consistent with the Lark grammar used by the source node parser which already uses CR? LF. Some adjustments in negative lookaheads and prepare_grammar follow from that.