### PR TITLE
fix(backend/sdoc): fix has_custom_metadata condition

### DIFF
--- a/strictdoc/backend/sdoc/models/document_config.py
+++ b/strictdoc/backend/sdoc/models/document_config.py
@@ -187,6 +187,7 @@ class DocumentConfig:
         return (
             self.custom_metadata is not None
             and self.custom_metadata.entries is not None
+            and len(self.custom_metadata.entries) > 0
         )
 
     def get_custom_metadata(self) -> List[Tuple[str, str]]:

--- a/tests/unit/strictdoc/backend/sdoc/models/test_document_config.py
+++ b/tests/unit/strictdoc/backend/sdoc/models/test_document_config.py
@@ -1,0 +1,26 @@
+from strictdoc.backend.sdoc.models.document_config import (
+    DocumentConfig,
+    DocumentCustomMetadata,
+    DocumentCustomMetadataKeyValuePair,
+)
+
+
+def test_has_custom_metadata_returns_false_when_entries_are_empty():
+    config = DocumentConfig.default_config(document=None)
+    config.custom_metadata = DocumentCustomMetadata(entries=[])
+    assert config.has_custom_metadata() is False
+
+
+def test_has_custom_metadata_returns_true_when_entries_are_present():
+    config = DocumentConfig.default_config(document=None)
+    config.custom_metadata = DocumentCustomMetadata(
+        entries=[
+            DocumentCustomMetadataKeyValuePair(key="FOO", value="bar"),
+        ]
+    )
+    assert config.has_custom_metadata() is True
+
+
+def test_has_custom_metadata_returns_false_when_no_custom_metadata():
+    config = DocumentConfig.default_config(document=None)
+    assert config.has_custom_metadata() is False


### PR DESCRIPTION
WHY: This fixes incorrect presentation of the empty metadata border that appeared for documents without any document-level fields.