### PR TITLE
fix(markdown): make ANCHOR compatible with following block elements

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -52,7 +52,9 @@ TITLE: Unreleased
 [TEXT]
 MID: 39b43201403544e585fa3dda188e24ec
 STATEMENT: >>>
-An ``[ANCHOR: uid, title]`` title can now contain hyphens and most other punctuation. Special characters are supported by quoting.
+1\) An ``[ANCHOR: uid, title]`` title can now contain hyphens and most other punctuation. Special characters are supported by quoting.
+
+2\) Fixed: in Markdown documents, block-level content (e.g. a table) immediately following an ``[ANCHOR: uid]`` tag is now rendered correctly instead of being swallowed as plain text.
 <<<
 
 [[/SECTION]]

--- a/strictdoc/export/html/templates/markup/anchor.jinja
+++ b/strictdoc/export/html/templates/markup/anchor.jinja
@@ -26,3 +26,5 @@
     {% endif %}
   </div>
 </sdoc-anchor>
+
+

--- a/tests/integration/features/markdown/24_anchor_before_block_markdown/input.md
+++ b/tests/integration/features/markdown/24_anchor_before_block_markdown/input.md
@@ -1,0 +1,13 @@
+# Anchor before block markdown
+
+## Section with anchor immediately followed by block-level content
+
+Some introductory text.
+
+[ANCHOR: ANCHOR-BEFORE-BLOCK]
+| Column A | Column B |
+|---|---|
+| cell A1 | cell B1 |
+| cell A2 | cell B2 |
+
+Text after the table.

--- a/tests/integration/features/markdown/24_anchor_before_block_markdown/test.itest
+++ b/tests/integration/features/markdown/24_anchor_before_block_markdown/test.itest
@@ -1,0 +1,12 @@
+# Block-level markdown (e.g. a table) immediately following an [ANCHOR:]
+# tag must not be swallowed as part of a raw HTML block.
+
+RUN: %strictdoc export %S --formats=html --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Anchor before block markdown
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+
+CHECK-HTML: id="ANCHOR-BEFORE-BLOCK"
+CHECK-HTML: <table>
+CHECK-HTML: Column A
+CHECK-HTML: cell A1

--- a/tests/unit/strictdoc/export/html/renderers/test_markup_renderer.py
+++ b/tests/unit/strictdoc/export/html/renderers/test_markup_renderer.py
@@ -2,8 +2,11 @@ from strictdoc.backend.markdown.markdown_to_html_fragment_writer import (
     MarkdownToHtmlFragmentWriter,
 )
 from strictdoc.backend.sdoc.constants import SDocMarkup
+from strictdoc.backend.sdoc.models.anchor import Anchor
+from strictdoc.backend.sdoc.models.node import SDocNodeField
 from strictdoc.core.document_tree import DocumentTree
 from strictdoc.core.traceability_index_builder import TraceabilityIndexBuilder
+from strictdoc.export.html.document_type import DocumentType
 from strictdoc.export.html.html_templates import HTMLTemplates
 from strictdoc.export.html.renderers.link_renderer import LinkRenderer
 from strictdoc.export.html.renderers.markup_renderer import MarkupRenderer
@@ -46,3 +49,51 @@ def test_01_uses_markdown_fragment_writer_for_markdown_markup():
     assert isinstance(
         markup_renderer.fragment_writer, MarkdownToHtmlFragmentWriter
     )
+
+
+def test_02_anchor_render_starts_new_block():
+    document_builder = DocumentBuilder()
+    document = document_builder.build()
+    document.config.markup = SDocMarkup.MARKDOWN
+
+    document_tree = DocumentTree(
+        file_tree=[],
+        document_list=[document],
+        map_docs_by_paths={},
+        map_docs_by_rel_paths={},
+        map_grammars_by_filenames={},
+    )
+    traceability_index = TraceabilityIndexBuilder.create_from_document_tree(
+        document_tree,
+        project_config=document_builder.project_config,
+    )
+
+    html_templates = HTMLTemplates.create(
+        project_config=document_builder.project_config,
+        enable_caching=False,
+        strictdoc_last_update=traceability_index.strictdoc_last_update,
+    )
+    link_renderer = LinkRenderer(root_path="", static_path="_static")
+
+    markup_renderer = MarkupRenderer.create(
+        markup=document.config.get_markup(),
+        traceability_index=traceability_index,
+        link_renderer=link_renderer,
+        html_templates=html_templates,
+        config=document_builder.project_config,
+        context_document=document,
+    )
+
+    field = SDocNodeField(
+        parent=None,
+        field_name="STATEMENT",
+        parts=[],
+        multiline__="multiline",
+    )
+
+    anchor = Anchor(parent=field, value="ANCHOR-1", title=None)
+    field.parts = [anchor, "\nText after."]
+
+    output = markup_renderer.render_node_field(DocumentType.DOCUMENT, field)
+
+    assert "<p>Text after." in output


### PR DESCRIPTION
What: Allow to write `[ANCHOR: uid]` in front of markdown block elements, for example tables. For example:

```
Some text.

[ANCHOR: MY-TABLE]
| Column A | Column B |
|---|---|
| cell A1 | cell B1 |
| cell A2 | cell B2 |
```

Why: It's useful and already supported in sdoc/RST.

How: The RST behavior is that `[ANCHOR:]` implicitly starts a new RST block. We can get the same with markdown. Both rst/anchor.jinja and markup/anchor.jinja render the anchor as its own raw-HTML block, and both need a blank line to follow so the next block-level content is recognized correctly. rst/anchor.jinja already ended with a blank line; markup/anchor.jinja did not, so we add one there too.