### PR TITLE
fix(tests/end2end): try to fix flaky test: edit_table_document_custom_meta_reorder

### DIFF
--- a/tests/end2end/helpers/screens/table/screen_table.py
+++ b/tests/end2end/helpers/screens/table/screen_table.py
@@ -336,6 +336,24 @@ class Screen_Table(Screen):  # pylint: disable=invalid-name
             lambda _: self.get_metadata_row_labels() == expected
         )
 
+    def get_metadata_row_testids(self) -> list:
+        return self.test_case.execute_script(
+            "return Array.from(document.querySelectorAll("
+            "  '[data-testid^=\"document-config-metadata-row-\"]'"
+            ")).map(row => row.dataset.testid);"
+        )
+
+    def wait_for_metadata_row_testids(
+        self, expected: list, timeout: float = 10
+    ) -> None:
+        # Polls the document-config metadata row testids until they match
+        # `expected`. Use after a reorder action that triggers a server
+        # round-trip: the testid attributes update asynchronously after the DOM
+        # is rebuilt, so an immediate assertion would race the update.
+        WebDriverWait(self.test_case.driver, timeout).until(
+            lambda _: self.get_metadata_row_testids() == expected
+        )
+
     def do_open_add_node_menu(self, row_order: int = 1) -> None:
         # The handle is a full-width but near-zero-height row. After a sort
         # reset the table rows are reordered while the page scroll position

--- a/tests/end2end/screens/table/view_table_edit/edit_table_document_custom_meta_reorder/test_case.py
+++ b/tests/end2end/screens/table/view_table_edit/edit_table_document_custom_meta_reorder/test_case.py
@@ -43,17 +43,12 @@ class Test(E2ECase):
                 "FIRST:",
                 "SECOND:",
             ]
-            row_testids = self.execute_script(
-                """
-                return Array.from(document.querySelectorAll(
-                    '[data-testid^="document-config-metadata-row-"]'
-                )).map(row => row.dataset.testid);
-                """
+            screen_table.wait_for_metadata_row_testids(
+                [
+                    "document-config-metadata-row-custom_meta_0",
+                    "document-config-metadata-row-custom_meta_1",
+                    "document-config-metadata-row-custom_meta_2",
+                ]
             )
-            assert row_testids == [
-                "document-config-metadata-row-custom_meta_0",
-                "document-config-metadata-row-custom_meta_1",
-                "document-config-metadata-row-custom_meta_2",
-            ]
 
         assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION


WHY: Fix a flaky test.

HOW: Set a more robust waiting expectation.