### PR TITLE
feat(cli): "manage new" command: add optional --node type parameter

### DIFF
--- a/developer/tasks/20260621_manage_new_node_type/task.md
+++ b/developer/tasks/20260621_manage_new_node_type/task.md
@@ -1,0 +1,22 @@
+# Extend "manage new" command with a required "node_type" parameter
+
+## WHAT
+
+Extend the "manage new" command with an optional "node_type" parameter which
+specifies which node type the new node should be created with.
+
+If a document has no grammar, not specifying "node_type" should set it to
+"REQUIREMENT" by default.
+
+If a document has a custom grammar and "node_type" is not specified by a user:
+
+* If the grammar has an element of type "REQUIREMENT", "node_type" should be set
+to "REQUIREMENT".
+* If the grammar has no "REQUIREMENT" element, StrictDoc shall raise an error,
+prompting the user to provide "node_type".
+
+## WHY
+
+When a document has a custom grammar, a user needs to specify which node they
+want to create with "manage new" command. Otherwise, StrictDoc cannot guess
+which node should be created.

--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -2783,6 +2783,21 @@ Use ``--parent-uid-or-mid`` to add the new node inside an existing document or c
     strictdoc manage new <path-to-project-tree> --parent-uid-or-mid <uid-or-mid>
 
 Both options can be combined. When both are given, StrictDoc validates that the specified parent node is actually present in the specified document.
+
+**Selecting the node type**
+
+Use ``--node-type`` to specify which grammar element type the new node should use:
+
+.. code:: text
+
+    strictdoc manage new <path-to-project-tree> --node-type <TYPE>
+
+The value must match a grammar element tag defined in the document (for example ``REQUIREMENT``, ``FEATURE``, or any custom type). If the type does not exist in the grammar, the command exits with an error listing the available types.
+
+When ``--node-type`` is omitted, ``manage new`` applies the following default:
+
+- If the document has no explicit grammar, or its grammar includes a ``REQUIREMENT`` element, the node type defaults to ``REQUIREMENT``.
+- If the document has a custom grammar with no ``REQUIREMENT`` element, the command exits with an error and asks the user to specify ``--node-type``.
 <<<
 
 [[/SECTION]]

--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -94,6 +94,14 @@ stylesheets in the generated PDF.
 
 9\) Fixed: custom-grammar Markdown documents now correctly write back field
 names when saving, instead of using the default ``STATEMENT`` key.
+
+10\) The ``strictdoc manage new`` command now accepts an optional
+``--node-type`` argument. When provided, it specifies which grammar element
+type the new node should use. When omitted, the command defaults to
+``REQUIREMENT`` if the document grammar includes a ``REQUIREMENT`` element (or
+has no explicit grammar at all). If the grammar is custom and contains no
+``REQUIREMENT`` element, the command exits with an error and prompts the user
+to supply ``--node-type``.
 <<<
 
 [[/SECTION]]

--- a/spec/Markdown.md
+++ b/spec/Markdown.md
@@ -1,6 +1,6 @@
 # Markdown Specification
 
-**Grammar**: Markdown.gra.md
+**Grammar**: Markdown.gra.md \
 **PREFIX**: MD-
 
 This specification defines a Markdown-based format for writing traceable documentation, including requirements. It covers two file formats: the Markdown document format (`.md`) for content and the Markdown grammar format (`.gra.md`) for schemas. Both are valid CommonMark files.

--- a/strictdoc/commands/manage_new_command.py
+++ b/strictdoc/commands/manage_new_command.py
@@ -64,6 +64,16 @@ added to that document's root level.
             ),
         )
         parser.add_argument(
+            "--node-type",
+            type=str,
+            dest="node_type",
+            default=None,
+            help=(
+                "Node type to create (must match a grammar element tag). "
+                "Defaults to REQUIREMENT when the grammar has one."
+            ),
+        )
+        parser.add_argument(
             "--config",
             type=str,
             help="Path to the StrictDoc TOML config file.",
@@ -188,18 +198,32 @@ added to that document's root level.
             )
             sys.exit(1)
 
-        # Determine the node type to create (first non-SECTION, non-TEXT
-        # grammar element, usually REQUIREMENT).
+        # Determine the node type to create.
         assert document.grammar is not None
         node_type: Optional[str] = None
-        for element in document.grammar.elements:
-            if element.tag not in ("SECTION", "TEXT"):
-                node_type = element.tag
-                break
-        if node_type is None:
+        if manage_config.node_type is not None:
+            requested_type = manage_config.node_type
+            if requested_type not in document.grammar.elements_by_type:
+                print(  # noqa: T201
+                    f"error: The document grammar has no element of type "
+                    f"'{requested_type}'. Available types: "
+                    + ", ".join(document.grammar.elements_by_type.keys())
+                    + "."
+                )
+                sys.exit(1)
+            node_type = requested_type
+        elif (
+            document.grammar.is_default
+            or "REQUIREMENT" in document.grammar.elements_by_type
+        ):
+            node_type = "REQUIREMENT"
+        else:
             print(  # noqa: T201
-                "error: The document grammar has no element type suitable for "
-                "creating a new node (no non-SECTION, non-TEXT element found)."
+                "error: The document has a custom grammar with no REQUIREMENT "
+                "element. Use --node-type to specify which node type to create. "
+                "Available types: "
+                + ", ".join(document.grammar.elements_by_type.keys())
+                + "."
             )
             sys.exit(1)
 

--- a/strictdoc/commands/manage_new_config.py
+++ b/strictdoc/commands/manage_new_config.py
@@ -14,6 +14,7 @@ class ManageNewCommandConfig:
         project_root_path: str,
         document_path: Optional[str],
         parent_uid_or_mid: Optional[str],
+        node_type: Optional[str],
         config: Optional[str],
     ):
         self.debug: bool = debug
@@ -22,6 +23,7 @@ class ManageNewCommandConfig:
         self.project_root_path: str = project_root_path
         self.document_path: Optional[str] = document_path
         self.parent_uid_or_mid: Optional[str] = parent_uid_or_mid
+        self.node_type: Optional[str] = node_type
         self._config_path: Optional[str] = config
 
     def get_path_to_config(self) -> str:

--- a/tests/integration/features/commands/manage/new/08_node_type_explicit_custom_grammar/input.expected.sdoc
+++ b/tests/integration/features/commands/manage/new/08_node_type_explicit_custom_grammar/input.expected.sdoc
@@ -1,0 +1,23 @@
+[DOCUMENT]
+TITLE: Test Document
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: FEATURE
+  FIELDS:
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+
+[FEATURE]

--- a/tests/integration/features/commands/manage/new/08_node_type_explicit_custom_grammar/input.sdoc
+++ b/tests/integration/features/commands/manage/new/08_node_type_explicit_custom_grammar/input.sdoc
@@ -1,0 +1,21 @@
+[DOCUMENT]
+TITLE: Test Document
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: FEATURE
+  FIELDS:
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False

--- a/tests/integration/features/commands/manage/new/08_node_type_explicit_custom_grammar/test.itest
+++ b/tests/integration/features/commands/manage/new/08_node_type_explicit_custom_grammar/test.itest
@@ -1,0 +1,8 @@
+#
+# When --node-type is given and the grammar has that element, manage new shall
+# create a node of that type.
+#
+
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage new %T/ --node-type FEATURE
+RUN: %diff %S/input.expected.sdoc %T/input.sdoc

--- a/tests/integration/features/commands/manage/new/09_node_type_default_when_requirement_exists/input.expected.sdoc
+++ b/tests/integration/features/commands/manage/new/09_node_type_default_when_requirement_exists/input.expected.sdoc
@@ -1,0 +1,33 @@
+[DOCUMENT]
+TITLE: Test Document
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+- TAG: FEATURE
+  FIELDS:
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+
+[REQUIREMENT]
+UID: REQ-1
+STATEMENT: First requirement.
+
+[REQUIREMENT]
+UID: REQ-2

--- a/tests/integration/features/commands/manage/new/09_node_type_default_when_requirement_exists/input.sdoc
+++ b/tests/integration/features/commands/manage/new/09_node_type_default_when_requirement_exists/input.sdoc
@@ -1,0 +1,30 @@
+[DOCUMENT]
+TITLE: Test Document
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+- TAG: FEATURE
+  FIELDS:
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+
+[REQUIREMENT]
+UID: REQ-1
+STATEMENT: First requirement.

--- a/tests/integration/features/commands/manage/new/09_node_type_default_when_requirement_exists/test.itest
+++ b/tests/integration/features/commands/manage/new/09_node_type_default_when_requirement_exists/test.itest
@@ -1,0 +1,8 @@
+#
+# When --node-type is not given and the custom grammar has a REQUIREMENT
+# element, manage new shall default to creating a REQUIREMENT node.
+#
+
+RUN: cp %S/input.sdoc %T/
+RUN: %strictdoc manage new %T/
+RUN: %diff %S/input.expected.sdoc %T/input.sdoc

--- a/tests/integration/features/commands/manage/new/10_node_type_error_no_requirement_no_flag/input.sdoc
+++ b/tests/integration/features/commands/manage/new/10_node_type_error_no_requirement_no_flag/input.sdoc
@@ -1,0 +1,25 @@
+[DOCUMENT]
+TITLE: Test Document
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: FEATURE
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+
+[FEATURE]
+UID: FEA-1
+STATEMENT: First feature.

--- a/tests/integration/features/commands/manage/new/10_node_type_error_no_requirement_no_flag/test.itest
+++ b/tests/integration/features/commands/manage/new/10_node_type_error_no_requirement_no_flag/test.itest
@@ -1,0 +1,11 @@
+#
+# When --node-type is not given and the custom grammar has no REQUIREMENT
+# element, manage new shall print an error and exit 1. The document shall
+# not be modified.
+#
+
+RUN: cp %S/input.sdoc %T/
+RUN: %expect_exit 1 %strictdoc manage new %T/ | filecheck %s --dump-input=fail
+RUN: %diff %S/input.sdoc %T/input.sdoc
+
+CHECK: error: The document has a custom grammar with no REQUIREMENT element. Use --node-type to specify which node type to create.

--- a/tests/integration/features/commands/manage/new/11_node_type_error_invalid_value/input.sdoc
+++ b/tests/integration/features/commands/manage/new/11_node_type_error_invalid_value/input.sdoc
@@ -1,0 +1,6 @@
+[DOCUMENT]
+TITLE: Test Document
+
+[REQUIREMENT]
+UID: REQ-1
+STATEMENT: First requirement.

--- a/tests/integration/features/commands/manage/new/11_node_type_error_invalid_value/test.itest
+++ b/tests/integration/features/commands/manage/new/11_node_type_error_invalid_value/test.itest
@@ -1,0 +1,10 @@
+#
+# When --node-type names a type that does not exist in the grammar, manage new
+# shall print an error and exit 1. The document shall not be modified.
+#
+
+RUN: cp %S/input.sdoc %T/
+RUN: %expect_exit 1 %strictdoc manage new %T/ --node-type NONEXISTENT | filecheck %s --dump-input=fail
+RUN: %diff %S/input.sdoc %T/input.sdoc
+
+CHECK: error: The document grammar has no element of type 'NONEXISTENT'.


### PR DESCRIPTION
WHY: When a document has a custom grammar, a user needs to specify which node they want to create with "manage new" command. Otherwise, StrictDoc cannot guess which node should be created.