### PR TITLE
fix(tests/end2end): prevent SDocTestServer from getting stuck when child processes don't terminate correctly

### DIFF
--- a/tests/end2end/server.py
+++ b/tests/end2end/server.py
@@ -245,7 +245,14 @@ class SDocTestServer:
             # process is being terminated.
             #
             self.process.send_signal(signal.SIGTERM)
-            self.process.wait(timeout=1)
+            try:
+                self.process.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                # The server process may not exit within 1 second, e.g. when
+                # running with code coverage which does extra work (flushing
+                # coverage data) on SIGTERM. It is still given a chance to
+                # exit gracefully below, together with the child processes.
+                pass
             self.process.terminate()
 
             for process_ in child_processes:
@@ -253,12 +260,14 @@ class SDocTestServer:
                     process_.send_signal(signal.SIGTERM)
 
             #
-            # Wait for all processes to exit gracefully.
+            # Wait for all processes (main server + children) to exit
+            # gracefully.
             #
+            all_processes = [parent, *child_processes]
             start_time = time.monotonic()
             timeout = 5
             while True:
-                alive = [p for p in child_processes if p.is_running()]
+                alive = [p for p in all_processes if p.is_running()]
                 if len(alive) == 0:
                     print(  # noqa: T201
                         "SDocTestServer: "
@@ -271,11 +280,11 @@ class SDocTestServer:
                 if (time.monotonic() - start_time) > timeout:
                     print(  # noqa: T201
                         "SDocTestServer: "
-                        "Timeout reached. Some StrictDoc server child processes "
+                        "Timeout reached. Some StrictDoc server processes "
                         "did not terminate: "
                         f"{alive}."
                     )
-                    for process in child_processes:
+                    for process in all_processes:
                         try:
                             if process.is_running():
                                 process.kill()


### PR DESCRIPTION

WHY: Fixed a case that sometimes happens on Windows CI:

```
tests\end2end\server.py:158: in __exit__
    self.close(exit_due_exception=reason_exception)
tests\end2end\server.py:239: in close
    self.process.wait(timeout=1)
C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\subprocess.py:1209: in wait
    return self._wait(timeout=timeout)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
self = <Popen: returncode: None args: ['C:\\hostedtoolcache\\windows\\Python\\3.10....>
timeout = 1
    def _wait(self, timeout):
        """Internal implementation of wait() on Windows."""
        if timeout is None:
            timeout_millis = _winapi.INFINITE
        else:
            timeout_millis = int(timeout * 1000)
        if self.returncode is None:
            # API note: Returns immediately if timeout_millis == 0.
            result = _winapi.WaitForSingleObject(self._handle,
                                                 timeout_millis)
            if result == _winapi.WAIT_TIMEOUT:
>               raise TimeoutExpired(self.args, timeout)
```