### PR TITLE
feat(markdown): Support reverse roles

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -66,6 +66,9 @@ swallowed as plain text.
 3\) Fixed: a document-level ``UID`` declared in a Markdown document's H1
 metadata block (``**UID**: ...``) is now registered correctly, so other
 documents can link to it via ``[LINK <uid>]``.
+
+4\) Markdown custom grammars now support ``**Reverse Role**`` on ``Parent`` and
+``Child`` relations.
 <<<
 
 [[/SECTION]]

--- a/spec/Markdown.md
+++ b/spec/Markdown.md
@@ -534,3 +534,6 @@ Supported field types:
 Within an element, `### Relations` opens the relations section. Each permitted relation type is declared as `#### Relation: <TYPE>` where `<TYPE>` is `Parent`, `Child`, or `File`.
 
 An optional `**Role**: <role>` property names the relation role.
+
+For `Parent` and `Child` relations, an optional `**Reverse Role**: <role>` defines the role name used when the relation is shown from the opposite direction (e.g. a parent showing its derived child link).
+`**Reverse Role**` requires `**Role**` to also be set. If `**Reverse Role**` is omitted, the `**Role**` value is shown in both directions.

--- a/strictdoc/backend/markdown/grammar_reader.py
+++ b/strictdoc/backend/markdown/grammar_reader.py
@@ -325,7 +325,7 @@ class MarkdownGrammarReader:
         properties = MarkdownGrammarReader._parse_properties(
             body, file_path, heading_node
         )
-        unknown_properties = set(properties.keys()) - {"ROLE"}
+        unknown_properties = set(properties.keys()) - {"ROLE", "REVERSE ROLE"}
         if len(unknown_properties) > 0:
             MarkdownGrammarReader._raise_error(
                 "unknown relation propertie(s): "
@@ -334,10 +334,15 @@ class MarkdownGrammarReader:
                 file_path,
             )
         role = properties.get("ROLE")
+        reverse_role = properties.get("REVERSE ROLE")
         if relation_type == "Parent":
-            return GrammarElementRelationParent(parent, relation_type, role)
+            return GrammarElementRelationParent(
+                parent, relation_type, role, reverse_role
+            )
         if relation_type == "Child":
-            return GrammarElementRelationChild(parent, relation_type, role)
+            return GrammarElementRelationChild(
+                parent, relation_type, role, reverse_role
+            )
         if relation_type == "File":
             return GrammarElementRelationFile(parent, relation_type, role)
         MarkdownGrammarReader._raise_error(

--- a/strictdoc/backend/markdown/writer.py
+++ b/strictdoc/backend/markdown/writer.py
@@ -543,9 +543,14 @@ class MarkdownGrammarWriter:
     @staticmethod
     def _serialize_relation(relation: GrammarElementRelationType) -> str:
         output = f"#### Relation: {relation.relation_type}"
+        properties: List[Tuple[str, str]] = []
         if relation.relation_role is not None:
+            properties.append(("Role", relation.relation_role))
+        if relation.reverse_relation_role is not None:
+            properties.append(("Reverse Role", relation.reverse_relation_role))
+        if len(properties) > 0:
             output += "\n\n" + MarkdownGrammarWriter._serialize_properties(
-                [("Role", relation.relation_role)]
+                properties
             )
         return output
 

--- a/tests/integration/features/markdown/11_relation_reverse_role/input.md
+++ b/tests/integration/features/markdown/11_relation_reverse_role/input.md
@@ -1,0 +1,19 @@
+# Reverse role document
+
+**Grammar**: `requirements.gra.md`
+
+## Parent requirement
+
+**UID**: REQ-1
+
+Parent requirement statement.
+
+## Child requirement
+
+**UID**: REQ-2
+**RELATIONS**:
+- **Type**: Parent
+  **ID**: REQ-1
+  **Role**: Refines
+
+Child requirement statement.

--- a/tests/integration/features/markdown/11_relation_reverse_role/requirements.gra.md
+++ b/tests/integration/features/markdown/11_relation_reverse_role/requirements.gra.md
@@ -1,0 +1,25 @@
+# StrictDoc Markdown Grammar
+
+## Element: REQUIREMENT
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: TITLE
+
+**Type**: String
+**Required**: False
+
+### Field: STATEMENT
+
+**Type**: String
+**Required**: False
+
+### Relations
+
+#### Relation: Parent
+
+**Role**: Refines
+**Reverse Role**: Refined by

--- a/tests/integration/features/markdown/11_relation_reverse_role/test.itest
+++ b/tests/integration/features/markdown/11_relation_reverse_role/test.itest
@@ -1,0 +1,24 @@
+#
+# This test verifies that a Markdown custom grammar can declare REVERSE_ROLE
+# on a Parent relation, and that the reverse-direction display label is used
+# when the derived Child relation is rendered on the parent's side.
+#
+
+RUN: %strictdoc export %S --formats=html --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Published: Reverse role document
+
+RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
+
+# REQ-1 gets a derived Child relation back to REQ-2. Since the grammar
+# defines REVERSE_ROLE: Refined by for Parent/Refines, that label is shown
+# instead of the canonical Refines.
+CHECK-HTML: id="REQ-1"
+CHECK-HTML: RELATIONS (Child):
+CHECK-HTML: class="requirement__link-child" href="#REQ-2"
+CHECK-HTML: (Refined by)
+
+# REQ-2 has an explicit Parent relation to REQ-1 with ROLE: Refines.
+CHECK-HTML: id="REQ-2"
+CHECK-HTML: RELATIONS (Parent):
+CHECK-HTML: class="requirement__link-parent" href="#REQ-1"
+CHECK-HTML: (Refines)

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_grammar.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_grammar.py
@@ -472,3 +472,39 @@ def test_010_markdown_writer_injects_mid_into_section_nodes_when_grammar_declare
     assert "**MID**:" in req_block, (
         f"MID not injected into requirement block: {req_block!r}"
     )
+
+
+def test_011_markdown_grammar_reader_and_writer_roundtrip_reverse_role():
+    grammar_markdown = """\
+# StrictDoc Markdown Grammar
+
+## Element: REQUIREMENT
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Relations
+
+#### Relation: Parent
+
+**Role**: Refines
+**Reverse Role**: Refined by
+"""
+
+    grammar = MarkdownGrammarReader.read(grammar_markdown)
+    relation = grammar.elements_by_type["REQUIREMENT"].relations[0]
+    assert relation.relation_role == "Refines"
+    assert relation.reverse_relation_role == "Refined by"
+
+    output_markdown = MarkdownGrammarWriter.write(grammar)
+    assert "**Role**: Refines" in output_markdown
+    assert "**Reverse Role**: Refined by" in output_markdown
+
+    roundtrip_grammar = MarkdownGrammarReader.read(output_markdown)
+    roundtrip_relation = roundtrip_grammar.elements_by_type[
+        "REQUIREMENT"
+    ].relations[0]
+    assert roundtrip_relation.relation_role == "Refines"
+    assert roundtrip_relation.reverse_relation_role == "Refined by"


### PR DESCRIPTION
What: Support REVERSE_ROLE in markdown grammar, written as `**Reverse Role**: <role>` on a Parent or Child relation.

Why: The feature was recently introduced for sdoc. It can be reused for markdown with minimal effort.

See #2901 for the previous work by @larsjohansson-saferadar.