### PR TITLE
fix(markdown): register document-level UID for LINK resolution

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -52,7 +52,9 @@ TITLE: Unreleased
 [TEXT]
 MID: 39b43201403544e585fa3dda188e24ec
 STATEMENT: >>>
-An ``[ANCHOR: uid, title]`` title can now contain hyphens and most other punctuation. Special characters are supported by quoting.
+1\) An ``[ANCHOR: uid, title]`` title can now contain hyphens and most other punctuation. Special characters are supported by quoting.
+
+2\) Fixed: a document-level ``UID`` declared in a Markdown document's H1 metadata block (``**UID**: ...``) is now registered correctly, so other documents can link to it via ``[LINK <uid>]``.
 <<<
 
 [[/SECTION]]

--- a/strictdoc/backend/markdown/reader.py
+++ b/strictdoc/backend/markdown/reader.py
@@ -301,6 +301,8 @@ class SDMarkdownReader:
                     continue
                 if field_.name == "PREFIX":
                     document.config.requirement_prefix = field_.value
+                if field_.name == "UID":
+                    document.config.uid = field_.value
                 metadata_entries.append(
                     DocumentCustomMetadataKeyValuePair(
                         key=field_.human_name,

--- a/tests/integration/features/markdown/25_document_level_uid_link/input1.md
+++ b/tests/integration/features/markdown/25_document_level_uid_link/input1.md
@@ -1,0 +1,5 @@
+# Document 1
+
+**UID**: DOC-1
+
+Read [LINK: DOC-2].

--- a/tests/integration/features/markdown/25_document_level_uid_link/input2.md
+++ b/tests/integration/features/markdown/25_document_level_uid_link/input2.md
@@ -1,0 +1,5 @@
+# Document 2
+
+**UID**: DOC-2
+
+Read [LINK: DOC-1].

--- a/tests/integration/features/markdown/25_document_level_uid_link/test.itest
+++ b/tests/integration/features/markdown/25_document_level_uid_link/test.itest
@@ -1,0 +1,12 @@
+# A document-level **UID**: in a Markdown H1 must be linkable via [LINK: uid].
+
+RUN: %strictdoc export %S --formats=html --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Document
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input1.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC1
+
+CHECK-HTML-DOC1: <a href="../25_document_level_uid_link/input2.html#DOC-2">{{.*}}Document 2
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input2.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC2
+
+CHECK-HTML-DOC2: <a href="../25_document_level_uid_link/input1.html#DOC-1">{{.*}}Document 1

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
@@ -533,3 +533,12 @@ def test_017_section_immediately_followed_by_child_section_has_no_empty_text_nod
     child = parent_section.section_contents[0]
     assert isinstance(child, SDocNode)
     assert child.node_type == "REQUIREMENT"
+
+
+def test_024_markdown_reader_registers_document_level_uid():
+    markdown_content = "# Document title\n\n**UID**: DOC-1\n"
+
+    reader = SDMarkdownReader()
+    document = reader.read(markdown_content, file_path=None)
+
+    assert document.config.uid == "DOC-1"


### PR DESCRIPTION
What: Make document-level UIDs from markdown traceable. For example

```
# Document 1

**UID**: DOC-1
```

linked by

```
# Document 2

Read [LINK: DOC-1].
```

Why: The markdown reader already parsed it, but did not yet set the corresponding meta data field.

How: Set `DocumentConfig.uid` accordingly during parsing.