### PR TITLE
feat(source_node): Merge source nodes with automatic TITLE as last option

### DIFF
--- a/strictdoc/core/file_traceability_index.py
+++ b/strictdoc/core/file_traceability_index.py
@@ -1182,12 +1182,9 @@ class FileTraceabilityIndex:
         sdoc_node.ng_including_document_reference = DocumentReference()
         sdoc_node_fields = source_node.get_sdoc_fields(source_node_config_entry)
         sdoc_node_fields["UID"] = sdoc_node_uid
-        if (
-            "TITLE" not in sdoc_node_fields
-            and source_node.entity_name is not None
-        ):
-            sdoc_node_fields["TITLE"] = source_node.entity_name
-        FileTraceabilityIndex.set_sdoc_node_fields(sdoc_node, sdoc_node_fields)
+        FileTraceabilityIndex.set_sdoc_node_fields(
+            sdoc_node, sdoc_node_fields, source_node
+        )
         # Recorded so that a later TEST_RESULT resolution pass can find this
         # node by its source_node/function and link it as a test case,
         # even though no explicit @relation marker exists for it.
@@ -1245,16 +1242,28 @@ class FileTraceabilityIndex:
                     f"Conflicting UID: {sdoc_node.reserved_uid} != {sdoc_node_fields['UID']}"
                 )
 
-        FileTraceabilityIndex.set_sdoc_node_fields(sdoc_node, sdoc_node_fields)
+        FileTraceabilityIndex.set_sdoc_node_fields(
+            sdoc_node, sdoc_node_fields, source_node
+        )
         source_node.sdoc_node = sdoc_node
 
     @staticmethod
     def set_sdoc_node_fields(
-        sdoc_node: SDocNode, sdoc_node_fields: dict[str, str]
+        sdoc_node: SDocNode,
+        sdoc_node_fields: Dict[str, str],
+        source_node: SourceNode,
     ) -> None:
         document = assert_cast(sdoc_node.get_document(), SDocDocumentIF)
         grammar = assert_cast(document.grammar, DocumentGrammar)
         element = grammar.elements_by_type[sdoc_node.node_type]
+
+        # Fall back to parser-suggested auto title as last option.
+        if (
+            "TITLE" not in sdoc_node_fields
+            and "TITLE" not in sdoc_node.ordered_fields_lookup
+            and source_node.entity_name is not None
+        ):
+            sdoc_node_fields["TITLE"] = source_node.entity_name
 
         for field_name, field_value in sdoc_node_fields.items():
             multiline = element.is_field_multiline(field_name)

--- a/tests/integration/features/source_code_traceability/_source_nodes/34_merge_with_sdoc_field_priority/source_node_base.sdoc
+++ b/tests/integration/features/source_code_traceability/_source_nodes/34_merge_with_sdoc_field_priority/source_node_base.sdoc
@@ -1,0 +1,37 @@
+[DOCUMENT]
+MID: 8a9d5f6c1b2e4d3f8a7c6b5e4d3f2a1b
+TITLE: Requirements from Source Nodes
+UID: SRC-NODES-BASE
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  PROPERTIES:
+    VIEW_STYLE: Narrative
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: DETAIL
+    TYPE: String
+    REQUIRED: False
+
+[REQUIREMENT]
+UID: SRC-NODES-BASE/src/example.c/example_title_fallback
+
+[REQUIREMENT]
+UID: SRC-NODES-BASE/src/example.c/example_title_static_wins
+TITLE: Static Title
+
+[REQUIREMENT]
+UID: SRC-NODES-BASE/src/example.c/example_field_source_overrides_stub
+TITLE: Static Title
+DETAIL: Stub detail (should be overridden)
+
+[REQUIREMENT]
+UID: SRC-NODES-BASE/src/example.c/example_field_preserved_when_absent_in_source
+TITLE: Static Title
+DETAIL: Stub detail (should be preserved)

--- a/tests/integration/features/source_code_traceability/_source_nodes/34_merge_with_sdoc_field_priority/src/example.c
+++ b/tests/integration/features/source_code_traceability/_source_nodes/34_merge_with_sdoc_field_priority/src/example.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+
+/**
+ * DETAIL: detail from source
+ */
+void example_title_fallback(void) {
+    printf("hello world\n");
+}
+
+/**
+ * DETAIL: detail from source
+ */
+void example_title_static_wins(void) {
+    printf("hello world\n");
+}
+
+/**
+ * DETAIL: detail from source (wins over stub)
+ */
+void example_field_source_overrides_stub(void) {
+    printf("hello world\n");
+}
+
+/**
+ * UID: SRC-NODES-BASE/src/example.c/example_field_preserved_when_absent_in_source
+ */
+void example_field_preserved_when_absent_in_source(void) {
+    printf("hello world\n");
+}

--- a/tests/integration/features/source_code_traceability/_source_nodes/34_merge_with_sdoc_field_priority/strictdoc_config.py
+++ b/tests/integration/features/source_code_traceability/_source_nodes/34_merge_with_sdoc_field_priority/strictdoc_config.py
@@ -1,0 +1,16 @@
+from strictdoc.core.project_config import ProjectConfig, SourceNodesEntry
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=["REQUIREMENT_TO_SOURCE_TRACEABILITY"],
+        exclude_source_paths=["test.itest"],
+        source_nodes=[
+            SourceNodesEntry(
+                path="src/",
+                uid="SRC-NODES-BASE",
+                node_type="REQUIREMENT",
+            ),
+        ],
+    )
+    return config

--- a/tests/integration/features/source_code_traceability/_source_nodes/34_merge_with_sdoc_field_priority/test.itest
+++ b/tests/integration/features/source_code_traceability/_source_nodes/34_merge_with_sdoc_field_priority/test.itest
@@ -1,0 +1,37 @@
+#
+# This test verifies field priority when a static sdoc stub is merged with a
+# source node. One document, four REQUIREMENT/function pairs, one scenario
+# each, to avoid four separate export runs:
+#
+# - example_title_fallback: neither side has TITLE -> falls back to the
+#   parser-suggested entity name.
+# - example_title_static_wins: stub has a static TITLE, source has none ->
+#   the static TITLE is kept, not replaced by the entity name.
+# - example_field_source_overrides_stub: both sides have a DETAIL value ->
+#   the source-parsed value wins.
+# - example_field_preserved_when_absent_in_source: stub has a DETAIL value,
+#   source has none -> the stub value is kept untouched.
+#
+# @relation(SDOC-SRS-141, scope=file)
+#
+
+RUN: %strictdoc --debug export %S --output-dir %T | filecheck %s
+
+CHECK: Published: Requirements from Source Nodes
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/source_node_base.html | filecheck %s --check-prefix CHECK-HTML
+
+CHECK-HTML: <sdoc-node-title
+CHECK-HTML: example_title_fallback</sdoc-autogen>
+
+CHECK-HTML: <sdoc-node-title
+CHECK-HTML: Static Title</sdoc-autogen>
+
+CHECK-HTML: <sdoc-node-title
+CHECK-HTML: Static Title</sdoc-autogen>
+CHECK-HTML: detail from source (wins over stub)
+CHECK-HTML-NOT: Stub detail (should be overridden)
+
+CHECK-HTML: <sdoc-node-title
+CHECK-HTML: Static Title</sdoc-autogen>
+CHECK-HTML: Stub detail (should be preserved)


### PR DESCRIPTION
What: When a sidecar stub node is merged with a source node, and neither stub nor source node kv-pairs contain a title, use the entity name suggested by the individual language parsers as TITLE field.

Why: The logic was already present in the create-case and is now reflected in the merge-case. To see why it's useful: Imagine a test suite with 100 robot tests (where all test cases already have a nice title from robot DSL syntax). Imagine a side-car stub document with 100 stubs for user-defined section grouping and user-defined parent-child relations of the test cases. In this case we don't want to copy/duplicate the title over from robot DSL to StrictDoc stubs. Copies are additional work and would drift away soon.