### PR TITLE
feat(html2pdf): show all METADATA fields for each sdoc in PDF bundle export

### DIFF
--- a/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
@@ -256,8 +256,17 @@ class DocumentScreenViewObject:
 
         return output
 
-    def render_document_version(self) -> Optional[str]:
-        if self.document.config.version is None:
+    def render_document_version(
+        self, included_document: Optional[SDocDocument] = None
+    ) -> Optional[str]:
+        # 'document' is the main view document or an included document
+        # (e.g., a bundle PDF member); defaults to the main view document.
+        document_ = (
+            included_document
+            if included_document is not None
+            else self.document
+        )
+        if document_.config.version is None:
             return None
 
         def resolver(variable_name: str) -> str:
@@ -267,12 +276,19 @@ class DocumentScreenViewObject:
                 return self.git_client.get_branch()
             return variable_name
 
-        return interpolate_at_pattern_lazy(
-            self.document.config.version, resolver
-        )
+        return interpolate_at_pattern_lazy(document_.config.version, resolver)
 
-    def render_document_date(self) -> Optional[str]:
-        if self.document.config.date is None:
+    def render_document_date(
+        self, included_document: Optional[SDocDocument] = None
+    ) -> Optional[str]:
+        # 'document' is the main view document or an included document
+        # (e.g., a bundle PDF member); defaults to the main view document.
+        document_ = (
+            included_document
+            if included_document is not None
+            else self.document
+        )
+        if document_.config.date is None:
             return None
 
         def resolver(variable_name: str) -> str:
@@ -282,7 +298,7 @@ class DocumentScreenViewObject:
                 return self.git_client.get_commit_datetime()
             return variable_name
 
-        return interpolate_at_pattern_lazy(self.document.config.date, resolver)
+        return interpolate_at_pattern_lazy(document_.config.date, resolver)
 
     def render_metadata_value(self, metadata_value: str) -> str:
         """

--- a/strictdoc/export/html/templates/components/node_field/document_meta/index.jinja
+++ b/strictdoc/export/html/templates/components/node_field/document_meta/index.jinja
@@ -1,19 +1,25 @@
-{%- set document_config = view_object.document.config -%}
+{#
+  Optional 'document': the main view document or an included document
+  (e.g., a bundle PDF member, passed in by components/section/pdf.jinja).
+  Defaults to view_object.document when not provided.
+#}
+{%- set document = document if document is defined else view_object.document -%}
+{%- set document_config = document.config -%}
 
-{{ view_object.render_issues(view_object.document) }}
+{{ view_object.render_issues(document) }}
 
 {%- if document_config.has_meta() or document_config.has_custom_metadata() -%}
   <sdoc-meta>
-    {%- if view_object.document.config.uid -%}
+    {%- if document.config.uid -%}
     <sdoc-meta-label data-testid="document-config-uid-label">UID:</sdoc-meta-label>
     <sdoc-meta-field data-testid="document-config-uid-field">
-      {%- with field_content = view_object.document.config.uid %}
+      {%- with field_content = document.config.uid %}
         {%- include "components/field/index.jinja" -%}
       {%- endwith -%}
     </sdoc-meta-field>
     {%- endif -%}
 
-    {% set document_version_ = view_object.render_document_version() %}
+    {% set document_version_ = view_object.render_document_version(document) %}
     {%- if document_version_ is not none -%}
     <sdoc-meta-label data-testid="document-config-version-label">VERSION:</sdoc-meta-label>
     <sdoc-meta-field data-testid="document-config-version-field">
@@ -23,7 +29,7 @@
     </sdoc-meta-field>
     {%- endif -%}
 
-    {% set document_date_ = view_object.render_document_date() %}
+    {% set document_date_ = view_object.render_document_date(document) %}
     {%- if document_date_ is not none -%}
     <sdoc-meta-label data-testid="document-config-date-label">DATE:</sdoc-meta-label>
     <sdoc-meta-field data-testid="document-config-date-field">
@@ -33,10 +39,10 @@
     </sdoc-meta-field>
     {%- endif -%}
 
-    {%- if view_object.document.config.classification -%}
+    {%- if document.config.classification -%}
     <sdoc-meta-label data-testid="document-config-classification-label">CLASSIFICATION:</sdoc-meta-label>
     <sdoc-meta-field data-testid="document-config-classification-field">
-      {%- with field_content = view_object.document.config.classification %}
+      {%- with field_content = document.config.classification %}
         {%- include "components/field/index.jinja" -%}
       {%- endwith -%}
     </sdoc-meta-field>

--- a/strictdoc/export/html/templates/components/section/pdf.jinja
+++ b/strictdoc/export/html/templates/components/section/pdf.jinja
@@ -1,10 +1,21 @@
 {#
   In this template:
   sdoc_entity = section
+
+  sdoc_entity.is_document() is true when this template is rendering an
+  included document (e.g., a member document inside a bundle PDF export)
+  rather than a regular [[SECTION]] node. In that case, show the full
+  document metadata block instead of just the UID.
 #}
 
 <sdoc-section>
   {# Use h/print, it contains anchor: #}
   {% include "components/node_field/section_h/pdf.jinja" %}
-  {% include "components/node_field/uid_standalone/index.jinja" %}
+  {%- if sdoc_entity.is_document() %}
+    {%- with document = sdoc_entity %}
+      {% include "components/node_field/document_meta/index.jinja" %}
+    {%- endwith %}
+  {%- else %}
+    {% include "components/node_field/uid_standalone/index.jinja" %}
+  {%- endif %}
 </sdoc-section>

--- a/tests/integration/features/html2pdf/05_generate_bundle_document/nested/input2.sdoc
+++ b/tests/integration/features/html2pdf/05_generate_bundle_document/nested/input2.sdoc
@@ -1,5 +1,11 @@
 [DOCUMENT]
 TITLE: Dummy Software Requirements Specification #2
+UID: DOC-2
+VERSION: 2.0
+DATE: 2026-02-02
+CLASSIFICATION: Internal
+METADATA:
+  AUTHOR: Jane Doe
 
 [TEXT]
 STATEMENT: >>>

--- a/tests/integration/features/html2pdf/05_generate_bundle_document/test.itest
+++ b/tests/integration/features/html2pdf/05_generate_bundle_document/test.itest
@@ -11,10 +11,19 @@ RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/input2-PDF.h
 RUN: %check_exists --file %T/html2pdf/html/%THIS_TEST_FOLDER/nested/subnested/input3-PDF.html
 
 RUN: %cat %T/html2pdf/html/bundle-PDF.html | filecheck %s --check-prefix CHECK-DOC-HTML
+
+# The metadata of the nested document (#2992) must also be shown in the bundle.
+CHECK-DOC-HTML: DOC-2
+CHECK-DOC-HTML: 2.0
+CHECK-DOC-HTML: 2026-02-02
+CHECK-DOC-HTML: Internal
+CHECK-DOC-HTML: AUTHOR
+CHECK-DOC-HTML: Jane Doe
+
 # This ensures that the link is resolved correctly.
 CHECK-DOC-HTML:<a href="#SEC-1">🔗&nbsp;1.1. Section #1</a>
 
-# Git meta information.
+# Git meta information (bundle document's own front page).
 CHECK-DOC-HTML: {{.* \(Git branch: .*\)}}
 CHECK-DOC-HTML: {{\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}}}
 


### PR DESCRIPTION

WHY: Ensures that bundle PDF document does not lose valuable meta information included from member documents.

Closes #2992