### PR TITLE
fix(autocomplete): empty-state message, value deduplication, and pan-on-arrow-key bug

### DIFF
--- a/developer/tasks/20260622_2938_autocomplete_empty_state/task.md
+++ b/developer/tasks/20260622_2938_autocomplete_empty_state/task.md
@@ -1,0 +1,63 @@
+# Fix the autocomplete display for empty results
+
+## WHAT
+
+When autocomplete cannot find any results to display, the message “No matches found” should appear.
+
+## WHY
+
+Right now, nothing is displayed at all. This is bad UX.
+
+## HOW
+
+The empty-state message is rendered entirely client-side.
+
+Test case:
+
+The test verifies that when a user enters a query into the TAGS autocomplete
+field that has no matching options, the dropdown displays a disabled
+“No matches found” entry and that this entry cannot be selected via keyboard
+navigation.
+
+Test steps:
+
+* Open a test document containing a requirement that already has the tag Tag1.
+* Open the requirement edit form.
+* Enter a guaranteed non-existent tag (ZzZ_no_such_tag) into the TAGS field.
+* Wait for the autocomplete dropdown and verify that it contains
+a aria-disabled="true" entry with the text “No matches found”.
+* Record the current field value, press Arrow Down and Enter (as if selecting
+a normal option), and verify that the field value remains unchanged, confirming
+that the placeholder entry cannot be selected.
+* Close the form using “Cancel” without saving.
+* Verify that the sandbox matches the original files, confirming that the
+document was not modified.
+
+### Implementation notes
+
+- Root cause: when the server returns zero matches, the autocomplete
+  fragment is an empty string. `AutoCompletable.replaceResults()` always
+  calls `open()` regardless of result count (`this.options` is an array,
+  which is always truthy), so the dropdown opened with zero `<li>` children
+  and rendered nothing visible.
+- `replaceResults()` detects an empty/whitespace-only fragment and
+  injects a single placeholder row instead:
+  `<li class="autocompletable-result-item autocompletable-result-item_no-results" role="option" aria-disabled="true">No matches found</li>`.
+- The placeholder reuses the existing `optionSelector` filter
+  (`[role='option']:not([aria-disabled])`): `aria-disabled="true"` means it
+  is automatically excluded from `this.options`, so keyboard navigation
+  (arrow keys, Tab, Enter → `commit()`) and mouse click on it are no-ops,
+  with no extra guard code required.
+- `strictdoc/export/html/templates/components/form/field/autocompletable/index.jinja`:
+  gets `aria-live="polite"` to the results `<ul>` so screen readers announce
+  the "No matches found" message when it's injected.
+- `strictdoc/export/html/_static/form.css`:
+  `.autocompletable-result-item_no-results` gets a modifier class (muted color,
+  italic, default cursor) for the placeholder row.
+
+- e2e test:
+  `tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_matches/`,
+  using a new helper `Form.assert_autocomplete_no_results()` /
+  `Form_EditRequirement.assert_field_autocomplete_no_results()` that asserts
+  the placeholder is shown and that Arrow-Down + Enter does not change the
+  field's content.

--- a/developer/tasks/20260622_2969_autocomplete_duplicates/task_ac.md
+++ b/developer/tasks/20260622_2969_autocomplete_duplicates/task_ac.md
@@ -1,0 +1,151 @@
+# Autocomplete: already-selected values are re-suggested (MultipleChoice/Tag)
+
+## WHAT
+
+In MultipleChoice/Tag fields (comma-separated multi-value autocomplete), a
+value that is already present in the field must not be insertable a second
+time via the autocomplete dropdown.
+
+- A value already present in the field (whether it's the only value typed
+  so far with no trailing comma, or it's the last, fully-typed
+  comma-separated segment) must stay visible in the dropdown, but visually
+  marked as already selected ("подсвечено").
+- Selecting it again (click or keyboard) must not insert a duplicate / must
+  not change the field's value.
+- Out of scope: detecting which value the user clicked on based on cursor
+  position (i.e. distinguishing "clicked on the in-progress query segment"
+  vs. "clicked on an earlier, already-committed value" elsewhere in the
+  text). The dropdown's query is always derived from the segment after the
+  last comma in the whole field text, regardless of where the user actually
+  places the cursor — this is a separate, harder problem and is
+  deliberately not addressed here.
+
+## WHY
+
+A Set-like field (Tag/MultipleChoice) should not let the same value be
+picked twice via autocomplete. Right now nothing prevents it:
+
+- The server (`get_autocomplete_field_results` in
+  `strictdoc/server/routers/main_router.py`) only excludes values found in
+  `parts[:-1]` — the comma-segments *before* the last one. The last
+  segment is always treated as "still being typed" and is matched against
+  itself, even once it's a complete, exact match for an existing option.
+- Concretely:
+  - If the field currently has a single value with no trailing comma yet
+    (e.g. `Tag1`), re-opening the dropdown (click/focus) shows `Tag1`
+    itself as a suggestion, even though it's already the field's value.
+  - After adding a comma and typing a second value in full (e.g.
+    `Tag1, Tag2`), re-opening the dropdown shows `Tag2` (the last,
+    already fully-typed value) as a suggestion again — regardless of
+    where in the text the user clicks, because the query is always derived
+    from the whole field text's last comma-segment, not from cursor
+    position.
+
+This is confusing: the user sees a value they already picked offered again
+as if it were a fresh, separate choice.
+
+This is the classic "multi-select combobox / tag input" duplicate-selection
+problem. The standard UX pattern (GitHub labels, Gmail "To:" field,
+MUI/Ant/Headless-UI multi-select, etc.) is to keep already-selected values
+visible in the list but visually marked and inert — not to hide them, and
+not to let them be re-inserted.
+
+## HOW
+
+> Note: during implementation it turned out a JS controller change *was*
+> required after all (see step 0 below) — the click handler was discarding
+> the current field text entirely for MultipleChoice/Tag fields, which is
+> the actual root cause of the most commonly reported case (re-opening the
+> dropdown via click right after picking a value). This was confirmed with
+> the user before implementing.
+
+Reuse the same `aria-disabled` pattern already used for the "No matches
+found" placeholder: `replaceResults()` in
+`strictdoc/export/html/_static/controllers/autocompletable_field_controller.js`
+already excludes `aria-disabled` rows from `this.options` (keyboard nav,
+`selectText()`, `onResultsClick` → `commit()`) for free, via the existing
+`optionSelector` constant (`[role='option']:not([aria-disabled])`).
+
+### 0. JS controller — `autocompletable_field_controller.js` (click handler)
+
+The click handler used `minLengthValue == 0 ? "" : innerText.trim()` as the
+query for *all* autocompletable fields (TAG/MultipleChoice/SingleChoice all
+use `autocomplete_len="0"`, see `row_with_text_field.jinja`). For
+MultipleChoice/Tag fields this meant a click **always** sent an empty
+query, discarding any already-typed value and its comma-context — so the
+server's existing `parts[:-1]` exclusion never had anything to exclude on
+click. This is the actual cause of "select Tag1, click the field again
+(no comma typed) → Tag1 is offered again."
+
+Fix, extracted into `buildClickQuery()`:
+- SingleChoice (`!multipleChoiceValue`): unchanged, always `""` (click acts
+  like a `<select>` dropdown showing the full list).
+- MultipleChoice/Tag, field empty or already ending with `,`: send the
+  current text as-is (same as typing).
+- MultipleChoice/Tag with a complete value and **no** trailing comma:
+  clicking to browse more options is equivalent to the user having just
+  typed a separating comma. We actually **insert** `", "` into the
+  contenteditable (not just into the query string) — otherwise `commit()`
+  later re-splits the *real* field text on commas, finds none, and
+  overwrites the existing value instead of appending the new one. The
+  cursor-move logic shared with `commit()` was extracted into
+  `moveCursorToEnd()` to avoid duplicating it.
+
+### 1. Server — `strictdoc/server/routers/main_router.py`
+
+In `get_autocomplete_field_results`, MULTIPLE_CHOICE/TAG branch:
+
+- Keep computing `already_selected` from `parts[:-1]` (unchanged).
+- Additionally treat the **last segment** (`last_part`) as "already
+  selected" too, but only on an **exact** (not substring) case-insensitive
+  match against an option. This single extra check covers both reported
+  cases (no-comma single value; fully-typed last value after a comma).
+- Build `resulting_values` as a list of `(value, is_selected: bool)` pairs
+  instead of plain strings, where `is_selected` is true if the value
+  (case-insensitive) is in `already_selected` or exactly equals
+  `last_part`.
+- Do **not** drop already-selected values from the list — keep them so
+  they're still rendered (per the "highlight, don't hide" requirement).
+
+### 2. Template —
+`strictdoc/export/html/templates/autocomplete/field/stream_autocomplete_field.jinja.html`
+
+For each `(value, is_selected)`, render:
+
+```html
+<li class="autocompletable-result-item{% if is_selected %} autocompletable-result-item_selected{% endif %}"
+    role="option"
+    {% if is_selected %}aria-disabled="true"{% endif %}
+    data-autocompletable-value="{{ value }}">{{ value }}</li>
+```
+
+### 3. CSS — `strictdoc/export/html/_static/form.css`
+
+Add `.autocompletable-result-item_selected` — muted color + `cursor:
+default`, matching the visual language of `.autocompletable-result-item_no-results`.
+
+### 4. Tests
+
+Added
+`tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_duplicates/`:
+opens a requirement whose TAGS field already has `Tag1` (document also has
+`Tag2` used elsewhere, so the dropdown has something else to legitimately
+offer), clicks the field, asserts no `<li data-autocompletable-value="Tag1">`
+is present in the results, then sends Arrow-Down + Enter and asserts
+`Tag1` isn't duplicated in the field's text.
+
+New helpers:
+- `Form.assert_autocomplete_no_duplicate_on_click()` /
+  `Form_EditRequirement.assert_field_autocomplete_no_duplicate_on_click()`
+  (click case).
+- `Form.assert_autocomplete_no_results()` /
+  `Form_EditRequirement.assert_field_autocomplete_no_results()` were added
+  earlier for the empty-state task and are reused/adjacent here.
+
+### Scope notes
+
+- Scoped to the MULTIPLE_CHOICE/TAG branch only — SingleChoice fields have
+  Set-of-one semantics where re-showing the current value is normal (e.g.
+  picking a different one), so they're unaffected and out of scope.
+- Cursor-position-aware filtering (clicking on an earlier value vs. the
+  in-progress segment) is explicitly out of scope, per the WHAT section.

--- a/developer/tasks/20260622_2969_autocomplete_duplicates/task_dp.md
+++ b/developer/tasks/20260622_2969_autocomplete_duplicates/task_dp.md
@@ -1,0 +1,70 @@
+# MultipleChoice/Tag field: deduplicate existing values when opening the edit form
+
+## WHAT
+
+When a requirement's MultipleChoice/Tag field already contains duplicate
+values (e.g. `Tag1, Tag1`), opening that field for editing must show it
+with duplicates already removed. No server-side validation or
+save-blocking is required — if the user saves as-is, the document is
+cleaned up as a side effect of the normal save.
+
+This requirement applies to **both** editing surfaces, as they are
+implemented and tested independently of each other:
+- the modal requirement-edit form;
+- the table-view inline cell editor.
+
+## WHY
+
+[[task_ac]] prevents *new* duplicates from being inserted via autocomplete,
+but does nothing for values that are already duplicated in the document
+(typed by hand, edited outside the UI, or present before that fix existed).
+There is currently no code path that detects or cleans up duplicates in
+already-saved field values.
+
+## HOW
+
+There are **two** independent code paths that load an existing field's
+value for editing, matching the two surfaces from WHAT — both need the fix:
+
+1. `strictdoc/export/html/form_objects/requirement_form_object.py`,
+   `RequirementFormField.create_existing_from_grammar_field()` — used when
+   opening the modal requirement-edit form
+   (`get_edit_requirement` in `main_router.py`).
+2. `strictdoc/server/routers/main_router.py`,
+   `table__get_node_autocomplete_inline()` (~line 1471) — used when
+   entering edit mode on a table-view cell. This reads
+   `node.ordered_fields_lookup[field_name][0].get_text_value()` directly,
+   completely bypassing `RequirementFormObject`.
+
+Implementation:
+- `deduplicate_comma_separated_value()` (public function in
+  `requirement_form_object.py`, used from both places): splits a
+  comma-separated value, strips each part, drops empty parts, and removes
+  case-insensitive duplicates while keeping the order and original casing
+  of the first occurrence.
+- Applied in (1) to `field_value` only when `grammar_field.gef_type` is
+  `MULTIPLE_CHOICE` or `TAG`.
+- Applied in (2) to `current_value` only when `is_multiple_choice` is true
+  (same two types, already computed there as `is_multiple_choice`).
+- `create_from_grammar_field()` (brand-new requirements) and the
+  read-only/display-mode cell rendering (`field_name in
+  node.ordered_fields_lookup` branch around main_router.py:2131, used to
+  render the cell when *not* editing) are intentionally left untouched —
+  no existing value to deduplicate in the first case, and the task is
+  scoped to the *edit* experience, not to silently changing what's
+  displayed for unsaved/unedited data.
+- A code comment at each call site explains why the dedup happens there
+  (existing documents may predate the autocomplete fix or be hand-edited).
+
+### Tests
+
+- Unit tests for `deduplicate_comma_separated_value()` covering: simple
+  duplicates, different casing, extra whitespace, empty parts, single
+  value, empty value.
+- Verified manually against a running server (both
+  `/actions/document/edit_requirement` and
+  `/actions/table/get_node_autocomplete_inline`) with a field value of
+  `Tag1, Tag1, Tag2` — both now return `Tag1, Tag2`.
+- Existing e2e tests for table-cell autocomplete
+  (`edit_table_cell_single_choice`, `edit_table_cell_multiple_choice`)
+  re-run, still passing.

--- a/developer/tasks/20260622_2970_autocomplete_pan_with_space/task.md
+++ b/developer/tasks/20260622_2970_autocomplete_pan_with_space/task.md
@@ -1,0 +1,30 @@
+# Arrow keys pan the diagram view while editing a field
+
+## WHAT
+
+Pressing Arrow Up/Down/Left/Right while focus is in any editable field
+(contenteditable, autocomplete dropdown navigation, input, textarea) must
+not also scroll/pan the table/diagram view. Only the field's own behavior
+(caret move, dropdown option navigation) should happen.
+
+## WHY
+
+`strictdoc/export/html/_static/pan_with_space.js` adds a `document`-level
+`keydown` listener for panning a `[js-pan_with_space]` view. The Spacebar
+branch already skips itself when `document.activeElement` is editable, but
+the Arrow* branches had no such check — they always ran
+`element.scrollTop/scrollLeft += 20`. So every arrow press anywhere on the
+page (typing in a field, navigating autocomplete options, etc.) also panned
+the view by a fixed 20px, on top of whatever the field itself did. This was
+most visible with the autocomplete dropdown (selection moved AND the page
+jumped on every key press), but affected any editable field equally, and
+reproduced the same way in Chrome/Firefox/Safari (not a browser quirk).
+
+## HOW
+
+`strictdoc/export/html/_static/pan_with_space.js`: compute `isEditable`
+once at the top of the keydown handler (same check already used for
+Spacebar — `INPUT`/`TEXTAREA`/`isContentEditable`) and `return` early for
+the Arrow* branches when it's true, mirroring the existing Spacebar guard.
+No changes needed elsewhere (the autocomplete controller itself was not at
+fault).

--- a/strictdoc/export/html/_static/controllers/autocompletable_field_controller.js
+++ b/strictdoc/export/html/_static/controllers/autocompletable_field_controller.js
@@ -7,6 +7,8 @@
 
   const optionSelector = "[role='option']:not([aria-disabled])"
   const activeSelector = "[aria-selected='true']"
+  const noResultsItemHTML =
+    '<li class="autocompletable-result-item autocompletable-result-item_no-results" role="option" aria-disabled="true">No matches found</li>'
 
   class AutoCompletable extends Stimulus.Controller {
     static targets = ["name"]
@@ -309,7 +311,8 @@
     }
 
     replaceResults(html) {
-      this.results.innerHTML = html
+      const hasResults = html != null && html.trim().length > 0
+      this.results.innerHTML = hasResults ? html : noResultsItemHTML
       this.identifyOptions()
       if (!!this.options) {
         this.open()

--- a/strictdoc/export/html/_static/controllers/autocompletable_field_controller.js
+++ b/strictdoc/export/html/_static/controllers/autocompletable_field_controller.js
@@ -58,16 +58,12 @@
         this.close()
       });
 
-      autocompletable.addEventListener("click", (event) => {      
+      autocompletable.addEventListener("click", (event) => {
         /* Toggle between showing / hiding results. */
         if (this.resultsShown) {
           this.hideAndRemoveOptions();
         } else {
-          /* If minLengthValue is 0, we want to get all possible options (i.e. for SingleChoice).
-             Otherwise, we want narrow-down-as-you-type behavior, and filter on remainig options.
-           */
-          const query = this.minLengthValue == 0 ? "" : this.autocompletable.innerText.trim();
-          this.fetchResults(query);
+          this.fetchResults(this.buildClickQuery());
         }
       });
 
@@ -194,14 +190,7 @@
       this.autocompletable.innerText = suggestion
       this.hidden.value = suggestion
 
-      // Move the cursor to the end of the input. 
-      this.autocompletable.focus();
-      const range = document.createRange();
-      range.selectNodeContents(this.autocompletable);
-      range.collapse(false);
-      const sel = window.getSelection();
-      sel.removeAllRanges();
-      sel.addRange(range);
+      this.moveCursorToEnd()
 
       this.hidden.dispatchEvent(new Event("input"))
       this.hidden.dispatchEvent(new Event("change"))
@@ -215,6 +204,16 @@
           detail: { value: suggestion, textValue: textValue, selected: selected }
         })
       )
+    }
+
+    moveCursorToEnd() {
+      this.autocompletable.focus();
+      const range = document.createRange();
+      range.selectNodeContents(this.autocompletable);
+      range.collapse(false);
+      const sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
     }
 
     clear() {
@@ -288,6 +287,44 @@
         this.element.dispatchEvent(new CustomEvent("loadend"))
         throw error
       }
+    }
+
+    buildClickQuery() {
+      /* If minLengthValue is greater than 0, narrow-down-as-you-type
+         behavior is in effect: use the current text as the query, same as
+         while typing. */
+      if (this.minLengthValue != 0) {
+        return this.autocompletable.innerText.trim()
+      }
+
+      if (!this.multipleChoiceValue) {
+        /* minLengthValue is 0 and not MultipleChoice/Tag: clicking should
+           act like a drop-down and show all possible options (i.e. for
+           SingleChoice). */
+        return ""
+      }
+
+      const currentText = this.autocompletable.innerText.trim()
+      if (!currentText || currentText.endsWith(",")) {
+        /* Nothing typed yet, or already mid-way through a new entry. */
+        return currentText
+      }
+
+      /* MultipleChoice/Tag with an already-complete value and no trailing
+         comma: clicking to browse more options is equivalent to the user
+         having just typed a separating comma. We actually insert it (not
+         just send it as the query) so that the values already present are
+         excluded from suggestions *and* so that selecting a suggestion
+         afterwards appends a new value via commit() instead of
+         overwriting the existing one. */
+      const newText = `${currentText}, `
+      this.autocompletable.innerText = newText
+      this.hidden.value = newText
+      this.moveCursorToEnd()
+      this.hidden.dispatchEvent(new Event("input"))
+      this.hidden.dispatchEvent(new Event("change"))
+
+      return newText.trim()
     }
 
     buildURL(query) {

--- a/strictdoc/export/html/_static/form.css
+++ b/strictdoc/export/html/_static/form.css
@@ -322,6 +322,11 @@ sdoc-autocompletable[contenteditable="false"] {
 }
 
 .autocomplete-items {
+  /* reset default ul */
+  padding: 0;
+  margin: 0;
+  list-style-type: none;
+  /* autocomplete wrapper */
   position: absolute;
   border: 1px solid var(--color-action);
   background-color: var(--color-bg-contrast);
@@ -346,6 +351,12 @@ sdoc-autocompletable[contenteditable="false"] {
   padding:.25rem 0.25rem;
   margin-bottom:-1px;
   border:1px solid rgba(0,0,0,.125)
+}
+
+.autocompletable-result-item_no-results {
+  color: var(--color-fg-secondary);
+  font-style: italic;
+  cursor: default;
 }
 
 .monospace {

--- a/strictdoc/export/html/_static/form.css
+++ b/strictdoc/export/html/_static/form.css
@@ -359,6 +359,11 @@ sdoc-autocompletable[contenteditable="false"] {
   cursor: default;
 }
 
+.autocompletable-result-item_selected {
+  color: var(--color-fg-secondary);
+  cursor: default;
+}
+
 .monospace {
   font-family: var(--code-font-family);
 }

--- a/strictdoc/export/html/_static/pan_with_space.js
+++ b/strictdoc/export/html/_static/pan_with_space.js
@@ -35,11 +35,12 @@ window.addEventListener('load', function () {
     console.assert(!!element, "Expected a valid element.");
 
     document.addEventListener("keydown", function (e) {
+      var tag = document.activeElement && document.activeElement.tagName;
+      var isEditable = tag === 'INPUT' || tag === 'TEXTAREA' || document.activeElement.isContentEditable;
+
       if (e.key === ' ' || e.key === 'Spacebar') {
         // ' ' is standard, 'Spacebar' was used by IE9 and Firefox < 37
 
-        var tag = document.activeElement && document.activeElement.tagName;
-        var isEditable = tag === 'INPUT' || tag === 'TEXTAREA' || document.activeElement.isContentEditable;
         if (isEditable) {
           return;
         }
@@ -49,6 +50,13 @@ window.addEventListener('load', function () {
         state.spacePressed = true;
         element.style.cursor = 'grab';
         element.style.scrollBehavior = 'auto';
+        return;
+      }
+
+      // Arrow keys are also used for normal text/caret navigation and for
+      // navigating dropdown options (e.g. the autocomplete field), so they
+      // must not pan the diagram while an editable element has focus.
+      if (isEditable) {
         return;
       }
 

--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -57,6 +57,28 @@ class RequirementFormFieldType(str, Enum):
     MULTILINE = "MULTILINE"
 
 
+def deduplicate_comma_separated_value(value: str) -> str:
+    """
+    MultipleChoice/Tag field values are a comma-separated set. Existing
+    documents can already contain duplicate entries (hand-edited, or
+    created before the autocomplete duplicate-prevention fix). Remove the
+    duplicates here, case-insensitively, keeping the order and casing of
+    the first occurrence.
+    """
+    seen: Set[str] = set()
+    deduplicated_parts: List[str] = []
+    for raw_part in value.split(","):
+        part = raw_part.strip()
+        if not part:
+            continue
+        key = part.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduplicated_parts.append(part)
+    return ", ".join(deduplicated_parts)
+
+
 @auto_described
 class RequirementFormField:
     def __init__(
@@ -142,6 +164,16 @@ class RequirementFormField:
             RequirementFieldType.TAG,
         ):
             field_value = requirement_field.get_text_value()
+            if grammar_field.gef_type in (
+                RequirementFieldType.MULTIPLE_CHOICE,
+                RequirementFieldType.TAG,
+            ):
+                # The document may already contain duplicate values (e.g.
+                # hand-edited, or saved before the autocomplete
+                # duplicate-prevention fix). Deduplicate when loading the
+                # value into the edit form, so saving the form as-is
+                # cleans up the document.
+                field_value = deduplicate_comma_separated_value(field_value)
             return RequirementFormField(
                 field_mid=MID.create(),
                 field_name=grammar_field.title,

--- a/strictdoc/export/html/templates/autocomplete/field/stream_autocomplete_field.jinja.html
+++ b/strictdoc/export/html/templates/autocomplete/field/stream_autocomplete_field.jinja.html
@@ -1,2 +1,2 @@
-{% for value in values %}
-<li class="autocompletable-result-item" role="option" data-autocompletable-value="{{ value }}">{{ value }}</li>{% endfor %}
+{% for value, is_selected in values %}
+<li class="autocompletable-result-item{% if is_selected %} autocompletable-result-item_selected{% endif %}" role="option" {% if is_selected %}aria-disabled="true" {% endif %}data-autocompletable-value="{{ value }}">{{ value }}</li>{% endfor %}

--- a/strictdoc/export/html/templates/components/form/field/autocompletable/index.jinja
+++ b/strictdoc/export/html/templates/components/form/field/autocompletable/index.jinja
@@ -60,7 +60,7 @@
   </sdoc-autocompletable>
 
   <input type="hidden" name="{{ field_input_name }}" value="{{ field_value }}" {% if field_required %}required{% endif %} data-autocompletable-target="hidden"/>
-  <ul class="autocomplete-items {{ result_class_name}}" ></ul>
+  <ul class="autocomplete-items {{ result_class_name}}" aria-live="polite"></ul>
 
   {%- if errors is defined and errors|length > 0 -%}
     {%- for error_ in errors -%}

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -104,6 +104,7 @@ from strictdoc.export.html.form_objects.requirement_form_object import (
     RequirementFormFieldType,
     RequirementFormObject,
     RequirementReferenceFormField,
+    deduplicate_comma_separated_value,
 )
 from strictdoc.export.html.generators.view_objects.document_screen_view_object import (
     DocumentScreenViewObject,
@@ -1496,6 +1497,13 @@ def create_main_router(
             current_value = node.ordered_fields_lookup[field_name][
                 0
             ].get_text_value()
+            if is_multiple_choice:
+                # The document may already contain duplicate values (e.g.
+                # hand-edited, or saved before the autocomplete
+                # duplicate-prevention fix). Deduplicate when loading the
+                # value into the table cell's edit mode, same as the
+                # modal requirement-edit form does.
+                current_value = deduplicate_comma_separated_value(current_value)
 
         output = env().render_template_as_markup(
             "actions/table/get_node_autocomplete_inline/stream_inline_form.jinja.html",
@@ -4390,9 +4398,12 @@ def create_main_router(
                         if choice.lower() not in already_selected
                     ]
                 else:
-                    # SingleChoice: we use the full query and all available options.
+                    # SingleChoice: we use the full query and all available
+                    # options. There is no notion of an "already selected"
+                    # segment, as a SingleChoice field holds only one value.
                     query_words = q.lower().split()
                     filtered_options = all_options
+                    last_part = None
 
                 resulting_values = []
 
@@ -4401,7 +4412,17 @@ def create_main_router(
                     words_ = option_.strip().lower()
 
                     if all(word_ in words_ for word_ in query_words):
-                        resulting_values.append(option_)
+                        # A MultipleChoice/Tag option that exactly matches
+                        # the segment currently being typed is, in fact,
+                        # already a complete value of the field (typed in
+                        # full, with or without a trailing comma). It is
+                        # still shown so the user has visual confirmation,
+                        # but marked as already selected so it can't be
+                        # inserted as a duplicate.
+                        is_selected = last_part is not None and (
+                            words_ == last_part
+                        )
+                        resulting_values.append((option_, is_selected))
                     if len(resulting_values) >= AUTOCOMPLETE_LIMIT:
                         break
 

--- a/tests/end2end/helpers/form/form.py
+++ b/tests/end2end/helpers/form/form.py
@@ -228,6 +228,48 @@ class Form:  # pylint: disable=invalid-name
         ).perform()
         assert element.text == text_before
 
+    def assert_autocomplete_no_duplicate_on_click(
+        self, test_id: str, already_selected_value: str
+    ) -> None:
+        assert isinstance(test_id, str)
+        assert isinstance(already_selected_value, str)
+
+        field_xpath = f"(//*[@data-testid='{test_id}'])"
+        element = self.test_case.find_element(field_xpath)
+        hidden_input = element.find_element(
+            By.XPATH, 'following-sibling::input[@type="hidden"]'
+        )
+        results_ul = hidden_input.find_element(
+            By.XPATH, "following-sibling::ul[1]"
+        )
+
+        # The field already contains already_selected_value (with no
+        # trailing comma). A click re-opens the dropdown: it must not
+        # offer already_selected_value again.
+        text_before = element.text
+        element.click()
+
+        WebDriverWait(self.test_case.driver, 3).until(
+            lambda _: results_ul.is_displayed()
+        )
+
+        self.test_case.assert_element_not_present(
+            f"{field_xpath}/following-sibling::input[@type='hidden']"
+            "/following-sibling::ul[1]"
+            f"//li[@data-autocompletable-value='{already_selected_value}']",
+            by=By.XPATH,
+        )
+
+        # Selecting whatever is offered (if anything) must not duplicate
+        # already_selected_value in the field.
+        select_action = ActionChains(self.test_case.driver)
+        select_action.send_keys(Keys.ARROW_DOWN).pause(0.1).send_keys(
+            Keys.RETURN
+        ).perform()
+        assert element.text.count(already_selected_value) == text_before.count(
+            already_selected_value
+        )
+
     def do_append_command_and_use_autocomplete_result_again(
         self, test_id: str, field_value: str
     ) -> None:

--- a/tests/end2end/helpers/form/form.py
+++ b/tests/end2end/helpers/form/form.py
@@ -190,6 +190,44 @@ class Form:  # pylint: disable=invalid-name
             )
         )
 
+    def assert_autocomplete_no_results(
+        self, test_id: str, field_value: str
+    ) -> None:
+        assert isinstance(test_id, str)
+        assert isinstance(field_value, str)
+
+        field_xpath = f"(//*[@data-testid='{test_id}'])"
+        element = self.test_case.find_element(field_xpath)
+        hidden_input = element.find_element(
+            By.XPATH, 'following-sibling::input[@type="hidden"]'
+        )
+        results_ul = hidden_input.find_element(
+            By.XPATH, "following-sibling::ul[1]"
+        )
+
+        # We simulate a user typing a query that has no matches.
+        self.test_case.type(field_xpath, f"{field_value}", by=By.XPATH)
+
+        # We wait until the results <ul> is displayed.
+        WebDriverWait(self.test_case.driver, 3).until(
+            lambda _: results_ul.is_displayed()
+        )
+
+        no_results_item = results_ul.find_element(
+            By.XPATH,
+            ".//li[@aria-disabled='true'][contains(., 'No matches found')]",
+        )
+        assert no_results_item.is_displayed()
+
+        # The "No matches found" row must not be selectable: Arrow-Down
+        # followed by Enter must not change the field's content.
+        text_before = element.text
+        select_action = ActionChains(self.test_case.driver)
+        select_action.send_keys(Keys.ARROW_DOWN).pause(0.1).send_keys(
+            Keys.RETURN
+        ).perform()
+        assert element.text == text_before
+
     def do_append_command_and_use_autocomplete_result_again(
         self, test_id: str, field_value: str
     ) -> None:

--- a/tests/end2end/helpers/screens/document/form_edit_requirement.py
+++ b/tests/end2end/helpers/screens/document/form_edit_requirement.py
@@ -130,6 +130,14 @@ class Form_EditRequirement(Form):  # pylint: disable=invalid-name
             f"form-field-{field_name}", field_value
         )
 
+    def assert_field_autocomplete_no_duplicate_on_click(
+        self, field_name: str, already_selected_value: str
+    ) -> None:
+        assert isinstance(already_selected_value, str)
+        super().assert_autocomplete_no_duplicate_on_click(
+            f"form-field-{field_name}", already_selected_value
+        )
+
     def do_select_relation_role(self, mid: MID, field_value: str) -> None:
         assert isinstance(mid, MID)
         assert isinstance(field_value, str)

--- a/tests/end2end/helpers/screens/document/form_edit_requirement.py
+++ b/tests/end2end/helpers/screens/document/form_edit_requirement.py
@@ -122,6 +122,14 @@ class Form_EditRequirement(Form):  # pylint: disable=invalid-name
             f"form-field-{field_name}", field_value
         )
 
+    def assert_field_autocomplete_no_results(
+        self, field_name: str, field_value: str
+    ) -> None:
+        assert isinstance(field_value, str)
+        super().assert_autocomplete_no_results(
+            f"form-field-{field_name}", field_value
+        )
+
     def do_select_relation_role(self, mid: MID, field_value: str) -> None:
         assert isinstance(mid, MID)
         assert isinstance(field_value, str)

--- a/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_duplicates/expected_output/document.sdoc
+++ b/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_duplicates/expected_output/document.sdoc
@@ -1,0 +1,56 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: LEVEL
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TAGS
+    TYPE: Tag
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: RATIONALE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File
+
+[REQUIREMENT]
+UID: REQ-1
+TAGS: Tag1
+TITLE: Requirement 1 ABC
+STATEMENT: >>>
+Shall test foo.
+<<<
+
+[REQUIREMENT]
+UID: REQ-2
+TAGS: Tag2
+TITLE: Requirement 2 XYZ
+STATEMENT: >>>
+Shall test bar.
+<<<
+

--- a/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_duplicates/input/document.sdoc
+++ b/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_duplicates/input/document.sdoc
@@ -1,0 +1,56 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: LEVEL
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TAGS
+    TYPE: Tag
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: RATIONALE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File
+
+[REQUIREMENT]
+UID: REQ-1
+TAGS: Tag1
+TITLE: Requirement 1 ABC
+STATEMENT: >>>
+Shall test foo.
+<<<
+
+[REQUIREMENT]
+UID: REQ-2
+TAGS: Tag2
+TITLE: Requirement 2 XYZ
+STATEMENT: >>>
+Shall test bar.
+<<<
+

--- a/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_duplicates/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_duplicates/test_case.py
@@ -1,0 +1,53 @@
+"""
+@relation(SDOC-SRS-106, SDOC-SRS-120, scope=file)
+"""
+
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.document.form_edit_requirement import (
+    Form_EditRequirement,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+
+            #
+            # Requirement 1 already has TAGS: Tag1 (no trailing comma).
+            # Re-opening the autocomplete dropdown (a click, with no text
+            # typed) must mark/exclude Tag1 so it cannot be inserted again
+            # as a duplicate.
+            #
+            requirement = screen_document.get_node(1)
+            form_edit_requirement: Form_EditRequirement = (
+                requirement.do_open_form_edit_requirement()
+            )
+            form_edit_requirement.assert_on_form()
+
+            form_edit_requirement.assert_field_autocomplete_no_duplicate_on_click(
+                "TAGS", "Tag1"
+            )
+
+            form_edit_requirement.do_form_cancel()
+
+        assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_matches/expected_output/document.sdoc
+++ b/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_matches/expected_output/document.sdoc
@@ -1,0 +1,55 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: LEVEL
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TAGS
+    TYPE: Tag
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: RATIONALE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File
+
+[REQUIREMENT]
+UID: REQ-1
+TAGS: Tag1
+TITLE: Requirement 1 ABC
+STATEMENT: >>>
+Shall test foo.
+<<<
+
+[REQUIREMENT]
+UID: REQ-2
+TITLE: Requirement 2 XYZ
+STATEMENT: >>>
+Shall test bar.
+<<<
+

--- a/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_matches/input/document.sdoc
+++ b/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_matches/input/document.sdoc
@@ -1,0 +1,55 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: TEXT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: LEVEL
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TAGS
+    TYPE: Tag
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: False
+  - TITLE: RATIONALE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: COMMENT
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: Parent
+  - TYPE: File
+
+[REQUIREMENT]
+UID: REQ-1
+TAGS: Tag1
+TITLE: Requirement 1 ABC
+STATEMENT: >>>
+Shall test foo.
+<<<
+
+[REQUIREMENT]
+UID: REQ-2
+TITLE: Requirement 2 XYZ
+STATEMENT: >>>
+Shall test bar.
+<<<
+

--- a/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_matches/test_case.py
+++ b/tests/end2end/screens/document/create_requirement/_Tag/create_requirement_Tag_field_autocomplete_no_matches/test_case.py
@@ -1,0 +1,52 @@
+"""
+@relation(SDOC-SRS-106, SDOC-SRS-120, scope=file)
+"""
+
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.document.form_edit_requirement import (
+    Form_EditRequirement,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+
+            #
+            # Edit the requirement 1 and type a TAGS query that matches
+            # nothing. The "No matches found" placeholder should be shown,
+            # and it must not be selectable.
+            #
+            requirement = screen_document.get_node(1)
+            form_edit_requirement: Form_EditRequirement = (
+                requirement.do_open_form_edit_requirement()
+            )
+            form_edit_requirement.assert_on_form()
+
+            form_edit_requirement.assert_field_autocomplete_no_results(
+                "TAGS", "ZzZ_no_such_tag"
+            )
+
+            form_edit_requirement.do_form_cancel()
+
+        assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/unit/strictdoc/export/html/form_objects/test_requirement_form_object_deduplicate.py
+++ b/tests/unit/strictdoc/export/html/form_objects/test_requirement_form_object_deduplicate.py
@@ -1,0 +1,37 @@
+from strictdoc.export.html.form_objects.requirement_form_object import (
+    deduplicate_comma_separated_value,
+)
+
+
+def test_no_duplicates_is_unchanged():
+    assert deduplicate_comma_separated_value("Tag1, Tag2") == "Tag1, Tag2"
+
+
+def test_simple_duplicate_is_removed():
+    assert deduplicate_comma_separated_value("Tag1, Tag1") == "Tag1"
+
+
+def test_duplicate_with_different_casing_is_removed():
+    assert (
+        deduplicate_comma_separated_value("Tag1, tag1, TAG1, Tag2")
+        == "Tag1, Tag2"
+    )
+
+
+def test_extra_whitespace_is_stripped():
+    assert (
+        deduplicate_comma_separated_value("  Tag1 ,Tag2,  Tag1  ")
+        == "Tag1, Tag2"
+    )
+
+
+def test_empty_parts_are_dropped():
+    assert deduplicate_comma_separated_value("Tag1,, ,Tag2") == "Tag1, Tag2"
+
+
+def test_single_value_is_unchanged():
+    assert deduplicate_comma_separated_value("Tag1") == "Tag1"
+
+
+def test_empty_value_is_unchanged():
+    assert deduplicate_comma_separated_value("") == ""


### PR DESCRIPTION

- Show "No matches found" in the autocomplete dropdown when there are no results (previously rendered nothing).
- Deduplicate MultipleChoice/Tag field values when opening them for editing (modal form and table-view inline cell), so duplicates already present in the document don't linger in the UI.
- Fix arrow keys (Up/Down/Left/Right) panning the diagram/table view while typing or navigating dropdown options in any editable field - `pan_with_space.js` was missing the same "skip if focus is editable" guard that already existed for the Spacebar pan trigger.

Closes #2938, #2969, #2970.
