### PR TITLE
feat(markdown): Allow markdown nodes without static title

### DIFF
--- a/spec/Markdown.gra.md
+++ b/spec/Markdown.gra.md
@@ -37,3 +37,8 @@
 
 **Type**: String
 **Required**: False
+
+### Field: RATIONALE
+
+**Type**: String
+**Required**: False

--- a/spec/Markdown.md
+++ b/spec/Markdown.md
@@ -160,6 +160,13 @@ A node without a title is a special case of the node defined by [LINK: MD-21].
 
 Compared to a node with a title, a node without a title starts directly with a node body.
 
+The resulting node shall have no `TITLE` (as opposed to a node where the title is an empty string).
+
+**RATIONALE**:
+
+No-title nodes are a valid use-case in scenarios where a title is automatically derived and merged from related source code.
+They rely on empty headings, which is uncommon but valid syntax in CommonMark.
+
 ### SECTION node
 
 **MID**: 7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d \

--- a/strictdoc/backend/markdown/reader.py
+++ b/strictdoc/backend/markdown/reader.py
@@ -747,9 +747,7 @@ class SDMarkdownReader:
             # Any other explicit TYPE is accepted as long as the markdown syntax
             # is well-formed and the heading has a non-empty title.  Grammar
             # field validation is deferred to TraceabilityIndexBuilder.
-            valid_for_requirement = (
-                meta_is_valid and content_is_valid and len(title) > 0
-            )
+            valid_for_requirement = meta_is_valid and content_is_valid
         elif has_custom_grammar:
             # When a custom grammar is attached, drop the hardcoded UID/STATEMENT
             # assumptions and defer field validation to TraceabilityIndexBuilder.
@@ -759,7 +757,6 @@ class SDMarkdownReader:
                 and has_only_known_fields
                 and not has_empty_field_values
                 and len(parsed_fields) > 0
-                and len(title) > 0
             )
         else:
             valid_for_requirement = (
@@ -1218,14 +1215,15 @@ class SDMarkdownReader:
                     multiline="\n" in field.value,
                 )
             )
-        requirement_fields.append(
-            SDocNodeField.create_from_string(
-                parent=None,
-                field_name="TITLE",
-                field_value=title,
-                multiline=False,
+        if len(title) > 0:
+            requirement_fields.append(
+                SDocNodeField.create_from_string(
+                    parent=None,
+                    field_name="TITLE",
+                    field_value=title,
+                    multiline=False,
+                )
             )
-        )
         for field in parsed_content_fields:
             sdoc_field = SDocNodeField(
                 parent=None,

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
@@ -542,3 +542,24 @@ def test_024_markdown_reader_registers_document_level_uid():
     document = reader.read(markdown_content, file_path=None)
 
     assert document.config.uid == "DOC-1"
+
+
+def test_025_markdown_reader_empty_heading_produces_no_title_field():
+    markdown_content = """\
+# Document title
+
+##
+
+**TYPE**: REQUIREMENT \\
+**UID**: REQ-1
+"""
+
+    reader = SDMarkdownReader()
+    document = reader.read(markdown_content, file_path=None)
+
+    requirement = document.section_contents[0]
+    assert isinstance(requirement, SDocNode)
+    assert requirement.node_type == "REQUIREMENT"
+    assert requirement.reserved_uid == "REQ-1"
+    assert requirement.reserved_title is None
+    assert "TITLE" not in requirement.ordered_fields_lookup


### PR DESCRIPTION
What: A markdown heading (`"##"`) followed by no or empty string shall produce a SDocNode that has no title field (as opposed to having a title field with empty string).

Why: This prepares for a use case where a side car stub requirement has no static title, but the title will be merged from a source node later. In this use case it will be important to decide the fallback path: If a static TITLE was given (higher priority), use it. If not, fall back to auto generated TITLE. Actual merge logic extension comes in a separate commit.