### PR TITLE
fix(features/table): clear new-node indicator on click outside the row

### DIFF
--- a/developer/tasks/20260622_2973_fix_table_new_node_indicator/task.md
+++ b/developer/tasks/20260622_2973_fix_table_new_node_indicator/task.md
@@ -1,0 +1,22 @@
+# Clear new-node indicator on click outside the row
+
+## WHAT
+
+Retain the previously implemented indicator `data-node-created=“true”` for
+a newly created TR (new node). This attribute controls the CSS styling.
+
+When a user clicks outside this TR, remove this attribute.
+When a user clicks inside this TR (for example, when editing cells within it),
+retain this indicator.
+
+## WHY
+
+The thick border does not disappear until a new element is created in the table
+or the window is refreshed. And some users find this indicator too intrusive.
+
+At the same time, we want to keep the indicator for a newly created node to make
+it easier to navigate the table.
+
+## HOW
+
+

--- a/developer/tasks/20260622_2973_fix_table_new_node_indicator/task.md
+++ b/developer/tasks/20260622_2973_fix_table_new_node_indicator/task.md
@@ -9,6 +9,14 @@ When a user clicks outside this TR, remove this attribute.
 When a user clicks inside this TR (for example, when editing cells within it),
 retain this indicator.
 
+### Test case
+
+- A new row is assigned the attribute `data-node-created=“true”`
+  when it is created.
+- Clicking inside the row (to open or close the cell for editing) -
+  the attribute remains.
+- Clicking outside the row - the attribute is removed.
+
 ## WHY
 
 The thick border does not disappear until a new element is created in the table

--- a/strictdoc/export/html/_static/table_view_edit.js
+++ b/strictdoc/export/html/_static/table_view_edit.js
@@ -1190,6 +1190,12 @@
                 getAutocompleteInput(activeAutocompleteCell)
             );
         }
+        const createdRow = document.querySelector(
+            'tr[data-node-created="true"]'
+        );
+        if (createdRow && !eventPath.includes(createdRow)) {
+            clearCreatedRowMarker();
+        }
     }
 
     function init() {

--- a/tests/end2end/helpers/screens/table/screen_table.py
+++ b/tests/end2end/helpers/screens/table/screen_table.py
@@ -772,3 +772,13 @@ class Screen_Table(Screen):  # pylint: disable=invalid-name
         self.test_case.assert_element_not_present(
             f'[data-node-mid="{node_mid}"]'
         )
+
+    def assert_node_row_marked_as_created(self, node_mid: str) -> None:
+        self.test_case.assert_element_present(
+            f'tr[data-node-mid="{node_mid}"][data-node-created="true"]'
+        )
+
+    def assert_node_row_not_marked_as_created(self, node_mid: str) -> None:
+        self.test_case.assert_element_not_present(
+            f'tr[data-node-mid="{node_mid}"][data-node-created="true"]'
+        )

--- a/tests/end2end/screens/table/view_table_edit/add_table_node_indicator_cleared_on_outside_click/expected_output/document.sdoc
+++ b/tests/end2end/screens/table/view_table_edit/add_table_node_indicator_cleared_on_outside_click/expected_output/document.sdoc
@@ -1,0 +1,10 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[[SECTION]]
+TITLE: Existing section
+
+[REQUIREMENT]
+UID: REQ-1
+
+[[/SECTION]]

--- a/tests/end2end/screens/table/view_table_edit/add_table_node_indicator_cleared_on_outside_click/input/document.sdoc
+++ b/tests/end2end/screens/table/view_table_edit/add_table_node_indicator_cleared_on_outside_click/input/document.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[[SECTION]]
+TITLE: Existing section
+
+[[/SECTION]]

--- a/tests/end2end/screens/table/view_table_edit/add_table_node_indicator_cleared_on_outside_click/test_case.py
+++ b/tests/end2end/screens/table/view_table_edit/add_table_node_indicator_cleared_on_outside_click/test_case.py
@@ -1,0 +1,63 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.viewtype_selector import ViewType_Selector
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+
+            screen_document = screen_project_index.do_click_on_first_document()
+            screen_document.assert_on_screen_document()
+
+            self.clear_local_storage()
+
+            viewtype_selector = ViewType_Selector(self)
+            screen_table = viewtype_selector.do_go_to_table()
+            screen_table.assert_on_screen_table()
+            screen_table.assert_not_empty_view()
+
+            screen_table.do_toggle_edit_mode()
+            screen_table.assert_edit_mode_on()
+            assert screen_table.get_table_row_count() == 1
+
+            screen_table.do_open_add_node_menu(row_order=2)
+            screen_table.do_click_add_node_action(
+                element_type="REQUIREMENT",
+                whereto="child",
+                row_order=2,
+            )
+            screen_table.wait_for_table_row_count(2)
+            assert screen_table.get_table_row_count() == 2
+
+            new_node_mid = screen_table.get_node_mid_from_row(row_order=2)
+            screen_table.assert_node_row_marked_as_created(new_node_mid)
+
+            # Clicking inside the new row (e.g. to edit a cell) must retain
+            # the "newly created" indicator.
+            screen_table.do_open_inline_cell(new_node_mid, "TITLE")
+            screen_table.assert_node_row_marked_as_created(new_node_mid)
+            screen_table.do_cancel_inline_cell_by_escape()
+            screen_table.wait_for_cell_not_editing(new_node_mid, "TITLE")
+            screen_table.assert_node_row_marked_as_created(new_node_mid)
+
+            # Clicking outside the row must clear the indicator.
+            self.click("#header-project-name")
+            screen_table.assert_node_row_not_marked_as_created(new_node_mid)
+
+            screen_table.do_toggle_edit_mode()
+            screen_table.assert_edit_mode_off()
+
+        assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
Closes #2973