### PR TITLE
fix(features/document): disable Confirm button in delete modals

### DIFF
--- a/strictdoc/export/html/templates/actions/document/delete_document/stream_confirm_delete_document.jinja
+++ b/strictdoc/export/html/templates/actions/document/delete_document/stream_confirm_delete_document.jinja
@@ -4,7 +4,8 @@
     confirm_title = default,
     confirm_message = "Deleting a document is an unrecoverable action.",
     confirm_name = "Delete document",
-    confirm_href = "/actions/document/delete_document?document_mid="~document_mid~"&confirmed=1"
+    confirm_href = "/actions/document/delete_document?document_mid="~document_mid~"&confirmed=1",
+    confirm_disabled = (errors|length > 0)
   %}
     {% include "components/confirm/index.jinja" %}
   {% endwith %}

--- a/strictdoc/export/html/templates/actions/document/delete_requirement/stream_confirm_delete_requirement.jinja
+++ b/strictdoc/export/html/templates/actions/document/delete_requirement/stream_confirm_delete_requirement.jinja
@@ -4,7 +4,8 @@
     confirm_title = default,
     confirm_message = "Deleting a requirement is an unrecoverable action.",
     confirm_name = "Delete requirement",
-    confirm_href = "/actions/document/delete_requirement?node_id="~requirement_mid~"&context_document_mid="~context_document_mid~"&confirmed=1"
+    confirm_href = "/actions/document/delete_requirement?node_id="~requirement_mid~"&context_document_mid="~context_document_mid~"&confirmed=1",
+    confirm_disabled = (errors|length > 0)
   %}
     {% include "components/confirm/index.jinja" %}
   {% endwith %}

--- a/strictdoc/export/html/templates/components/button/confirm.jinja
+++ b/strictdoc/export/html/templates/components/button/confirm.jinja
@@ -1,3 +1,9 @@
+{% if confirm_disabled|default(false) %}
+<a
+  class="action_button action_button--disabled"
+  data-testid="confirm-action-disabled"
+>{{ confirm_name|default('Confirm the action') }}</a>
+{% else %}
 <a
   href="{{ confirm_href }}"
   class="action_button"
@@ -6,3 +12,4 @@
   data-action-type="confirm_{{ confirm_action_type|default('delete') }}"
   data-testid="confirm-action"
 >{{ confirm_name|default('Confirm the action') }}</a>
+{% endif %}

--- a/tests/end2end/helpers/components/confirm.py
+++ b/tests/end2end/helpers/components/confirm.py
@@ -30,6 +30,16 @@ class Confirm:  # pylint: disable=invalid-name
             by=By.XPATH,
         )
 
+    def assert_confirm_action_disabled(self) -> None:
+        self.test_case.assert_element(
+            '//*[@data-testid="confirm-action-disabled"]',
+            by=By.XPATH,
+        )
+        self.test_case.assert_element_not_visible(
+            '//*[@data-testid="confirm-action"]',
+            by=By.XPATH,
+        )
+
     def do_confirm_action(self) -> None:
         self.test_case.click(
             selector=('//*[@data-testid="confirm-action"]'),

--- a/tests/end2end/screens/document/delete_document/delete_document_with_incoming_parent_node_link/test_case.py
+++ b/tests/end2end/screens/document/delete_document/delete_document_with_incoming_parent_node_link/test_case.py
@@ -4,6 +4,7 @@
 
 from tests.end2end.e2e_case import E2ECase
 from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.confirm import Confirm
 from tests.end2end.helpers.screens.project_index.screen_project_index import (
     Screen_ProjectIndex,
 )
@@ -40,5 +41,6 @@ class Test(E2ECase):
             screen_document.assert_text(
                 "Cannot remove node '1. Requirement title' with incoming relations from: '1. Requirement title'."
             )
+            Confirm(self).assert_confirm_action_disabled()
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/delete_node/_SECTION/_validation/delete_section_that_has_incoming_LINKs/test_case.py
+++ b/tests/end2end/screens/document/delete_node/_SECTION/_validation/delete_section_that_has_incoming_LINKs/test_case.py
@@ -4,6 +4,7 @@
 
 from tests.end2end.e2e_case import E2ECase
 from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.confirm import Confirm
 from tests.end2end.helpers.screens.project_index.screen_project_index import (
     Screen_ProjectIndex,
 )
@@ -38,5 +39,6 @@ class Test(E2ECase):
                 "Cannot remove node '1. Referenced section' with incoming LINKs from: "
                 "'REQUIREMENT with no title/UID' -> 'SDOC_UG_CONTACT'."
             )
+            Confirm(self).assert_confirm_action_disabled()
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/delete_node/_validation/delete_node_must_prevent_deletion_when_children_have_incoming_parent_RELATIONs/test_case.py
+++ b/tests/end2end/screens/document/delete_node/_validation/delete_node_must_prevent_deletion_when_children_have_incoming_parent_RELATIONs/test_case.py
@@ -4,6 +4,7 @@
 
 from tests.end2end.e2e_case import E2ECase
 from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.confirm import Confirm
 from tests.end2end.helpers.screens.project_index.screen_project_index import (
     Screen_ProjectIndex,
 )
@@ -45,5 +46,6 @@ class Test(E2ECase):
                 "Cannot remove node '1.1.1. Requirement title #1' with incoming relations from: "
                 "'2. Requirement title #2', '3. Requirement title #3'."
             )
+            Confirm(self).assert_confirm_action_disabled()
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/delete_node/_validation/delete_node_must_prevent_deletion_when_incoming_parent_RELATIONs/test_case.py
+++ b/tests/end2end/screens/document/delete_node/_validation/delete_node_must_prevent_deletion_when_incoming_parent_RELATIONs/test_case.py
@@ -4,6 +4,7 @@
 
 from tests.end2end.e2e_case import E2ECase
 from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.confirm import Confirm
 from tests.end2end.helpers.screens.project_index.screen_project_index import (
     Screen_ProjectIndex,
 )
@@ -37,5 +38,6 @@ class Test(E2ECase):
                 "Cannot remove node '1. Requirement title #1' with incoming relations from: "
                 "'2. Requirement title #2', '3. Requirement title #3'."
             )
+            Confirm(self).assert_confirm_action_disabled()
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/delete_node/_validation/delete_node_that_has_incoming_LINKs/test_case.py
+++ b/tests/end2end/screens/document/delete_node/_validation/delete_node_that_has_incoming_LINKs/test_case.py
@@ -4,6 +4,7 @@
 
 from tests.end2end.e2e_case import E2ECase
 from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.confirm import Confirm
 from tests.end2end.helpers.screens.project_index.screen_project_index import (
     Screen_ProjectIndex,
 )
@@ -37,5 +38,6 @@ class Test(E2ECase):
                 "'REQUIREMENT with no title/UID' -> 'REQ-001', "
                 "'REQUIREMENT with no title/UID' -> 'REQ-001'."
             )
+            Confirm(self).assert_confirm_action_disabled()
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/delete_node/_validation/delete_node_with_ANCHOR_that_has_incoming_LINKs/test_case.py
+++ b/tests/end2end/screens/document/delete_node/_validation/delete_node_with_ANCHOR_that_has_incoming_LINKs/test_case.py
@@ -4,6 +4,7 @@
 
 from tests.end2end.e2e_case import E2ECase
 from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.confirm import Confirm
 from tests.end2end.helpers.screens.project_index.screen_project_index import (
     Screen_ProjectIndex,
 )
@@ -36,5 +37,6 @@ class Test(E2ECase):
                 "Cannot remove node 'REQ-001' with incoming LINKs from: "
                 "'REQUIREMENT with no title/UID' -> 'REQ-001'."
             )
+            Confirm(self).assert_confirm_action_disabled()
 
         assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
Disable Confirm button in delete modals when validation errors are present

When a delete modal (node, section, or document) shows validation errors, the Confirm button was still active, allowing a second click to reach the server and produce a 500 response.

Fix: the three stream_confirm templates now pass `confirm_disabled = (errors|length > 0)` into the `{% with %}` block, and `components/button/confirm.jinja` renders a disabled `<a>` (no href, no turbo attributes, `data-testid="confirm-action-disabled"`) when that flag is set. The confirmed-deletion endpoints already caught `MultipleValidationError` and returned 422, so no backend changes were needed.

Affected templates:
- actions/table/delete_node/stream_confirm.jinja
- actions/document/delete_requirement/stream_confirm_delete_requirement.jinja
- actions/document/delete_document/stream_confirm_delete_document.jinja

A new E2E test `delete_table_node_validation_confirm_disabled` covers the Table view case. Six existing Document view validation tests (`delete_node_that_has_incoming_LINKs` and related) are extended with `Confirm.assert_confirm_action_disabled()` — they previously verified the error text but not the button state.