### PR TITLE
feat(toc): expand the TOC branch to the active anchor

### DIFF
--- a/developer/tasks/20260626_2939_toc_expand_to_anchor/task.md
+++ b/developer/tasks/20260626_2939_toc_expand_to_anchor/task.md
@@ -1,0 +1,74 @@
+# Expand the TOC branch to the active anchor
+
+## WHAT
+
+When the user navigates to an anchor (clicking a TOC link, clicking an
+in-content link, following an external/bookmarked URL with a `#fragment`,
+or loading the page directly on a fragment), the TOC branch containing
+that anchor shall expand if it was collapsed — up to the anchor, not
+deeper. If the anchor itself is a collapsed folder, its own children
+stay collapsed; only the chain of ancestor branches above it opens.
+
+## WHY
+
+Issue #2939. `collapsible_toc.js` (collapse/expand) and
+`toc_highlighting.js` (anchor → TOC link mapping, hash navigation) do
+not coordinate. If the anchor's branch is collapsed, the link stays
+hidden in the DOM, and `toc_highlighting.js` silently moves the
+highlight up to the nearest *visible* ancestor instead of revealing the
+actual target. The TOC selection and the URL fragment then disagree
+about what's "current".
+
+## HOW
+
+`collapsible_toc.js` (collapse/expand state) and `toc_highlighting.js`
+(anchor → TOC-link mapping, IntersectionObserver-based highlighting)
+are independent concerns reacting to independent triggers (clicks vs.
+scroll). That separation is preserved: `collapsible_toc.js` reacts to
+URL navigation on its own, the same way it already reacts to clicks,
+rather than being driven through `toc_highlighting.js`'s highlight
+recompute pipeline.
+
+- `collapsible_toc.js` adds a `hashchange` listener, plus re-checks the
+  current `location.hash` after every TOC re-render (covers Turbo-frame
+  swaps, which use the History API and don't fire `hashchange`).
+- On a match, it walks up the ancestor `<li>` chain from the target
+  link, expanding any collapsed branch — stopping at the link's own
+  `<li>`, so a collapsed *target* folder is not auto-expanded into its
+  children.
+- The target link is resolved by anchor id, not by receiving a live DOM
+  reference from `toc_highlighting.js` — the two scripts don't need to
+  share internal state for this.
+- One narrow cross-script signal is needed, declared in `app_core.js`
+  alongside the existing `TOC_STATE_CHANGED`: `TOC_FRAGMENT_RESOLVED`.
+  `toc_highlighting.js` emits it only when a hash points at a
+  renamed/renumbered anchor and it silently corrects the URL via
+  `history.replaceState()` — which, unlike a real navigation, does not
+  fire `hashchange`, so `collapsible_toc.js` has no other way to learn
+  about the corrected target. Payload is `{ anchor: string }` (an id),
+  not a DOM reference. The full bus contract (each event, who
+  emits/listens, why) is documented once in `app_core.js`.
+
+This design has no feedback-loop risk: collapsing a branch doesn't
+change the URL, so it can never re-trigger `hashchange` or
+`TOC_FRAGMENT_RESOLVED`.
+
+### Files touched
+
+- `strictdoc/export/html/_static/app_core.js` — `TOC_FRAGMENT_RESOLVED`
+  event and the bus contract documentation.
+- `strictdoc/export/html/_static/collapsible_toc.js` — ancestor-expand
+  logic, anchor-id resolution, the `hashchange` listener, and the
+  `TOC_FRAGMENT_RESOLVED` listener.
+- `strictdoc/export/html/_static/toc_highlighting.js` — emits
+  `TOC_FRAGMENT_RESOLVED` from the renamed-anchor branch of
+  `handleHashChange()`.
+- `tests/end2end/navigation/toc/toc_navigation/test_case.py` (and its
+  `input`/`expected_output` fixtures) — covers: collapse a 3-level-
+  nested branch (`Parent section` > `Child section` > `Grandchild
+  section`), navigate directly to the hidden `#SECTION_CHILD` URL (full
+  page load, not a TOC click), assert the ancestor branch opens, and
+  that `Child section`'s own collapsed state (hiding `Grandchild
+  section`) is left untouched — "up to the anchor, not deeper". This
+  belongs in `toc_navigation` (anchor-navigation behavior), not
+  `toc_highlighting` (IntersectionObserver-driven highlighting).

--- a/strictdoc/export/html/_static/app_core.js
+++ b/strictdoc/export/html/_static/app_core.js
@@ -11,6 +11,34 @@ Supported shared namespaces:
 
 Feature scripts should keep their own logic in local scope and only use
 StrictDoc.* for intentional cross-script contracts and shared runtime data.
+
+Bus contract (event name -> emitter -> listener(s) -> payload):
+- TOC_STATE_CHANGED ('toc:state-changed')
+    emitted by: collapsible_toc.js, after any collapse/expand change
+      (manual click, bulk action, undo).
+    listened by: toc_highlighting.js, to recompute which TOC items are
+      currently visible/highlighted.
+    payload: none.
+    Note: unrelated to navigation. collapsible_toc.js reacts to URL
+    navigation on its own (a plain `hashchange` listener, mirroring how
+    toc_highlighting.js already reacts to `hashchange` independently) -
+    it does not derive that from this event. Keeping these reactions on
+    their own native triggers, instead of chaining them through each
+    other's recompute cycle, is what avoids a feedback loop (a manual
+    collapse triggering this event must never be able to re-expand
+    itself via some other listener's reaction to it).
+- TOC_FRAGMENT_RESOLVED ('toc:fragment-resolved')
+    emitted by: toc_highlighting.js, only for the edge case where the
+      URL hash points at a renamed/renumbered anchor: it resolves the
+      new id and silently corrects the URL via history.replaceState(),
+      which - unlike a real navigation - does not fire `hashchange`.
+    listened by: collapsible_toc.js, to expand collapsed ancestor
+      branches up to (not including) the corrected anchor (its own
+      `hashchange` listener could not have seen this correction).
+    payload: { anchor: string } - the corrected anchor id (matches the
+      TOC link's `anchor` attribute), not a DOM reference, so this event
+      is safe to log/replay without reaching into either module's
+      internal state.
 */
 
 (function (global) {
@@ -23,6 +51,9 @@ StrictDoc.* for intentional cross-script contracts and shared runtime data.
   strictDoc.project = strictDoc.project || {};
   if (!strictDoc.events.TOC_STATE_CHANGED) {
     strictDoc.events.TOC_STATE_CHANGED = 'toc:state-changed';
+  }
+  if (!strictDoc.events.TOC_FRAGMENT_RESOLVED) {
+    strictDoc.events.TOC_FRAGMENT_RESOLVED = 'toc:fragment-resolved';
   }
 
   // Minimal event bus wrapper over document-level CustomEvent transport.

--- a/strictdoc/export/html/_static/collapsible_toc.js
+++ b/strictdoc/export/html/_static/collapsible_toc.js
@@ -85,6 +85,7 @@ const CONTROLS_PANEL_HEIGHT = `32px`;
 const BULK_MODE = 'bulk';
 const UNDO_MODE = 'undo';
 const TOC_STATE_CHANGED_EVENT = strictDoc.events.TOC_STATE_CHANGED;
+const TOC_FRAGMENT_RESOLVED_EVENT = strictDoc.events.TOC_FRAGMENT_RESOLVED;
 let lastBulkSnapshot = null;
 
 const _TRUE = 'collapsed';
@@ -231,7 +232,7 @@ function main() {
       if (mutation.type === 'childList') {
         let addedToc = Array.from(mutation.addedNodes).find(node => isCollapsibleList(node));
         if (addedToc) {
-          run(mutatingFrame)
+          runAndExpandToHash(mutatingFrame)
         }
       }
     }
@@ -244,7 +245,23 @@ function main() {
     }
   );
 
-  run(mutatingFrame)
+  // * React to URL navigation directly (own concern, independent of
+  // * toc_highlighting.js): a plain `hashchange` covers back/forward and
+  // * manually edited/external/bookmarked URLs. Turbo-frame navigations
+  // * that swap in a new TOC don't fire `hashchange` (they use the History
+  // * API), so those are covered by runAndExpandToHash() above instead.
+  window.addEventListener('hashchange', () => expandToCurrentHash(mutatingFrame));
+
+  // * toc_highlighting.js notifies us only for the narrow edge case where a
+  // * hash points at a renamed/renumbered anchor: it silently corrects the
+  // * URL via history.replaceState, which does not fire `hashchange`, so we
+  // * would otherwise never learn about the corrected target.
+  // * See app_core.js for the full bus contract.
+  strictDoc.bus.on(TOC_FRAGMENT_RESOLVED_EVENT, event => {
+    expandToAnchorId(mutatingFrame, event.detail && event.detail.anchor);
+  });
+
+  runAndExpandToHash(mutatingFrame)
 }
 
 // Run TOC processing for the collapsible-list root
@@ -255,6 +272,31 @@ function run(mount) {
     return;
   }
   processToc(toc);
+}
+
+// run() followed by expanding to the anchor currently in the URL, if any -
+// covers the turbo-frame-swap navigation case (no native `hashchange`).
+function runAndExpandToHash(mount) {
+  run(mount);
+  expandToCurrentHash(mount);
+}
+
+// Expand collapsed ancestor branches for whatever anchor is currently in
+// `window.location.hash`, if there's a matching TOC link.
+function expandToCurrentHash(mount) {
+  const hash = window.location.hash;
+  const anchorId = hash ? decodeURIComponent(hash.slice(1)) : null;
+  expandToAnchorId(mount, anchorId);
+}
+
+// Expand collapsed ancestor branches up to (not including) the TOC link
+// matching `anchorId`.
+function expandToAnchorId(mount, anchorId) {
+  const link = resolveTocLinkByAnchor(mount, anchorId);
+  if (expandAncestorsToLink(link)) {
+    updateSessionStorage();
+    notifyTocStateChanged();
+  }
 }
 
 // Detect the TOC root node when it is injected into the frame.
@@ -341,6 +383,41 @@ function bulkToggleChildBrunches(controls, handler) {
   });
   updateSessionStorage();
   notifyTocStateChanged();
+}
+
+// Resolve a TOC <a> element by anchor id (e.g. from the URL hash or a bus
+// event), rather than receiving a live DOM reference from another script.
+function resolveTocLinkByAnchor(mount, anchorId) {
+  if (!anchorId) {
+    return null;
+  }
+  const toc = mount.querySelector(`[${ROOT_SELECTOR}]`);
+  return toc ? toc.querySelector(`a[anchor="${CSS.escape(anchorId)}"]`) : null;
+}
+
+// Expand collapsed ancestor branches of a TOC link, stopping at the link itself.
+// The link's own branch (if it is a folder) is left untouched: navigation
+// should reveal the anchor, not auto-expand what is below it.
+function expandAncestorsToLink(link) {
+  if (!link) {
+    return false;
+  }
+  let changed = false;
+  // Walk up one branch <li> at a time: from `li`, its parent <ul> is the
+  // list it sits in, and the nearest <li> ancestor of that <ul> is the
+  // branch one level up (markup pattern: <li><a/><ul>...<li>...</li>...</ul></li>).
+  let ancestorLi = link.closest('li')?.parentElement?.closest('li');
+  while (ancestorLi) {
+    if (ancestorLi.dataset[BRANCH_DATA_ATTR] === _TRUE) {
+      const handler = ancestorLi.querySelector(`:scope > [data-${HANDLER_DATA_ATTR}]`);
+      if (handler) {
+        setBranchState(handler, _FALSE);
+        changed = true;
+      }
+    }
+    ancestorLi = ancestorLi.parentElement?.closest('li');
+  }
+  return changed;
 }
 
 // ===== Bulk Controls =====

--- a/strictdoc/export/html/_static/toc_highlighting.js
+++ b/strictdoc/export/html/_static/toc_highlighting.js
@@ -15,6 +15,7 @@ const TOC_ELEMENT_SELECTOR = 'a';
 const CONTENT_FRAME_SELECTOR = 'turbo-frame#frame_document_content'; // action="replace" => parentNode is needed
 const CONTENT_ELEMENT_SELECTOR = 'sdoc-anchor';
 const TOC_STATE_CHANGED_EVENT = strictDoc.events.TOC_STATE_CHANGED;
+const TOC_FRAGMENT_RESOLVED_EVENT = strictDoc.events.TOC_FRAGMENT_RESOLVED;
 
 // Virtual viewport for TOC section highlighting.
 // We do not use the raw screen edges (0..innerHeight): we shrink the effective
@@ -131,6 +132,11 @@ function handleHashChange() {
         TOC_HIGHLIGHT_DEBUG && console.log('handleHashChange(): remapped fragment', fragment, '→', resolved);
         history.replaceState(null, '', '#' + encodeURIComponent(resolved));
         pair = tocHighlightingState.data[resolved];
+        // * history.replaceState() does not fire `hashchange`, so
+        // * collapsible_toc.js's own `hashchange` listener cannot rely on
+        // * seeing this correction by itself - tell it explicitly. See
+        // * app_core.js for the full bus contract.
+        strictDoc.bus.emit(TOC_FRAGMENT_RESOLVED_EVENT, { anchor: resolved });
       }
     }
     if (pair && pair.link) {
@@ -425,6 +431,9 @@ function isElementVisible(element) {
   return !!(element && element.getClientRects().length);
 }
 
+// The TOC link one branch level up from `link`: from its <li>, the parent
+// <ul> is the list it sits in, and the nearest <li> ancestor of that <ul>
+// is the branch one level up (markup pattern: <li><a/><ul>...</ul></li>).
 function getParentTocLink(link) {
   const li = link?.closest('li');
   const parentUl = li?.parentElement;

--- a/tests/end2end/navigation/toc/toc_navigation/expected_output/document.sdoc
+++ b/tests/end2end/navigation/toc/toc_navigation/expected_output/document.sdoc
@@ -24,3 +24,21 @@ TITLE: Requirement 2 title
 STATEMENT: >>>
 Requirement statement.
 <<<
+
+[[SECTION]]
+UID: SECTION_PARENT
+TITLE: Parent section
+
+[[SECTION]]
+UID: SECTION_CHILD
+TITLE: Child section
+
+[[SECTION]]
+UID: SECTION_GRANDCHILD
+TITLE: Grandchild section
+
+[[/SECTION]]
+
+[[/SECTION]]
+
+[[/SECTION]]

--- a/tests/end2end/navigation/toc/toc_navigation/input/document.sdoc
+++ b/tests/end2end/navigation/toc/toc_navigation/input/document.sdoc
@@ -24,3 +24,21 @@ TITLE: Requirement 2 title
 STATEMENT: >>>
 Requirement statement.
 <<<
+
+[[SECTION]]
+UID: SECTION_PARENT
+TITLE: Parent section
+
+[[SECTION]]
+UID: SECTION_CHILD
+TITLE: Child section
+
+[[SECTION]]
+UID: SECTION_GRANDCHILD
+TITLE: Grandchild section
+
+[[/SECTION]]
+
+[[/SECTION]]
+
+[[/SECTION]]

--- a/tests/end2end/navigation/toc/toc_navigation/test_case.py
+++ b/tests/end2end/navigation/toc/toc_navigation/test_case.py
@@ -1,5 +1,6 @@
 from tests.end2end.e2e_case import E2ECase
 from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.collapsible_list import CollapsibleList
 from tests.end2end.helpers.components.toc import TOC
 from tests.end2end.helpers.screens.project_index.screen_project_index import (
     Screen_ProjectIndex,
@@ -55,5 +56,43 @@ class Test(E2ECase):
             screen_document.assert_target_by_anchor(
                 toc_requirement_with_title_anchor
             )
+
+            # TOC - expanding a collapsed branch when navigating to its anchor
+
+            collapsible_list: CollapsibleList = (
+                screen_document.get_collapsible_list()
+            )
+            collapsible_list.do_bulk_expand_all()
+
+            # Collapse "Child section" so its own child ("Grandchild section")
+            # becomes hidden.
+            collapsible_list.do_toggle_collapsible("Child section")
+            collapsible_list.assert_is_collapsed("Child section")
+            collapsible_list.assert_visible_not("Grandchild section")
+
+            # Also collapse "Parent section" so "Child section" itself
+            # becomes hidden.
+            collapsible_list.do_toggle_collapsible("Parent section")
+            collapsible_list.assert_is_collapsed("Parent section")
+            collapsible_list.assert_visible_not("Child section")
+
+            base_url = self.get_current_url().split("#")[0]
+
+            # Navigate to the page directly on a hidden anchor (e.g. an
+            # external/bookmarked link), as opposed to clicking inside the
+            # TOC. Expected: the collapsed ancestor branch ("Parent section")
+            # opens up to the anchor, revealing "Child section".
+            self.open(f"{base_url}#SECTION_CHILD")
+            collapsible_list.assert_is_expanded("Parent section")
+            collapsible_list.assert_visible("Child section")
+            screen_toc.assert_toc_link_has_attribute(
+                "SECTION_CHILD", "targeted"
+            )
+
+            # "Child section" is itself a collapsed folder: its own child
+            # ("Grandchild section") must stay hidden — the branch opens up
+            # to the anchor, not deeper than it.
+            collapsible_list.assert_is_collapsed("Child section")
+            collapsible_list.assert_visible_not("Grandchild section")
 
         assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
Closes #2939 

When the user navigates to an anchor (clicking a TOC link, clicking an in-content link, following an external/bookmarked URL with a `#fragment`, or loading the page directly on a fragment), the TOC branch containing that anchor now expands if it was collapsed — up to the anchor, not deeper. If the anchor itself is a collapsed folder, its own children stay collapsed; only the chain of ancestor branches above it opens.

Previously, if the anchor's branch was collapsed, the link stayed hidden in the DOM and the TOC highlight silently jumped up to the nearest visible ancestor instead of revealing the actual target — the TOC selection and the URL fragment would disagree about what's "current".

**Approach**
- `collapsible_toc.js` (collapse/expand state) and `toc_highlighting.js` (anchor → TOC-link mapping, scroll-driven highlighting) remain independent, reacting to independent triggers — clicks/URL vs. scroll. 
`collapsible_toc.js` now reacts to URL navigation on its own (a `hashchange` listener, plus a re-check after every TOC re-render to also cover Turbo-frame swaps), the same way it already reacts to clicks, rather than being driven through the highlighting module's recompute pipeline.

One narrow cross-script signal remains for an edge case: `toc_highlighting.js` already resolves renamed/renumbered anchors and silently corrects the URL via `history.replaceState()`, which doesn't fire `hashchange` — so it notifies `collapsible_toc.js` of the corrected anchor id directly. The bus contract (event names, emitters/listeners, payloads) is documented once in `app_core.js`.

**Test**
- tests/end2end/navigation/toc/toc_navigation/test_case.py — new case: collapse a 3-level-nested branch (Parent section > Child section > Grandchild section), navigate directly to the hidden #SECTION_CHILD URL, assert the ancestor branch opens and that Child section's own collapsed state (hiding Grandchild section) is left untouched.

