### PR TITLE
fix(tree-sitter): Pin py-tree-sitter 0.25.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "markdown-it-py >= 4.0.0, == 4.*",
 
     # Tree Sitter is used for language/AST-aware parsing of Python, C and other files.
-    "tree-sitter >= 0.25",
+    "tree-sitter == 0.25.2",
     "tree-sitter-c",
     "tree_sitter_cpp",
     "tree-sitter-python",

--- a/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/test.itest
+++ b/tests/integration/features/source_code_traceability/_language_parsers/rust/01_rust_doc_comments/test.itest
@@ -1,5 +1,3 @@
-UNSUPPORTED: true
-
 RUN: %strictdoc export %S --output-dir %T | filecheck %s
 CHECK: Published: Hello world doc
 


### PR DESCRIPTION
Why: py-tree-sitter's [bdc236723e52](https://github.com/tree-sitter/py-tree-sitter/commit/bdc236723e52cdd1bf67127154b5be08fc9e7658) ("feat!: add edit method to point & range"), included in 0.26.0, introduced a bug where certain usage patterns lead to dangling pointer inside Point objects. Our 01_rust_doc_comments triggered it reliably, however the problem can occur for any language.

What: Pin py-tree-sitter to the most recent working version until the issue is fixed upstream.