### PR TITLE
feat(markdown): add and specify the behavior of the node TYPE meta field

### DIFF
--- a/developer/tasks/20260618_node_type/task.md
+++ b/developer/tasks/20260618_node_type/task.md
@@ -1,0 +1,121 @@
+# Extend the Markdown specification to support node TYPE
+
+## WHAT
+
+Extend the Markdown specification to support node TYPE.
+
+If a TYPE is specified explicitly for a node, this node type shall be preserved across all operations, such as UI editing, running `format` or `manage auto-uid` commands, etc.
+
+This rules extends to the SECTION element as well as to all other elements, such as the default REQUIREMENT or other custom elements, such as ASSUMPTION, TEST_CASE, etc.
+
+The TYPE-related rules do not extend/cover the TEXT nodes whose Markdown rules are not affected by this node TYPE feature.
+
+To define whether or not a node shall have an explicit node type, StrictDoc shall derive it from the document grammar using the following rules:
+
+- If a document grammar has elements outside of the default set {"SECTION", "TEXT", "REQUIREMENT"}, the REQUIREMENT and nodes other than SECTION and TEXT shall have their TYPE specified explicitly.
+
+The SECTION node must not have a STATEMENT field defined for its grammar element. This is to ensure there is no conflict possible with TEXT nodes that are children nodes to a SECTION node.
+
+If a TEXT grammar element defines an MID field, all TEXT nodes must appear in the document along with their `TYPE` and `MID` values explicitly specified. If a text node in such a grammar is missing in the Markdown file initially, StrictDoc shall parse the document without raising a validation error. However, when writing a document back, the written file shall contain explicit `TYPE`/`MID` fields.
+
+### Updates to Markdown specification
+
+The following cases shall be reflected explicitly:
+
+- In the Markdown specification.
+- In the unit tests.
+- In the integration tests.
+- In the end-to-end tests.
+
+#### SECTION with TYPE/MID + TEXT without meta information
+
+```markdown
+# Document title
+
+**Grammar**: requirements.gra.md
+
+## Introduction
+
+**TYPE**: SECTION \
+**MID**: 11111111111111111111111111111111
+
+**STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+```
+
+#### SECTION with TYPE/MID + TEXT with TYPE/MID
+
+```markdown
+# Document title
+
+**Grammar**: requirements.gra.md
+
+## Introduction
+
+**TYPE**: SECTION \
+**MID**: 11111111111111111111111111111111
+
+**TYPE**: TEXT \
+**MID**: 22222222222222222222222222222222
+
+**STATEMENT**: This is a text statement.
+```
+
+## WHY
+
+This allows StrictDoc to distinguish between different node types when it parses Markdown nodes.
+
+## HOW
+
+### Implementation details
+
+- Update the Markdown specification to reflect the formality of the node TYPE.
+
+**Reader** (`strictdoc/backend/markdown/reader.py`):
+
+- `ParsedMarkdownNode` gains two new fields: `explicit_node_type` (the value from `**TYPE**:`) and `processed_body` (body after the meta block, used when `TYPE=SECTION` to prevent the raw `**TYPE**:` line from becoming a TEXT child).
+- `_parse_markdown_node` strips the `TYPE` field from the parsed fields before validation. If `TYPE=SECTION` the node is forced to become a section; any other explicit TYPE value bypasses the UID/MID and STATEMENT requirements so the node is always accepted as a typed node.
+- `_create_requirement_node` gains a `node_type` parameter (default `"REQUIREMENT"`) so non-REQUIREMENT custom types are constructed directly.
+
+**Writer** (`strictdoc/backend/markdown/writer.py`):
+
+- `_serialize_node_fields` calls `Grammar.has_custom_elements()` to decide whether to prepend `**TYPE**: <name>` to the meta block. TYPE is emitted for every non-TEXT node (including SECTION) when the grammar has custom elements. SECTION must be included because the reader treats any heading that has a meta block as a typed node under a custom grammar, so omitting TYPE: SECTION would cause the reader to mis-classify the SECTION as a REQUIREMENT on the next read.
+
+**Grammar** (`strictdoc/backend/sdoc/models/document_grammar.py`):
+
+- `DocumentGrammar.has_custom_elements()` encapsulates the detection logic: returns `True` when `elements_by_type` contains any element type outside `{"SECTION", "TEXT", "REQUIREMENT"}`. When the grammar is not yet resolved (empty `elements_by_type` but `import_from_file` set) it returns `True` as a safe fallback.
+
+**Markdown specification** (`spec/Markdown.md`):
+
+- MD-25 documents the reader behaviour for the TYPE field.
+- MD-26 documents the writer emission rule and its grammar-based condition.
+
+### Valid examples as per this task
+
+```markdown
+# Document example
+
+**Grammar**: @DO-178C-MD
+
+## Test Section
+
+**TYPE**: SECTION
+
+### Requirement nested in a section
+
+**TYPE**: REQUIREMENT \
+**MID**: 6758694447fe418ba1ca94dc1080acf0 \
+**UID**: REQ-3 \
+**DERIVED**: No \
+**SAFETY**: No \
+**SECURITY**: No
+
+Some statement text.
+
+### Assumption nested in a section
+
+**TYPE**: ASSUMPTION \
+**MID**: 123456744357418ba17a94dc1080a865 \
+**UID**: REQ-3 \
+
+Some statement text.
+```

--- a/spec/Formatting.md
+++ b/spec/Formatting.md
@@ -61,7 +61,9 @@ document. It only changes line-break positions within wrappable prose.
 **MID**: e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1 \
 **UID**: FMT-6
 
-**STATEMENT**: The formatter preserves the following block types unchanged,
+**STATEMENT**:
+
+The formatter preserves the following block types unchanged,
 regardless of line length:
 
 - Fenced code blocks (Markdown ` ``` ` or `~~~`, and analogous RST forms).
@@ -78,7 +80,9 @@ regardless of line length:
 **MID**: f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2 \
 **UID**: FMT-7
 
-**STATEMENT**: The formatter treats inline links as atomic tokens that are
+**STATEMENT**:
+
+The formatter treats inline links as atomic tokens that are
 never broken across lines:
 
 - Markdown inline links: `[text](url)`
@@ -97,7 +101,9 @@ when no line-break position within the token exists.
 **MID**: 08b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3 \
 **UID**: FMT-MD-1
 
-**STATEMENT**: The formatter recognises and preserves the following unordered
+**STATEMENT**:
+
+The formatter recognises and preserves the following unordered
 Markdown list markers: `-`, `*`, `+`. The following ordered list markers are
 also recognised: digit-based styles such as `1.`, `2.`, `1)`.
 
@@ -109,7 +115,9 @@ preserved.
 **MID**: 19c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4 \
 **UID**: FMT-MD-2
 
-**STATEMENT**: When a Markdown list item is wrapped, continuation lines are
+**STATEMENT**:
+
+When a Markdown list item is wrapped, continuation lines are
 indented to align with the content of the list item, not with the list marker.
 
 Example:
@@ -129,7 +137,9 @@ the marker (including its trailing space). For a `- ` marker the indent is
 **MID**: 2ad1e2f3a4b5c6d7e8f9a0b1c2d3e4f5 \
 **UID**: FMT-MD-3
 
-**STATEMENT**: The formatter does not rewrap the following Markdown constructs:
+**STATEMENT**:
+
+The formatter does not rewrap the following Markdown constructs:
 
 - ATX headings (lines starting with one to six `#` characters).
 - Fenced code blocks (content between ` ``` ` or `~~~` fence lines).
@@ -145,7 +155,9 @@ the marker (including its trailing space). For a `- ` marker the indent is
 **MID**: 3be2f3a4b5c6d7e8f9a0b1c2d3e4f5a6 \
 **UID**: FMT-RST-1
 
-**STATEMENT**: The formatter recognises and preserves the following RST list
+**STATEMENT**:
+
+The formatter recognises and preserves the following RST list
 markers:
 
 - Unordered: `-`, `*`, `+`.
@@ -159,7 +171,9 @@ markers:
 **MID**: 4cf3a4b5c6d7e8f9a0b1c2d3e4f5a6b7 \
 **UID**: FMT-RST-2
 
-**STATEMENT**: When an RST list item is wrapped, continuation lines are
+**STATEMENT**:
+
+When an RST list item is wrapped, continuation lines are
 indented to align with the content of the list item, not with the list marker.
 
 Example:
@@ -180,7 +194,9 @@ the marker (including its trailing space).
 **MID**: 5da4b5c6d7e8f9a0b1c2d3e4f5a6b7c8 \
 **UID**: FMT-RST-3
 
-**STATEMENT**: The formatter does not rewrap the following RST constructs:
+**STATEMENT**:
+
+The formatter does not rewrap the following RST constructs:
 
 - Any line with leading whitespace (indented code, continuation lines, or
   nested content).
@@ -215,7 +231,9 @@ the same line-break rules as FMT-SD-1.
 **MID**: 80d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1 \
 **UID**: FMT-SD-3
 
-**STATEMENT**: If an inline link or a StrictDoc cross-reference keyword
+**STATEMENT**:
+
+If an inline link or a StrictDoc cross-reference keyword
 (`[LINK: uid]` or `[ANCHOR: uid]`) is the first content of a list item —
 immediately following the list marker with no preceding prose — the formatter
 keeps the token on the same line as the list marker, even if the resulting line

--- a/spec/Markdown.md
+++ b/spec/Markdown.md
@@ -100,7 +100,18 @@ The node body consists of three consecutive regions:
 
 A node terminates at the next heading or end of file.
 
-### Sections
+### Node without title
+
+**MID**: b0294b7fcb4343f19fbab31c399849fb \
+**UID**: MD-29
+
+**STATEMENT**:
+
+A node without a title is a special case of the node defined by MD-21.
+
+Compared to a node with a title, a node without a title starts directly with a node body.
+
+### SECTION node
 
 **MID**: 7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d \
 **UID**: MD-7
@@ -111,7 +122,14 @@ An H2–H6 heading that does not qualify as a requirement node (see MD-8, MD-9) 
 
 Free-form Markdown prose in a section body is stored as a TEXT node.
 
-### Requirement nodes — default grammar
+### TEXT node
+
+**MID**: 1a8b12341e2f3a4b5c6d7e8f9a0b1c2d \
+**UID**: MD-30
+
+**STATEMENT**: TEXT nodes are always nodes without a title. Parsing a TEXT element with a TITLE shall raise a validation error.
+
+### Default grammar
 
 **MID**: 8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e \
 **UID**: MD-8
@@ -128,14 +146,14 @@ Without a custom grammar, an H2–H6 heading becomes a REQUIREMENT node when all
 
 The heading text is assigned to the `TITLE` field.
 
-### Requirement nodes — custom grammar
+### Custom grammar
 
 **MID**: 9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f \
 **UID**: MD-9
 
 **STATEMENT**:
 
-With a custom grammar, an H2–H6 heading becomes a REQUIREMENT node when the meta block contains at least one field and the heading text is non-empty.
+With a custom grammar, an H2–H6 heading becomes a node when the meta block contains at least one field and the heading text is non-empty.
 
 Field validation against the grammar schema is deferred to a later build stage. The heading text is assigned to the `TITLE` field.
 
@@ -153,6 +171,117 @@ This is the Markdown equivalent of SDoc's document-level `ENABLE_MID` option. Th
 On the first write-back, every node without a `MID` receives a freshly generated UUID. On subsequent reads, the persisted value is loaded and the node's machine identifier is treated as permanent.
 
 This behavior applies only to custom (user-defined) grammars. The built-in default grammar also declares `MID` for the `REQUIREMENT` element, but the default grammar does not trigger auto-generation.
+
+### Node TYPE field — reader behaviour
+
+**MID**: a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8 \
+**UID**: MD-25
+
+**STATEMENT**:
+
+The `**TYPE**: <name>` meta field specifies the element type of a node explicitly and takes precedence over the automatic node-type determination rules of MD-7, MD-8, and MD-9.
+
+- `**TYPE**: SECTION` forces the heading to become a SECTION regardless of other fields. Any content following the meta block (after the TYPE line) forms a TEXT child as usual; the TYPE line itself is not included in the TEXT body.
+- Any other `**TYPE**: <name>` value forces the heading to become a node of type `<name>`, bypassing the UID/MID and STATEMENT requirements of MD-8. Grammar field validation is deferred to the build stage as per MD-9.
+
+The TYPE field is parsed out of the meta block and is not forwarded as a regular node field.
+
+### Node TYPE field — writer behaviour
+
+**MID**: b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9 \
+**UID**: MD-26
+
+**STATEMENT**:
+
+When a document's grammar defines element types outside the built-in set `{SECTION, TEXT, REQUIREMENT}`, the writer emits `**TYPE**: <name>` as the first field in the meta block of every non-TEXT node (including SECTION). This ensures the element type is preserved across `format`, `manage auto-uid`, and UI-edit operations.
+
+SECTION is included because the reader treats any heading with a valid meta block as a typed node when a custom grammar is active; without `**TYPE**: SECTION` the reader would mis-classify a SECTION node as a REQUIREMENT on the next read.
+
+When the grammar only contains built-in element types the TYPE field is not emitted. The determination is performed by `Grammar.has_custom_elements()`.
+
+### SECTION MID with TEXT child — no TEXT meta
+
+**MID**: c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0 \
+**UID**: MD-27
+
+**STATEMENT**:
+
+When a SECTION heading carries both `**TYPE**: SECTION` and a `**MID**` field in its meta block, the MID is preserved as the section's machine identifier across all read-write cycles.
+
+Any content following the section meta block (after the next blank line) forms a TEXT child node whose statement is the verbatim body text. The `**TYPE**:` line from the meta block is not included in the TEXT body.
+
+The behavior of the TEXT child on a subsequent format pass depends on whether the document grammar declares a `MID` field for the `TEXT` element.
+
+**Subcase A: Grammar does NOT declare MID for TEXT**
+
+The writer emits the TEXT statement as plain verbatim content — no `**TYPE**:` or `**MID**:` prefix is added. The SECTION MID is still preserved.
+
+Example (input and output are identical after a format pass):
+
+```markdown
+## Introduction
+
+**TYPE**: SECTION \
+**MID**: 11111111111111111111111111111111
+
+**STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+```
+
+**Subcase B: Grammar declares MID for TEXT**
+
+The writer automatically emits a `**TYPE**: TEXT \` / `**MID**: <mid>` prefix before the TEXT statement body, auto-generating the MID if not already present. This ensures every TEXT node has a tracked machine identifier.
+
+Example input (TEXT child without explicit MID):
+
+```markdown
+## Introduction
+
+**TYPE**: SECTION \
+**MID**: 11111111111111111111111111111111
+
+**STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+```
+
+After a format pass with a grammar that declares `MID` for `TEXT`, the output becomes:
+
+```markdown
+## Introduction
+
+**TYPE**: SECTION \
+**MID**: 11111111111111111111111111111111
+
+**TYPE**: TEXT \
+**MID**: <auto-generated-mid>
+
+**STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+```
+
+### SECTION MID with TEXT child — TEXT TYPE and MID present
+
+**MID**: d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1 \
+**UID**: MD-28
+
+**STATEMENT**:
+
+When the section body begins with a `**TYPE**: TEXT \` / `**MID**: <value>` prefix block (separated by a blank line from the following content), the reader extracts the `MID` value as the TEXT child node's machine identifier. The remaining body text becomes the TEXT statement.
+
+The writer re-emits this prefix whenever the grammar's `TEXT` element declares a `MID` field, preserving the TEXT MID across format passes.
+
+Example:
+
+```markdown
+## Introduction
+
+**TYPE**: SECTION \
+**MID**: 11111111111111111111111111111111
+
+**TYPE**: TEXT \
+**MID**: 22222222222222222222222222222222
+
+**STATEMENT**: This is a text statement.
+```
+
+After a format pass the SECTION MID (11111111111111111111111111111111) is preserved in the section meta block, and the TEXT MID (22222222222222222222222222222222) is preserved in the TEXT prefix block.
 
 ### Meta-field styles
 
@@ -201,7 +330,7 @@ When a dictionary appears as an item in a bullet list (as in RELATIONS), continu
 
 The `RELATIONS` field is a list-valued meta field. It must immediately follow the rest of the meta block without an intervening blank line.
 
-Its value is a bullet list where each item represents one relation. Within an item, attributes are written as `**Key**: \`value\`` pairs; continuation lines are indented by two spaces and end with ` \` except for the last pair.
+Its value is a bullet list where each item represents one relation. Within an item, attributes are written as `**<Key>**: <Value>` pairs; continuation lines are indented by two spaces and end with ` \` except for the last pair.
 
 A `RELATIONS` list must contain at least one item.
 
@@ -223,7 +352,7 @@ An optional `**Role**` key names the relation role. No other keys are allowed.
 
 **STATEMENT**:
 
-A File relation requires `**Type**: \`File\`` and a mandatory `**Path**` key.
+A File relation requires `**Type**: File` and a mandatory `**Path**` key.
 
 Optional keys are `**Lines**` (line range), `**Element**` (language element type), `**ID**` (element identifier), and `**Hash**` (content hash).
 

--- a/strictdoc/backend/markdown/reader.py
+++ b/strictdoc/backend/markdown/reader.py
@@ -33,6 +33,7 @@ from strictdoc.backend.sdoc_source_code.reader_registry import (
 )
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.helpers.cast import assert_cast
+from strictdoc.helpers.mid import MID
 from strictdoc.helpers.string import strip_bom
 
 
@@ -61,6 +62,10 @@ class ParsedMarkdownNode:
     fields: List[ParsedField]
     valid_for_requirement: bool
     has_duplicates: bool
+    explicit_node_type: Optional[str] = None
+    # When explicit_node_type == "SECTION", body after the meta block (TYPE
+    # stripped) so the raw **TYPE**: line is not duplicated as a TEXT child.
+    processed_body: Optional[str] = None
 
 
 class SDMarkdownReader:
@@ -69,6 +74,10 @@ class SDMarkdownReader:
     plain_field_pattern = re.compile(
         r"^\*\*(?P<name>[A-Za-z0-9][A-Za-z0-9 _-]*)\*\*:(?P<value>.*)$"
     )
+    # Patterns for detecting the **TYPE**: TEXT \ **MID**: ... prefix in TEXT
+    # node bodies (used when the grammar's TEXT element declares a MID field).
+    _text_type_line_re = re.compile(r"^\*\*TYPE\*\*: TEXT(?: \\)?$")
+    _text_mid_line_re = re.compile(r"^\*\*MID\*\*: (\S+)$")
     dict_entry_pattern = re.compile(
         r"^\s*\*\*(?P<name>[A-Za-z0-9][A-Za-z0-9 _-]*)\*\*:\s*`?(?P<value>[^`]*)`?\s*(?:\\)?$"
     )
@@ -390,6 +399,7 @@ class SDMarkdownReader:
                     including_document_reference=including_document_reference,
                     file_path=file_path,
                     project_config=project_config,
+                    node_type=parsed_node.explicit_node_type or "REQUIREMENT",
                 )
                 parent_node.section_contents.append(requirement_node)
                 stack.append((heading_node.level, requirement_node))
@@ -421,14 +431,45 @@ class SDMarkdownReader:
                 section_node.ng_including_document_reference = (
                     including_document_reference
                 )
+                # Preserve MID from the section meta block (e.g. **TYPE**: SECTION \ **MID**: ...).
+                # create_section does not accept fields, so we patch it in afterwards.
+                # MID must be inserted before TITLE to match the grammar field order.
+                mid_field = next(
+                    (f for f in parsed_node.fields if f.name == "MID"), None
+                )
+                if mid_field is not None:
+                    mid_sdoc_field = SDocNodeField.create_from_string(
+                        parent=section_node,
+                        field_name="MID",
+                        field_value=mid_field.value,
+                        multiline=False,
+                    )
+                    existing = list(section_node.ordered_fields_lookup.items())
+                    section_node.ordered_fields_lookup.clear()
+                    section_node.ordered_fields_lookup["MID"] = [mid_sdoc_field]
+                    section_node.ordered_fields_lookup.update(existing)
+                    section_node.reserved_mid = MID(mid_field.value)
+                    section_node.mid_permanent = True
                 parent_node.section_contents.append(section_node)
 
-                if len(heading_node.body) > 0:
+                # When TYPE was explicit, use the processed body (meta block
+                # already stripped) to avoid duplicating the **TYPE**: line as
+                # a TEXT child.  Otherwise fall back to the raw heading body.
+                effective_body = (
+                    parsed_node.processed_body
+                    if parsed_node.processed_body is not None
+                    else heading_node.body
+                )
+                if len(effective_body) > 0:
+                    text_mid, text_statement = (
+                        SDMarkdownReader._try_parse_text_meta(effective_body)
+                    )
                     text_node = SDMarkdownReader._create_text_node(
                         parent=section_node,
-                        statement=heading_node.body,
+                        statement=text_statement,
                         document_reference=document_reference,
                         including_document_reference=including_document_reference,
+                        mid=text_mid,
                     )
                     section_node.section_contents.append(text_node)
 
@@ -633,6 +674,23 @@ class SDMarkdownReader:
         )
 
         parsed_fields = meta_fields + content_fields
+
+        # Extract TYPE before further validation; it controls the node type and
+        # must not be forwarded as a regular SDoc field.
+        # Only the first TYPE field is honoured: for SECTION nodes the body may
+        # contain a **TYPE**: TEXT \ prefix in the TEXT child content (MD-28),
+        # and that body-level TYPE must not override the meta-block TYPE.
+        explicit_node_type: Optional[str] = None
+        parsed_fields_without_type: List[ParsedField] = []
+        for field_ in parsed_fields:
+            if field_.name == "TYPE":
+                if explicit_node_type is None:
+                    explicit_node_type = field_.value.strip()
+                # Subsequent TYPE fields (e.g. in the TEXT body) are discarded.
+            else:
+                parsed_fields_without_type.append(field_)
+        parsed_fields = parsed_fields_without_type
+
         parsed_field_names = list(
             map(lambda field_: field_.name, parsed_fields)
         )
@@ -648,7 +706,18 @@ class SDMarkdownReader:
             len(field_.value) == 0 for field_ in parsed_fields
         )
 
-        if has_custom_grammar:
+        if explicit_node_type == "SECTION":
+            # Explicit TYPE: SECTION always creates a section, regardless of
+            # whether the body would otherwise qualify as a requirement.
+            valid_for_requirement = False
+        elif explicit_node_type is not None:
+            # Any other explicit TYPE is accepted as long as the markdown syntax
+            # is well-formed and the heading has a non-empty title.  Grammar
+            # field validation is deferred to TraceabilityIndexBuilder.
+            valid_for_requirement = (
+                meta_is_valid and content_is_valid and len(title) > 0
+            )
+        elif has_custom_grammar:
             # When a custom grammar is attached, drop the hardcoded UID/STATEMENT
             # assumptions and defer field validation to TraceabilityIndexBuilder.
             valid_for_requirement = (
@@ -670,10 +739,20 @@ class SDMarkdownReader:
                 and len(title) > 0
             )
 
+        # For explicit SECTION nodes, record the body after the meta block so
+        # that _create_document_tree can skip the raw **TYPE**: lines when
+        # building the TEXT child (otherwise TYPE would appear both as a field
+        # and as prose inside the section).
+        processed_body: Optional[str] = None
+        if explicit_node_type == "SECTION":
+            processed_body = "".join(body_lines_without_meta)
+
         return ParsedMarkdownNode(
             fields=parsed_fields,
             valid_for_requirement=valid_for_requirement,
             has_duplicates=has_duplicates,
+            explicit_node_type=explicit_node_type,
+            processed_body=processed_body,
         )
 
     @staticmethod
@@ -864,6 +943,35 @@ class SDMarkdownReader:
         line_index = 0
         line_count = len(body_lines)
 
+        # Pre-compute line indices that fall *inside* fenced code blocks
+        # (between the opening and closing fence markers).  Those lines must
+        # not be matched against plain_field_pattern — they are opaque content.
+        fence_interior: Set[int] = set()
+        _fence_open_re = re.compile(r"^(`{3,}|~{3,})")
+        _fi = 0
+        while _fi < line_count:
+            _m = _fence_open_re.match(
+                SDMarkdownReader._line_without_line_ending(body_lines[_fi])
+            )
+            if _m:
+                _fence_char = _m.group(1)[0]
+                _fence_min = len(_m.group(1))
+                _close_re = re.compile(
+                    rf"^{re.escape(_fence_char)}{{{_fence_min},}}\s*$"
+                )
+                _fi += 1
+                while _fi < line_count:
+                    _inner = SDMarkdownReader._line_without_line_ending(
+                        body_lines[_fi]
+                    )
+                    if _close_re.match(_inner):
+                        _fi += 1
+                        break
+                    fence_interior.add(_fi)
+                    _fi += 1
+            else:
+                _fi += 1
+
         while line_index < line_count:
             line = body_lines[line_index]
             if SDMarkdownReader._is_empty_line(line):
@@ -910,7 +1018,7 @@ class SDMarkdownReader:
 
             line_text = SDMarkdownReader._line_without_line_ending(line)
             plain_match = SDMarkdownReader.plain_field_pattern.match(line_text)
-            if plain_match is not None:
+            if plain_match is not None and line_index not in fence_interior:
                 field_name_upper = plain_match.group("name").upper()
                 field_name_human = plain_match.group("name")
                 inline_value = SDMarkdownReader._trim_single_space_prefix(
@@ -932,6 +1040,7 @@ class SDMarkdownReader:
                                 candidate_line_text
                             )
                             is not None
+                            and line_index not in fence_interior
                         ):
                             break
                         continuation_lines.append(candidate_line)
@@ -987,6 +1096,7 @@ class SDMarkdownReader:
                             candidate_line_text
                         )
                         is not None
+                        and line_index not in fence_interior
                     ):
                         break
                     if is_list_field and SDMarkdownReader._is_empty_line(
@@ -1013,8 +1123,11 @@ class SDMarkdownReader:
                 candidate_line_text = (
                     SDMarkdownReader._line_without_line_ending(candidate_line)
                 )
-                if SDMarkdownReader.plain_field_pattern.match(
-                    candidate_line_text
+                if (
+                    SDMarkdownReader.plain_field_pattern.match(
+                        candidate_line_text
+                    )
+                    and line_index not in fence_interior
                 ):
                     break
                 statement_lines.append(candidate_line)
@@ -1042,8 +1155,9 @@ class SDMarkdownReader:
         including_document_reference: DocumentReference,
         file_path: Optional[str] = None,
         project_config: Optional[ProjectConfig] = None,
+        node_type: str = "REQUIREMENT",
     ) -> SDocNode:
-        """Build a REQUIREMENT SDocNode from parsed fields, attaching relations and document references."""
+        """Build a SDocNode from parsed fields, attaching relations and document references."""
         parsed_meta_fields: List[ParsedField] = []
         parsed_content_fields: List[ParsedField] = []
         relations_field: Optional[ParsedField] = None
@@ -1086,7 +1200,7 @@ class SDMarkdownReader:
 
         requirement = SDocNode(
             parent=parent,
-            node_type="REQUIREMENT",
+            node_type=node_type,
             fields=requirement_fields,
             relations=[],
         )
@@ -1106,24 +1220,72 @@ class SDMarkdownReader:
         return requirement
 
     @staticmethod
+    def _try_parse_text_meta(body: str) -> Tuple[Optional[str], str]:
+        r"""
+        Detect and extract a **TYPE**: TEXT \\ **MID**: <value> prefix block
+        from a section body string.
+
+        Returns (mid_value, remaining_body) when the prefix is found, or
+        (None, body) when it is not present.  The remaining_body is the content
+        after the blank line that follows the meta block.
+        """
+        lines = body.splitlines(keepends=True)
+        if len(lines) < 2:
+            return None, body
+
+        line0 = lines[0].rstrip("\r\n")
+        if not SDMarkdownReader._text_type_line_re.match(line0):
+            return None, body
+
+        line1 = lines[1].rstrip("\r\n")
+        mid_match = SDMarkdownReader._text_mid_line_re.match(line1)
+        if not mid_match:
+            return None, body
+
+        mid_value = mid_match.group(1)
+
+        idx = 2
+        while idx < len(lines) and not SDMarkdownReader._is_empty_line(
+            lines[idx]
+        ):
+            idx += 1
+        while idx < len(lines) and SDMarkdownReader._is_empty_line(lines[idx]):
+            idx += 1
+
+        remaining = "".join(lines[idx:])
+        return mid_value, remaining
+
+    @staticmethod
     def _create_text_node(
         parent: Union[SDocDocument, SDocNode],
         statement: str,
         document_reference: DocumentReference,
         including_document_reference: DocumentReference,
+        mid: Optional[str] = None,
     ) -> SDocNode:
         """Build a TEXT SDocNode wrapping raw Markdown prose."""
+        fields = []
+        if mid is not None:
+            fields.append(
+                SDocNodeField.create_from_string(
+                    parent=None,
+                    field_name="MID",
+                    field_value=mid,
+                    multiline=False,
+                )
+            )
+        fields.append(
+            SDocNodeField.create_from_string(
+                parent=None,
+                field_name="STATEMENT",
+                field_value=statement,
+                multiline="\n" in statement,
+            )
+        )
         text_node = SDocNode(
             parent=parent,
             node_type="TEXT",
-            fields=[
-                SDocNodeField.create_from_string(
-                    parent=None,
-                    field_name="STATEMENT",
-                    field_value=statement,
-                    multiline="\n" in statement,
-                )
-            ],
+            fields=fields,
             relations=[],
         )
         text_node.ng_document_reference = document_reference

--- a/strictdoc/backend/markdown/writer.py
+++ b/strictdoc/backend/markdown/writer.py
@@ -174,6 +174,18 @@ class SDMarkdownWriter:
                 node.node_type, None
             )
 
+        # Emit TYPE for every non-TEXT node when the grammar defines element
+        # types beyond the built-in set (see MD-26). SECTION is included
+        # because the reader treats any heading with a valid meta block as a
+        # typed node when a custom grammar is active; without TYPE: SECTION the
+        # reader would mis-classify a SECTION as a REQUIREMENT on re-read.
+        if (
+            document_grammar is not None
+            and document_grammar.has_custom_elements()
+            and node.node_type != "TEXT"
+        ):
+            meta_fields.append(("TYPE", node.node_type))
+
         # If a custom (user-defined) grammar declares MID and the node doesn't
         # have one, auto-write the reserved_mid so it becomes permanent on the
         # next read. This is the Markdown equivalent of SDoc's ENABLE_MID.
@@ -349,6 +361,33 @@ class SDMarkdownWriter:
         ).strip("\n")
         if line_width is not None:
             statement_value = wrap_md_text(statement_value, line_width)
+
+        # When the grammar's TEXT element declares a MID field, emit
+        # **TYPE**: TEXT \ **MID**: <mid> before the statement body so that
+        # the TEXT node's machine identifier is preserved across read/write cycles.
+        document = node.get_document()
+        if document is not None and document.grammar is not None:
+            grammar = assert_cast(document.grammar, DocumentGrammar)
+            text_element = grammar.elements_by_type.get("TEXT", None)
+            if (
+                text_element is not None
+                and "MID" in text_element.fields_map
+                and not grammar.is_default
+            ):
+                existing_mid_fields = node.ordered_fields_lookup.get(
+                    "MID", None
+                )
+                if existing_mid_fields:
+                    mid_str = existing_mid_fields[0].get_text_value()
+                else:
+                    mid_str = str(node.reserved_mid)
+                meta_block = SDMarkdownWriter._serialize_meta_fields(
+                    [("TYPE", "TEXT"), ("MID", mid_str)]
+                )
+                if len(statement_value) > 0:
+                    return f"{meta_block}\n\n{statement_value}"
+                return meta_block
+
         return statement_value
 
     @staticmethod

--- a/strictdoc/backend/sdoc/models/document_grammar.py
+++ b/strictdoc/backend/sdoc/models/document_grammar.py
@@ -269,6 +269,22 @@ class DocumentGrammar(SDocGrammarIF):
                 return True
         return False
 
+    def has_custom_elements(self) -> bool:
+        """
+        Return True when the grammar defines element types beyond the
+        built-in set {SECTION, TEXT, REQUIREMENT}.
+
+        When the grammar has not yet been resolved (elements_by_type is
+        empty but import_from_file is set), True is returned so that the
+        Markdown writer can emit TYPE fields for round-trip safety.
+        """
+        if self.is_default:
+            return False
+        _builtin = {"SECTION", "TEXT", "REQUIREMENT"}
+        if len(self.elements_by_type) == 0:
+            return self.import_from_file is not None
+        return any(t not in _builtin for t in self.elements_by_type)
+
     def add_element_first(self, element: GrammarElement) -> None:
         self.elements.insert(0, element)
         self.elements_by_type[element.tag] = element

--- a/tests/integration/features/commands/format/05_markdown_section_mid_text/input.md
+++ b/tests/integration/features/commands/format/05_markdown_section_mid_text/input.md
@@ -1,0 +1,10 @@
+# Document title
+
+**Grammar**: requirements.gra.md
+
+## Introduction
+
+**TYPE**: SECTION \
+**MID**: 11111111111111111111111111111111
+
+**STATEMENT**: This is a TEXT node statement, not a SECTION node statement.

--- a/tests/integration/features/commands/format/05_markdown_section_mid_text/requirements.gra.md
+++ b/tests/integration/features/commands/format/05_markdown_section_mid_text/requirements.gra.md
@@ -1,0 +1,71 @@
+# StrictDoc Markdown Grammar
+
+## Element: SECTION
+
+**Composite**: True
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: TITLE
+
+**Type**: String
+**Required**: True
+
+## Element: TEXT
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False
+
+## Element: REQUIREMENT
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: TITLE
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False
+
+## Element: ASSUMPTION
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: TITLE
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False

--- a/tests/integration/features/commands/format/05_markdown_section_mid_text/strictdoc.toml
+++ b/tests/integration/features/commands/format/05_markdown_section_mid_text/strictdoc.toml
@@ -1,0 +1,2 @@
+[project]
+title = "Test"

--- a/tests/integration/features/commands/format/05_markdown_section_mid_text/test.itest
+++ b/tests/integration/features/commands/format/05_markdown_section_mid_text/test.itest
@@ -1,0 +1,33 @@
+REQUIRES: PLATFORM_IS_NOT_WINDOWS
+
+#
+# Verify MD-27: SECTION with TYPE+MID meta block; grammar TEXT element has MID.
+# The SECTION MID is preserved across format passes.
+# The TEXT child gets TYPE+MID auto-assigned on the first format pass.
+# A second format pass must produce identical output (idempotency).
+#
+
+RUN: mkdir -p %T/pass1
+RUN: cp %S/input.md %T/pass1/input.md
+RUN: cp %S/requirements.gra.md %T/pass1/requirements.gra.md
+RUN: cp %S/strictdoc.toml %T/pass1/strictdoc.toml
+
+RUN: %strictdoc format %T/pass1/
+
+RUN: %cat %T/pass1/input.md | filecheck %s --dump-input=fail
+
+# SECTION meta block: TYPE and original MID are preserved.
+CHECK: **TYPE**: SECTION \
+CHECK-NEXT: **MID**: 11111111111111111111111111111111
+
+# TEXT child: TYPE and auto-generated MID are emitted.
+CHECK: **TYPE**: TEXT \
+CHECK-NEXT: **MID**:
+
+# TEXT statement content is preserved.
+CHECK: **STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+
+# Second pass must produce identical output (idempotency).
+RUN: cp -r %T/pass1 %T/pass2
+RUN: %strictdoc format %T/pass2/
+RUN: diff %T/pass1/input.md %T/pass2/input.md

--- a/tests/integration/features/commands/format/06_markdown_section_mid_text_mid/input.md
+++ b/tests/integration/features/commands/format/06_markdown_section_mid_text_mid/input.md
@@ -1,0 +1,13 @@
+# Document title
+
+**Grammar**: requirements.gra.md
+
+## Introduction
+
+**TYPE**: SECTION \
+**MID**: 11111111111111111111111111111111
+
+**TYPE**: TEXT \
+**MID**: 22222222222222222222222222222222
+
+**STATEMENT**: This is a text statement.

--- a/tests/integration/features/commands/format/06_markdown_section_mid_text_mid/requirements.gra.md
+++ b/tests/integration/features/commands/format/06_markdown_section_mid_text_mid/requirements.gra.md
@@ -1,0 +1,71 @@
+# StrictDoc Markdown Grammar
+
+## Element: SECTION
+
+**Composite**: True
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: TITLE
+
+**Type**: String
+**Required**: True
+
+## Element: TEXT
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False
+
+## Element: REQUIREMENT
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: TITLE
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False
+
+## Element: ASSUMPTION
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: TITLE
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False

--- a/tests/integration/features/commands/format/06_markdown_section_mid_text_mid/strictdoc.toml
+++ b/tests/integration/features/commands/format/06_markdown_section_mid_text_mid/strictdoc.toml
@@ -1,0 +1,2 @@
+[project]
+title = "Test"

--- a/tests/integration/features/commands/format/06_markdown_section_mid_text_mid/test.itest
+++ b/tests/integration/features/commands/format/06_markdown_section_mid_text_mid/test.itest
@@ -1,0 +1,34 @@
+REQUIRES: PLATFORM_IS_NOT_WINDOWS
+
+#
+# Verify MD-28: SECTION with TYPE+MID meta block, where the TEXT child body
+# begins with an embedded **TYPE**: TEXT \ **MID**: ... prefix.
+# The SECTION MID is preserved in the meta block; the embedded TEXT MID
+# (including the TYPE and MID lines) is preserved verbatim in the TEXT body.
+# A second format pass must produce identical output (idempotency).
+#
+
+RUN: mkdir -p %T/pass1
+RUN: cp %S/input.md %T/pass1/input.md
+RUN: cp %S/requirements.gra.md %T/pass1/requirements.gra.md
+RUN: cp %S/strictdoc.toml %T/pass1/strictdoc.toml
+
+RUN: %strictdoc format %T/pass1/
+
+RUN: %cat %T/pass1/input.md | filecheck %s --dump-input=fail
+
+# SECTION meta block: TYPE and original MID are preserved.
+CHECK: **TYPE**: SECTION \
+CHECK-NEXT: **MID**: 11111111111111111111111111111111
+
+# Embedded TEXT MID prefix is preserved verbatim in the TEXT body.
+CHECK: **TYPE**: TEXT \
+CHECK-NEXT: **MID**: 22222222222222222222222222222222
+
+# TEXT statement is preserved.
+CHECK: **STATEMENT**: This is a text statement.
+
+# Second pass must produce identical output (idempotency).
+RUN: cp -r %T/pass1 %T/pass2
+RUN: %strictdoc format %T/pass2/
+RUN: diff %T/pass1/input.md %T/pass2/input.md

--- a/tests/integration/features/commands/format/07_markdown_section_mid_text_no_text_mid/input.md
+++ b/tests/integration/features/commands/format/07_markdown_section_mid_text_no_text_mid/input.md
@@ -1,0 +1,10 @@
+# Document title
+
+**Grammar**: requirements.gra.md
+
+## Introduction
+
+**TYPE**: SECTION \
+**MID**: 11111111111111111111111111111111
+
+**STATEMENT**: This is a TEXT node statement, not a SECTION node statement.

--- a/tests/integration/features/commands/format/07_markdown_section_mid_text_no_text_mid/requirements.gra.md
+++ b/tests/integration/features/commands/format/07_markdown_section_mid_text_no_text_mid/requirements.gra.md
@@ -1,0 +1,66 @@
+# StrictDoc Markdown Grammar
+
+## Element: SECTION
+
+**Composite**: True
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: TITLE
+
+**Type**: String
+**Required**: True
+
+## Element: TEXT
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False
+
+## Element: REQUIREMENT
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: TITLE
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False
+
+## Element: ASSUMPTION
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: TITLE
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False

--- a/tests/integration/features/commands/format/07_markdown_section_mid_text_no_text_mid/strictdoc.toml
+++ b/tests/integration/features/commands/format/07_markdown_section_mid_text_no_text_mid/strictdoc.toml
@@ -1,0 +1,2 @@
+[project]
+title = "Test"

--- a/tests/integration/features/commands/format/07_markdown_section_mid_text_no_text_mid/test.itest
+++ b/tests/integration/features/commands/format/07_markdown_section_mid_text_no_text_mid/test.itest
@@ -1,0 +1,32 @@
+REQUIRES: PLATFORM_IS_NOT_WINDOWS
+
+#
+# Verify MD-27 Subcase A: SECTION with TYPE+MID meta block; grammar TEXT element has NO MID.
+# The SECTION MID is preserved across format passes.
+# The TEXT child is written as plain verbatim content — no TYPE/MID prefix is emitted.
+# A second format pass must produce identical output (idempotency).
+#
+
+RUN: mkdir -p %T/pass1
+RUN: cp %S/input.md %T/pass1/input.md
+RUN: cp %S/requirements.gra.md %T/pass1/requirements.gra.md
+RUN: cp %S/strictdoc.toml %T/pass1/strictdoc.toml
+
+RUN: %strictdoc format %T/pass1/
+
+RUN: %cat %T/pass1/input.md | filecheck %s --dump-input=fail
+
+# SECTION meta block: TYPE and original MID are preserved.
+CHECK: **TYPE**: SECTION \
+CHECK-NEXT: **MID**: 11111111111111111111111111111111
+
+# TEXT statement is written verbatim — no TYPE or MID prefix.
+CHECK: **STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+
+# The output must NOT contain a TYPE field for the TEXT node.
+CHECK-NOT: **TYPE**: TEXT
+
+# Second pass must produce identical output (idempotency).
+RUN: cp -r %T/pass1 %T/pass2
+RUN: %strictdoc format %T/pass2/
+RUN: diff %T/pass1/input.md %T/pass2/input.md

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_roundtrip.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_roundtrip.py
@@ -696,3 +696,331 @@ def test_017_sdoc_to_markdown_roundtrip(
     input_sdoc: str, expected_markdown: str
 ):
     _assert_sdoc_to_markdown_roundtrip(input_sdoc, expected_markdown)
+
+
+# ---------------------------------------------------------------------------
+# TYPE field tests
+# ---------------------------------------------------------------------------
+
+
+def test_018_type_section_input_is_parsed_as_section():
+    """**TYPE**: SECTION in input creates a SECTION; writer drops TYPE for default grammar."""
+    input_markdown = """\
+# Document title
+
+## Test Section
+
+**TYPE**: SECTION
+"""
+    # With the default grammar, TYPE is never written back by the writer.
+    expected_markdown = """\
+# Document title
+
+## Test Section
+"""
+    document, _ = _assert_markdown_roundtrip(input_markdown, expected_markdown)
+
+    section = document.section_contents[0]
+    assert isinstance(section, SDocNode)
+    assert section.node_type == "SECTION"
+    assert section.reserved_title == "Test Section"
+    # No TEXT child: the **TYPE**: line must not become prose.
+    assert len(section.section_contents) == 0
+
+
+def test_019_type_section_with_body_strips_type_line():
+    """**TYPE**: SECTION with a body: TYPE is dropped in output, body text is preserved."""
+    input_markdown = """\
+# Document title
+
+## Test Section
+
+**TYPE**: SECTION
+
+Informative text.
+"""
+    expected_markdown = """\
+# Document title
+
+## Test Section
+
+Informative text.
+"""
+    document, _ = _assert_markdown_roundtrip(input_markdown, expected_markdown)
+
+    section = document.section_contents[0]
+    assert isinstance(section, SDocNode)
+    assert section.node_type == "SECTION"
+    assert len(section.section_contents) == 1
+
+    text_node = section.section_contents[0]
+    assert isinstance(text_node, SDocNode)
+    assert text_node.node_type == "TEXT"
+    assert text_node.reserved_statement is not None
+    assert "Informative text." in text_node.reserved_statement
+    # The raw **TYPE**: line must not appear in the text body.
+    assert "**TYPE**" not in text_node.reserved_statement
+
+
+def test_020_type_requirement_in_default_grammar_strips_type():
+    """
+    **TYPE**: REQUIREMENT in a default-grammar doc is accepted by the reader
+    but not written back (TYPE is only emitted for custom-grammar documents).
+    """
+    input_markdown = """\
+# Document title
+
+## Requirement title
+
+**TYPE**: REQUIREMENT \\
+**UID**: REQ-1
+
+System shall do X.
+"""
+    expected_markdown = """\
+# Document title
+
+## Requirement title
+
+**UID**: REQ-1
+
+**Statement**: System shall do X.
+"""
+    document, _ = _assert_markdown_roundtrip(input_markdown, expected_markdown)
+
+    requirement = document.section_contents[0]
+    assert isinstance(requirement, SDocNode)
+    assert requirement.node_type == "REQUIREMENT"
+    assert requirement.reserved_uid == "REQ-1"
+
+
+def test_021_type_custom_grammar_preserves_node_type():
+    """Custom-grammar documents: TYPE is written for every non-SECTION/TEXT node."""
+    input_markdown = """\
+# Document title
+
+**Grammar**: `requirements.gra.md`
+
+## Some Assumption
+
+**TYPE**: ASSUMPTION \\
+**UID**: ASM-1
+
+Some assumption text.
+"""
+    # Grammar backticks are stripped by the reader and not re-added by the
+    # writer.  With an unresolved grammar (element is None) STATEMENT cannot be
+    # detected as multiline, so it is serialised as a single-line meta field.
+    expected_markdown = """\
+# Document title
+
+**Grammar**: requirements.gra.md
+
+## Some Assumption
+
+**TYPE**: ASSUMPTION \\
+**UID**: ASM-1 \\
+**STATEMENT**: Some assumption text.
+"""
+    document, _ = _assert_markdown_roundtrip(input_markdown, expected_markdown)
+
+    node = document.section_contents[0]
+    assert isinstance(node, SDocNode)
+    assert node.node_type == "ASSUMPTION"
+    assert node.reserved_title == "Some Assumption"
+
+
+def test_022_type_section_emitted_in_custom_grammar():
+    """
+    With a custom grammar, the writer emits **TYPE**: SECTION for SECTION nodes.
+
+    Without the TYPE field the reader would treat any heading that has a meta
+    block (e.g. auto-generated MID) as a typed node and mis-classify it as a
+    REQUIREMENT on the next read cycle.
+    """
+    input_markdown = """\
+# Document title
+
+**Grammar**: `requirements.gra.md`
+
+## Test Section
+
+**TYPE**: SECTION
+
+### Some Assumption
+
+**TYPE**: ASSUMPTION \\
+**UID**: ASM-1
+
+Some assumption text.
+"""
+    expected_markdown = """\
+# Document title
+
+**Grammar**: requirements.gra.md
+
+## Test Section
+
+**TYPE**: SECTION
+
+### Some Assumption
+
+**TYPE**: ASSUMPTION \\
+**UID**: ASM-1 \\
+**STATEMENT**: Some assumption text.
+"""
+    document, _ = _assert_markdown_roundtrip(input_markdown, expected_markdown)
+
+    section = document.section_contents[0]
+    assert isinstance(section, SDocNode)
+    assert section.node_type == "SECTION"
+    assert section.reserved_title == "Test Section"
+
+    assumption = section.section_contents[0]
+    assert isinstance(assumption, SDocNode)
+    assert assumption.node_type == "ASSUMPTION"
+    assert assumption.reserved_title == "Some Assumption"
+
+
+def test_023_type_section_mid_preserved():
+    """SECTION MID from meta block is preserved as the section's reserved_mid (MD-27)."""
+    input_markdown = """\
+# Document title
+
+**Grammar**: `requirements.gra.md`
+
+## Introduction
+
+**TYPE**: SECTION \\
+**MID**: 11111111111111111111111111111111
+
+**STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+"""
+    expected_markdown = """\
+# Document title
+
+**Grammar**: requirements.gra.md
+
+## Introduction
+
+**TYPE**: SECTION \\
+**MID**: 11111111111111111111111111111111
+
+**STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+"""
+    document, _ = _assert_markdown_roundtrip(input_markdown, expected_markdown)
+
+    section = document.section_contents[0]
+    assert isinstance(section, SDocNode)
+    assert section.node_type == "SECTION"
+    assert section.reserved_title == "Introduction"
+    assert str(section.reserved_mid) == "11111111111111111111111111111111"
+    assert section.mid_permanent is True
+
+    text_node = section.section_contents[0]
+    assert isinstance(text_node, SDocNode)
+    assert text_node.node_type == "TEXT"
+    statement_fields = text_node.ordered_fields_lookup.get("STATEMENT", [])
+    assert len(statement_fields) > 0
+    assert (
+        "This is a TEXT node statement" in statement_fields[0].get_text_value()
+    )
+
+
+def test_024_type_section_mid_with_text_mid_body():
+    r"""
+    SECTION MID is preserved; **TYPE**: TEXT \\ **MID**: ... prefix in the section
+    body is parsed as the TEXT node's machine identifier (MD-28).
+
+    With an unresolved grammar the writer does not re-emit the TEXT TYPE/MID
+    header (no TEXT element in elements_by_type), so the output contains only
+    the TEXT statement.  The SECTION MID is still preserved.
+    """
+    input_markdown = """\
+# Document title
+
+**Grammar**: `requirements.gra.md`
+
+## Introduction
+
+**TYPE**: SECTION \\
+**MID**: 11111111111111111111111111111111
+
+**TYPE**: TEXT \\
+**MID**: 22222222222222222222222222222222
+
+**STATEMENT**: This is a text statement.
+"""
+    # With an unresolved grammar the writer cannot know that TEXT has a MID
+    # field, so it emits only the statement verbatim (without TYPE/MID header).
+    expected_markdown = """\
+# Document title
+
+**Grammar**: requirements.gra.md
+
+## Introduction
+
+**TYPE**: SECTION \\
+**MID**: 11111111111111111111111111111111
+
+**STATEMENT**: This is a text statement.
+"""
+    document, _ = _assert_markdown_roundtrip(input_markdown, expected_markdown)
+
+    section = document.section_contents[0]
+    assert isinstance(section, SDocNode)
+    assert section.node_type == "SECTION"
+    assert str(section.reserved_mid) == "11111111111111111111111111111111"
+    assert section.mid_permanent is True
+
+    text_node = section.section_contents[0]
+    assert isinstance(text_node, SDocNode)
+    assert text_node.node_type == "TEXT"
+    # The TEXT MID was parsed from the TYPE/MID prefix in the input body.
+    assert str(text_node.reserved_mid) == "22222222222222222222222222222222"
+    assert text_node.mid_permanent is True
+    statement_fields = text_node.ordered_fields_lookup.get("STATEMENT", [])
+    assert len(statement_fields) > 0
+    assert "This is a text statement." in statement_fields[0].get_text_value()
+
+
+def test_025_statement_body_with_fenced_code_block_containing_field_patterns():
+    """
+    A multiline STATEMENT whose body contains a fenced code block with
+    **KEY**: value lines must NOT have those lines interpreted as duplicate
+    field declarations.
+    """
+    input_markdown = """\
+# Document title
+
+## Requirement with code-block example
+
+**UID**: REQ-1
+
+**STATEMENT**:
+
+The heading meta block uses the following syntax:
+
+```
+**TYPE**: SECTION \\
+**MID**: 11111111111111111111111111111111
+```
+
+A second example shows the TEXT prefix:
+
+```
+**TYPE**: TEXT \\
+**MID**: 22222222222222222222222222222222
+
+**STATEMENT**: Body text here.
+```
+"""
+    reader = SDMarkdownReader()
+    # This currently raises StrictDocSemanticError due to duplicate field
+    # names found inside the fenced code blocks.
+    document = reader.read(input_markdown, file_path=None)
+
+    req = document.section_contents[0]
+    assert isinstance(req, SDocNode)
+    statement_fields = req.ordered_fields_lookup.get("STATEMENT", [])
+    assert len(statement_fields) == 1


### PR DESCRIPTION
WHY: If a Markdown document has nodes other than {SECTION, TEXT, REQUIREMENT}, the Markdown parser has to rely on a mechanism to distinguish between different nodes defined in a document grammar.