### PR TITLE
fix(markdown): stop duplicating document UID in the HTML metadata panel

### DIFF
--- a/strictdoc/backend/sdoc/models/document_config.py
+++ b/strictdoc/backend/sdoc/models/document_config.py
@@ -184,20 +184,28 @@ class DocumentConfig:
         )
 
     def has_custom_metadata(self) -> bool:
-        return (
-            self.custom_metadata is not None
-            and self.custom_metadata.entries is not None
-            and len(self.custom_metadata.entries) > 0
-        )
+        return len(self.get_custom_metadata()) > 0
 
     def get_custom_metadata(self) -> List[Tuple[str, str]]:
         if (
             self.custom_metadata is not None
             and self.custom_metadata.entries is not None
         ):
+            reserved_keys = {
+                key
+                for key, value in (
+                    ("UID", self.uid),
+                    ("VERSION", self.version),
+                    ("DATE", self.date),
+                    ("CLASSIFICATION", self.classification),
+                )
+                if value is not None and len(value) > 0
+            }
             return [
                 (entry.key, entry.value)
                 for entry in self.custom_metadata.entries
-                if entry.key is not None and entry.value is not None
+                if entry.key is not None
+                and entry.value is not None
+                and entry.key.upper() not in reserved_keys
             ]
         return []

--- a/tests/unit/strictdoc/backend/sdoc/models/test_document_config.py
+++ b/tests/unit/strictdoc/backend/sdoc/models/test_document_config.py
@@ -24,3 +24,27 @@ def test_has_custom_metadata_returns_true_when_entries_are_present():
 def test_has_custom_metadata_returns_false_when_no_custom_metadata():
     config = DocumentConfig.default_config(document=None)
     assert config.has_custom_metadata() is False
+
+
+def test_get_custom_metadata_excludes_entry_present_in_config():
+    config = DocumentConfig.default_config(document=None)
+    config.uid = "DOC-1"
+    config.custom_metadata = DocumentCustomMetadata(
+        entries=[
+            DocumentCustomMetadataKeyValuePair(key="UID", value="DOC-1"),
+            DocumentCustomMetadataKeyValuePair(key="Author", value="Jane"),
+        ]
+    )
+
+    assert config.get_custom_metadata() == [("Author", "Jane")]
+
+
+def test_get_custom_metadata_keeps_entry_not_present_in_config():
+    config = DocumentConfig.default_config(document=None)
+    config.custom_metadata = DocumentCustomMetadata(
+        entries=[
+            DocumentCustomMetadataKeyValuePair(key="UID", value="DOC-1"),
+        ]
+    )
+
+    assert config.get_custom_metadata() == [("UID", "DOC-1")]


### PR DESCRIPTION
What: Prevent rendering document UID twice (1 from config, 1 from metadata). #2995 missed to consider this.

Why: The markdown reader uses custom metadata to remember field order for write-back by storing a copy of config fields there. The renderer doesn't know about this trick and just displays config along with metadata. If we want to prevent rendered duplicates we need to filter somewhere.