### PR TITLE
feat(table): allow creating the first node from an empty TABLE screen

### DIFF
--- a/developer/tasks/20260621_add_node_on_empty_table_screen_2957/task.md
+++ b/developer/tasks/20260621_add_node_on_empty_table_screen_2957/task.md
@@ -1,0 +1,76 @@
+# Implement adding nodes from the table screen if the document is empty
+
+## WHY
+
+The TABLE screen is intended to become a complete document editing surface.
+Users can already modify existing nodes without switching to Document view,
+but newly created documents still require a context switch because the first
+node cannot be created from the TABLE screen.
+
+This limitation prevents users from completing the entire document creation
+workflow in one place and makes the TABLE screen inconsistent with its editing
+goals.
+
+## WHAT
+
+Implement the creation of the first document node directly from the TABLE screen
+when the document is empty, and preserve the existing ability to edit an empty
+ROOT node.
+
+For the view types menu (id=“viewtype_handler”), for the TABLE screen item
+(data-viewtype_link=“table”), disable the `(empty)` suffix and the
+`.dropdown_menu_item.empty` class. (Just as this option is not used for the
+Document screen.)
+
+### Test cases
+
+are verified for the minimal fixture without nodes, on the table screen.
+
+- We are in display mode
+- In display mode, we see an empty root node with the Title,
+- In display mode, we see a table with a text placeholder.
+- We switch to edit mode.
+- The root placeholder shows block with meta fields (currently empty; we’re checking for integrity).
+- In the table, the placeholder is replaced by a handler for the “Add Node” menu.
+- Add the first node. Verify that it was successful (the node exists, and there are menu rows before and after the node).
+- Add something to the meta fields and save.
+- Exit edit mode.
+- Verify that there is the content we entered in the meta fields in the root.
+- Verify that there is no placeholder in the table, and that the single node we added is present.
+- Switch to edit mode.
+- Delete everything in the meta field(s).
+- Delete the single node from the table.
+- Check the single menu item for adding nodes.
+- Exit edit mode.
+- Check there is no meta in the root (only Title).
+- Check for a placeholder in the table.
+
+## HOW
+
+Now on the empty TABLE screen we can see placeholder "This view is empty because
+the document has no content." only.
+
+At the same time, on the document page, we see the ROOT node, along with
+a header and buttons that allow us to edit the ROOT and add new nodes relative
+to it.
+
+The idea is to reuse what has already been implemented; this does not involve
+creating a separate “empty document” mode, but rather removing the special
+“empty” table mode that contains only a placeholder.
+
+The TABLE screen in **display mode** should show:
+
+- The ROOT node, exactly as it appears alongside a non-empty table:
+title, and meta is optional (no placeholder, that is on DOCUMENT screen).
+- An empty table with a single row `colspan=“100%”`, containing the placeholder
+text: “This table is empty because the document has no content.”
+
+When **edit mode** is enabled:
+
+- The ROOT node gains all the capabilities that have already been implemented
+(editing title, meta, and custom meta).
+- In the table, instead of the placeholder row `colspan=“100%”`, display a row
+to open the menu for adding nodes.
+
+For technical details on this feature, see the files in
+`developer/tasks/20260606_table_view_edit_mode/` (excluding _draft).

--- a/strictdoc/export/html/_static/table_view.css
+++ b/strictdoc/export/html/_static/table_view.css
@@ -522,6 +522,23 @@ background-image:
 /* Doc-config fields (root node above the table)               */
 /* =========================================================== */
 
+/* sdoc-meta has its own border/padding regardless of children, so it
+   renders as an empty box even when every field is hidden. Hide it when
+   empty.
+
+   <sdoc-autogen> wraps every rendered field value (config fields, custom
+   meta) and is only ever included once that value is non-empty; the "Add
+   metadata" control doesn't use it. So "no <sdoc-autogen> inside" means
+   "nothing to show" — no need to check field types individually.
+
+   :has() re-evaluates live, so per-field inline saves are picked up with
+   no extra backend work. :not([data-mode="edit"]) avoids a specificity
+   fight with edit mode, where the wrapper must stay visible regardless of
+   emptiness so the (empty) fields can be filled in. */
+[js-table_view_edit]:not([data-mode="edit"]) sdoc-meta:not(:has(sdoc-autogen)) {
+  display: none;
+}
+
 /* Empty editable document config fields are hidden until edit mode. */
 [js-table_view_edit] sdoc-meta-label:has(+ sdoc-meta-field > [id^="doc-field-"]:empty),
 [js-table_view_edit] sdoc-meta-field:has(> [id^="doc-field-"]:empty),
@@ -709,6 +726,18 @@ background-image:
 
 [js-table_view_edit][data-mode="edit"] .content-view__add_new_row-TR {
   display: table-row;
+}
+
+/* Inverse of .content-view__add_new_row-TR: visible in display mode,
+   hidden in edit mode (where the add-node handler row takes its place). */
+[js-table_view_edit][data-mode="edit"] .content-view__empty-row-TR {
+  display: none;
+}
+
+.content-view__empty-row-TR sdoc-main-placeholder {
+  padding-inline: calc(4 * var(--base-rhythm));
+  padding-block: calc(3 * var(--base-rhythm));
+  width: fit-content; /* to push left */
 }
 
 .content-view__add_new_row-TD {

--- a/strictdoc/export/html/_static/table_view.css
+++ b/strictdoc/export/html/_static/table_view.css
@@ -294,6 +294,14 @@ background-image:
 
 /* editable */
 
+/*
+  The presence of .editable-cell-indicator determines
+  whether the parent cell appears as editable.
+*/
+*:has(> .editable-cell-indicator) {
+  position: relative;
+}
+
 .editable-cell-indicator {
   position: absolute;
   inset: 0;
@@ -301,29 +309,28 @@ background-image:
   pointer-events: none;
 }
 
-[js-table_view_edit][data-mode="edit"] .content-view-td:hover {
+[js-table_view_edit][data-mode="edit"] *:has(> .editable-cell-indicator):hover {
   cursor: pointer;
 }
 
-.content-view-table[data-mode="editable"] .content-view-td[data-mode="editing"]:hover {
+.content-view-table[data-mode="editable"] *:has(> .editable-cell-indicator)[data-mode="editing"]:hover {
   cursor: default;
 }
 
-[js-table_view_edit][data-mode="edit"] sdoc-meta-field:hover .editable-cell-indicator,
-[js-table_view_edit][data-mode="edit"] .content-view-td:hover .editable-cell-indicator {
+[js-table_view_edit][data-mode="edit"] *:has(> .editable-cell-indicator):hover .editable-cell-indicator {
   background-color: var(--color-bg-accent);
   outline: 2px dotted var(--color-fg-accent);
   outline-offset: -2px;
 }
 
-[js-table_view_edit][data-mode="edit"] .content-view-td[data-mode="editing"] .editable-cell-indicator {
+[js-table_view_edit][data-mode="edit"] *:has(> .editable-cell-indicator)[data-mode="editing"] .editable-cell-indicator {
   background-color: transparent;
   outline: 2px solid var(--color-fg-accent);
   outline-offset: -2px;
   cursor: default;
 }
 
-[js-table_view_edit][data-mode="edit"] .content-view-td form {
+[js-table_view_edit][data-mode="edit"] *:has(> .editable-cell-indicator) form {
   display: flex;
   flex-direction: column;
   gap: var(--base-rhythm);
@@ -515,11 +522,6 @@ background-image:
 /* Doc-config fields (root node above the table)               */
 /* =========================================================== */
 
-/* TITLE wrapper: block-level so the h1 fills it naturally. */
-[js-table_view_edit] sdoc-node > sdoc-meta-field[data-field-name="TITLE"] {
-  display: block;
-}
-
 /* Empty editable document config fields are hidden until edit mode. */
 [js-table_view_edit] sdoc-meta-label:has(+ sdoc-meta-field > [id^="doc-field-"]:empty),
 [js-table_view_edit] sdoc-meta-field:has(> [id^="doc-field-"]:empty),
@@ -537,6 +539,13 @@ background-image:
 
 [js-table_view_edit][data-mode="edit"] sdoc-meta-field {
   min-width: 100px;
+}
+
+[js-table_view_edit][data-mode="edit"] sdoc-meta-field[data-field-name] {
+  /* to have the reserved (not custom) meta field
+     take the place of the right (delete) button
+  */
+  grid-column: 3 / 5;
 }
 
 [js-table_view_edit][data-mode="edit"] sdoc-meta-label:has(+ sdoc-meta-field > [id^="doc-field-"]:empty),

--- a/strictdoc/export/html/templates/screens/document/_shared/viewtype_menu.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/viewtype_menu.jinja
@@ -1,11 +1,12 @@
 {#
   Empty-state flags: a view is "empty" if it would show the placeholder instead of content.
-  - Table and Traceability: no nodes at all in the document.
+  - Table: no longer flagged here — the TABLE screen now supports creating the first
+    node directly from an empty document, so it is never marked "(empty)" (same as Document).
+  - Traceability: no nodes at all in the document.
   - Deep Traceability: uses has_any_requirements() which historically excluded sections,
     but after a refactoring sections now appear in DTR as well.
     TODO: revisit deeptrace_is_empty condition if the DTR output changes to exclude sections again.
 #}
-{%- set table_is_empty = not view_object.has_any_nodes() -%}
 {%- set trace_is_empty = not view_object.has_any_nodes() -%}
 {%- set deeptrace_is_empty = not view_object.document.has_any_requirements() -%}
 
@@ -39,10 +40,10 @@
     <li>
       <a
         data-viewtype_link="table"
-        class="dropdown_menu_item{% if table_is_empty %} empty{% endif %}"
-        title="{% if table_is_empty %}This page has no content{% else %}Go to Table view{% endif %}"
+        class="dropdown_menu_item"
+        title="Go to Table view"
         href="{{ view_object.render_document_link(view_object.document, none, "TABLE") }}">
-      Table{% if table_is_empty %} (empty){% endif %}</a>
+      Table</a>
     </li>
     {%- endif -%}
     {%- if view_object.project_config.is_activated_trace_screen() -%}

--- a/strictdoc/export/html/templates/screens/document/table/body.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/body.jinja
@@ -1,6 +1,16 @@
 {%- set is_server = view_object.is_running_on_server -%}
 <tbody id="table-content-body" data-testid="table-content-body">
 
+  {%- if not content_entries %}
+  <tr class="content-view__empty-row-TR" data-testid="table-empty-placeholder">
+    <td class="content-view__empty-row-TD" colspan="100%">
+      <sdoc-main-placeholder data-testid="empty-table-placeholder">
+        This table is empty because the document has no content.
+      </sdoc-main-placeholder>
+    </td>
+  </tr>
+  {%- endif %}
+
   {%- if is_server %}
   {%- with
     prev_node=none,

--- a/strictdoc/export/html/templates/screens/document/table/main.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/main.jinja
@@ -71,7 +71,6 @@
   When a column exists in the document grammar but a specific node's grammar
   does not declare that field, the cell gets the "content-view-td--dimmed" modifier.
 #}
-{%- if view_object.has_any_nodes() -%}
   <div class="main"
        js-pan_with_space="true"
        js-table_view_edit
@@ -137,10 +136,3 @@
       {# /.content #}
   </div>
   {# /.main #}
-{%- else -%}
-  <sdoc-main-placeholder data-testid="document-main-placeholder">
-  This view is empty because
-  <br />
-  the document has no content.
-  </sdoc-main-placeholder>
-{%- endif -%}

--- a/strictdoc/export/html/templates/screens/document/table/root_node.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/root_node.jinja
@@ -5,6 +5,8 @@
 
 {%- set doc_mid = view_object.document.reserved_mid -%}
 {%- set document_config = view_object.document.config -%}
+{%- set document_version_ = view_object.render_document_version() -%}
+{%- set document_date_ = view_object.render_document_date() -%}
 <sdoc-node>
   <h1 data-testid="document-title">
     {%- with
@@ -32,7 +34,6 @@
     {%- endwith -%}
 
     {# -- VERSION ------------------------------------------------ #}
-    {%- set document_version_ = view_object.render_document_version() -%}
     {%- with
       field_content=document_version_,
       field_label="VERSION",
@@ -43,11 +44,11 @@
     {%- endwith -%}
 
     {# -- DATE (read-only) --------------------------------------- #}
-    {%- set document_date_ = view_object.render_document_date() -%}
     {%- if document_date_ is not none -%}
       {%- with
         field_content=document_date_,
         field_label="DATE",
+        field_name="DATE",
         field_testid="date"
       -%}
         {%- include "screens/document/table/field_display_mode/document_meta_readonly_field.jinja" -%}

--- a/strictdoc/export/html/templates/screens/document/table/row_add_new_node.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/row_add_new_node.jinja
@@ -1,6 +1,7 @@
 {% assert view_object.is_running_on_server %}
 {%- set table_document_mid = view_object.document.reserved_mid -%}
-{%- set can_use_separator = prev_node is not none or next_node is not none -%}
+{%- set can_add_first_node = prev_node is none and next_node is none and view_object.can_add_node(view_object.document) -%}
+{%- set can_use_separator = prev_node is not none or next_node is not none or can_add_first_node -%}
 {%- set can_add_before_next = next_node is not none and view_object.can_insert_next_to_node(next_node) -%}
 {%- set can_add_after_prev = prev_node is not none and view_object.can_insert_next_to_node(prev_node) -%}
 {%- set can_add_child_of_prev = prev_node is not none and (prev_node.is_document() or prev_node.is_composite) and view_object.can_add_node(prev_node) -%}
@@ -47,6 +48,21 @@
                 js-table_view_edit-add-node-actions>
               {%- for element in view_object.get_grammar_elements() -%}
                 <li class="table-add-node__element">{{ element.tag }}:</li>
+                {%- if can_add_first_node -%}
+                  <li class="table-add-node__action" data-whereto="child">
+                    <button class="table-add-node__action-button"
+                            type="button"
+                            js-table_view_edit-add-node-action
+                            data-testid="table-add-node-action-{{ element.tag|lower }}-child"
+                            data-context-document-mid="{{ table_document_mid }}"
+                            data-reference-mid="{{ table_document_mid }}"
+                            data-element-type="{{ element.tag }}"
+                            data-whereto="child"
+                            title="Add first {{ element.tag }}">
+                      {% include "icons/ico16_add.svg" %}
+                    </button>
+                  </li>
+                {%- endif -%}
                 {%- if can_add_before_next -%}
                   <li class="table-add-node__action" data-whereto="before">
                     <button class="table-add-node__action-button"

--- a/tests/end2end/navigation/viewtype_selector/viewtype_menu_empty_state/test_case.py
+++ b/tests/end2end/navigation/viewtype_selector/viewtype_menu_empty_state/test_case.py
@@ -29,10 +29,11 @@ class Test(E2ECase):
 
             viewtype_selector = ViewType_Selector(self)
 
-            # Open menu — all views should be marked as empty.
+            # Open menu — Table is never marked empty (same as Document); the
+            # other views should be marked as empty.
             viewtype_selector.do_click_viewtype_handler()
             viewtype_selector.assert_viewtype_menu_opened()
-            viewtype_selector.assert_menu_item_is_empty("table")
+            viewtype_selector.assert_menu_item_is_not_empty("table")
             viewtype_selector.assert_menu_item_is_empty("traceability")
             viewtype_selector.assert_menu_item_is_empty("deep_traceability")
 

--- a/tests/end2end/screens/table/view_table_document/view_table_document_document_has_no_content/test_case.py
+++ b/tests/end2end/screens/table/view_table_document/view_table_document_document_has_no_content/test_case.py
@@ -33,6 +33,26 @@ class Test(E2ECase):
             viewtype_selector = ViewType_Selector(self)
             screen_table = viewtype_selector.do_go_to_table()
             screen_table.assert_on_screen_table()
-            screen_table.assert_empty_view()
+
+            # Display mode: Title is visible, meta is simply absent (no
+            # placeholder banner — that one belongs to the Document screen
+            # only), the table shows its own empty-state placeholder.
+            self.assert_text("Document title", '[data-testid="document-title"]')
+            self.assert_element_not_visible(
+                '[data-testid="document-config-uid-field"]'
+            )
+            self.assert_element_not_visible(
+                '[data-testid="document-config-version-field"]'
+            )
+            screen_table.assert_empty_view("table-empty-placeholder")
+            self.assert_element_not_visible('[data-testid="table-add-row"]')
+
+            # The Table item in the viewtype menu is never marked "(empty)"
+            # (same as Document).
+            viewtype_selector.do_click_viewtype_handler()
+            viewtype_selector.assert_viewtype_menu_opened()
+            viewtype_selector.assert_menu_item_is_not_empty("table")
+            viewtype_selector.do_click_viewtype_handler()
+            viewtype_selector.assert_viewtype_menu_closed()
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/table/view_table_edit/add_table_node_on_empty_table/expected_output/document.sdoc
+++ b/tests/end2end/screens/table/view_table_edit/add_table_node_on_empty_table/expected_output/document.sdoc
@@ -1,0 +1,2 @@
+[DOCUMENT]
+TITLE: Document title

--- a/tests/end2end/screens/table/view_table_edit/add_table_node_on_empty_table/input/document.sdoc
+++ b/tests/end2end/screens/table/view_table_edit/add_table_node_on_empty_table/input/document.sdoc
@@ -1,0 +1,2 @@
+[DOCUMENT]
+TITLE: Document title

--- a/tests/end2end/screens/table/view_table_edit/add_table_node_on_empty_table/test_case.py
+++ b/tests/end2end/screens/table/view_table_edit/add_table_node_on_empty_table/test_case.py
@@ -1,0 +1,121 @@
+from selenium.webdriver.common.keys import Keys
+
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.confirm import Confirm
+from tests.end2end.helpers.components.viewtype_selector import ViewType_Selector
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_document = screen_project_index.do_click_on_first_document()
+            screen_document.assert_on_screen_document()
+
+            self.clear_local_storage()
+
+            screen_table = ViewType_Selector(self).do_go_to_table()
+            screen_table.assert_on_screen_table()
+
+            # Switch to edit mode: the table-empty placeholder is replaced by
+            # the "Add Node" handler; the (still empty) meta fields become
+            # visible/editable for integrity.
+            screen_table.do_toggle_edit_mode()
+            screen_table.assert_edit_mode_on()
+            screen_table.assert_not_empty_view("table-empty-placeholder")
+            self.assert_element_visible('[data-testid="table-add-node-handle"]')
+            self.assert_element_visible(
+                '[data-testid="document-config-uid-field"]'
+            )
+
+            # Add the first node from the empty table.
+            screen_table.do_open_add_node_menu(row_order=1)
+            screen_table.do_click_add_node_action(
+                element_type="REQUIREMENT",
+                whereto="child",
+                row_order=1,
+            )
+            screen_table.wait_for_table_row_count(1)
+            assert screen_table.get_table_row_count() == 1
+            new_node_mid = screen_table.get_node_mid_from_row(row_order=1)
+
+            # There are now menu rows both before and after the new node.
+            add_rows = self.find_elements('[data-testid="table-add-row"]')
+            assert len(add_rows) == 2
+
+            # Fill in some meta fields and save.
+            uid = '[data-testid="document-config-uid-field"]'
+            self.click(uid)
+            self.type('[data-testid="form-field-UID"]', "DOC-001")
+            screen_table.do_save_inline_cell_by_outside_click()
+
+            version = '[data-testid="document-config-version-field"]'
+            self.click(version)
+            self.type('[data-testid="form-field-VERSION"]', "1.0")
+            screen_table.do_save_inline_cell_by_outside_click()
+
+            screen_table.do_toggle_edit_mode()
+            screen_table.assert_edit_mode_off()
+
+            # No placeholders left: meta content and the added node are present.
+            self.assert_text("DOC-001", uid)
+            self.assert_text("1.0", version)
+            screen_table.assert_not_empty_view("table-empty-placeholder")
+            assert screen_table.get_table_row_count() == 1
+            assert (
+                screen_table.get_node_mid_from_row(row_order=1) == new_node_mid
+            )
+
+            # Switch back to edit mode: clear the meta fields and delete the node.
+            screen_table.do_toggle_edit_mode()
+            screen_table.assert_edit_mode_on()
+
+            self.click(uid)
+            self.type('[data-testid="form-field-UID"]', "X")
+            self.find_element('[data-testid="form-field-UID"]').send_keys(
+                Keys.BACKSPACE
+            )
+            screen_table.do_save_inline_cell_by_outside_click()
+
+            self.click(version)
+            self.type('[data-testid="form-field-VERSION"]', "X")
+            self.find_element('[data-testid="form-field-VERSION"]').send_keys(
+                Keys.BACKSPACE
+            )
+            screen_table.do_save_inline_cell_by_outside_click()
+
+            screen_table.do_click_delete_action(new_node_mid)
+            Confirm(self).do_confirm_action()
+            screen_table.assert_node_row_not_present(new_node_mid)
+
+            # Back to a single add-row with the "add first node" menu item.
+            add_rows = self.find_elements('[data-testid="table-add-row"]')
+            assert len(add_rows) == 1
+            screen_table.do_open_add_node_menu(row_order=1)
+            screen_table.assert_add_node_actions_visible(row_order=1)
+            self.assert_element(
+                '[data-testid="table-add-node-action-requirement-child"]'
+            )
+            screen_table.do_close_add_node_menu_by_escape()
+
+            screen_table.do_toggle_edit_mode()
+            screen_table.assert_edit_mode_off()
+
+            # Placeholders are back: no meta in the root (only Title), table
+            # shows its empty-state placeholder again.
+            self.assert_element_not_visible(uid)
+            self.assert_element_not_visible(version)
+            screen_table.assert_empty_view("table-empty-placeholder")
+
+        assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
Closes  #2957

## Summary
- The TABLE screen no longer shows a full-screen "empty" placeholder. It now
  renders the ROOT node and table as usual, and lets you create the first
  node directly from the empty table (same backend path as the existing
  "Add first child" on the DOCUMENT screen).
- The "Table" item in the view-type menu no longer gets the `(empty)`
  marker for an empty document (same as "Document").
  
- Additionally, the CSS for the editable cell has been corrected

## Tests
- Fixed the existing `view_table_document_document_has_no_content` test
  (now scoped to display mode only) and the `viewtype_menu_empty_state` test.
- Added a new test, `view_table_edit/add_table_node_on_empty_table`, covering
  the edit-mode flow: add first node, fill/save meta, delete node, verify
  placeholders return.