### PR TITLE
feat(markdown): add ENABLE_MID behavior in Markdown

### DIFF
--- a/developer/tasks/20260617_markdown_enable_mid/task.md
+++ b/developer/tasks/20260617_markdown_enable_mid/task.md
@@ -4,49 +4,10 @@
 
 Enable the `ENABLE_MID` behavior in Markdown similar how it is done by the SDoc machinery.
 
-Implement in the following way:
-
-- DO NOT introduce a document level `ENABLE_MID` option.
-- Instead, make the `ENABLE_MID` behavior be activated if a user grammar contains the MID field.
-
 ## WHY
 
-- The `ENABLE_MID` feature is very important for many users. We want to have it enabled for Markdown.
-- At the same time, we would like to avoid adding a yet another document-level option to active it.
+The `ENABLE_MID` feature is very important for many users. We want to have it enabled for Markdown.
+
+At the same time, we would like to avoid adding a yet another document-level option to active it.
 
 The automatic recognition based on the grammar field should be enough to do the job.
-
-## HOW
-
-### Trigger condition
-
-ENABLE_MID behavior is activated when **all three** conditions are met:
-
-1. The document uses a custom (non-default) grammar (`document_grammar.is_default == False`).
-2. The grammar element (e.g. `REQUIREMENT`) declares a `MID` field in its `fields_map`.
-3. The node being written does not already have a `MID` field in its `ordered_fields_lookup`.
-
-The default Markdown grammar also carries a `MID` field (for backward compatibility), so guarding with `is_default` prevents MID injection into plain Markdown documents that do not reference any custom grammar.
-
-### Changes
-
-**`strictdoc/backend/markdown/writer.py` — `_serialize_node_fields`**
-
-Before iterating the node's own fields, check the trigger condition. If met, prepend `("MID", node.reserved_mid)` to `meta_fields`. This causes the auto-generated UUID to be written to the document on the next save, making it permanent on the subsequent read (because `SDocNode.__init__` sets `mid_permanent = True` whenever a MID value is present in the parsed fields).
-
-**`strictdoc/core/transforms/update_requirement.py`**
-
-When the web UI creates a new requirement node, `mid_permanent = True` is set if `document.config.enable_mid` is True (SDoc path) **or** if the grammar element has a `MID` field (Markdown custom grammar path).
-
-**`strictdoc/core/file_traceability_index.py`**
-
-Same extension: when a MID field is updated via the server merge path, `mid_permanent = True` is set if the grammar element has a `MID` field (in addition to the existing `enable_mid` check).
-
-### Tests
-
-Three new unit tests were added to
-`tests/unit/strictdoc/backend/markdown/test_markdown_grammar.py`:
-
-- `test_007` — writer auto-writes MID when grammar has MID but node has none.
-- `test_008` — writer preserves an existing MID (no duplicate injection).
-- `test_009` — writer does NOT inject MID when grammar has no MID field.

--- a/spec/Markdown.md
+++ b/spec/Markdown.md
@@ -172,6 +172,8 @@ On the first write-back, every node without a `MID` receives a freshly generated
 
 This behavior applies only to custom (user-defined) grammars. The built-in default grammar also declares `MID` for the `REQUIREMENT` element, but the default grammar does not trigger auto-generation.
 
+For SECTION nodes, MID auto-generation is triggered only when the grammar's `SECTION` element declares a `MID` field. When MID is written to a SECTION node, the writer also emits `**TYPE**: SECTION` as the first meta field to prevent the reader from misidentifying the section as a requirement node on the next read.
+
 ### Node TYPE field — reader behaviour
 
 **MID**: a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8 \

--- a/strictdoc/backend/markdown/writer.py
+++ b/strictdoc/backend/markdown/writer.py
@@ -174,30 +174,33 @@ class SDMarkdownWriter:
                 node.node_type, None
             )
 
-        # Emit TYPE for every non-TEXT node when the grammar defines element
-        # types beyond the built-in set (see MD-26). SECTION is included
-        # because the reader treats any heading with a valid meta block as a
-        # typed node when a custom grammar is active; without TYPE: SECTION the
-        # reader would mis-classify a SECTION as a REQUIREMENT on re-read.
-        if (
-            document_grammar is not None
-            and document_grammar.has_custom_elements()
-            and node.node_type != "TEXT"
-        ):
-            meta_fields.append(("TYPE", node.node_type))
-
-        # If a custom (user-defined) grammar declares MID and the node doesn't
-        # have one, auto-write the reserved_mid so it becomes permanent on the
-        # next read. This is the Markdown equivalent of SDoc's ENABLE_MID.
+        # Determine whether MID will be auto-injected for this node (MD-24).
         # The default grammar also carries MID, so guard with is_default to
         # avoid injecting MID into plain Markdown documents.
-        if (
+        should_inject_mid = (
             document_grammar is not None
             and not document_grammar.is_default
             and element is not None
             and "MID" in element.fields_map
             and "MID" not in node.ordered_fields_lookup
+        )
+
+        # Emit TYPE for every non-TEXT node when:
+        # - the grammar defines element types beyond the built-in set (MD-26), OR
+        # - a SECTION node carries a MID field (MD-24): TYPE: SECTION must
+        #   accompany the MID on every write so the reader does not misidentify
+        #   the heading as a REQUIREMENT on re-read.
+        section_has_mid = node.node_type == "SECTION" and (
+            should_inject_mid or "MID" in node.ordered_fields_lookup
+        )
+        if (
+            document_grammar is not None
+            and node.node_type != "TEXT"
+            and (document_grammar.has_custom_elements() or section_has_mid)
         ):
+            meta_fields.append(("TYPE", node.node_type))
+
+        if should_inject_mid:
             meta_fields.append(("MID", node.reserved_mid))
 
         for field in node.enumerate_fields():

--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -400,7 +400,16 @@ class RequirementFormObject(ErrorObject):
             form_fields.append(form_field)
             if form_field.field_name == "UID" and next_uid is not None:
                 form_field.field_value = next_uid
-            elif form_field.field_name == "MID" and document.config.enable_mid:
+            elif form_field.field_name == "MID" and (
+                document.config.enable_mid
+                or (
+                    "MID" in element.fields_map
+                    and document.meta is not None
+                    and document.meta.input_doc_full_path.lower().endswith(
+                        (".md", ".markdown")
+                    )
+                )
+            ):
                 form_field.field_value = new_requirement_mid.get_string_value()
 
         return RequirementFormObject(
@@ -522,13 +531,25 @@ class RequirementFormObject(ErrorObject):
                 context_document_mid=context_document_mid,
             )
         )
+        grammar = document.grammar
+        assert grammar is not None
+        grammar_element = grammar.elements_by_type[requirement.node_type]
         form_object.requirement_mid = MID.create()
         for field_name, fields_ in form_object.fields.items():
             field: RequirementFormField
             if field_name == "UID":
                 field = fields_[0]
                 field.field_value = clone_uid
-            elif field_name == "MID" and document.config.enable_mid:
+            elif field_name == "MID" and (
+                document.config.enable_mid
+                or (
+                    "MID" in grammar_element.fields_map
+                    and document.meta is not None
+                    and document.meta.input_doc_full_path.lower().endswith(
+                        (".md", ".markdown")
+                    )
+                )
+            ):
                 field = fields_[0]
                 field.field_value = (
                     form_object.requirement_mid.get_string_value()

--- a/tests/integration/features/commands/format/08_markdown_section_mid_inject/input.md
+++ b/tests/integration/features/commands/format/08_markdown_section_mid_inject/input.md
@@ -1,0 +1,11 @@
+# Document title
+
+**Grammar**: requirements.gra.md
+
+## Section heading
+
+### Requirement inside section
+
+**UID**: REQ-1
+
+**STATEMENT**: System shall do X.

--- a/tests/integration/features/commands/format/08_markdown_section_mid_inject/requirements.gra.md
+++ b/tests/integration/features/commands/format/08_markdown_section_mid_inject/requirements.gra.md
@@ -1,0 +1,37 @@
+# StrictDoc Markdown Grammar
+
+## Element: SECTION
+
+**Composite**: True
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: TITLE
+
+**Type**: String
+**Required**: True
+
+## Element: REQUIREMENT
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: TITLE
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False

--- a/tests/integration/features/commands/format/08_markdown_section_mid_inject/strictdoc.toml
+++ b/tests/integration/features/commands/format/08_markdown_section_mid_inject/strictdoc.toml
@@ -1,0 +1,2 @@
+[project]
+title = "Test"

--- a/tests/integration/features/commands/format/08_markdown_section_mid_inject/test.itest
+++ b/tests/integration/features/commands/format/08_markdown_section_mid_inject/test.itest
@@ -1,0 +1,40 @@
+#
+# Regression test for https://github.com/strictdoc-project/strictdoc/issues/2924
+#
+# When a custom grammar declares a MID field for the SECTION element, the writer
+# must auto-inject MID into SECTION nodes AND emit **TYPE**: SECTION alongside
+# it. Without TYPE: SECTION the reader mis-classifies the heading as a
+# REQUIREMENT on the next parse, causing a grammar validation error.
+#
+# Scenario:
+#   pass1: SECTION has no MID and no TYPE → writer injects both TYPE: SECTION
+#          and a fresh MID.
+#   pass2: document is re-read, SECTION is correctly identified, writer
+#          produces identical output (idempotency confirms no mis-classification).
+#
+
+RUN: mkdir -p %T/pass1
+RUN: cp %S/input.md %T/pass1/input.md
+RUN: cp %S/requirements.gra.md %T/pass1/requirements.gra.md
+RUN: cp %S/strictdoc.toml %T/pass1/strictdoc.toml
+
+RUN: %strictdoc format %T/pass1/
+
+RUN: %cat %T/pass1/input.md | filecheck %s --dump-input=fail
+
+# After the first format pass the SECTION heading must carry TYPE: SECTION and
+# a freshly generated MID.
+CHECK: ## Section heading
+CHECK: **TYPE**: SECTION \
+CHECK-NEXT: **MID**:
+
+# The REQUIREMENT inside the section must also carry a freshly generated MID.
+# TYPE is not emitted for built-in element types (see MD-26).
+CHECK: ### Requirement inside section
+CHECK: **MID**:
+
+# A second format pass must produce identical output — proving the reader
+# correctly identifies the SECTION (not as a REQUIREMENT) on re-read.
+RUN: cp -r %T/pass1 %T/pass2
+RUN: %strictdoc format %T/pass2/
+RUN: diff %T/pass1/input.md %T/pass2/input.md

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_grammar.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_grammar.py
@@ -370,3 +370,105 @@ def test_009_markdown_writer_no_mid_when_grammar_has_no_mid_field():
 
     assert "**MID**" not in output_markdown
     assert "**UID**: REQ-1" in output_markdown
+
+
+def test_010_markdown_writer_injects_mid_into_section_nodes_when_grammar_declares_mid():
+    """
+    When a grammar declares a MID field for the SECTION element, the writer
+    auto-injects MID into SECTION nodes that do not already carry one, and
+    also emits TYPE: SECTION as the first meta field so the reader does not
+    misidentify the heading as a REQUIREMENT on the next parse.
+    """
+    grammar_markdown = """\
+# StrictDoc Markdown Grammar
+
+## Element: SECTION
+
+**Composite**: True
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: TITLE
+
+**Type**: String
+**Required**: True
+
+## Element: REQUIREMENT
+
+### Field: MID
+
+**Type**: String
+**Required**: False
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False
+"""
+    doc_markdown = """\
+# Document
+
+**Grammar**: `requirements.gra.md`
+
+## Section heading
+
+### Requirement inside section
+
+**UID**: REQ-1
+
+**Statement**: System shall do X.
+"""
+
+    document = SDMarkdownReader.read(doc_markdown, file_path=None)
+    assert document.grammar is not None
+
+    # Simulate grammar resolution (normally done by TraceabilityIndexBuilder).
+    resolved_grammar = MarkdownGrammarReader.read(grammar_markdown)
+    resolved_grammar.import_from_file = "requirements.gra.md"
+    resolved_grammar.parent = document
+    document.grammar = resolved_grammar
+
+    output_markdown = SDMarkdownWriter.write(document)
+
+    lines = output_markdown.splitlines()
+
+    # The SECTION node must receive TYPE and MID injection.
+    section_idx = next(
+        i for i, line in enumerate(lines) if "Section heading" in line
+    )
+    section_block_lines = []
+    for line in lines[section_idx + 1 :]:
+        if line.startswith("#"):
+            break
+        section_block_lines.append(line)
+    section_block = "\n".join(section_block_lines)
+    assert "**TYPE**: SECTION" in section_block, (
+        f"TYPE: SECTION not found in section block: {section_block!r}"
+    )
+    assert "**MID**:" in section_block, (
+        f"MID not injected into section block: {section_block!r}"
+    )
+
+    # The REQUIREMENT node must also receive TYPE and MID injection.
+    req_idx = next(
+        i
+        for i, line in enumerate(lines)
+        if "Requirement inside section" in line
+    )
+    req_block_lines = []
+    for line in lines[req_idx + 1 :]:
+        if line.startswith("#"):
+            break
+        req_block_lines.append(line)
+    req_block = "\n".join(req_block_lines)
+    assert "**MID**:" in req_block, (
+        f"MID not injected into requirement block: {req_block!r}"
+    )


### PR DESCRIPTION
WHY: Automatic generation of MID is a core feature of StrictDoc that is available in SDoc. Now we are adding the same mechanism to be supported when working with Markdown documents.