### PR TITLE
fix(html2pdf): fix edge case of resolving relative asset paths when printing bundle documents

### DIFF
--- a/strictdoc/backend/markdown/markdown_to_html_fragment_writer.py
+++ b/strictdoc/backend/markdown/markdown_to_html_fragment_writer.py
@@ -2,6 +2,7 @@
 @relation(SDOC-SRS-24, scope=file)
 """
 
+import re
 from html import escape
 from typing import Callable, MutableMapping, Optional, Sequence, Tuple, cast
 
@@ -106,6 +107,16 @@ def _render_math_inline_double(
     return f'<div class="math notranslate nohighlight">\\[ {tokens[idx].content} \\]</div>'
 
 
+def _strip_dotdot_from_img_src(html: str) -> str:
+    def _rebase(m: "re.Match[str]") -> str:
+        src = m.group(1)
+        while src.startswith("../"):
+            src = src[3:]
+        return f'src="{src}"'
+
+    return re.sub(r'src="(\.\./[^"]*)"', _rebase, html)
+
+
 class MarkdownToHtmlFragmentWriter:
     # Use the default preset to support common Markdown extensions such as
     # pipe tables when rendering HTML fragments.
@@ -117,14 +128,17 @@ class MarkdownToHtmlFragmentWriter:
     _MARKDOWN_RENDERER_RULES["math_inline"] = _render_math_inline
     _MARKDOWN_RENDERER_RULES["math_inline_double"] = _render_math_inline_double
 
-    @staticmethod
-    def write(markdown_fragment: str) -> Markup:
+    def __init__(self, flat_assets: bool = False) -> None:
+        self.flat_assets: bool = flat_assets
+
+    def write(self, markdown_fragment: str) -> Markup:
         assert isinstance(markdown_fragment, str), markdown_fragment
-        return Markup(
-            MarkdownToHtmlFragmentWriter.markdown_parser.render(
-                markdown_fragment
-            )
+        html = MarkdownToHtmlFragmentWriter.markdown_parser.render(
+            markdown_fragment
         )
+        if self.flat_assets:
+            html = _strip_dotdot_from_img_src(html)
+        return Markup(html)
 
     @staticmethod
     def write_with_validation(

--- a/strictdoc/backend/rst/directives/wildcard_enhanced_image.py
+++ b/strictdoc/backend/rst/directives/wildcard_enhanced_image.py
@@ -5,6 +5,7 @@ from docutils import nodes
 from docutils.parsers.rst.directives.images import Image
 
 STRICTDOC_REFERENCE_PATH_SETTING = "strictdoc_reference_path"
+STRICTDOC_FLAT_ASSETS_SETTING = "strictdoc_flat_assets"
 
 
 class WildcardEnhancedImage(Image):  # type: ignore[misc]
@@ -44,16 +45,33 @@ class WildcardEnhancedImage(Image):  # type: ignore[misc]
             STRICTDOC_REFERENCE_PATH_SETTING,
             os.getcwd(),
         )
+        flat_assets = getattr(
+            self.state.document.settings,
+            STRICTDOC_FLAT_ASSETS_SETTING,
+            False,
+        )
         rel_path_to_image = self.arguments[0]
+        # When flat_assets is True (bundle document), all project assets are
+        # copied to the root _assets/ directory. Paths like '../_assets/file.svg'
+        # authored relative to a nested document's location must be rebased to
+        # '_assets/file.svg' so they resolve correctly from the bundle root.
+        # This rebasing must happen before wildcard resolution so the file lookup
+        # also uses the correct flat path.
+        if flat_assets:
+            while rel_path_to_image.startswith("../"):
+                rel_path_to_image = rel_path_to_image[3:]
+            self.arguments[0] = rel_path_to_image
         if rel_path_to_image.endswith(".*"):
             rel_path_to_image_no_wc = rel_path_to_image[:-2]
             for extension in WildcardEnhancedImage.WILDCARD_EXTENSIONS:
                 rel_path_to_image_with_extension = (
                     rel_path_to_image_no_wc + "." + extension
                 )
-                full_path_to_image_with_extension = os.path.join(
-                    current_reference_path,
-                    rel_path_to_image_with_extension,
+                full_path_to_image_with_extension = os.path.normpath(
+                    os.path.join(
+                        current_reference_path,
+                        rel_path_to_image_with_extension,
+                    )
                 )
                 if os.path.exists(full_path_to_image_with_extension):
                     # We have found a matching file, let's use it.

--- a/strictdoc/backend/rst/rst_to_html_fragment_writer.py
+++ b/strictdoc/backend/rst/rst_to_html_fragment_writer.py
@@ -27,6 +27,7 @@ from strictdoc.backend.rst.directives.sphinx_style_math import (
     math_role_for_server,
 )
 from strictdoc.backend.rst.directives.wildcard_enhanced_image import (
+    STRICTDOC_FLAT_ASSETS_SETTING,
     STRICTDOC_REFERENCE_PATH_SETTING,
     WildcardEnhancedImage,
 )
@@ -60,6 +61,8 @@ class RstToHtmlFragmentWriter:
         *,
         project_config: ProjectConfig,
         context_document: Optional[SDocDocument],
+        flat_assets: bool = False,
+        reference_path_override: Optional[str] = None,
     ):
         self.source_path: str
         path_to_output_dir_md5: str = hashlib.md5(
@@ -72,7 +75,14 @@ class RstToHtmlFragmentWriter:
         )
         self.reference_path = os.getcwd()
 
-        if context_document is not None:
+        if reference_path_override is not None:
+            self.reference_path = reference_path_override
+            # See the comment below in the elif branch for why source_path is
+            # set to a file inside the reference directory.
+            self.source_path = os.path.join(
+                reference_path_override, "STRICTDOC-FRAGMENT.rst"
+            )
+        elif context_document is not None:
             assert context_document.meta is not None
             self.reference_path = (
                 context_document.meta.output_document_dir_full_path
@@ -96,6 +106,8 @@ class RstToHtmlFragmentWriter:
             self.source_path = "<string>"
         self.context_document: Optional[SDocDocument] = context_document
 
+        self.flat_assets: bool = flat_assets
+
         if project_config.is_feature_activated(ProjectFeature.MATHJAX):
             if project_config.is_running_on_server:
                 roles.register_canonical_role("eq", eq_role_for_server)
@@ -117,8 +129,11 @@ class RstToHtmlFragmentWriter:
             self.path_to_rst_cache_dir, str(len(rst_fragment))
         )
         fragment_md5 = hashlib.md5(rst_fragment.encode("utf-8")).hexdigest()
+        # flat_assets mode produces different HTML (rebased image paths) for the
+        # same RST fragment, so it needs its own cache entry.
+        cache_key = fragment_md5 + ("_flat" if self.flat_assets else "")
         path_to_cached_fragment = os.path.join(
-            path_to_rst_fragment_bucket_dir, fragment_md5
+            path_to_rst_fragment_bucket_dir, cache_key
         )
         if use_cache and os.path.isdir(path_to_rst_fragment_bucket_dir):
             if os.path.isfile(path_to_cached_fragment):
@@ -180,6 +195,7 @@ class RstToHtmlFragmentWriter:
             **self.BASE_SETTINGS,
             "warning_stream": warning_stream,
             STRICTDOC_REFERENCE_PATH_SETTING: self.reference_path,
+            STRICTDOC_FLAT_ASSETS_SETTING: self.flat_assets,
         }
 
         output = publish_parts(
@@ -231,6 +247,7 @@ class RstToHtmlFragmentWriter:
             **self.BASE_SETTINGS,
             "warning_stream": warning_stream,
             STRICTDOC_REFERENCE_PATH_SETTING: self.reference_path,
+            STRICTDOC_FLAT_ASSETS_SETTING: self.flat_assets,
         }
 
         try:

--- a/strictdoc/export/html/renderers/markup_renderer.py
+++ b/strictdoc/export/html/renderers/markup_renderer.py
@@ -42,6 +42,8 @@ class MarkupRenderer:
         html_templates: HTMLTemplates,
         config: ProjectConfig,
         context_document: Optional[SDocDocument],
+        flat_assets: bool = False,
+        reference_path_override: Optional[str] = None,
     ) -> "MarkupRenderer":
         assert isinstance(html_templates, HTMLTemplates)
         html_fragment_writer: FragmentWriterType
@@ -49,9 +51,13 @@ class MarkupRenderer:
             html_fragment_writer = RstToHtmlFragmentWriter(
                 project_config=config,
                 context_document=context_document,
+                flat_assets=flat_assets,
+                reference_path_override=reference_path_override,
             )
         elif markup == SDocMarkup.MARKDOWN:
-            html_fragment_writer = MarkdownToHtmlFragmentWriter()
+            html_fragment_writer = MarkdownToHtmlFragmentWriter(
+                flat_assets=flat_assets
+            )
         elif markup == SDocMarkup.HTML:
             html_fragment_writer = HTMLFragmentWriter()
         else:
@@ -62,6 +68,8 @@ class MarkupRenderer:
             link_renderer,
             html_templates,
             context_document,
+            flat_assets=flat_assets,
+            primary_markup=markup,
         )
 
     def __init__(
@@ -71,6 +79,8 @@ class MarkupRenderer:
         link_renderer: LinkRenderer,
         html_templates: HTMLTemplates,
         context_document: Optional[SDocDocument],
+        flat_assets: bool = False,
+        primary_markup: Optional[str] = None,
     ) -> None:
         assert isinstance(traceability_index, TraceabilityIndex)
         assert isinstance(link_renderer, LinkRenderer)
@@ -83,6 +93,15 @@ class MarkupRenderer:
         self.traceability_index: TraceabilityIndex = traceability_index
         self.link_renderer: LinkRenderer = link_renderer
         self.context_document: Optional[SDocDocument] = context_document
+        self.flat_assets: bool = flat_assets
+
+        # Cache of fragment writers keyed by markup string. Pre-populated with
+        # the primary writer so the dispatch method reuses it without creating
+        # duplicates for the common case.
+        primary_key: str = primary_markup or SDocMarkup.RST
+        self._writers_by_markup: Dict[str, FragmentWriterType] = {
+            primary_key: fragment_writer
+        }
 
         # FIXME: Now that the underlying RST fragment caching is in place,
         # This caching could be removed. It is unlikely that it adds any serious
@@ -103,6 +122,36 @@ class MarkupRenderer:
                     "rst/anchor.jinja"
                 )
             )
+
+    def _get_writer_for_node_field(
+        self, node_field: SDocNodeField
+    ) -> FragmentWriterType:
+        """
+        Return the fragment writer appropriate for the node field's markup.
+
+        When the bundle document (RST by default) contains sub-documents with
+        different markup (e.g. Markdown), nodes from those sub-documents must be
+        rendered with the correct writer, not the bundle's primary RST writer.
+        """
+        if node_field.parent is None:
+            return self.fragment_writer
+        doc = node_field.parent.get_document()
+        if doc is None or doc.config is None:
+            return self.fragment_writer
+        markup = doc.config.markup  # raw value; None means RST
+        key = markup or SDocMarkup.RST
+        if key not in self._writers_by_markup:
+            if not markup or markup == SDocMarkup.RST:
+                self._writers_by_markup[key] = self.fragment_writer
+            elif markup == SDocMarkup.MARKDOWN:
+                self._writers_by_markup[key] = MarkdownToHtmlFragmentWriter(
+                    flat_assets=self.flat_assets
+                )
+            elif markup == SDocMarkup.HTML:
+                self._writers_by_markup[key] = HTMLFragmentWriter()
+            else:
+                self._writers_by_markup[key] = TextToHtmlWriter()
+        return self._writers_by_markup[key]
 
     def render_node_statement(
         self, document_type: DocumentType, node: SDocNode
@@ -135,12 +184,14 @@ class MarkupRenderer:
         if (document_type, node_field) in self.cache:
             return self.cache[(document_type, node_field)]
 
+        fragment_writer = self._get_writer_for_node_field(node_field)
+
         prev_part = None
         parts_output = ""
         for part in node_field.parts:
             if isinstance(part, str):
                 if isinstance(prev_part, InlineLink) and isinstance(
-                    self.fragment_writer, RstToHtmlFragmentWriter
+                    fragment_writer, RstToHtmlFragmentWriter
                 ):
                     parts_output += escape_str_after_inline_markup(part)
                 else:
@@ -152,7 +203,7 @@ class MarkupRenderer:
                 href = self.link_renderer.render_node_link(
                     linkable_node, self.context_document, document_type
                 )
-                parts_output += self.fragment_writer.write_anchor_link(
+                parts_output += fragment_writer.write_anchor_link(
                     linkable_node.get_display_title(), href
                 )
             elif isinstance(part, Anchor):
@@ -166,7 +217,7 @@ class MarkupRenderer:
                 raise NotImplementedError
             prev_part = part
 
-        output = self.fragment_writer.write(parts_output)
+        output = fragment_writer.write(parts_output)
         self.cache[(document_type, node_field)] = output
 
         return output

--- a/strictdoc/features/html2pdf/html2pdf_generator.py
+++ b/strictdoc/features/html2pdf/html2pdf_generator.py
@@ -61,6 +61,20 @@ class HTML2PDFGenerator:
                 root_path=root_path,
                 static_path=project_config.dir_for_sdoc_assets,
             )
+            # The document meta's output_document_dir_full_path points to the
+            # regular HTML output directory, but html2pdf copies assets to a
+            # separate html2pdf/html/ tree. Pass the correct directory so that
+            # RST wildcard image resolution (image.*) finds assets at the right
+            # location. For the bundle (flat_assets=True) all assets sit at the
+            # root of path_to_output_pdf_html_dir; for individual documents they
+            # sit inside each document's own subdirectory.
+            if flat_assets:
+                rst_reference_path = path_to_output_pdf_html_dir
+            else:
+                rst_reference_path = os.path.join(
+                    path_to_output_pdf_html_dir,
+                    document_.meta.output_document_dir_rel_path.relative_path,
+                )
             markup_renderer = MarkupRenderer.create(
                 document_.config.get_markup(),
                 traceability_index,
@@ -68,6 +82,8 @@ class HTML2PDFGenerator:
                 html_templates,
                 project_config,
                 document_,
+                flat_assets=flat_assets,
+                reference_path_override=rst_reference_path,
             )
 
             with measure_performance("Generating printable HTML document"):

--- a/tests/integration/features/html2pdf/10_bundle_document_with_cross_directory_image_refs/_assets/root_image.svg
+++ b/tests/integration/features/html2pdf/10_bundle_document_with_cross_directory_image_refs/_assets/root_image.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-40 -40 80 80">
+  <circle r="39"/>
+  <path fill="#fff" d="M0,38a38,38 0 0 1 0,-76a19,19 0 0 1 0,38a19,19 0 0 0 0,38"/>
+  <circle r="5" cy="19" fill="#fff"/>
+  <circle r="5" cy="-19"/>
+</svg>

--- a/tests/integration/features/html2pdf/10_bundle_document_with_cross_directory_image_refs/input.sdoc
+++ b/tests/integration/features/html2pdf/10_bundle_document_with_cross_directory_image_refs/input.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: Root Document
+
+[TEXT]
+STATEMENT: >>>
+.. image:: _assets/root_image.svg
+   :alt: Root image
+   :class: image
+   :width: 100%
+<<<

--- a/tests/integration/features/html2pdf/10_bundle_document_with_cross_directory_image_refs/nested/input2.sdoc
+++ b/tests/integration/features/html2pdf/10_bundle_document_with_cross_directory_image_refs/nested/input2.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: Nested Document
+
+[TEXT]
+STATEMENT: >>>
+This nested document references an image from the parent directory's assets.
+
+.. image:: ../_assets/root_image.svg
+   :alt: Root image referenced from nested doc
+   :class: image
+   :width: 100%
+<<<

--- a/tests/integration/features/html2pdf/10_bundle_document_with_cross_directory_image_refs/strictdoc.toml
+++ b/tests/integration/features/html2pdf/10_bundle_document_with_cross_directory_image_refs/strictdoc.toml
@@ -1,0 +1,7 @@
+[project]
+
+cache_dir = "./Output/cache"
+
+features = [
+  "HTML2PDF",
+]

--- a/tests/integration/features/html2pdf/10_bundle_document_with_cross_directory_image_refs/test.itest
+++ b/tests/integration/features/html2pdf/10_bundle_document_with_cross_directory_image_refs/test.itest
@@ -1,0 +1,22 @@
+# @relation(SDOC-SRS-51, scope=file)
+
+REQUIRES: TEST_HTML2PDF
+
+RUN: %strictdoc export %S --formats=html2pdf --generate-bundle-document --output-dir %T | filecheck %s --dump-input=fail
+CHECK: html2pdf4doc: JS logs from the print session
+
+RUN: %check_exists --file %T/html2pdf/html/bundle-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/input-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/input2-PDF.html
+
+# The individual nested document HTML should have the original relative path
+# (going up to the root _assets/ from the nested output location).
+# SVG images are rendered by docutils as <object data="...">.
+RUN: %cat %T/html2pdf/html/%THIS_TEST_FOLDER/nested/input2-PDF.html | filecheck %s --check-prefix CHECK-INDIVIDUAL-HTML
+CHECK-INDIVIDUAL-HTML: data="../_assets/root_image.svg"
+
+# The bundle HTML must NOT have the original '../_assets/' path which would
+# resolve incorrectly from the bundle root. It must be rebased to '_assets/'.
+RUN: %cat %T/html2pdf/html/bundle-PDF.html | filecheck %s --check-prefix CHECK-BUNDLE-HTML
+CHECK-BUNDLE-HTML: data="_assets/root_image.svg"
+CHECK-BUNDLE-HTML-NOT: data="../_assets/root_image.svg"

--- a/tests/integration/features/html2pdf/11_bundle_document_with_wildcard_image_refs/_assets/root_image.svg
+++ b/tests/integration/features/html2pdf/11_bundle_document_with_wildcard_image_refs/_assets/root_image.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-40 -40 80 80">
+  <circle r="39"/>
+  <path fill="#fff" d="M0,38a38,38 0 0 1 0,-76a19,19 0 0 1 0,38a19,19 0 0 0 0,38"/>
+  <circle r="5" cy="19" fill="#fff"/>
+  <circle r="5" cy="-19"/>
+</svg>

--- a/tests/integration/features/html2pdf/11_bundle_document_with_wildcard_image_refs/input.sdoc
+++ b/tests/integration/features/html2pdf/11_bundle_document_with_wildcard_image_refs/input.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: Root Document
+
+[TEXT]
+STATEMENT: >>>
+.. image:: _assets/root_image.*
+   :alt: Root image
+   :class: image
+   :width: 100%
+<<<

--- a/tests/integration/features/html2pdf/11_bundle_document_with_wildcard_image_refs/nested/input2.sdoc
+++ b/tests/integration/features/html2pdf/11_bundle_document_with_wildcard_image_refs/nested/input2.sdoc
@@ -1,0 +1,13 @@
+[DOCUMENT]
+TITLE: Nested Document
+
+[TEXT]
+STATEMENT: >>>
+This nested document references an image from the parent directory using a
+wildcard extension.
+
+.. image:: ../_assets/root_image.*
+   :alt: Root image referenced from nested doc via wildcard
+   :class: image
+   :width: 100%
+<<<

--- a/tests/integration/features/html2pdf/11_bundle_document_with_wildcard_image_refs/nested/subnested/input3.sdoc
+++ b/tests/integration/features/html2pdf/11_bundle_document_with_wildcard_image_refs/nested/subnested/input3.sdoc
@@ -1,0 +1,13 @@
+[DOCUMENT]
+TITLE: Subnested Document
+
+[TEXT]
+STATEMENT: >>>
+This document is two levels deep and references an image from the root
+assets directory using a wildcard extension.
+
+.. image:: ../../_assets/root_image.*
+   :alt: Root image referenced from subnested doc via wildcard
+   :class: image
+   :width: 100%
+<<<

--- a/tests/integration/features/html2pdf/11_bundle_document_with_wildcard_image_refs/strictdoc.toml
+++ b/tests/integration/features/html2pdf/11_bundle_document_with_wildcard_image_refs/strictdoc.toml
@@ -1,0 +1,7 @@
+[project]
+
+cache_dir = "./Output/cache"
+
+features = [
+  "HTML2PDF",
+]

--- a/tests/integration/features/html2pdf/11_bundle_document_with_wildcard_image_refs/test.itest
+++ b/tests/integration/features/html2pdf/11_bundle_document_with_wildcard_image_refs/test.itest
@@ -1,0 +1,28 @@
+# @relation(SDOC-SRS-51, scope=file)
+
+REQUIRES: TEST_HTML2PDF
+
+RUN: %strictdoc export %S --formats=html2pdf --generate-bundle-document --output-dir %T | filecheck %s --dump-input=fail
+CHECK: html2pdf4doc: JS logs from the print session
+
+RUN: %check_exists --file %T/html2pdf/html/bundle-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/input-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/input2-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/subnested/input3-PDF.html
+
+# Individual nested doc (one level deep): wildcard must resolve using the
+# original '../' path relative to its own location.
+RUN: %cat %T/html2pdf/html/%THIS_TEST_FOLDER/nested/input2-PDF.html | filecheck %s --check-prefix CHECK-NESTED
+CHECK-NESTED: data="../_assets/root_image.svg"
+
+# Individual subnested doc (two levels deep): wildcard must resolve using the
+# original '../../' path relative to its own location.
+RUN: %cat %T/html2pdf/html/%THIS_TEST_FOLDER/nested/subnested/input3-PDF.html | filecheck %s --check-prefix CHECK-SUBNESTED
+CHECK-SUBNESTED: data="../../_assets/root_image.svg"
+
+# Bundle HTML: all '../' prefixes must be stripped so every image resolves
+# correctly from the bundle root, regardless of original nesting depth.
+RUN: %cat %T/html2pdf/html/bundle-PDF.html | filecheck %s --check-prefix CHECK-BUNDLE
+CHECK-BUNDLE: data="_assets/root_image.svg"
+CHECK-BUNDLE-NOT: data="../_assets/root_image.svg"
+CHECK-BUNDLE-NOT: data="../../_assets/root_image.svg"

--- a/tests/integration/features/html2pdf/12_bundle_document_with_markdown_image_refs/_assets/root_image.svg
+++ b/tests/integration/features/html2pdf/12_bundle_document_with_markdown_image_refs/_assets/root_image.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-40 -40 80 80">
+  <circle r="39"/>
+  <path fill="#fff" d="M0,38a38,38 0 0 1 0,-76a19,19 0 0 1 0,38a19,19 0 0 0 0,38"/>
+  <circle r="5" cy="19" fill="#fff"/>
+  <circle r="5" cy="-19"/>
+</svg>

--- a/tests/integration/features/html2pdf/12_bundle_document_with_markdown_image_refs/input.sdoc
+++ b/tests/integration/features/html2pdf/12_bundle_document_with_markdown_image_refs/input.sdoc
@@ -1,0 +1,11 @@
+[DOCUMENT]
+TITLE: Root Document
+OPTIONS:
+  MARKUP: Markdown
+
+[TEXT]
+STATEMENT: >>>
+This root document has an image in the root assets directory.
+
+![Root image](_assets/root_image.svg)
+<<<

--- a/tests/integration/features/html2pdf/12_bundle_document_with_markdown_image_refs/nested/input2.sdoc
+++ b/tests/integration/features/html2pdf/12_bundle_document_with_markdown_image_refs/nested/input2.sdoc
@@ -1,0 +1,11 @@
+[DOCUMENT]
+TITLE: Nested Document
+OPTIONS:
+  MARKUP: Markdown
+
+[TEXT]
+STATEMENT: >>>
+This nested document references an image from the parent directory using Markdown syntax.
+
+![Root image](../_assets/root_image.svg)
+<<<

--- a/tests/integration/features/html2pdf/12_bundle_document_with_markdown_image_refs/nested/subnested/input3.sdoc
+++ b/tests/integration/features/html2pdf/12_bundle_document_with_markdown_image_refs/nested/subnested/input3.sdoc
@@ -1,0 +1,11 @@
+[DOCUMENT]
+TITLE: Subnested Document
+OPTIONS:
+  MARKUP: Markdown
+
+[TEXT]
+STATEMENT: >>>
+This document is two levels deep and references an image using Markdown syntax.
+
+![Root image](../../_assets/root_image.svg)
+<<<

--- a/tests/integration/features/html2pdf/12_bundle_document_with_markdown_image_refs/strictdoc.toml
+++ b/tests/integration/features/html2pdf/12_bundle_document_with_markdown_image_refs/strictdoc.toml
@@ -1,0 +1,7 @@
+[project]
+
+cache_dir = "./Output/cache"
+
+features = [
+  "HTML2PDF",
+]

--- a/tests/integration/features/html2pdf/12_bundle_document_with_markdown_image_refs/test.itest
+++ b/tests/integration/features/html2pdf/12_bundle_document_with_markdown_image_refs/test.itest
@@ -1,0 +1,27 @@
+# @relation(SDOC-SRS-51, scope=file)
+
+REQUIRES: TEST_HTML2PDF
+
+RUN: %strictdoc export %S --formats=html2pdf --generate-bundle-document --output-dir %T | filecheck %s --dump-input=fail
+CHECK: html2pdf4doc: JS logs from the print session
+
+RUN: %check_exists --file %T/html2pdf/html/bundle-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/input-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/input2-PDF.html
+RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/subnested/input3-PDF.html
+
+# Individual nested doc (one level deep): Markdown image must keep original
+# '../' path relative to its own output location.
+RUN: %cat %T/html2pdf/html/%THIS_TEST_FOLDER/nested/input2-PDF.html | filecheck %s --check-prefix CHECK-NESTED
+CHECK-NESTED: src="../_assets/root_image.svg"
+
+# Individual subnested doc (two levels deep): must keep original '../../' path.
+RUN: %cat %T/html2pdf/html/%THIS_TEST_FOLDER/nested/subnested/input3-PDF.html | filecheck %s --check-prefix CHECK-SUBNESTED
+CHECK-SUBNESTED: src="../../_assets/root_image.svg"
+
+# Bundle HTML: all '../' prefixes must be stripped from Markdown image src
+# attributes so every image resolves from the bundle root.
+RUN: %cat %T/html2pdf/html/bundle-PDF.html | filecheck %s --check-prefix CHECK-BUNDLE
+CHECK-BUNDLE: src="_assets/root_image.svg"
+CHECK-BUNDLE-NOT: src="../_assets/root_image.svg"
+CHECK-BUNDLE-NOT: src="../../_assets/root_image.svg"

--- a/tests/unit/strictdoc/export/markdown/test_markdown_to_html_fragment_writer.py
+++ b/tests/unit/strictdoc/export/markdown/test_markdown_to_html_fragment_writer.py
@@ -6,7 +6,7 @@ from strictdoc.backend.markdown.markdown_to_html_fragment_writer import (
 def test_01_writes_markdown_to_html_fragment():
     markdown_input = "This is **bold** text."
 
-    html_output = MarkdownToHtmlFragmentWriter.write(markdown_input)
+    html_output = MarkdownToHtmlFragmentWriter().write(markdown_input)
 
     assert html_output == "<p>This is <strong>bold</strong> text.</p>\n"
 
@@ -36,7 +36,7 @@ def test_03_write_with_validation_returns_html_without_error():
 def test_04_writes_markdown_table_to_html_table():
     markdown_input = "| Col A | Col B |\n| --- | --- |\n| A1 | B1 |\n"
 
-    html_output = MarkdownToHtmlFragmentWriter.write(markdown_input)
+    html_output = MarkdownToHtmlFragmentWriter().write(markdown_input)
 
     assert "<table>" in html_output
     assert "<th>Col A</th>" in html_output
@@ -48,7 +48,7 @@ def test_04_writes_markdown_table_to_html_table():
 def test_05_writes_mermaid_fence_as_mermaid_pre_block():
     markdown_input = "```mermaid\ngraph TD\n  A-->B\n```\n"
 
-    html_output = MarkdownToHtmlFragmentWriter.write(markdown_input)
+    html_output = MarkdownToHtmlFragmentWriter().write(markdown_input)
 
     assert html_output == (
         '<pre class="mermaid">graph TD\n  A--&gt;B\n</pre>\n'
@@ -58,7 +58,7 @@ def test_05_writes_mermaid_fence_as_mermaid_pre_block():
 def test_06_writes_regular_fence_as_code_block():
     markdown_input = "```python\nprint(1)\n```\n"
 
-    html_output = MarkdownToHtmlFragmentWriter.write(markdown_input)
+    html_output = MarkdownToHtmlFragmentWriter().write(markdown_input)
 
     assert html_output == (
         '<pre><code class="language-python">print(1)\n</code></pre>\n'
@@ -71,7 +71,7 @@ def test_07_renders_anchor_link_as_raw_html_not_escaped():
         "foo.bar",
     )
 
-    html_output = MarkdownToHtmlFragmentWriter.write(markdown_input)
+    html_output = MarkdownToHtmlFragmentWriter().write(markdown_input)
 
     assert html_output == '<p><a href="foo.bar">🔗\u00a0Title</a></p>\n'
 
@@ -79,7 +79,7 @@ def test_07_renders_anchor_link_as_raw_html_not_escaped():
 def test_08_renders_inline_math_formula():
     markdown_input = "The mass is $m_d = 120\\,kg$."
 
-    html_output = MarkdownToHtmlFragmentWriter.write(markdown_input)
+    html_output = MarkdownToHtmlFragmentWriter().write(markdown_input)
 
     assert (
         html_output
@@ -90,7 +90,7 @@ def test_08_renders_inline_math_formula():
 def test_09_renders_display_math_formula():
     markdown_input = "The formula $$E = mc^2$$."
 
-    html_output = MarkdownToHtmlFragmentWriter.write(markdown_input)
+    html_output = MarkdownToHtmlFragmentWriter().write(markdown_input)
 
     assert (
         html_output
@@ -103,7 +103,7 @@ def test_10_renders_two_inline_math_formulas_in_one_paragraph():
         "The dry mass $m_d = 120\\,kg$ and propellant mass $m_p = 30\\,kg$."
     )
 
-    html_output = MarkdownToHtmlFragmentWriter.write(markdown_input)
+    html_output = MarkdownToHtmlFragmentWriter().write(markdown_input)
 
     assert (
         '<span class="math notranslate nohighlight">\\( m_d = 120\\,kg \\)</span>'


### PR DESCRIPTION


WHY: Closes #2896