### PR TITLE
chore(server, cli): print a summary of all deprecation messages

### DIFF
--- a/strictdoc/helpers/deprecation_engine.py
+++ b/strictdoc/helpers/deprecation_engine.py
@@ -31,12 +31,15 @@ class DeprecationEngine:
         if len(self.deprecations) == 0:
             return
 
+        print()  # noqa: T201
         self._print("DEPRECATION: This project has the following issues:")
         for message_idx_, message_ in enumerate(
             self.deprecations.values(), start=1
         ):
             self._print(f"\nIssue #{message_idx_}\n")
             self._print(message_)
+        print()  # noqa: T201
+
         sys.stdout.flush()
 
     @staticmethod

--- a/strictdoc/server/app.py
+++ b/strictdoc/server/app.py
@@ -16,6 +16,7 @@ from starlette.responses import Response
 from strictdoc import __version__
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.helpers.coverage import register_code_coverage_hook
+from strictdoc.helpers.deprecation_engine import DEPRECATION_ENGINE
 from strictdoc.helpers.pickle import pickle_load
 from strictdoc.server.config import SDocServerEnvVariable
 from strictdoc.server.helpers.hierarchical_rw_lock_manager import (
@@ -75,6 +76,7 @@ def print_welcome_message(project_config: ProjectConfig) -> None:
 
 def create_app(*, project_config: ProjectConfig) -> FastAPI:
     def lifespan(_: FastAPI) -> Generator[None, None, None]:
+        DEPRECATION_ENGINE.print_all_messages()
         print_welcome_message(project_config)
         yield
 


### PR DESCRIPTION
WHY: Ensures that important deprecation messages are clearly visible to the user.