### PR TITLE
feat(sdoc): Allow same characters in ANCHOR title as allowed for node title

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -2368,6 +2368,8 @@ MID: 294d6a0e96424dc8a93d6502c43e8501
 STATEMENT: >>>
 The ``[ANCHOR: <anchor uid>, <optional anchor title>]`` tag creates an anchor that can be referenced from other pages using ``[LINK <Anchor UID>]``.
 
+The optional title can be an unquoted string, but must be enclosed in double quotes if it contains special characters.
+
 Example:
 
 This is a link to anchor: [LINK: ANCHOR-EXAMPLE].

--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -46,6 +46,18 @@ This document maintains a record of all changes to StrictDoc since November 2023
 <<<
 
 [[SECTION]]
+MID: 650087b6a70d4451af7ddffde5e8b567
+TITLE: Unreleased
+
+[TEXT]
+MID: 39b43201403544e585fa3dda188e24ec
+STATEMENT: >>>
+An ``[ANCHOR: uid, title]`` title can now contain hyphens and most other punctuation. Special characters are supported by quoting.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
 MID: 68a0524db27443c1a5bb0785dd595c1b
 TITLE: 0.25.1 (2026-07-02)
 

--- a/strictdoc/backend/sdoc/grammar/grammar.py
+++ b/strictdoc/backend/sdoc/grammar/grammar.py
@@ -33,8 +33,12 @@ InlineLink[noskipws]:
 
 Anchor[noskipws]:
   /^\[ANCHOR: /
-  value = /{REGEX_UID}/ (', ' title = /\w+[\s\w+]*/)?
+  value = /{REGEX_UID}/ (', ' title = AnchorTitle)?
   /\](\Z|\r?\n)/
+;
+
+AnchorTitle[noskipws]:
+  /(["])[^"\r\n]+\1|[^,\]\r\n]+/
 ;
 
 // According to the Strict Grammar Rule #3, both SingleLineString and

--- a/strictdoc/backend/sdoc/models/anchor.py
+++ b/strictdoc/backend/sdoc/models/anchor.py
@@ -21,10 +21,6 @@ class Anchor:
     def __init__(
         self, parent: SDocNodeFieldIF, value: str, title: Optional[str]
     ) -> None:
-        # In the grammar, the title is optional but textX passes it as an empty
-        # string. Putting an assert to monitor the regressions/changes if the
-        # grammar gets changed.
-        assert title is not None
         # FIXME: Cannot enable this assert because the parent can also be
         #        FreeTextContainer. Refactor the types.
         # assert isinstance(parent, SDocNodeFieldIF), parent  # noqa: ERA001
@@ -32,9 +28,12 @@ class Anchor:
         self.parent: SDocNodeFieldIF = parent
         self.value: str = value
 
-        has_title = len(title) > 0
-        self.title: str = title if has_title else value
-        self.has_title = has_title
+        if title is not None and len(title) > 0:
+            self.title: str = title.strip('"')
+            self.has_title = True
+        else:
+            self.title = value
+            self.has_title = False
 
         # FIXME: Remove either mid or reserved_mid.
         self.mid: MID = MID.create()
@@ -44,6 +43,11 @@ class Anchor:
         self,
         include_toc_number: bool = True,  # noqa: ARG002
     ) -> str:
+        return self.title
+
+    def get_source_title(self) -> str:
+        if "," in self.title or "]" in self.title:
+            return f'"{self.title}"'
         return self.title
 
     def get_document(self) -> SDocDocumentIF:

--- a/strictdoc/backend/sdoc/models/node.py
+++ b/strictdoc/backend/sdoc/models/node.py
@@ -129,7 +129,7 @@ class SDocNodeField:
                 text += part.value
                 if part.has_title:
                     text += ", "
-                    text += part.title
+                    text += part.get_source_title()
                 text += "]"
                 text += "\n"
             else:

--- a/tests/integration/features/sdoc/markup/05_anchor_title_with_punctuation/input.sdoc
+++ b/tests/integration/features/sdoc/markup/05_anchor_title_with_punctuation/input.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Anchor title punctuation
+
+[TEXT]
+STATEMENT: >>>
+[ANCHOR: A-PLAIN, Plain title]
+
+[ANCHOR: A-HYPHEN, Human-readable title]
+
+[ANCHOR: A-MIXED, Title with hyphens. And (parens)]
+
+Link to plain: [LINK: A-PLAIN].
+
+Link to hyphenated: [LINK: A-HYPHEN].
+
+Link to mixed: [LINK: A-MIXED].
+<<<

--- a/tests/integration/features/sdoc/markup/05_anchor_title_with_punctuation/test.itest
+++ b/tests/integration/features/sdoc/markup/05_anchor_title_with_punctuation/test.itest
@@ -1,0 +1,16 @@
+#
+# Verify that [ANCHOR: uid, title] accepts titles containing hyphens and other
+# punctuation characters that are common in human-readable labels.
+#
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Anchor title punctuation
+
+RUN: %cat %T/html/05_anchor_title_with_punctuation/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+
+CHECK-HTML: <sdoc-anchor id="A-PLAIN"
+CHECK-HTML: <sdoc-anchor id="A-HYPHEN"
+CHECK-HTML: <sdoc-anchor id="A-MIXED"
+CHECK-HTML: Plain title
+CHECK-HTML: Human-readable title
+CHECK-HTML: Title with hyphens. And (parens)

--- a/tests/integration/features/sdoc/markup/06_anchor_title_quoted_comma/input.sdoc
+++ b/tests/integration/features/sdoc/markup/06_anchor_title_quoted_comma/input.sdoc
@@ -1,0 +1,13 @@
+[DOCUMENT]
+TITLE: Anchor title quoted comma
+
+[TEXT]
+STATEMENT: >>>
+[ANCHOR: A-QUOTED, "Title with, a comma"]
+
+[ANCHOR: A-BRACKET, "Title [with] brackets"]
+
+Link to quoted: [LINK: A-QUOTED].
+
+Link to bracketed: [LINK: A-BRACKET].
+<<<

--- a/tests/integration/features/sdoc/markup/06_anchor_title_quoted_comma/test.itest
+++ b/tests/integration/features/sdoc/markup/06_anchor_title_quoted_comma/test.itest
@@ -1,0 +1,11 @@
+# A quoted ANCHOR title may contain a comma or a closing bracket.
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Anchor title quoted comma
+
+RUN: %cat %T/html/06_anchor_title_quoted_comma/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+
+CHECK-HTML: <sdoc-anchor id="A-QUOTED"
+CHECK-HTML: <sdoc-anchor id="A-BRACKET"
+CHECK-HTML: Title with, a comma
+CHECK-HTML: Title [with] brackets

--- a/tests/integration/features/sdoc/markup/07_anchor_title_unquoted_comma_is_rejected/input.sdoc
+++ b/tests/integration/features/sdoc/markup/07_anchor_title_unquoted_comma_is_rejected/input.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Anchor title unquoted comma is rejected
+
+[TEXT]
+STATEMENT: >>>
+[ANCHOR: A-BAD, Unquoted, comma title]
+<<<

--- a/tests/integration/features/sdoc/markup/07_anchor_title_unquoted_comma_is_rejected/test.itest
+++ b/tests/integration/features/sdoc/markup/07_anchor_title_unquoted_comma_is_rejected/test.itest
@@ -1,0 +1,5 @@
+# An unquoted ANCHOR title must not contain a comma.
+
+RUN: %expect_exit 1 %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+
+CHECK: error: Could not parse file: {{.*}}input.sdoc. Error: TextXSyntaxError: {{.*}}input.sdoc:6:25: Expected '\](\Z|\r?\n)' => ', Unquoted*, comma ti'

--- a/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_dsl_passthrough.py
@@ -1252,3 +1252,47 @@ def test_crlf_multiline_field():
     node = document.section_contents[0]
     assert isinstance(node, SDocNode)
     assert node.reserved_statement == "Multiline content.\r\n"
+
+
+def test_anchor_title_with_quoted_comma_roundtrip(default_project_config):
+    input_sdoc = """
+[DOCUMENT]
+TITLE: Test Doc
+
+[TEXT]
+STATEMENT: >>>
+[ANCHOR: A1, "Title with, a comma"]
+<<<
+""".lstrip()
+
+    reader = SDReader()
+
+    document = reader.read(input_sdoc)
+    assert isinstance(document, SDocDocument)
+
+    writer = SDWriter(default_project_config)
+    output = writer.write(document)
+
+    assert input_sdoc == output
+
+
+def test_anchor_title_with_quoted_bracket_roundtrip(default_project_config):
+    input_sdoc = """
+[DOCUMENT]
+TITLE: Test Doc
+
+[TEXT]
+STATEMENT: >>>
+[ANCHOR: A1, "Title [with] brackets"]
+<<<
+""".lstrip()
+
+    reader = SDReader()
+
+    document = reader.read(input_sdoc)
+    assert isinstance(document, SDocDocument)
+
+    writer = SDWriter(default_project_config)
+    output = writer.write(document)
+
+    assert input_sdoc == output

--- a/tests/unit/strictdoc/backend/sdoc/test_free_text_reader.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_free_text_reader.py
@@ -145,7 +145,51 @@ def test_016_anchor_crlf_line_ending():
     assert free_text_container.parts[1].value == "AD1"
 
 
-def test_020_link():
+def test_017_anchor_title_with_quoted_comma():
+    free_text_input = '[ANCHOR: AD1, "Title with, a comma"]\n'
+
+    reader = SDFreeTextReader()
+    free_text_container = reader.read(free_text_input)
+    anchor = free_text_container.parts[0]
+    assert isinstance(anchor, Anchor)
+    assert anchor.value == "AD1"
+    assert anchor.title == "Title with, a comma"
+    assert anchor.has_title is True
+
+
+def test_018_anchor_title_with_quoted_closing_bracket():
+    free_text_input = '[ANCHOR: AD1, "Title [with] brackets"]\n'
+
+    reader = SDFreeTextReader()
+    free_text_container = reader.read(free_text_input)
+    anchor = free_text_container.parts[0]
+    assert isinstance(anchor, Anchor)
+    assert anchor.value == "AD1"
+    assert anchor.title == "Title [with] brackets"
+    assert anchor.has_title is True
+
+
+def test_019_anchor_title_with_unquoted_comma_raises():
+    free_text_input = "[ANCHOR: AD1, Unquoted, comma title]\n"
+
+    reader = SDFreeTextReader()
+    with pytest.raises(TextXSyntaxError):
+        reader.read(free_text_input)
+
+
+def test_020_anchor_without_title_has_no_title():
+    free_text_input = "[ANCHOR: AD1]\n"
+
+    reader = SDFreeTextReader()
+    free_text_container = reader.read(free_text_input)
+    anchor = free_text_container.parts[0]
+    assert isinstance(anchor, Anchor)
+    assert anchor.value == "AD1"
+    assert anchor.title == "AD1"
+    assert anchor.has_title is False
+
+
+def test_021_link():
     free_text_input = """
 Hello world [LINK: FOO] Part
 """.lstrip()


### PR DESCRIPTION
What: `[ANCHOR: uid, title]` titles now accept any printable character. The special characters `","` and `"]"` are also supported if title is enclosed in quotes.

Why: The previous title regex only matched `/\w+[\s\w+]*/`, which for example rejects `"Human-readable title"`. This is overly strict. Since a TITLE field in SDocNodes and the title in ANCHOR are similar entities, they should also allow same character set. In ANCHOR context, `"]"` is special (delimiter), and `","` may become special (if we allow for more arguments in future). Thus support them by quoting.

How: The textX regex now handles two branches, one for quoted strings, and one for unquoted strings. Special characters are only allowed in the quoted branch. Similar to how ChoiceOption already does it.