### PR TITLE
chore: remove obsolete config files with section_behavior= as the only argument

### DIFF
--- a/tests/end2end/navigation/toc/collapsible_list/expected_output/strictdoc.toml
+++ b/tests/end2end/navigation/toc/collapsible_list/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/navigation/toc/collapsible_list/input/strictdoc.toml
+++ b/tests/end2end/navigation/toc/collapsible_list/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/navigation/toc/toc_highlighting/expected_output/strictdoc.toml
+++ b/tests/end2end/navigation/toc/toc_highlighting/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/navigation/toc/toc_highlighting/input/strictdoc.toml
+++ b/tests/end2end/navigation/toc/toc_highlighting/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/navigation/toc/toc_navigation/expected_output/strictdoc.toml
+++ b/tests/end2end/navigation/toc/toc_navigation/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/navigation/toc/toc_navigation/input/strictdoc.toml
+++ b/tests/end2end/navigation/toc/toc_navigation/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/navigation/toc/toggle_toc_saves_state/expected_output/strictdoc.toml
+++ b/tests/end2end/navigation/toc/toggle_toc_saves_state/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/navigation/toc/toggle_toc_saves_state/input/strictdoc.toml
+++ b/tests/end2end/navigation/toc/toggle_toc_saves_state/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/navigation/toc/toggle_toc_show_and_hide/expected_output/strictdoc.toml
+++ b/tests/end2end/navigation/toc/toggle_toc_show_and_hide/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/navigation/toc/toggle_toc_show_and_hide/input/strictdoc.toml
+++ b/tests/end2end/navigation/toc/toggle_toc_show_and_hide/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/deep_traceability/view_document/view_document_requirement_show_more_modal_window/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/deep_traceability/view_document/view_document_requirement_show_more_modal_window/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/deep_traceability/view_document/view_document_requirement_show_more_modal_window/input/strictdoc.toml
+++ b/tests/end2end/screens/deep_traceability/view_document/view_document_requirement_show_more_modal_window/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_create/create_section_with_uid_and_node_with_LINK/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_create/create_section_with_uid_and_node_with_LINK/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_create/create_section_with_uid_and_node_with_LINK/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_create/create_section_with_uid_and_node_with_LINK/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_update/update_node_add_link_to_existing_section_anchor_from_clipboard/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_update/update_node_add_link_to_existing_section_anchor_from_clipboard/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_update/update_node_add_link_to_existing_section_anchor_from_clipboard/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/LINK_and_ANCHOR/node/_update/update_node_add_link_to_existing_section_anchor_from_clipboard/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/concurrent_editing/update_text_node_concurrently_triggers_validation/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/concurrent_editing/update_text_node_concurrently_triggers_validation/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/concurrent_editing/update_text_node_concurrently_triggers_validation/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/concurrent_editing/update_text_node_concurrently_triggers_validation/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_included_grammar/update_included_document_with_included_grammar_create_requirement/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_included_grammar/update_included_document_with_included_grammar_create_requirement/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_included_grammar/update_included_document_with_included_grammar_create_requirement/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_included_grammar/update_included_document_with_included_grammar_create_requirement/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document__fragment_nested_in_section__create_section_above/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document__fragment_nested_in_section__create_section_above/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document__fragment_nested_in_section__create_section_above/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document__fragment_nested_in_section__create_section_above/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_requirement_above_but_below_another_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_requirement_above_but_below_another_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_requirement_above_but_below_another_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_requirement_above_but_below_another_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_above/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_above/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_above/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_above/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_above_but_below_another_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_above_but_below_another_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_above_but_below_another_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_above_but_below_another_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_below/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_below/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_below/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/_outside_fragment/update_included_document_create_section_below/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_child_requirement/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_child_requirement/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_child_requirement/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_child_requirement/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_child_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_child_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_child_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_child_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_first_child_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_first_child_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_first_child_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_create_first_child_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_delete_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_delete_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_delete_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_delete_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_edit_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_edit_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_edit_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/included_documents/update_included_document_edit_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/_edge_cases/update_node_update_relation_uid/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/_edge_cases/update_node_update_relation_uid/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/_edge_cases/update_node_update_relation_uid/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/_edge_cases/update_node_update_relation_uid/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/update_text_node_add_uid/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/update_text_node_add_uid/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/update_text_node_add_uid/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/update_text_node_add_uid/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/update_text_node_basic/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/update_text_node_basic/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/update_text_node_basic/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/update_text_node_basic/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/update_text_node_update_uid/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/update_text_node_update_uid/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/update_text_node_update_uid/input/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/update_text_node_update_uid/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/_cross_cutting/text_nodes/view_document_with_text_node/strictdoc.toml
+++ b/tests/end2end/screens/document/_cross_cutting/text_nodes/view_document_with_text_node/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/clone_node/clone_node/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/clone_node/clone_node/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/clone_node/clone_node/input/strictdoc.toml
+++ b/tests/end2end/screens/document/clone_node/clone_node/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/copy_stable_link/input/strictdoc.toml
+++ b/tests/end2end/screens/document/copy_stable_link/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_section_must_validate_empty_name/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_section_must_validate_empty_name/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_section_must_validate_empty_name/input/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_section_must_validate_empty_name/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_section_with_nonunique_uid/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_section_with_nonunique_uid/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_section_with_nonunique_uid/input/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_section_with_nonunique_uid/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_two_section_with_same_uid/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_two_section_with_same_uid/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_two_section_with_same_uid/input/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_two_section_with_same_uid/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_two_sections_then_update_with_same_uid/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_two_sections_then_update_with_same_uid/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_two_sections_then_update_with_same_uid/input/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/_validations/create_two_sections_then_update_with_same_uid/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/create_section_after_requirement/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/create_section_after_requirement/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/create_section_after_requirement/input/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/create_section_after_requirement/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/create_section_before_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/create_section_before_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/create_section_before_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/create_section_before_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/create_section_cancel_new_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/create_section_cancel_new_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/create_section_cancel_new_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/create_section_cancel_new_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/create_section_three_nested_sections/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/create_section_three_nested_sections/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/create_section_three_nested_sections/input/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/create_section_three_nested_sections/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/create_section_two_sibling_sections/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/create_section_two_sibling_sections/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_SECTION/create_section_two_sibling_sections/input/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_SECTION/create_section_two_sibling_sections/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_in_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_in_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_in_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/_arbitrary_elements/create_requirement_create_test_element_in_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/create_requirement_after_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/create_requirement_after_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/create_requirement_after_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/create_requirement_after_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/create_requirement_in_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/create_requirement_in_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/create_requirement/create_requirement_in_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/create_requirement/create_requirement_in_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/delete_node/_SECTION/_validation/delete_section_that_has_incoming_LINKs/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/delete_node/_SECTION/_validation/delete_section_that_has_incoming_LINKs/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/delete_node/_SECTION/_validation/delete_section_that_has_incoming_LINKs/input/strictdoc.toml
+++ b/tests/end2end/screens/document/delete_node/_SECTION/_validation/delete_section_that_has_incoming_LINKs/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/delete_node/_SECTION/delete_simple_non_nested_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/delete_node/_SECTION/delete_simple_non_nested_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/delete_node/_SECTION/delete_simple_non_nested_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/delete_node/_SECTION/delete_simple_non_nested_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/_validation/update_section_create_two_duplicate_uids/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/_validation/update_section_create_two_duplicate_uids/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/_validation/update_section_create_two_duplicate_uids/input/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/_validation/update_section_create_two_duplicate_uids/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/_validation/update_section_create_uid_that_already_exists/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/_validation/update_section_create_uid_that_already_exists/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/_validation/update_section_create_uid_that_already_exists/input/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/_validation/update_section_create_uid_that_already_exists/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/_validation/update_section_with_empty_title/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/_validation/update_section_with_empty_title/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/_validation/update_section_with_empty_title/input/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/_validation/update_section_with_empty_title/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/update_section_cancel_edit_nested_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/update_section_cancel_edit_nested_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/update_section_cancel_edit_nested_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/update_section_cancel_edit_nested_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/update_section_cancel_edit_section/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/update_section_cancel_edit_section/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/update_section_cancel_edit_section/input/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/update_section_cancel_edit_section/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/update_section_nominal_fields_editing/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/update_section_nominal_fields_editing/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/update_section_nominal_fields_editing/input/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/update_section_nominal_fields_editing/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/update_section_update_uid/expected_output/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/update_section_update_uid/expected_output/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/document/update_node/_SECTION/update_section_update_uid/input/strictdoc.toml
+++ b/tests/end2end/screens/document/update_node/_SECTION/update_section_update_uid/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/screens/project_index/show_hide_included_documents/input/strictdoc.toml
+++ b/tests/end2end/screens/project_index/show_hide_included_documents/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/stable_url_links/01_static_html_export/input/strictdoc.toml
+++ b/tests/end2end/stable_url_links/01_static_html_export/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"

--- a/tests/end2end/stable_url_links/02_web_server/input/strictdoc.toml
+++ b/tests/end2end/stable_url_links/02_web_server/input/strictdoc.toml
@@ -1,3 +1,0 @@
-[project]
-
-section_behavior = "[[SECTION]]"


### PR DESCRIPTION

WHY: `section_behavior` has been deprecated since long time ago but many test fixtures still use it. We want to clean this up.