### PR TITLE
feat(source-nodes): automatically link test results to test case source nodes

### DIFF
--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -521,6 +521,25 @@ class FileTraceabilityIndex:
                                 rhs_node=forward_requirement_,
                                 edge="IsSatisfiedBy",
                             )
+
+                    for source_node_ in function.parent.source_nodes:
+                        if (
+                            source_node_.function is function
+                            and source_node_.sdoc_node is not None
+                        ):
+                            testcase_node = source_node_.sdoc_node
+                            traceability_index.graph_database.create_link(
+                                link_type=GraphLinkType.NODE_TO_PARENT_NODES,
+                                lhs_node=forward_requirement_,
+                                rhs_node=testcase_node,
+                                edge="Tests",
+                            )
+                            traceability_index.graph_database.create_link(
+                                link_type=GraphLinkType.NODE_TO_CHILD_NODES,
+                                lhs_node=testcase_node,
+                                rhs_node=forward_requirement_,
+                                edge="TestedBy",
+                            )
                 #
                 # Validate that all requirements reference existing files.
                 #
@@ -1106,6 +1125,7 @@ class FileTraceabilityIndex:
         ):
             sdoc_node_fields["TITLE"] = source_node.entity_name
         FileTraceabilityIndex.set_sdoc_node_fields(sdoc_node, sdoc_node_fields)
+        source_node.sdoc_node = sdoc_node
         return sdoc_node
 
     @staticmethod

--- a/tests/integration/features/test_reports/robot_xml/02_source_node_link_without_relation_marker/strictdoc_config.py
+++ b/tests/integration/features/test_reports/robot_xml/02_source_node_link_without_relation_marker/strictdoc_config.py
@@ -1,0 +1,16 @@
+from strictdoc.core.project_config import ProjectConfig, SourceNodesEntry
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=["REQUIREMENT_TO_SOURCE_TRACEABILITY"],
+        source_nodes=[
+            SourceNodesEntry(
+                path="tests/",
+                uid="TEST_DOC",
+                node_type="TEST_SPEC",
+            )
+        ],
+        include_source_paths=["tests/**.robot"],
+    )
+    return config

--- a/tests/integration/features/test_reports/robot_xml/02_source_node_link_without_relation_marker/test.itest
+++ b/tests/integration/features/test_reports/robot_xml/02_source_node_link_without_relation_marker/test.itest
@@ -1,0 +1,12 @@
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Test Specification
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/testcases.html | filecheck %s --dump-input=fail --check-prefix CHECK-TESTCASE
+CHECK-TESTCASE: RELATIONS (Child):
+CHECK-TESTCASE: href="../02_source_node_link_without_relation_marker/test_report/output.robot.html#SYSTEM-TEST-FEATURE-CHECK-VALID-LOGIN">{{.*}}
+CHECK-TESTCASE: (TestedBy)
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/test_report/output.robot.html | filecheck %s --dump-input=fail --check-prefix CHECK-RESULT
+CHECK-RESULT: RELATIONS (Parent):
+CHECK-RESULT: href="../../02_source_node_link_without_relation_marker/testcases.html#TC-AUTH-001">{{.*}}
+CHECK-RESULT: (Tests)

--- a/tests/integration/features/test_reports/robot_xml/02_source_node_link_without_relation_marker/test_report/output.robot.xml
+++ b/tests/integration/features/test_reports/robot_xml/02_source_node_link_without_relation_marker/test_report/output.robot.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 7.2.2 (Python 3.11.2 on linux)" generated="2025-05-15T22:23:03.446474" rpa="false" schemaversion="5">
+<suite id="s1" name="System Test" source="/home/user/strictdoc/tests/integration/features/test_reports/robot_xml/02_source_node_link_without_relation_marker/tests">
+<suite id="s1-s1" name="Feature" source="/home/user/strictdoc/tests/integration/features/test_reports/robot_xml/02_source_node_link_without_relation_marker/tests/feature.robot">
+<test id="s1-s1-t1" name="Check Valid Login" line="1">
+<kw name="Log To Console" owner="BuiltIn">
+<arg>Simulate login</arg>
+<doc>Logs the given message to the console.</doc>
+<status status="PASS" start="2025-05-15T22:23:03.464943" elapsed="0.000157"/>
+</kw>
+<doc>UID: TC-AUTH-001
+INTENTION: Verify that valid credentials grant access.</doc>
+<status status="PASS" start="2025-05-15T22:23:03.464352" elapsed="0.000884"/>
+</test>
+<status status="PASS" start="2025-05-15T22:23:03.463504" elapsed="0.003037"/>
+</suite>
+<status status="PASS" start="2025-05-15T22:23:03.447306" elapsed="0.025562"/>
+</suite>
+<statistics>
+<total>
+<stat pass="1" fail="0" skip="0">All Tests</stat>
+</total>
+<tag>
+</tag>
+<suite>
+<stat name="System Test" id="s1" pass="1" fail="0" skip="0">System Test</stat>
+<stat name="Feature" id="s1-s1" pass="1" fail="0" skip="0">System Test.Feature</stat>
+</suite>
+</statistics>
+<errors>
+</errors>
+</robot>

--- a/tests/integration/features/test_reports/robot_xml/02_source_node_link_without_relation_marker/testcases.sdoc
+++ b/tests/integration/features/test_reports/robot_xml/02_source_node_link_without_relation_marker/testcases.sdoc
@@ -1,0 +1,29 @@
+[DOCUMENT]
+TITLE: Test Specification
+UID: TEST_DOC
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: TEST_SPEC
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  - TITLE: INTENTION
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: File

--- a/tests/integration/features/test_reports/robot_xml/02_source_node_link_without_relation_marker/tests/feature.robot
+++ b/tests/integration/features/test_reports/robot_xml/02_source_node_link_without_relation_marker/tests/feature.robot
@@ -1,0 +1,5 @@
+*** Test Cases ***
+Check Valid Login
+    [Documentation]    UID: TC-AUTH-001
+    ...    INTENTION: Verify that valid credentials grant access.
+    Log To Console    Simulate login


### PR DESCRIPTION
What: automatically link an auto-generated TEST_RESULT node to the auto-generated document node of a source node.

Why: We can create nicer traceability:

```
                             (actual test implementation,
                                      e.g. robot code)
                              +----[LanguageItem]
                              |
  [REQ] <--------------> [TEST_CASE] <--------------> [TEST_RESULT]
        (relation from   (from source  (new, this change)
         merge with side   node)
         car stub)
```

How: the automatic linking matches as follows
1. for a given auto-generated TEST_RESULT node
2. find a LanguageItem where LanguageItem.name equals TEST_RESULT.TEST_FUNCTION
3. find the SourceNode that was parsed from this LanguageItem, if one exists and was already merged into a document node
4. link that SourceNode's document node and the TEST_RESULT node