### PR TITLE
feat(markdown): harmonize naming conventions to sentence case: RELATIONS->Relations etc.

### DIFF
--- a/developer/tasks/20260705_markdown_consistency_cleanup/task.md
+++ b/developer/tasks/20260705_markdown_consistency_cleanup/task.md
@@ -1,0 +1,49 @@
+# Make Markdown markup convention more consistent
+
+## WHAT
+
+In all Markdown-related code and specs change:
+
+- `RELATIONS` shall be renamed to `Relations` which is from now on the new baseline.
+- `Reverse Role` shall always be `Reverse role`.
+
+Currently, SDMarkdownReader always upper-cases parsed field names. Remove this behavior completely. A user shall be free to choose whether they work with:
+  - `ALL_CAPS` or `Camel-Case` or `Camel Case` node field titles.
+  - The field names are constrained by the user grammar and nothing else.
+- Update code, specs, and tests to reflect these changes.
+
+Remove the ALL_CAPS hardcoding or uppercasing from everywhere.
+
+The `UID`/`MID` stay as abbreviations but things like `PREFIX` -> `Prefix`, `VERSION` -> `Version`, `DATE` -> `Date` etc.
+
+Update the spec/ folder's Markdown grammar and files to follow the new convention, i.e., `TITLE` -> `Title`, `STATEMENT` -> `Statement`, `RATIONALE` -> `Rationale`.
+
+### New default grammar fields
+
+Make default grammar fields to be:
+
+- MID
+- UID
+- Level
+- Status
+- Tags
+- Title
+- Statement
+- Rationale
+- Comment
+- Relations
+
+### Human titles are not affected
+
+Don't remove the handling of human titles. A user may still want to customize their titles for displaying them differently in the UI.
+
+## WHY
+
+Compared to the SDoc conventions, where the `ALL_CAPS` style is used everywhere,
+we want maximum readability and ease-of-use for Markdown. The WHAT changes are
+supposed to bring Markdown a little away from SDoc/ALL_CAPS style adding
+better readability.
+
+## HOW
+
+- If present, highlight conflicts in this task given the existing implementation.

--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -67,7 +67,7 @@ swallowed as plain text.
 metadata block (``**UID**: ...``) is now registered correctly, so other
 documents can link to it via ``[LINK <uid>]``.
 
-4\) Markdown custom grammars now support ``**Reverse Role**`` on ``Parent`` and
+4\) Markdown custom grammars now support ``**Reverse role**`` on ``Parent`` and
 ``Child`` relations.
 <<<
 

--- a/spec/Formatting.md
+++ b/spec/Formatting.md
@@ -18,7 +18,7 @@ nodes and standalone `.md` files.
 **MID**: f1e2d3c4b5a6f7e8d9c0b1a2f3e4d5c6 \
 **UID**: FMT-1
 
-**STATEMENT**: The formatter wraps text lines to a configurable maximum line
+**Statement**: The formatter wraps text lines to a configurable maximum line
 width. The minimum acceptable line width is 80 characters.
 
 ### Prose wrapping
@@ -26,7 +26,7 @@ width. The minimum acceptable line width is 80 characters.
 **MID**: a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7 \
 **UID**: FMT-2
 
-**STATEMENT**: The formatter wraps plain prose paragraphs so that no output
+**Statement**: The formatter wraps plain prose paragraphs so that no output
 line exceeds the configured line width. Paragraph boundaries (two or more
 consecutive blank lines) are preserved. The formatter does not split individual
 words.
@@ -36,7 +36,7 @@ words.
 **MID**: b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8 \
 **UID**: FMT-3
 
-**STATEMENT**: The formatter preserves blank lines that separate paragraphs or
+**Statement**: The formatter preserves blank lines that separate paragraphs or
 list items. No blank lines are added or removed during formatting.
 
 ### Idempotency
@@ -44,7 +44,7 @@ list items. No blank lines are added or removed during formatting.
 **MID**: c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9 \
 **UID**: FMT-4
 
-**STATEMENT**: Formatting an already-formatted document produces identical
+**Statement**: Formatting an already-formatted document produces identical
 output. Running the formatter twice on the same input produces the same result
 as running it once.
 
@@ -53,7 +53,7 @@ as running it once.
 **MID**: d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0 \
 **UID**: FMT-5
 
-**STATEMENT**: The formatter does not alter the semantic content of the
+**Statement**: The formatter does not alter the semantic content of the
 document. It only changes line-break positions within wrappable prose.
 
 ### Blocks that must not be rewrapped
@@ -61,7 +61,7 @@ document. It only changes line-break positions within wrappable prose.
 **MID**: e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1 \
 **UID**: FMT-6
 
-**STATEMENT**:
+**Statement**:
 
 The formatter preserves the following block types unchanged,
 regardless of line length:
@@ -80,7 +80,7 @@ regardless of line length:
 **MID**: f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2 \
 **UID**: FMT-7
 
-**STATEMENT**:
+**Statement**:
 
 The formatter treats inline links as atomic tokens that are
 never broken across lines:
@@ -101,7 +101,7 @@ when no line-break position within the token exists.
 **MID**: 08b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3 \
 **UID**: FMT-MD-1
 
-**STATEMENT**:
+**Statement**:
 
 The formatter recognises and preserves the following unordered
 Markdown list markers: `-`, `*`, `+`. The following ordered list markers are
@@ -115,7 +115,7 @@ preserved.
 **MID**: 19c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4 \
 **UID**: FMT-MD-2
 
-**STATEMENT**:
+**Statement**:
 
 When a Markdown list item is wrapped, continuation lines are
 indented to align with the content of the list item, not with the list marker.
@@ -137,7 +137,7 @@ the marker (including its trailing space). For a `- ` marker the indent is
 **MID**: 2ad1e2f3a4b5c6d7e8f9a0b1c2d3e4f5 \
 **UID**: FMT-MD-3
 
-**STATEMENT**:
+**Statement**:
 
 The formatter does not rewrap the following Markdown constructs:
 
@@ -155,7 +155,7 @@ The formatter does not rewrap the following Markdown constructs:
 **MID**: 3be2f3a4b5c6d7e8f9a0b1c2d3e4f5a6 \
 **UID**: FMT-RST-1
 
-**STATEMENT**:
+**Statement**:
 
 The formatter recognises and preserves the following RST list
 markers:
@@ -171,7 +171,7 @@ markers:
 **MID**: 4cf3a4b5c6d7e8f9a0b1c2d3e4f5a6b7 \
 **UID**: FMT-RST-2
 
-**STATEMENT**:
+**Statement**:
 
 When an RST list item is wrapped, continuation lines are
 indented to align with the content of the list item, not with the list marker.
@@ -194,7 +194,7 @@ the marker (including its trailing space).
 **MID**: 5da4b5c6d7e8f9a0b1c2d3e4f5a6b7c8 \
 **UID**: FMT-RST-3
 
-**STATEMENT**:
+**Statement**:
 
 The formatter does not rewrap the following RST constructs:
 
@@ -213,7 +213,7 @@ The formatter does not rewrap the following RST constructs:
 **MID**: 6eb5c6d7e8f9a0b1c2d3e4f5a6b7c8d9 \
 **UID**: FMT-SD-1
 
-**STATEMENT**: The formatter treats `[LINK: uid]` as an atomic token. The
+**Statement**: The formatter treats `[LINK: uid]` as an atomic token. The
 space between the colon and the UID is not a valid line-break position. If the
 keyword would cause the current line to exceed the configured width, the entire
 `[LINK: uid]` expression is moved to the next line as a single unit.
@@ -223,7 +223,7 @@ keyword would cause the current line to exceed the configured width, the entire
 **MID**: 7fc6d7e8f9a0b1c2d3e4f5a6b7c8d9e0 \
 **UID**: FMT-SD-2
 
-**STATEMENT**: The formatter treats `[ANCHOR: uid]` as an atomic token with
+**Statement**: The formatter treats `[ANCHOR: uid]` as an atomic token with
 the same line-break rules as FMT-SD-1.
 
 ### Link as first content of a list item
@@ -231,7 +231,7 @@ the same line-break rules as FMT-SD-1.
 **MID**: 80d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1 \
 **UID**: FMT-SD-3
 
-**STATEMENT**:
+**Statement**:
 
 If an inline link or a StrictDoc cross-reference keyword
 (`[LINK: uid]` or `[ANCHOR: uid]`) is the first content of a list item —

--- a/spec/Markdown.gra.md
+++ b/spec/Markdown.gra.md
@@ -4,14 +4,14 @@
 
 **Composite**: True
 
-### Field: TITLE
+### Field: Title
 
 **Type**: String
 **Required**: True
 
 ## Element: TEXT
 
-### Field: STATEMENT
+### Field: Statement
 
 **Type**: String
 **Required**: False
@@ -28,17 +28,17 @@
 **Type**: String
 **Required**: False
 
-### Field: TITLE
+### Field: Title
 
 **Type**: String
 **Required**: False
 
-### Field: STATEMENT
+### Field: Statement
 
 **Type**: String
 **Required**: False
 
-### Field: RATIONALE
+### Field: Rationale
 
 **Type**: String
 **Required**: False

--- a/spec/Markdown.md
+++ b/spec/Markdown.md
@@ -1,7 +1,7 @@
 # Markdown Specification
 
 **Grammar**: Markdown.gra.md \
-**PREFIX**: MD-
+**Prefix**: MD-
 
 This specification defines a Markdown-based format for writing traceable documentation, including requirements. It covers two file formats: the Markdown document format (`.md`) for content and the Markdown grammar format (`.gra.md`) for schemas. Both are valid CommonMark files.
 
@@ -12,14 +12,14 @@ This specification defines a Markdown-based format for writing traceable documen
 **MID**: 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d \
 **UID**: MD-1
 
-**STATEMENT**: Markdown documents use the `.md` file extension.
+**Statement**: Markdown documents use the `.md` file extension.
 
 ### CommonMark standard
 
 **MID**: c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8 \
 **UID**: MD-23
 
-**STATEMENT**:
+**Statement**:
 
 Both the Markdown document format and the Markdown grammar format are valid CommonMark files conforming to CommonMark core syntax v0.31.2.
 
@@ -30,7 +30,7 @@ Extended Markdown features outside the CommonMark core are passed through verbat
 **MID**: 2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e \
 **UID**: MD-2
 
-**STATEMENT**:
+**Statement**:
 
 A document must begin with an H1 heading (`# Title`). No non-blank content may precede it.
 
@@ -43,7 +43,7 @@ Body text following the H1 heading and its optional metadata block accumulates a
 **MID**: 3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f \
 **UID**: MD-3
 
-**STATEMENT**:
+**Statement**:
 
 Heading levels must not skip forward: following an H_N heading, the next heading may not be at level M where M > N + 1.
 
@@ -54,7 +54,7 @@ Level decreases and same-level headings are permitted.
 **MID**: 4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a \
 **UID**: MD-4
 
-**STATEMENT**:
+**Statement**:
 
 At most one consecutive blank line is allowed. Two or more consecutive blank lines are invalid, except inside fenced code blocks and blockquotes.
 
@@ -65,31 +65,31 @@ Whitespace-only lines are treated as blank lines.
 **MID**: 5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b \
 **UID**: MD-5
 
-**STATEMENT**:
+**Statement**:
 
 Immediately after the H1 heading, an optional metadata block may appear, separated from the heading by one blank line and ending at the next blank line. Each line has the form `**Key**: value`.
 
-Recognized document-level keys are `Grammar`, `UID`, `VERSION`, `DATE`, `CLASSIFICATION`, and `PREFIX`. Any other key is stored as custom metadata.
+Recognized document-level keys are `Grammar`, `UID`, `Version`, `Date`, `Classification`, and `Prefix`. Any other key is stored as custom metadata.
 
 Duplicate key names are not allowed. Values may optionally be enclosed in backticks.
 
-### Document PREFIX field
+### Document Prefix field
 
 **MID**: f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6 \
 **UID**: MD-31
 
-**STATEMENT**:
+**Statement**:
 
-The `PREFIX` metadata key controls the prefix used when auto-generating UIDs for nodes in the document or section. It may be set at the document level or at the section level.
+The `Prefix` metadata key controls the prefix used when auto-generating UIDs for nodes in the document or section. It may be set at the document level or at the section level.
 
-**1. Document-level PREFIX**
+**1. Document-level Prefix**
 
-A `PREFIX` key in the H1 metadata block sets the default UID prefix for the entire document.
+A `Prefix` key in the H1 metadata block sets the default UID prefix for the entire document.
 
 ```markdown
 # Requirements specification
 
-**PREFIX**: MYDOC-
+**Prefix**: MYDOC-
 
 ## Section
 
@@ -100,17 +100,17 @@ A `PREFIX` key in the H1 metadata block sets the default UID prefix for the enti
 System A shall do B.
 ```
 
-**2. Section-level PREFIX**
+**2. Section-level Prefix**
 
-A section may declare its own prefix by using the `**PREFIX**` meta field together with `**TYPE**: SECTION`. The section-level prefix overrides the document-level prefix for all nodes within that section.
+A section may declare its own prefix by using the `**Prefix**` meta field together with `**Type**: SECTION`. The section-level prefix overrides the document-level prefix for all nodes within that section.
 
 ```markdown
 # Requirements specification
 
 ## Chapter 2
 
-**TYPE**: SECTION \
-**PREFIX**: LEVEL2-REQ-
+**Type**: SECTION \
+**Prefix**: LEVEL2-REQ-
 
 ### Requirement
 
@@ -119,14 +119,14 @@ A section may declare its own prefix by using the `**PREFIX**` meta field togeth
 System A shall do B.
 ```
 
-The section-level `PREFIX` is parsed out of the meta block and is not forwarded as a regular node field.
+The section-level `Prefix` is parsed out of the meta block and is not forwarded as a regular node field.
 
 ### Grammar attachment
 
 **MID**: 6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c \
 **UID**: MD-6
 
-**STATEMENT**:
+**Statement**:
 
 The `Grammar` metadata key attaches an external grammar to the document. Its value is either a relative path to a `.gra.md` file or a named alias prefixed with `@`.
 
@@ -137,15 +137,15 @@ Named aliases are resolved from the project configuration. Without a `Grammar` d
 **MID**: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6 \
 **UID**: MD-21
 
-**STATEMENT**:
+**Statement**:
 
 An H2–H6 heading forms a node. The heading text is the node TITLE. There is no limit on heading depth: nodes may be at H2, H3, H4, etc.
 
 The node body consists of three consecutive regions:
 
 1. The meta-field block — a contiguous run of `**Key**: value` lines beginning after the first blank line and ending at the next blank line.
-2. An optional RELATIONS list — immediately following the meta block without an intervening blank line.
-3. Content fields — named or implicit, following the first blank line after the meta/RELATIONS block.
+2. An optional Relations list — immediately following the meta block without an intervening blank line.
+3. Content fields — named or implicit, following the first blank line after the meta/Relations block.
 
 A node terminates at the next heading or end of file.
 
@@ -154,7 +154,7 @@ A node terminates at the next heading or end of file.
 **MID**: b0294b7fcb4343f19fbab31c399849fb \
 **UID**: MD-29
 
-**STATEMENT**:
+**Statement**:
 
 A node without a title is a special case of the node defined by [LINK: MD-21].
 
@@ -162,7 +162,7 @@ Compared to a node with a title, a node without a title starts directly with a n
 
 The resulting node shall have no `TITLE` (as opposed to a node where the title is an empty string).
 
-**RATIONALE**:
+**Rationale**:
 
 No-title nodes are a valid use-case in scenarios where a title is automatically derived and merged from related source code.
 They rely on empty headings, which is uncommon but valid syntax in CommonMark.
@@ -172,7 +172,7 @@ They rely on empty headings, which is uncommon but valid syntax in CommonMark.
 **MID**: 7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d \
 **UID**: MD-7
 
-**STATEMENT**:
+**Statement**:
 
 An H2–H6 heading that does not qualify as a requirement node (see [LINK: MD-8], [LINK: MD-9]) becomes a section.
 
@@ -183,20 +183,20 @@ Free-form Markdown prose in a section body is stored as a TEXT node.
 **MID**: 1a8b12341e2f3a4b5c6d7e8f9a0b1c2d \
 **UID**: MD-30
 
-**STATEMENT**: TEXT nodes are always nodes without a title. Parsing a TEXT element with a TITLE shall raise a validation error.
+**Statement**: TEXT nodes are always nodes without a title. Parsing a TEXT element with a TITLE shall raise a validation error.
 
 ### Default grammar
 
 **MID**: 8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e \
 **UID**: MD-8
 
-**STATEMENT**:
+**Statement**:
 
 Without a custom grammar, an H2–H6 heading becomes a REQUIREMENT node when all of the following hold:
 
 1. The meta block contains a `UID` or `MID` field.
 2. A `STATEMENT` is present (named or implicit).
-3. All field names belong to `{MID, UID, LEVEL, STATUS, TAGS, TITLE, STATEMENT, RATIONALE, COMMENT, RELATIONS}`.
+3. All field names belong to `{MID, UID, Level, Status, Tags, Title, Statement, Rationale, Comment, Relations}`.
 4. No field name is duplicated.
 5. No field value is empty.
 
@@ -207,7 +207,7 @@ The heading text is assigned to the `TITLE` field.
 **MID**: 9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f \
 **UID**: MD-9
 
-**STATEMENT**:
+**Statement**:
 
 With a custom grammar, an H2–H6 heading becomes a node when the meta block contains at least one field and the heading text is non-empty.
 
@@ -218,7 +218,7 @@ Field validation against the grammar schema is deferred to a later build stage. 
 **MID**: 00fc24ee2f5c44f08c1d7f543a3677b0 \
 **UID**: MD-24
 
-**STATEMENT**:
+**Statement**:
 
 When a custom grammar declares a `MID` field for an element type, the writer automatically inserts the node's auto-generated machine identifier into the output for any node of that type that does not already carry a `MID` field.
 
@@ -228,76 +228,76 @@ On the first write-back, every node without a `MID` receives a freshly generated
 
 This behavior applies only to custom (user-defined) grammars. The built-in default grammar also declares `MID` for the `REQUIREMENT` element, but the default grammar does not trigger auto-generation.
 
-For SECTION nodes, MID auto-generation is triggered only when the grammar's `SECTION` element declares a `MID` field. When MID is written to a SECTION node, the writer also emits `**TYPE**: SECTION` as the first meta field to prevent the reader from misidentifying the section as a requirement node on the next read.
+For SECTION nodes, MID auto-generation is triggered only when the grammar's `SECTION` element declares a `MID` field. When MID is written to a SECTION node, the writer also emits `**Type**: SECTION` as the first meta field to prevent the reader from misidentifying the section as a requirement node on the next read.
 
-### Node TYPE field — reader behaviour
+### Node Type field — reader behaviour
 
 **MID**: a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8 \
 **UID**: MD-25
 
-**STATEMENT**:
+**Statement**:
 
-The `**TYPE**: <name>` meta field specifies the element type of a node explicitly and takes precedence over the automatic node-type determination rules of [LINK: MD-7], [LINK: MD-8], and [LINK: MD-9].
+The `**Type**: <name>` meta field specifies the element type of a node explicitly and takes precedence over the automatic node-type determination rules of [LINK: MD-7], [LINK: MD-8], and [LINK: MD-9].
 
-- `**TYPE**: SECTION` forces the heading to become a SECTION regardless of other fields. Any content following the meta block (after the TYPE line) forms a TEXT child as usual; the TYPE line itself is not included in the TEXT body.
-- Any other `**TYPE**: <name>` value forces the heading to become a node of type `<name>`, bypassing the UID/MID and STATEMENT requirements of [LINK: MD-8]. Grammar field validation is deferred to the build stage as per [LINK: MD-9].
+- `**Type**: SECTION` forces the heading to become a SECTION regardless of other fields. Any content following the meta block (after the Type line) forms a TEXT child as usual; the Type line itself is not included in the TEXT body.
+- Any other `**Type**: <name>` value forces the heading to become a node of type `<name>`, bypassing the UID/MID and STATEMENT requirements of [LINK: MD-8]. Grammar field validation is deferred to the build stage as per [LINK: MD-9].
 
-The TYPE field is parsed out of the meta block and is not forwarded as a regular node field.
+The Type field is parsed out of the meta block and is not forwarded as a regular node field.
 
-### Node TYPE field — writer behaviour
+### Node Type field — writer behaviour
 
 **MID**: b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9 \
 **UID**: MD-26
 
-**STATEMENT**:
+**Statement**:
 
-When a document's grammar defines element types outside the built-in set `{SECTION, TEXT, REQUIREMENT}`, the writer emits `**TYPE**: <name>` as the first field in the meta block of every non-TEXT node (including SECTION). This ensures the element type is preserved across `format`, `manage auto-uid`, and UI-edit operations.
+When a document's grammar defines element types outside the built-in set `{SECTION, TEXT, REQUIREMENT}`, the writer emits `**Type**: <name>` as the first field in the meta block of every non-TEXT node (including SECTION). This ensures the element type is preserved across `format`, `manage auto-uid`, and UI-edit operations.
 
-SECTION is included because the reader treats any heading with a valid meta block as a typed node when a custom grammar is active; without `**TYPE**: SECTION` the reader would mis-classify a SECTION node as a REQUIREMENT on the next read.
+SECTION is included because the reader treats any heading with a valid meta block as a typed node when a custom grammar is active; without `**Type**: SECTION` the reader would mis-classify a SECTION node as a REQUIREMENT on the next read.
 
-When the grammar only contains built-in element types the TYPE field is not emitted. The determination is performed by `Grammar.has_custom_elements()`.
+When the grammar only contains built-in element types the Type field is not emitted. The determination is performed by `Grammar.has_custom_elements()`.
 
 ### SECTION MID with TEXT child — no TEXT meta
 
 **MID**: c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0 \
 **UID**: MD-27
 
-**STATEMENT**:
+**Statement**:
 
-When a SECTION heading carries both `**TYPE**: SECTION` and a `**MID**` field in its meta block, the MID is preserved as the section's machine identifier across all read-write cycles.
+When a SECTION heading carries both `**Type**: SECTION` and a `**MID**` field in its meta block, the MID is preserved as the section's machine identifier across all read-write cycles.
 
-Any content following the section meta block (after the next blank line) forms a TEXT child node whose statement is the verbatim body text. The `**TYPE**:` line from the meta block is not included in the TEXT body.
+Any content following the section meta block (after the next blank line) forms a TEXT child node whose statement is the verbatim body text. The `**Type**:` line from the meta block is not included in the TEXT body.
 
 The behavior of the TEXT child on a subsequent format pass depends on whether the document grammar declares a `MID` field for the `TEXT` element.
 
 **Subcase A: Grammar does NOT declare MID for TEXT**
 
-The writer emits the TEXT statement as plain verbatim content — no `**TYPE**:` or `**MID**:` prefix is added. The SECTION MID is still preserved.
+The writer emits the TEXT statement as plain verbatim content — no `**Type**:` or `**MID**:` prefix is added. The SECTION MID is still preserved.
 
 Example (input and output are identical after a format pass):
 
 ```markdown
 ## Introduction
 
-**TYPE**: SECTION \
+**Type**: SECTION \
 **MID**: 11111111111111111111111111111111
 
-**STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+**Statement**: This is a TEXT node statement, not a SECTION node statement.
 ```
 
 **Subcase B: Grammar declares MID for TEXT**
 
-The writer automatically emits a `**TYPE**: TEXT \` / `**MID**: <mid>` prefix before the TEXT statement body, auto-generating the MID if not already present. This ensures every TEXT node has a tracked machine identifier.
+The writer automatically emits a `**Type**: TEXT \` / `**MID**: <mid>` prefix before the TEXT statement body, auto-generating the MID if not already present. This ensures every TEXT node has a tracked machine identifier.
 
 Example input (TEXT child without explicit MID):
 
 ```markdown
 ## Introduction
 
-**TYPE**: SECTION \
+**Type**: SECTION \
 **MID**: 11111111111111111111111111111111
 
-**STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+**Statement**: This is a TEXT node statement, not a SECTION node statement.
 ```
 
 After a format pass with a grammar that declares `MID` for `TEXT`, the output becomes:
@@ -305,23 +305,23 @@ After a format pass with a grammar that declares `MID` for `TEXT`, the output be
 ```markdown
 ## Introduction
 
-**TYPE**: SECTION \
+**Type**: SECTION \
 **MID**: 11111111111111111111111111111111
 
-**TYPE**: TEXT \
+**Type**: TEXT \
 **MID**: <auto-generated-mid>
 
-**STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+**Statement**: This is a TEXT node statement, not a SECTION node statement.
 ```
 
-### SECTION MID with TEXT child — TEXT TYPE and MID present
+### SECTION MID with TEXT child — TEXT Type and MID present
 
 **MID**: d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1 \
 **UID**: MD-28
 
-**STATEMENT**:
+**Statement**:
 
-When the section body begins with a `**TYPE**: TEXT \` / `**MID**: <value>` prefix block (separated by a blank line from the following content), the reader extracts the `MID` value as the TEXT child node's machine identifier. The remaining body text becomes the TEXT statement.
+When the section body begins with a `**Type**: TEXT \` / `**MID**: <value>` prefix block (separated by a blank line from the following content), the reader extracts the `MID` value as the TEXT child node's machine identifier. The remaining body text becomes the TEXT statement.
 
 The writer re-emits this prefix whenever the grammar's `TEXT` element declares a `MID` field, preserving the TEXT MID across format passes.
 
@@ -330,13 +330,13 @@ Example:
 ```markdown
 ## Introduction
 
-**TYPE**: SECTION \
+**Type**: SECTION \
 **MID**: 11111111111111111111111111111111
 
-**TYPE**: TEXT \
+**Type**: TEXT \
 **MID**: 22222222222222222222222222222222
 
-**STATEMENT**: This is a text statement.
+**Statement**: This is a text statement.
 ```
 
 After a format pass the SECTION MID (11111111111111111111111111111111) is preserved in the section meta block, and the TEXT MID (22222222222222222222222222222222) is preserved in the TEXT prefix block.
@@ -346,9 +346,11 @@ After a format pass the SECTION MID (11111111111111111111111111111111) is preser
 **MID**: 0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a \
 **UID**: MD-10
 
-**STATEMENT**:
+**Statement**:
 
-The meta block is a contiguous group of `**Key**: value` lines following the first blank line after the heading. It ends at the next blank line. Field names match `[A-Za-z0-9][A-Za-z0-9 _-]*` and are stored uppercase. Values may optionally be enclosed in backticks.
+The meta block is a contiguous group of `**Key**: value` lines following the first blank line after the heading. It ends at the next blank line. Field names match `[A-Za-z0-9][A-Za-z0-9 _-]*` and are stored using the exact casing written. Values may optionally be enclosed in backticks.
+
+With a custom grammar, a field name must match the exact casing declared for it in the grammar (e.g. `ALL_CAPS`, `Camel-Case`, or `Camel Case`); there is no case-insensitive fallback. With the built-in default grammar, `**Level**:`, `**Status**:`, `**Tags**:`, `**Title**:`, `**Statement**:`, `**Rationale**:`, `**Comment**:`, and `**Prefix**:` (Title-Case) are the canonical surface form for those fields, with `**MID**:` and `**UID**:` kept as uppercase abbreviations.
 
 The meta block uses backslash style: each field except the last ends with ` \`.
 
@@ -357,7 +359,7 @@ The meta block uses backslash style: each field except the last ends with ` \`.
 **MID**: 1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b \
 **UID**: MD-11
 
-**STATEMENT**:
+**Statement**:
 
 After the meta block, content fields are written as `**FieldName**: value` lines.
 
@@ -371,7 +373,7 @@ Prose not starting with a `**Key**:` header is accumulated as an implicit `STATE
 **MID**: e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3 \
 **UID**: MD-32
 
-**STATEMENT**:
+**Statement**:
 
 A `[LINK: <uid>]` token may appear anywhere in a content field value (e.g. STATEMENT, RATIONALE, COMMENT). It creates a traceable inline reference to the node or anchor identified by `<uid>`. The UID must match the `REGEX_UID` pattern: `[\w]+[\w()\-\/.: ]*`.
 
@@ -392,7 +394,7 @@ System shall do X. See also [LINK: REQ-2].
 **MID**: f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4 \
 **UID**: MD-33
 
-**STATEMENT**:
+**Statement**:
 
 An `[ANCHOR: <uid>]` or `[ANCHOR: <uid>, <title>]` token places a named anchor in a content field value. The anchor must appear at the start of a line and occupy the entire line (no other text on the same line). The UID follows the `REGEX_UID` pattern. The optional title is a human-readable label.
 
@@ -415,33 +417,33 @@ Additional content.
 **MID**: b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7 \
 **UID**: MD-22
 
-**STATEMENT**:
+**Statement**:
 
 Attribute dictionaries use bold-key notation: each key-value pair is written as `**Key**: value`. Values may optionally be enclosed in backticks; if present, the backtick delimiters are stripped when parsed.
 
 When a dictionary spans multiple key-value pairs, all pairs except the last end with ` \` (a space followed by a backslash).
 
-When a dictionary appears as an item in a bullet list (as in RELATIONS), continuation attribute lines must be indented by at least one space relative to the enclosing `- ` marker.
+When a dictionary appears as an item in a bullet list (as in Relations), continuation attribute lines must be indented by at least one space relative to the enclosing `- ` marker.
 
-### RELATIONS field
+### Relations field
 
 **MID**: 2f3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c \
 **UID**: MD-12
 
-**STATEMENT**:
+**Statement**:
 
-The `RELATIONS` field is a list-valued meta field. It must immediately follow the rest of the meta block without an intervening blank line.
+The `Relations` field is a list-valued meta field. It must immediately follow the rest of the meta block without an intervening blank line.
 
 Its value is a bullet list where each item represents one relation. Within an item, attributes are written as `**<Key>**: <Value>` pairs; continuation lines are indented by two spaces and end with ` \` except for the last pair.
 
-A `RELATIONS` list must contain at least one item.
+A `Relations` list must contain at least one item.
 
 ### Parent and Child relations
 
 **MID**: 3a4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d \
 **UID**: MD-13
 
-**STATEMENT**:
+**Statement**:
 
 A Parent or Child relation requires `**Type**` (`Parent` or `Child`) and a mandatory `**ID**` key holding the UID of the related node.
 
@@ -452,7 +454,7 @@ An optional `**Role**` key names the relation role. No other keys are allowed.
 **MID**: 4b5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e \
 **UID**: MD-14
 
-**STATEMENT**:
+**Statement**:
 
 A File relation requires `**Type**: File` and a mandatory `**Path**` key.
 
@@ -467,14 +469,14 @@ Optional keys are `**Lines**` (line range), `**Element**` (language element type
 **MID**: 5c6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f \
 **UID**: MD-15
 
-**STATEMENT**: Markdown grammar files use the `.gra.md` file extension.
+**Statement**: Markdown grammar files use the `.gra.md` file extension.
 
 ### Grammar document structure
 
 **MID**: 6d7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a \
 **UID**: MD-16
 
-**STATEMENT**:
+**Statement**:
 
 A grammar file must start with an H1 heading with no content before it.
 
@@ -485,7 +487,7 @@ The body uses a fixed heading hierarchy: H2 for element declarations, H3 for fie
 **MID**: 7e8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b \
 **UID**: MD-17
 
-**STATEMENT**:
+**Statement**:
 
 Each grammar element is declared as `## Element: <NAME>`. Element names must be unique within the file. At least one element is required.
 
@@ -493,18 +495,18 @@ Optional element properties:
 
 - `**Composite**: True|False` — whether the element may contain child elements.
 - `**Prefix**: <string>` — default UID prefix.
-- `**View Style**: <string>` — display style hint.
+- `**View style**: <string>` — display style hint.
 
 ### Field declaration
 
 **MID**: 8f9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c \
 **UID**: MD-18
 
-**STATEMENT**:
+**Statement**:
 
 Each field is declared as `### Field: <NAME>`. Field names must be unique within the element.
 
-Required properties: `**Type**: <type>` and `**Required**: True|False`. Optional property: `**Human Title**: <string>`.
+Required properties: `**Type**: <type>` and `**Required**: True|False`. Optional property: `**Human title**: <string>`.
 
 Field properties are written as plain `**Key**: value` lines with no continuation marker.
 
@@ -513,7 +515,7 @@ Field properties are written as plain `**Key**: value` lines with no continuatio
 **MID**: 9a0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d \
 **UID**: MD-19
 
-**STATEMENT**:
+**Statement**:
 
 Supported field types:
 
@@ -529,11 +531,11 @@ Supported field types:
 **MID**: 0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e \
 **UID**: MD-20
 
-**STATEMENT**:
+**Statement**:
 
 Within an element, `### Relations` opens the relations section. Each permitted relation type is declared as `#### Relation: <TYPE>` where `<TYPE>` is `Parent`, `Child`, or `File`.
 
 An optional `**Role**: <role>` property names the relation role.
 
-For `Parent` and `Child` relations, an optional `**Reverse Role**: <role>` defines the role name used when the relation is shown from the opposite direction (e.g. a parent showing its derived child link).
-`**Reverse Role**` requires `**Role**` to also be set. If `**Reverse Role**` is omitted, the `**Role**` value is shown in both directions.
+For `Parent` and `Child` relations, an optional `**Reverse role**: <role>` defines the role name used when the relation is shown from the opposite direction (e.g. a parent showing its derived child link).
+`**Reverse role**` requires `**Role**` to also be set. If `**Reverse role**` is omitted, the `**Role**` value is shown in both directions.

--- a/strictdoc/backend/markdown/default_grammar.py
+++ b/strictdoc/backend/markdown/default_grammar.py
@@ -1,0 +1,193 @@
+from typing import List, Optional
+
+from strictdoc.backend.sdoc.models.document_grammar import DocumentGrammar
+from strictdoc.backend.sdoc.models.grammar_element import (
+    GrammarElement,
+    GrammarElementFieldString,
+    GrammarElementFieldType,
+)
+from strictdoc.backend.sdoc.models.model import SDocDocumentIF
+
+
+def create_markdown_default_grammar(
+    parent: Optional[SDocDocumentIF],
+    enable_mid: bool = False,
+    include_child_relation: bool = False,
+) -> DocumentGrammar:
+    """
+    Build the Markdown-only default grammar.
+
+    This mirrors DocumentGrammar.create_default() (shared with SDoc) field
+    for field, but sets a Title-Case human_title on every field beyond MID/UID
+    (kept as uppercase abbreviations). The field *title* (the internal key
+    used by SDocNode.ordered_fields_lookup and GrammarElement's content-field
+    detection) is left as the shared ALL_CAPS constant so that node.rationale,
+    node.reserved_title, node.reserved_level, etc. keep working unmodified.
+    SDMarkdownReader/SDMarkdownWriter alias the Title-Case surface syntax
+    (**Statement**:, **Rationale**:, ...) onto these keys at the text level.
+    """
+    text_element = _create_text_element(enable_mid=enable_mid)
+    section_element = _create_section_element(enable_mid=enable_mid)
+
+    fields: List[GrammarElementFieldType] = []
+    if enable_mid:
+        fields.append(
+            GrammarElementFieldString(
+                parent=None, title="MID", human_title=None, required="False"
+            )
+        )
+    fields.extend(
+        [
+            GrammarElementFieldString(
+                parent=None, title="UID", human_title=None, required="False"
+            ),
+            GrammarElementFieldString(
+                parent=None,
+                title="LEVEL",
+                human_title="Level",
+                required="False",
+            ),
+            GrammarElementFieldString(
+                parent=None,
+                title="STATUS",
+                human_title="Status",
+                required="False",
+            ),
+            GrammarElementFieldString(
+                parent=None,
+                title="TAGS",
+                human_title="Tags",
+                required="False",
+            ),
+            GrammarElementFieldString(
+                parent=None,
+                title="TITLE",
+                human_title="Title",
+                required="False",
+            ),
+            GrammarElementFieldString(
+                parent=None,
+                title="STATEMENT",
+                human_title="Statement",
+                required="False",
+            ),
+            GrammarElementFieldString(
+                parent=None,
+                title="RATIONALE",
+                human_title="Rationale",
+                required="False",
+            ),
+            GrammarElementFieldString(
+                parent=None,
+                title="COMMENT",
+                human_title="Comment",
+                required="False",
+            ),
+        ]
+    )
+
+    requirement_element = GrammarElement(
+        parent=None,
+        tag="REQUIREMENT",
+        property_is_composite="",
+        property_prefix="",
+        property_view_style="",
+        fields=fields,
+        relations=[],
+    )
+    requirement_element.relations = GrammarElement.create_default_relations(
+        requirement_element,
+        include_child=include_child_relation,
+    )
+
+    elements: List[GrammarElement] = [
+        section_element,
+        text_element,
+        requirement_element,
+    ]
+
+    grammar = DocumentGrammar(
+        parent=parent, elements=elements, import_from_file=None
+    )
+    grammar.is_default = True
+    text_element.parent = grammar
+    section_element.parent = grammar
+    requirement_element.parent = grammar
+
+    return grammar
+
+
+def _create_text_element(enable_mid: bool = False) -> GrammarElement:
+    fields: List[GrammarElementFieldType] = []
+    if enable_mid:
+        fields.append(
+            GrammarElementFieldString(
+                parent=None, title="MID", human_title=None, required="False"
+            )
+        )
+    fields.extend(
+        [
+            GrammarElementFieldString(
+                parent=None, title="UID", human_title=None, required="False"
+            ),
+            GrammarElementFieldString(
+                parent=None,
+                title="STATEMENT",
+                human_title="Statement",
+                required="True",
+            ),
+        ]
+    )
+    return GrammarElement(
+        parent=None,
+        tag="TEXT",
+        property_is_composite="",
+        property_prefix="",
+        property_view_style="",
+        fields=fields,
+        relations=[],
+    )
+
+
+def _create_section_element(enable_mid: bool = False) -> GrammarElement:
+    fields: List[GrammarElementFieldType] = []
+    if enable_mid:
+        fields.append(
+            GrammarElementFieldString(
+                parent=None, title="MID", human_title=None, required="False"
+            )
+        )
+    fields.extend(
+        [
+            GrammarElementFieldString(
+                parent=None, title="UID", human_title=None, required="False"
+            ),
+            GrammarElementFieldString(
+                parent=None,
+                title="LEVEL",
+                human_title="Level",
+                required="False",
+            ),
+            GrammarElementFieldString(
+                parent=None,
+                title="PREFIX",
+                human_title="Prefix",
+                required="False",
+            ),
+            GrammarElementFieldString(
+                parent=None,
+                title="TITLE",
+                human_title="Title",
+                required="True",
+            ),
+        ]
+    )
+    return GrammarElement(
+        parent=None,
+        tag="SECTION",
+        property_is_composite="True",
+        property_prefix="",
+        property_view_style="",
+        fields=fields,
+        relations=[],
+    )

--- a/strictdoc/backend/markdown/grammar_reader.py
+++ b/strictdoc/backend/markdown/grammar_reader.py
@@ -75,9 +75,9 @@ class MarkdownGrammarReader:
                     heading_node.body, file_path, heading_node
                 )
                 unknown_properties = set(properties.keys()) - {
-                    "COMPOSITE",
-                    "PREFIX",
-                    "VIEW STYLE",
+                    "Composite",
+                    "Prefix",
+                    "View style",
                 }
                 if len(unknown_properties) > 0:
                     MarkdownGrammarReader._raise_error(
@@ -86,7 +86,7 @@ class MarkdownGrammarReader:
                         heading_node,
                         file_path,
                     )
-                property_is_composite = properties.get("COMPOSITE", "")
+                property_is_composite = properties.get("Composite", "")
                 if property_is_composite not in ("", "True", "False"):
                     MarkdownGrammarReader._raise_error(
                         "Composite must be True or False.",
@@ -98,8 +98,8 @@ class MarkdownGrammarReader:
                         parent=None,
                         tag=tag,
                         property_is_composite=property_is_composite,
-                        property_prefix=properties.get("PREFIX", ""),
-                        property_view_style=properties.get("VIEW STYLE", ""),
+                        property_prefix=properties.get("Prefix", ""),
+                        property_view_style=properties.get("View style", ""),
                         fields=[],
                         relations=[],
                     )
@@ -134,8 +134,13 @@ class MarkdownGrammarReader:
                 field_name = MarkdownGrammarReader._parse_named_heading(
                     heading_node, "Field", file_path
                 )
+                canonical_field_name = (
+                    SDMarkdownReader.default_grammar_field_aliases.get(
+                        field_name, field_name
+                    )
+                )
                 if any(
-                    field_.title == field_name
+                    field_.title == canonical_field_name
                     for field_ in current_element.fields
                 ):
                     MarkdownGrammarReader._raise_error(
@@ -234,9 +239,9 @@ class MarkdownGrammarReader:
             body, file_path, heading_node
         )
         unknown_properties = set(properties.keys()) - {
-            "TYPE",
-            "REQUIRED",
-            "HUMAN TITLE",
+            "Type",
+            "Required",
+            "Human title",
         }
         if len(unknown_properties) > 0:
             MarkdownGrammarReader._raise_error(
@@ -245,21 +250,41 @@ class MarkdownGrammarReader:
                 heading_node,
                 file_path,
             )
-        field_type = properties.get("TYPE")
+        field_type = properties.get("Type")
         if field_type is None:
             MarkdownGrammarReader._raise_error(
                 f"field {field_name} has no Type.",
                 heading_node,
                 file_path,
             )
-        required = properties.get("REQUIRED")
+        required = properties.get("Required")
         if required not in ("True", "False"):
             MarkdownGrammarReader._raise_error(
                 f"field {field_name} Required must be True or False.",
                 heading_node,
                 file_path,
             )
-        human_title = properties.get("HUMAN TITLE")
+        human_title = properties.get("Human title")
+
+        # 8 field roles (Title, Statement, Rationale, Comment, Level, Status,
+        # Tags, Prefix) back shared SDocNode accessors (reserved_title,
+        # reserved_statement, rationale, comment, reserved_level,
+        # reserved_status, reserved_tags, get_prefix) that hardcode the exact
+        # ALL_CAPS key — this holds for the built-in default grammar AND any
+        # custom grammar, since SDocNode has no per-markup subclass. A
+        # grammar author may declare one of these fields using the readable
+        # surface name (e.g. "Statement"); it is canonicalized to the
+        # required internal key here, with the declared surface name kept as
+        # the default human title. Declaring the field under any other name
+        # (e.g. ASIL, DERIVED_RATIONALE) is untouched — those are free-form.
+        canonical_field_name = (
+            SDMarkdownReader.default_grammar_field_aliases.get(
+                field_name, field_name
+            )
+        )
+        if human_title is None and field_name != canonical_field_name:
+            human_title = field_name
+        field_name = canonical_field_name
 
         if field_type == "String":
             return GrammarElementFieldString(
@@ -325,7 +350,7 @@ class MarkdownGrammarReader:
         properties = MarkdownGrammarReader._parse_properties(
             body, file_path, heading_node
         )
-        unknown_properties = set(properties.keys()) - {"ROLE", "REVERSE ROLE"}
+        unknown_properties = set(properties.keys()) - {"Role", "Reverse role"}
         if len(unknown_properties) > 0:
             MarkdownGrammarReader._raise_error(
                 "unknown relation propertie(s): "
@@ -333,8 +358,8 @@ class MarkdownGrammarReader:
                 heading_node,
                 file_path,
             )
-        role = properties.get("ROLE")
-        reverse_role = properties.get("REVERSE ROLE")
+        role = properties.get("Role")
+        reverse_role = properties.get("Reverse role")
         if relation_type == "Parent":
             return GrammarElementRelationParent(
                 parent, relation_type, role, reverse_role
@@ -368,7 +393,7 @@ class MarkdownGrammarReader:
                     heading_node,
                     file_path,
                 )
-            key = match.group("name").strip().upper()
+            key = match.group("name").strip()
             value = SDMarkdownReader._trim_single_space_prefix(
                 match.group("value")
             ).strip()

--- a/strictdoc/backend/markdown/reader.py
+++ b/strictdoc/backend/markdown/reader.py
@@ -10,6 +10,9 @@ from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Union
 from markdown_it import MarkdownIt
 from markdown_it.token import Token
 
+from strictdoc.backend.markdown.default_grammar import (
+    create_markdown_default_grammar,
+)
 from strictdoc.backend.sdoc.constants import SDocMarkup
 from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.error_handling import StrictDocSemanticError
@@ -54,7 +57,6 @@ class ParsedField:
 
     name: str
     value: str
-    human_name: str
     is_block_format: bool = False
 
 
@@ -67,7 +69,7 @@ class ParsedMarkdownNode:
     has_duplicates: bool
     explicit_node_type: Optional[str] = None
     # Body after the meta block stripped, used as effective body for section
-    # TEXT children so that **TYPE**: / **PREFIX**: / **MID**: lines do not
+    # TEXT children so that **Type**: / **Prefix**: / **MID**: lines do not
     # reappear as prose.  None means "use the raw heading body" (fallback for
     # ambiguous meta blocks such as duplicate-field invalid nodes).
     processed_body: Optional[str] = None
@@ -79,9 +81,9 @@ class SDMarkdownReader:
     plain_field_pattern = re.compile(
         r"^\*\*(?P<name>[A-Za-z0-9][A-Za-z0-9 _-]*)\*\*:(?P<value>.*)$"
     )
-    # Patterns for detecting the **TYPE**: TEXT \ **MID**: ... prefix in TEXT
+    # Patterns for detecting the **Type**: TEXT \ **MID**: ... prefix in TEXT
     # node bodies (used when the grammar's TEXT element declares a MID field).
-    _text_type_line_re = re.compile(r"^\*\*TYPE\*\*: TEXT(?: \\)?$")
+    _text_type_line_re = re.compile(r"^\*\*Type\*\*: TEXT(?: \\)?$")
     _text_mid_line_re = re.compile(r"^\*\*MID\*\*: (\S+)$")
     dict_entry_pattern = re.compile(
         r"^\s*\*\*(?P<name>[A-Za-z0-9][A-Za-z0-9 _-]*)\*\*:\s*`?(?P<value>[^`]*)`?\s*(?:\\)?$"
@@ -94,13 +96,31 @@ class SDMarkdownReader:
         "LEVEL",
         "STATUS",
         "TAGS",
-        "RELATIONS",
+        "Relations",
         "TITLE",
         "STATEMENT",
         "RATIONALE",
         "COMMENT",
     }
     requirement_meta_fields = {"MID", "UID", "LEVEL", "STATUS", "TAGS"}
+    # The built-in default grammar's REQUIREMENT/SECTION/TEXT elements are
+    # shared with SDoc: SDocNode's own convenience accessors (reserved_title,
+    # reserved_level, rationale, comment, etc.) and GrammarElement's
+    # content-field detection hardcode these exact ALL_CAPS keys. Markdown's
+    # more readable surface syntax (e.g. **Statement**:) is therefore mapped
+    # onto the required internal key here; this alias applies only when no
+    # custom grammar is attached (has_custom_grammar=False) — custom grammars
+    # are matched exactly against whatever casing their author declared.
+    default_grammar_field_aliases = {
+        "Level": "LEVEL",
+        "Status": "STATUS",
+        "Tags": "TAGS",
+        "Title": "TITLE",
+        "Statement": "STATEMENT",
+        "Rationale": "RATIONALE",
+        "Comment": "COMMENT",
+        "Prefix": "PREFIX",
+    }
 
     @staticmethod
     def read(
@@ -252,7 +272,7 @@ class SDMarkdownReader:
             section_contents=[],
         )
         document.config.markup = SDocMarkup.MARKDOWN
-        document.grammar = DocumentGrammar.create_default(
+        document.grammar = create_markdown_default_grammar(
             parent=document,
             enable_mid=True,
             include_child_relation=True,
@@ -309,20 +329,20 @@ class SDMarkdownReader:
 
             metadata_entries = []
             for field_ in root_meta_fields:
-                if field_.name == "GRAMMAR":
+                if field_.name == "Grammar":
                     document.grammar = DocumentGrammar(
                         parent=document,
                         elements=[],
                         import_from_file=field_.value,
                     )
                     continue
-                if field_.name == "PREFIX":
+                if field_.name == "Prefix":
                     document.config.requirement_prefix = field_.value
                 if field_.name == "UID":
                     document.config.uid = field_.value
                 metadata_entries.append(
                     DocumentCustomMetadataKeyValuePair(
-                        key=field_.human_name,
+                        key=field_.name,
                         parts=SDMarkdownReader._parse_text_parts(field_.value),
                     )
                 )
@@ -433,11 +453,6 @@ class SDMarkdownReader:
                 parent_node.section_contents.append(requirement_node)
                 stack.append((heading_node.level, requirement_node))
 
-                SDMarkdownReader._memorize_requirement_human_titles(
-                    document=document,
-                    markdown_fields=parsed_node.fields,
-                )
-
                 document.ng_has_requirements = True
                 cursor_node: Optional[SDocNode]
                 if isinstance(parent_node, SDocNode):
@@ -460,7 +475,7 @@ class SDMarkdownReader:
                 section_node.ng_including_document_reference = (
                     including_document_reference
                 )
-                # Preserve MID from the section meta block (e.g. **TYPE**: SECTION \ **MID**: ...).
+                # Preserve MID from the section meta block (e.g. **Type**: SECTION \ **MID**: ...).
                 # create_section does not accept fields, so we patch it in afterwards.
                 # MID must be inserted before TITLE to match the grammar field order.
                 mid_field = next(
@@ -479,9 +494,9 @@ class SDMarkdownReader:
                     section_node.ordered_fields_lookup.update(existing)
                     section_node.reserved_mid = MID(mid_field.value)
                     section_node.mid_permanent = True
-                # Preserve PREFIX from the section meta block.
-                # PREFIX is inserted before TITLE (after MID) to keep the
-                # field order: MID, LEVEL, PREFIX, TITLE.
+                # Preserve Prefix from the section meta block.
+                # The internal PREFIX key is inserted before TITLE (after
+                # MID) to keep the field order: MID, LEVEL, PREFIX, TITLE.
                 prefix_field = next(
                     (f for f in parsed_node.fields if f.name == "PREFIX"), None
                 )
@@ -505,7 +520,7 @@ class SDMarkdownReader:
                 parent_node.section_contents.append(section_node)
 
                 # When processed_body is set the meta block has been stripped;
-                # use it to avoid duplicating **TYPE**: / **PREFIX**: / **MID**:
+                # use it to avoid duplicating **Type**: / **Prefix**: / **MID**:
                 # lines as prose in the TEXT child.  Otherwise fall back to the
                 # raw heading body so ambiguous content is preserved.
                 effective_body = (
@@ -529,28 +544,6 @@ class SDMarkdownReader:
                 stack.append((heading_node.level, section_node))
 
             previous_level = heading_node.level
-
-    @staticmethod
-    def _memorize_requirement_human_titles(
-        document: SDocDocument, markdown_fields: List[ParsedField]
-    ) -> None:
-        """
-        Copy markdown field names (e.g. "Statement") from markdown to default grammar REQUIREMENT element.
-
-        The markdown writer will later use the names to reproduce original capitalisation.
-        """
-        assert document.grammar is not None
-        requirement_element = document.grammar.elements_by_type.get(
-            "REQUIREMENT"
-        )
-        if requirement_element is None:
-            return
-        for markdown_field in markdown_fields:
-            if markdown_field.name not in requirement_element.fields_map:
-                continue
-            grammar_field = requirement_element.fields_map[markdown_field.name]
-            if grammar_field.human_title is None:
-                grammar_field.human_title = markdown_field.human_name
 
     @staticmethod
     def _fallback_document_title(file_path: Optional[str]) -> str:
@@ -728,18 +721,30 @@ class SDMarkdownReader:
 
         parsed_fields = meta_fields + content_fields
 
-        # Extract TYPE before further validation; it controls the node type and
+        # These 8 reserved field roles back shared SDocNode accessors
+        # (reserved_title, reserved_statement, rationale, comment,
+        # reserved_level, reserved_status, reserved_tags, get_prefix) that
+        # hardcode the exact ALL_CAPS key, in both the default and any custom
+        # grammar. The alias is therefore applied unconditionally here; it
+        # only ever matches these 8 fixed names, never an arbitrary
+        # grammar-specific field (e.g. ASIL, DERIVED_RATIONALE).
+        for field_ in parsed_fields:
+            field_.name = SDMarkdownReader.default_grammar_field_aliases.get(
+                field_.name, field_.name
+            )
+
+        # Extract Type before further validation; it controls the node type and
         # must not be forwarded as a regular SDoc field.
-        # Only the first TYPE field is honoured: for SECTION nodes the body may
-        # contain a **TYPE**: TEXT \ prefix in the TEXT child content (MD-28),
-        # and that body-level TYPE must not override the meta-block TYPE.
+        # Only the first Type field is honoured: for SECTION nodes the body may
+        # contain a **Type**: TEXT \ prefix in the TEXT child content (MD-28),
+        # and that body-level Type must not override the meta-block Type.
         explicit_node_type: Optional[str] = None
         parsed_fields_without_type: List[ParsedField] = []
         for field_ in parsed_fields:
-            if field_.name == "TYPE":
+            if field_.name == "Type":
                 if explicit_node_type is None:
                     explicit_node_type = field_.value.strip()
-                # Subsequent TYPE fields (e.g. in the TEXT body) are discarded.
+                # Subsequent Type fields (e.g. in the TEXT body) are discarded.
             else:
                 parsed_fields_without_type.append(field_)
         parsed_fields = parsed_fields_without_type
@@ -760,11 +765,11 @@ class SDMarkdownReader:
         )
 
         if explicit_node_type == "SECTION":
-            # Explicit TYPE: SECTION always creates a section, regardless of
+            # Explicit Type: SECTION always creates a section, regardless of
             # whether the body would otherwise qualify as a requirement.
             valid_for_requirement = False
         elif explicit_node_type is not None:
-            # Any other explicit TYPE is accepted as long as the markdown syntax
+            # Any other explicit Type is accepted as long as the markdown syntax
             # is well-formed and the heading has a non-empty title.  Grammar
             # field validation is deferred to TraceabilityIndexBuilder.
             valid_for_requirement = meta_is_valid and content_is_valid
@@ -790,8 +795,8 @@ class SDMarkdownReader:
             )
 
         # Use body_lines_without_meta (meta block stripped) as processed_body
-        # only when the meta block contains section-specific fields (TYPE, MID,
-        # PREFIX) so those lines do not reappear as prose in the TEXT child.
+        # only when the meta block contains section-specific fields (Type, MID,
+        # Prefix) so those lines do not reappear as prose in the TEXT child.
         # For ambiguous meta blocks (e.g. duplicate UID fields in an invalid
         # requirement node) fall back to None so _create_document_tree uses the
         # raw heading body and preserves the content.
@@ -881,7 +886,7 @@ class SDMarkdownReader:
                 )
                 if (
                     next_field_match is not None
-                    and next_field_match.group("name").upper() == "RELATIONS"
+                    and next_field_match.group("name") == "Relations"
                 ):
                     raise StrictDocSemanticError(
                         title=(
@@ -968,8 +973,7 @@ class SDMarkdownReader:
 
             parsed_fields.append(
                 ParsedField(
-                    name=match.group("name").upper(),
-                    human_name=match.group("name"),
+                    name=match.group("name"),
                     value=value,
                 )
             )
@@ -986,7 +990,7 @@ class SDMarkdownReader:
 
         A **Key**: line at column 0 starts a named field. If its value is empty
         and the next line opens a dict bullet (- **), the field is a structured
-        list (e.g. RELATIONS); otherwise the field value is collected as
+        list (e.g. Relations); otherwise the field value is collected as
         multiline prose until the next field header or end of body.
         Lines that match no field header are accumulated as an implicit STATEMENT.
 
@@ -1053,8 +1057,7 @@ class SDMarkdownReader:
                     )
                     if (
                         next_field_match is not None
-                        and next_field_match.group("name").upper()
-                        == "RELATIONS"
+                        and next_field_match.group("name") == "Relations"
                     ):
                         raise StrictDocSemanticError(
                             title=(
@@ -1074,8 +1077,7 @@ class SDMarkdownReader:
             line_text = SDMarkdownReader._line_without_line_ending(line)
             plain_match = SDMarkdownReader.plain_field_pattern.match(line_text)
             if plain_match is not None and line_index not in fence_interior:
-                field_name_upper = plain_match.group("name").upper()
-                field_name_human = plain_match.group("name")
+                field_name = plain_match.group("name")
                 inline_value = SDMarkdownReader._trim_single_space_prefix(
                     plain_match.group("value")
                 )
@@ -1115,8 +1117,7 @@ class SDMarkdownReader:
                         field_value = inline_value
                     parsed_fields.append(
                         ParsedField(
-                            name=field_name_upper,
-                            human_name=field_name_human,
+                            name=field_name,
                             value=field_value,
                         )
                     )
@@ -1164,8 +1165,7 @@ class SDMarkdownReader:
                 field_value = "".join(multiline_field_lines)
                 parsed_fields.append(
                     ParsedField(
-                        name=field_name_upper,
-                        human_name=field_name_human,
+                        name=field_name,
                         value=field_value,
                         is_block_format=True,
                     )
@@ -1194,7 +1194,6 @@ class SDMarkdownReader:
             parsed_fields.append(
                 ParsedField(
                     name="STATEMENT",
-                    human_name="Statement",
                     value=statement_value,
                 )
             )
@@ -1217,7 +1216,7 @@ class SDMarkdownReader:
         parsed_content_fields: List[ParsedField] = []
         relations_field: Optional[ParsedField] = None
         for field in fields:
-            if field.name == "RELATIONS":
+            if field.name == "Relations":
                 relations_field = field
                 continue
             if field.name in SDMarkdownReader.requirement_meta_fields:
@@ -1278,7 +1277,7 @@ class SDMarkdownReader:
     @staticmethod
     def _try_parse_text_meta(body: str) -> Tuple[Optional[str], str]:
         r"""
-        Detect and extract a **TYPE**: TEXT \\ **MID**: <value> prefix block
+        Detect and extract a **Type**: TEXT \\ **MID**: <value> prefix block
         from a section body string.
 
         Returns (mid_value, remaining_body) when the prefix is found, or
@@ -1497,7 +1496,7 @@ class SDMarkdownReader:
 
         Each "- " line starts a new dict item; continuation lines (indented)
         belong to the same item. Returns a list of {key: value} dicts,
-        one per bullet. RELATIONS-agnostic: any structured list field can use this.
+        one per bullet. Relations-agnostic: any structured list field can use this.
         """
         items: List[List[str]] = []
         current_item: Optional[List[str]] = None

--- a/strictdoc/backend/markdown/writer.py
+++ b/strictdoc/backend/markdown/writer.py
@@ -2,6 +2,7 @@ import re
 from typing import List, Optional, Sequence, Tuple
 
 from strictdoc.backend.markdown.formatter import wrap_md_text
+from strictdoc.backend.markdown.reader import SDMarkdownReader
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_config import (
     DocumentCustomMetadataKeyValuePair,
@@ -25,6 +26,18 @@ from strictdoc.helpers.cast import assert_cast
 
 
 class SDMarkdownWriter:
+    # Reverse of SDMarkdownReader.default_grammar_field_aliases: the Markdown
+    # surface convention for the built-in default grammar applies regardless
+    # of which concrete grammar object produced the document (a genuinely
+    # markdown-authored document, or one converted from SDoc/ReqIF/Excel),
+    # so this is independent of any particular grammar's human_title.
+    _default_grammar_field_surface_names = {
+        internal: surface
+        for surface, internal in (
+            SDMarkdownReader.default_grammar_field_aliases.items()
+        )
+    }
+
     @staticmethod
     def write(document: SDocDocument, line_width: Optional[int] = None) -> str:
         top_level_blocks: List[str] = []
@@ -82,7 +95,7 @@ class SDMarkdownWriter:
             metadata_entries.append(
                 ("Grammar", document.grammar.import_from_file)
             )
-            seen_keys.add("GRAMMAR")
+            seen_keys.add("Grammar")
 
         custom_metadata = document.config.custom_metadata
         if custom_metadata is not None:
@@ -93,14 +106,14 @@ class SDMarkdownWriter:
                 ):
                     continue
                 metadata_entries.append((entry.key, entry.get_text_value()))
-                seen_keys.add(entry.key.upper())
+                seen_keys.add(entry.key)
 
         default_config_entries: Sequence[Tuple[str, Optional[str]]] = (
             ("UID", document.config.uid),
-            ("VERSION", document.config.version),
-            ("DATE", document.config.date),
-            ("CLASSIFICATION", document.config.classification),
-            ("PREFIX", document.config.requirement_prefix),
+            ("Version", document.config.version),
+            ("Date", document.config.date),
+            ("Classification", document.config.classification),
+            ("Prefix", document.config.requirement_prefix),
         )
         for entry_key, entry_value in default_config_entries:
             if entry_value is None or entry_key in seen_keys:
@@ -184,9 +197,9 @@ class SDMarkdownWriter:
             and "MID" not in node.ordered_fields_lookup
         )
 
-        # Emit TYPE for every non-TEXT node when:
+        # Emit Type for every non-TEXT node when:
         # - the grammar defines element types beyond the built-in set (MD-26), OR
-        # - a SECTION node carries a MID field (MD-24): TYPE: SECTION must
+        # - a SECTION node carries a MID field (MD-24): Type: SECTION must
         #   accompany the MID on every write so the reader does not misidentify
         #   the heading as a REQUIREMENT on re-read.
         section_has_mid = node.node_type == "SECTION" and (
@@ -197,7 +210,7 @@ class SDMarkdownWriter:
             and node.node_type != "TEXT"
             and (document_grammar.has_custom_elements() or section_has_mid)
         ):
-            meta_fields.append(("TYPE", node.node_type))
+            meta_fields.append(("Type", node.node_type))
 
         if should_inject_mid:
             meta_fields.append(("MID", node.reserved_mid))
@@ -207,9 +220,6 @@ class SDMarkdownWriter:
                 continue
 
             field_name = field.field_name
-            field_human_name = SDMarkdownWriter._resolve_human_field_name(
-                node=node, field_name=field_name
-            )
             field_value = SDMarkdownWriter._to_lf(field.get_text_value())
 
             if element is None or field_name not in element.fields_map:
@@ -219,10 +229,25 @@ class SDMarkdownWriter:
             else:
                 is_content_field = element.is_field_multiline(field_name)
 
+            # The 8 reserved field roles (Title/Statement/Rationale/Comment/
+            # Level/Status/Tags/Prefix) always use this fixed Markdown
+            # surface convention on write-back, for the default grammar AND
+            # any custom grammar, since their internal key is always ALL_CAPS
+            # (see default_grammar_field_aliases). Any other field keeps its
+            # raw key: a custom grammar's **Human title** on such a field is
+            # an arbitrary display string (e.g. "Example Human Title" for
+            # "DERIVED_RATIONALE") that would not round-trip if written back
+            # as the field's key.
+            surface_field_name = (
+                SDMarkdownWriter._default_grammar_field_surface_names.get(
+                    field_name, field_name
+                )
+            )
+
             if is_content_field:
-                content_fields.append((field_human_name, field_value))
+                content_fields.append((surface_field_name, field_value))
             else:
-                meta_fields.append((field_human_name, field_value))
+                meta_fields.append((surface_field_name, field_value))
 
         relations_block = SDMarkdownWriter._serialize_relations(node)
 
@@ -330,28 +355,6 @@ class SDMarkdownWriter:
         return "\n".join(lines)
 
     @staticmethod
-    def _resolve_human_field_name(node: SDocNode, field_name: str) -> str:
-        document = node.get_document()
-        if document is None or document.grammar is None:
-            return field_name
-        grammar = assert_cast(document.grammar, DocumentGrammar)
-        # For imported (custom) grammars, always write the field key name so
-        # that the reader can recover it via .upper(). Human titles in custom
-        # grammars are arbitrary strings (e.g. "Example Human Title" for key
-        # "DERIVED_RATIONALE") and do not round-trip through the reader's
-        # name.upper() normalisation. For the built-in default grammar the
-        # human title is always a simple capitalisation variant of the key
-        # (e.g. "Statement" for "STATEMENT"), so .upper() recovers it safely.
-        if grammar.import_from_file is not None:
-            return field_name
-        element = grammar.elements_by_type.get(node.node_type, None)
-        if element is None:
-            return field_name
-        if field_name not in element.fields_map:
-            return field_name
-        return element.fields_map[field_name].get_field_human_name()
-
-    @staticmethod
     def _serialize_text_node(
         node: SDocNode, line_width: Optional[int] = None
     ) -> Optional[str]:
@@ -365,7 +368,7 @@ class SDMarkdownWriter:
             statement_value = wrap_md_text(statement_value, line_width)
 
         # When the grammar's TEXT element declares a MID field, emit
-        # **TYPE**: TEXT \ **MID**: <mid> before the statement body so that
+        # **Type**: TEXT \ **MID**: <mid> before the statement body so that
         # the TEXT node's machine identifier is preserved across read/write cycles.
         document = node.get_document()
         if document is not None and document.grammar is not None:
@@ -384,7 +387,7 @@ class SDMarkdownWriter:
                 else:
                     mid_str = str(node.reserved_mid)
                 meta_block = SDMarkdownWriter._serialize_meta_fields(
-                    [("TYPE", "TEXT"), ("MID", mid_str)]
+                    [("Type", "TEXT"), ("MID", mid_str)]
                 )
                 if len(statement_value) > 0:
                     return f"{meta_block}\n\n{statement_value}"
@@ -484,7 +487,7 @@ class MarkdownGrammarWriter:
                 element_properties.append(("Prefix", element.property_prefix))
             if element.property_view_style is not None:
                 element_properties.append(
-                    ("View Style", element.property_view_style)
+                    ("View style", element.property_view_style)
                 )
             if len(element_properties) > 0:
                 element_lines.append(
@@ -523,7 +526,7 @@ class MarkdownGrammarWriter:
             ("Required", "True" if field.required else "False"),
         ]
         if field.human_title is not None:
-            field_properties.insert(1, ("Human Title", field.human_title))
+            field_properties.insert(1, ("Human title", field.human_title))
         return (
             f"### Field: {field.title}\n\n"
             + MarkdownGrammarWriter._serialize_properties(field_properties)
@@ -546,7 +549,7 @@ class MarkdownGrammarWriter:
         if relation.relation_role is not None:
             properties.append(("Role", relation.relation_role))
         if relation.reverse_relation_role is not None:
-            properties.append(("Reverse Role", relation.reverse_relation_role))
+            properties.append(("Reverse role", relation.reverse_relation_role))
         if len(properties) > 0:
             output += "\n\n" + MarkdownGrammarWriter._serialize_properties(
                 properties

--- a/tests/end2end/screens/document/update_document_config/update_document_config_metadata_with_link_markdown/expected_output/document.md
+++ b/tests/end2end/screens/document/update_document_config/update_document_config_metadata_with_link_markdown/expected_output/document.md
@@ -6,4 +6,4 @@
 
 **UID**: REQ-1
 
-**STATEMENT**: Requirement statement.
+**Statement**: Requirement statement.

--- a/tests/end2end/screens/document/update_node/update_requirement_toc_remove_title_from_node_MARKDOWN/expected_output/document.md
+++ b/tests/end2end/screens/document/update_node/update_requirement_toc_remove_title_from_node_MARKDOWN/expected_output/document.md
@@ -4,10 +4,10 @@
 
 **UID**: REQ-001
 
-**STATEMENT**: Requirement 1 statement.
+**Statement**: Requirement 1 statement.
 
 ## Requirement 3
 
 **UID**: REQ-003
 
-**STATEMENT**: Requirement 3 statement.
+**Statement**: Requirement 3 statement.

--- a/tests/end2end/screens/document/update_node/update_requirement_when_MARKDOWN_markup/expected_output/document.md
+++ b/tests/end2end/screens/document/update_node/update_requirement_when_MARKDOWN_markup/expected_output/document.md
@@ -4,4 +4,4 @@
 
 **UID**: REQ-1
 
-**STATEMENT**: Modified statement.
+**Statement**: Modified statement.

--- a/tests/end2end/screens/document/update_node/update_requirement_when_MARKDOWN_markup_statement_with_multiple_paragraphs/expected_output/document.md
+++ b/tests/end2end/screens/document/update_node/update_requirement_when_MARKDOWN_markup_statement_with_multiple_paragraphs/expected_output/document.md
@@ -4,7 +4,7 @@
 
 **UID**: REQ-1
 
-**STATEMENT**:
+**Statement**:
 
 Modified statement.
 

--- a/tests/integration/features/commands/format/03_markdown_statement_idempotency/test.itest
+++ b/tests/integration/features/commands/format/03_markdown_statement_idempotency/test.itest
@@ -2,8 +2,8 @@ REQUIRES: PLATFORM_IS_NOT_WINDOWS
 
 #
 # Verify that the Markdown formatter preserves the STATEMENT format:
-# - inline format (**STATEMENT**: text) stays inline
-# - block format (**STATEMENT**:\n\ntext) stays block
+# - inline format (**Statement**: text) stays inline
+# - block format (**Statement**:\n\ntext) stays block
 # A second format pass must produce identical output (idempotency).
 #
 
@@ -17,10 +17,10 @@ RUN: %strictdoc format %T/pass1/
 RUN: %cat %T/pass1/input.md | filecheck %s --dump-input=fail
 
 # Inline format: statement content on same line as field name.
-CHECK: **STATEMENT**: The statement content starts on the same line as the field name.
+CHECK: **Statement**: The statement content starts on the same line as the field name.
 
 # Block format: field name alone on its line, blank line, then content.
-CHECK: **STATEMENT**:
+CHECK: **Statement**:
 CHECK-EMPTY:
 CHECK-NEXT: Paragraph one.
 

--- a/tests/integration/features/commands/format/04_markdown_statement_conversion/input_expected.md
+++ b/tests/integration/features/commands/format/04_markdown_statement_conversion/input_expected.md
@@ -6,13 +6,13 @@
 
 **UID**: REQ-INLINE
 
-**STATEMENT**: The statement content starts on the same line as the field name.
+**Statement**: The statement content starts on the same line as the field name.
 
 ## Block statement
 
 **UID**: REQ-BLOCK
 
-**STATEMENT**:
+**Statement**:
 
 Paragraph one.
 

--- a/tests/integration/features/commands/format/05_markdown_section_mid_text/input.md
+++ b/tests/integration/features/commands/format/05_markdown_section_mid_text/input.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-**TYPE**: SECTION \
+**Type**: SECTION \
 **MID**: 11111111111111111111111111111111
 
-**STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+**Statement**: This is a TEXT node statement, not a SECTION node statement.

--- a/tests/integration/features/commands/format/05_markdown_section_mid_text/test.itest
+++ b/tests/integration/features/commands/format/05_markdown_section_mid_text/test.itest
@@ -17,15 +17,15 @@ RUN: %strictdoc format %T/pass1/
 RUN: %cat %T/pass1/input.md | filecheck %s --dump-input=fail
 
 # SECTION meta block: TYPE and original MID are preserved.
-CHECK: **TYPE**: SECTION \
+CHECK: **Type**: SECTION \
 CHECK-NEXT: **MID**: 11111111111111111111111111111111
 
 # TEXT child: TYPE and auto-generated MID are emitted.
-CHECK: **TYPE**: TEXT \
+CHECK: **Type**: TEXT \
 CHECK-NEXT: **MID**:
 
 # TEXT statement content is preserved.
-CHECK: **STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+CHECK: **Statement**: This is a TEXT node statement, not a SECTION node statement.
 
 # Second pass must produce identical output (idempotency).
 RUN: cp -r %T/pass1 %T/pass2

--- a/tests/integration/features/commands/format/06_markdown_section_mid_text_mid/input.md
+++ b/tests/integration/features/commands/format/06_markdown_section_mid_text_mid/input.md
@@ -4,10 +4,10 @@
 
 ## Introduction
 
-**TYPE**: SECTION \
+**Type**: SECTION \
 **MID**: 11111111111111111111111111111111
 
-**TYPE**: TEXT \
+**Type**: TEXT \
 **MID**: 22222222222222222222222222222222
 
-**STATEMENT**: This is a text statement.
+**Statement**: This is a text statement.

--- a/tests/integration/features/commands/format/06_markdown_section_mid_text_mid/test.itest
+++ b/tests/integration/features/commands/format/06_markdown_section_mid_text_mid/test.itest
@@ -2,7 +2,7 @@ REQUIRES: PLATFORM_IS_NOT_WINDOWS
 
 #
 # Verify MD-28: SECTION with TYPE+MID meta block, where the TEXT child body
-# begins with an embedded **TYPE**: TEXT \ **MID**: ... prefix.
+# begins with an embedded **Type**: TEXT \ **MID**: ... prefix.
 # The SECTION MID is preserved in the meta block; the embedded TEXT MID
 # (including the TYPE and MID lines) is preserved verbatim in the TEXT body.
 # A second format pass must produce identical output (idempotency).
@@ -18,15 +18,15 @@ RUN: %strictdoc format %T/pass1/
 RUN: %cat %T/pass1/input.md | filecheck %s --dump-input=fail
 
 # SECTION meta block: TYPE and original MID are preserved.
-CHECK: **TYPE**: SECTION \
+CHECK: **Type**: SECTION \
 CHECK-NEXT: **MID**: 11111111111111111111111111111111
 
 # Embedded TEXT MID prefix is preserved verbatim in the TEXT body.
-CHECK: **TYPE**: TEXT \
+CHECK: **Type**: TEXT \
 CHECK-NEXT: **MID**: 22222222222222222222222222222222
 
 # TEXT statement is preserved.
-CHECK: **STATEMENT**: This is a text statement.
+CHECK: **Statement**: This is a text statement.
 
 # Second pass must produce identical output (idempotency).
 RUN: cp -r %T/pass1 %T/pass2

--- a/tests/integration/features/commands/format/07_markdown_section_mid_text_no_text_mid/input.md
+++ b/tests/integration/features/commands/format/07_markdown_section_mid_text_no_text_mid/input.md
@@ -4,7 +4,7 @@
 
 ## Introduction
 
-**TYPE**: SECTION \
+**Type**: SECTION \
 **MID**: 11111111111111111111111111111111
 
-**STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+**Statement**: This is a TEXT node statement, not a SECTION node statement.

--- a/tests/integration/features/commands/format/07_markdown_section_mid_text_no_text_mid/test.itest
+++ b/tests/integration/features/commands/format/07_markdown_section_mid_text_no_text_mid/test.itest
@@ -17,14 +17,14 @@ RUN: %strictdoc format %T/pass1/
 RUN: %cat %T/pass1/input.md | filecheck %s --dump-input=fail
 
 # SECTION meta block: TYPE and original MID are preserved.
-CHECK: **TYPE**: SECTION \
+CHECK: **Type**: SECTION \
 CHECK-NEXT: **MID**: 11111111111111111111111111111111
 
 # TEXT statement is written verbatim — no TYPE or MID prefix.
-CHECK: **STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
+CHECK: **Statement**: This is a TEXT node statement, not a SECTION node statement.
 
 # The output must NOT contain a TYPE field for the TEXT node.
-CHECK-NOT: **TYPE**: TEXT
+CHECK-NOT: **Type**: TEXT
 
 # Second pass must produce identical output (idempotency).
 RUN: cp -r %T/pass1 %T/pass2

--- a/tests/integration/features/commands/format/08_markdown_section_mid_inject/input.md
+++ b/tests/integration/features/commands/format/08_markdown_section_mid_inject/input.md
@@ -8,4 +8,4 @@
 
 **UID**: REQ-1
 
-**STATEMENT**: System shall do X.
+**Statement**: System shall do X.

--- a/tests/integration/features/commands/format/08_markdown_section_mid_inject/test.itest
+++ b/tests/integration/features/commands/format/08_markdown_section_mid_inject/test.itest
@@ -2,7 +2,7 @@
 # Regression test for https://github.com/strictdoc-project/strictdoc/issues/2924
 #
 # When a custom grammar declares a MID field for the SECTION element, the writer
-# must auto-inject MID into SECTION nodes AND emit **TYPE**: SECTION alongside
+# must auto-inject MID into SECTION nodes AND emit **Type**: SECTION alongside
 # it. Without TYPE: SECTION the reader mis-classifies the heading as a
 # REQUIREMENT on the next parse, causing a grammar validation error.
 #
@@ -25,7 +25,7 @@ RUN: %cat %T/pass1/input.md | filecheck %s --dump-input=fail
 # After the first format pass the SECTION heading must carry TYPE: SECTION and
 # a freshly generated MID.
 CHECK: ## Section heading
-CHECK: **TYPE**: SECTION \
+CHECK: **Type**: SECTION \
 CHECK-NEXT: **MID**:
 
 # The REQUIREMENT inside the section must also carry a freshly generated MID.

--- a/tests/integration/features/commands/format/09_markdown_prefix_document_level/input.md
+++ b/tests/integration/features/commands/format/09_markdown_prefix_document_level/input.md
@@ -1,6 +1,6 @@
 # Requirements specification
 
-**PREFIX**: MYDOC-
+**Prefix**: MYDOC-
 
 ## A requirement
 

--- a/tests/integration/features/commands/format/09_markdown_prefix_document_level/test.itest
+++ b/tests/integration/features/commands/format/09_markdown_prefix_document_level/test.itest
@@ -4,7 +4,7 @@ REQUIRES: PLATFORM_IS_NOT_WINDOWS
 # Verify MD-31: document-level PREFIX declared in the H1 metadata block is
 # preserved across format passes.
 #
-# Pass 1: format the document, check that **PREFIX**: appears in the output.
+# Pass 1: format the document, check that **Prefix**: appears in the output.
 # Pass 2: format again and verify identical output (idempotency).
 #
 
@@ -17,7 +17,7 @@ RUN: %strictdoc format %T/pass1/
 RUN: %cat %T/pass1/input.md | filecheck %s --dump-input=fail
 
 # Document-level PREFIX must be present in the output.
-CHECK: **PREFIX**: MYDOC-
+CHECK: **Prefix**: MYDOC-
 
 # The requirement UID that uses the prefix must be preserved.
 CHECK: **UID**: MYDOC-001

--- a/tests/integration/features/commands/format/10_markdown_prefix_section_level/test.itest
+++ b/tests/integration/features/commands/format/10_markdown_prefix_section_level/test.itest
@@ -21,7 +21,7 @@ CHECK: ## Chapter 2
 
 # Section-level PREFIX must be present directly after the section heading.
 CHECK-NEXT:
-CHECK-NEXT: **PREFIX**: LEVEL2-REQ-
+CHECK-NEXT: **Prefix**: LEVEL2-REQ-
 
 # The requirement UID that uses the section prefix must be preserved.
 CHECK: **UID**: LEVEL2-REQ-001

--- a/tests/integration/features/markdown/02_statement/test.itest
+++ b/tests/integration/features/markdown/02_statement/test.itest
@@ -10,5 +10,5 @@ RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail 
 CHECK-HTML-FILE: Markdown example
 CHECK-HTML-FILE: data-testid="node-requirement"
 CHECK-HTML-FILE: data-uid="FMT-1"
-CHECK-HTML-FILE: <sdoc-node-field-label>STATEMENT:</sdoc-node-field-label>
+CHECK-HTML-FILE: <sdoc-node-field-label>Statement:</sdoc-node-field-label>
 CHECK-HTML-FILE: The formatter wraps text lines to a configurable maximum line

--- a/tests/integration/features/markdown/03_consecutive_requirements/test.itest
+++ b/tests/integration/features/markdown/03_consecutive_requirements/test.itest
@@ -10,6 +10,6 @@ RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail 
 
 CHECK-HTML-FILE: data-testid="node-requirement"
 CHECK-HTML-FILE: data-uid="FMT-2"
-CHECK-HTML-FILE: <sdoc-node-field-label>STATEMENT:</sdoc-node-field-label>
+CHECK-HTML-FILE: <sdoc-node-field-label>Statement:</sdoc-node-field-label>
 CHECK-HTML-FILE: The statement continues below after the colon:
 CHECK-HTML-FILE: Item 1.

--- a/tests/integration/features/markdown/05_relations/input.md
+++ b/tests/integration/features/markdown/05_relations/input.md
@@ -15,7 +15,7 @@ Parent requirement shall do B.
 ## Child requirement
 
 **UID**: REQ-3
-**RELATIONS**:
+**Relations**:
 - **Type**: Parent
   **ID**: REQ-1
 - **Type**: Parent

--- a/tests/integration/features/markdown/07_relations_all_types/input.md
+++ b/tests/integration/features/markdown/07_relations_all_types/input.md
@@ -9,7 +9,7 @@ Parent requirement statement.
 ## Child requirement
 
 **UID**: REQ-CHILD
-**RELATIONS**:
+**Relations**:
 - **Type**: Parent
   **ID**: REQ-PARENT
 
@@ -18,7 +18,7 @@ Child requirement statement.
 ## Parent with child relation
 
 **UID**: REQ-PARENT-EXPLICIT-CHILD
-**RELATIONS**:
+**Relations**:
 - **Type**: Child
   **ID**: REQ-CHILD
 
@@ -27,7 +27,7 @@ Parent with explicit child relation.
 ## File relation C function
 
 **UID**: REQ-FILE-C
-**RELATIONS**:
+**Relations**:
 - **Type**: File
   **Path**: file.c
   **Element**: function
@@ -38,7 +38,7 @@ File relation to C function.
 ## File relation Python class
 
 **UID**: REQ-FILE-PY
-**RELATIONS**:
+**Relations**:
 - **Type**: File
   **Path**: file.py
   **Element**: class
@@ -49,7 +49,7 @@ File relation to Python class.
 ## File relation Rust no element
 
 **UID**: REQ-FILE-RUST
-**RELATIONS**:
+**Relations**:
 - **Type**: File
   **Path**: file.rs
   **ID**: my_function
@@ -59,7 +59,7 @@ File relation to Rust function without element annotation.
 ## File relation line range
 
 **UID**: REQ-FILE-LINE-RANGE
-**RELATIONS**:
+**Relations**:
 - **Type**: File
   **Path**: file.c
   **Lines**: `10, 20`
@@ -69,7 +69,7 @@ File relation to a line range.
 ## Requirement with multiple relations
 
 **UID**: REQ-MULTI
-**RELATIONS**:
+**Relations**:
 - **Type**: Parent
   **ID**: REQ-PARENT
 - **Type**: Parent

--- a/tests/integration/features/markdown/08_grammar_from_file/requirements.gra.md
+++ b/tests/integration/features/markdown/08_grammar_from_file/requirements.gra.md
@@ -17,7 +17,7 @@
 **Type**: SingleChoice(A, B, C, D)
 **Required**: True
 
-### Field: STATEMENT
+### Field: Statement
 
 **Type**: String
 **Required**: False

--- a/tests/integration/features/markdown/08_grammar_from_file/test.itest
+++ b/tests/integration/features/markdown/08_grammar_from_file/test.itest
@@ -7,3 +7,5 @@ CHECK-HTML-FILE: show-node-type-name="REQUIREMENT"
 CHECK-HTML-FILE: data-uid="REQ-1"
 CHECK-HTML-FILE: ASIL
 CHECK-HTML-FILE: A
+CHECK-HTML-FILE: <sdoc-node-field-label>Statement:</sdoc-node-field-label>
+CHECK-HTML-FILE: System shall do X.

--- a/tests/integration/features/markdown/09_grammar_from_alias/requirements.gra.md
+++ b/tests/integration/features/markdown/09_grammar_from_alias/requirements.gra.md
@@ -17,7 +17,7 @@
 **Type**: SingleChoice(A, B, C, D)
 **Required**: True
 
-### Field: STATEMENT
+### Field: Statement
 
 **Type**: String
 **Required**: False

--- a/tests/integration/features/markdown/09_grammar_from_alias/test.itest
+++ b/tests/integration/features/markdown/09_grammar_from_alias/test.itest
@@ -7,3 +7,5 @@ CHECK-HTML-FILE: show-node-type-name="REQUIREMENT"
 CHECK-HTML-FILE: data-uid="REQ-1"
 CHECK-HTML-FILE: ASIL
 CHECK-HTML-FILE: B
+CHECK-HTML-FILE: <sdoc-node-field-label>Statement:</sdoc-node-field-label>
+CHECK-HTML-FILE: System shall do X.

--- a/tests/integration/features/markdown/10_grammar_no_uid/requirements.gra.md
+++ b/tests/integration/features/markdown/10_grammar_no_uid/requirements.gra.md
@@ -12,7 +12,7 @@
 **Type**: SingleChoice(A, B, C, D)
 **Required**: True
 
-### Field: STATEMENT
+### Field: Statement
 
 **Type**: String
 **Required**: False

--- a/tests/integration/features/markdown/10_grammar_no_uid/test.itest
+++ b/tests/integration/features/markdown/10_grammar_no_uid/test.itest
@@ -6,3 +6,5 @@ RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail 
 CHECK-HTML-FILE: show-node-type-name="REQUIREMENT"
 CHECK-HTML-FILE: ASIL
 CHECK-HTML-FILE: A
+CHECK-HTML-FILE: <sdoc-node-field-label>Statement:</sdoc-node-field-label>
+CHECK-HTML-FILE: System shall do X.

--- a/tests/integration/features/markdown/11_grammar_composite/requirements.gra.md
+++ b/tests/integration/features/markdown/11_grammar_composite/requirements.gra.md
@@ -14,7 +14,7 @@
 **Type**: String
 **Required**: False
 
-### Field: STATEMENT
+### Field: Statement
 
 **Type**: String
 **Required**: False

--- a/tests/integration/features/markdown/11_grammar_composite/test.itest
+++ b/tests/integration/features/markdown/11_grammar_composite/test.itest
@@ -4,4 +4,8 @@ CHECK: Published: Composite requirement document
 RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-FILE
 
 CHECK-HTML-FILE: data-uid="REQ-1"
+CHECK-HTML-FILE: <sdoc-node-field-label>Statement:</sdoc-node-field-label>
+CHECK-HTML-FILE: Parent statement.
 CHECK-HTML-FILE: data-uid="REQ-2"
+CHECK-HTML-FILE: <sdoc-node-field-label>Statement:</sdoc-node-field-label>
+CHECK-HTML-FILE: Child statement.

--- a/tests/integration/features/markdown/11_relation_reverse_role/input.md
+++ b/tests/integration/features/markdown/11_relation_reverse_role/input.md
@@ -11,7 +11,7 @@ Parent requirement statement.
 ## Child requirement
 
 **UID**: REQ-2
-**RELATIONS**:
+**Relations**:
 - **Type**: Parent
   **ID**: REQ-1
   **Role**: Refines

--- a/tests/integration/features/markdown/11_relation_reverse_role/requirements.gra.md
+++ b/tests/integration/features/markdown/11_relation_reverse_role/requirements.gra.md
@@ -22,4 +22,4 @@
 #### Relation: Parent
 
 **Role**: Refines
-**Reverse Role**: Refined by
+**Reverse role**: Refined by

--- a/tests/integration/features/markdown/11_relation_reverse_role/test.itest
+++ b/tests/integration/features/markdown/11_relation_reverse_role/test.itest
@@ -1,5 +1,5 @@
 #
-# This test verifies that a Markdown custom grammar can declare REVERSE_ROLE
+# This test verifies that a Markdown custom grammar can declare Reverse role
 # on a Parent relation, and that the reverse-direction display label is used
 # when the derived Child relation is rendered on the parent's side.
 #
@@ -10,7 +10,7 @@ CHECK: Published: Reverse role document
 RUN: %cat %T/html/%THIS_TEST_FOLDER/input.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML
 
 # REQ-1 gets a derived Child relation back to REQ-2. Since the grammar
-# defines REVERSE_ROLE: Refined by for Parent/Refines, that label is shown
+# defines Reverse role: Refined by for Parent/Refines, that label is shown
 # instead of the canonical Refines.
 CHECK-HTML: id="REQ-1"
 CHECK-HTML: RELATIONS (Child):

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_grammar.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_grammar.py
@@ -24,7 +24,7 @@ def test_001_markdown_grammar_reader_parses_default_model():
 ### Field: ASIL
 
 **Type**: SingleChoice(A, B, C, D)
-**Human Title**: Safety Level
+**Human title**: Safety Level
 **Required**: True
 
 ### Relations
@@ -136,7 +136,7 @@ def test_003_markdown_document_grammar_metadata_sets_import_from_file():
 
 **UID**: REQ-1
 
-**Statement**: System shall do X.
+**STATEMENT**: System shall do X.
 """
 
     document = SDMarkdownReader.read(input_markdown, file_path=None)
@@ -176,7 +176,7 @@ def test_004_markdown_grammar_custom_grammar_relaxes_uid_and_statement_requireme
     # Both custom fields must be present on the node.
     field_names = {f.field_name for f in node.enumerate_fields()}
     assert "ASIL" in field_names
-    assert "NAME" in field_names
+    assert "Name" in field_names
 
 
 def test_005_markdown_grammar_writer_uses_field_key_not_human_title_for_custom_grammar():
@@ -184,11 +184,11 @@ def test_005_markdown_grammar_writer_uses_field_key_not_human_title_for_custom_g
     Regression test for https://github.com/strictdoc-project/strictdoc/issues/2918.
 
     When a document has a custom (imported) grammar whose fields carry a
-    Human Title, the writer must serialise each field using the grammar key
+    Human title, the writer must serialise each field using the grammar key
     name (e.g. DERIVED_RATIONALE), not the human-readable title
-    (e.g. "Example Human Title").  The reader canonicalises field names with
-    .upper(), so writing the human title produces an unrecoverable key on
-    the next parse.
+    (e.g. "Example Human Title").  The reader matches field names exactly, so
+    writing the human title would produce an unrecognized key on the next
+    parse.
     """
     grammar_markdown = """\
 # StrictDoc Markdown Grammar
@@ -203,7 +203,7 @@ def test_005_markdown_grammar_writer_uses_field_key_not_human_title_for_custom_g
 ### Field: DERIVED_RATIONALE
 
 **Type**: String
-**Human Title**: Example Human Title
+**Human title**: Example Human Title
 **Required**: False
 
 ### Relations
@@ -290,7 +290,7 @@ def test_007_markdown_writer_auto_writes_mid_when_grammar_has_mid_field():
 
 **UID**: REQ-1
 
-**Statement**: System shall do X.
+**STATEMENT**: System shall do X.
 """
 
     document = SDMarkdownReader.read(doc_markdown, file_path=None)
@@ -346,7 +346,7 @@ def test_008_markdown_writer_preserves_existing_mid_when_grammar_has_mid_field()
 **MID**: abc123 \\
 **UID**: REQ-1
 
-**Statement**: System shall do X.
+**STATEMENT**: System shall do X.
 """
 
     document = SDMarkdownReader.read(doc_markdown, file_path=None)
@@ -397,7 +397,7 @@ def test_009_markdown_writer_no_mid_when_grammar_has_no_mid_field():
 
 **UID**: REQ-1
 
-**Statement**: System shall do X.
+**STATEMENT**: System shall do X.
 """
 
     document = SDMarkdownReader.read(doc_markdown, file_path=None)
@@ -418,7 +418,7 @@ def test_010_markdown_writer_injects_mid_into_section_nodes_when_grammar_declare
     """
     When a grammar declares a MID field for the SECTION element, the writer
     auto-injects MID into SECTION nodes that do not already carry one, and
-    also emits TYPE: SECTION as the first meta field so the reader does not
+    also emits Type: SECTION as the first meta field so the reader does not
     misidentify the heading as a REQUIREMENT on the next parse.
     """
     grammar_markdown = """\
@@ -466,7 +466,7 @@ def test_010_markdown_writer_injects_mid_into_section_nodes_when_grammar_declare
 
 **UID**: REQ-1
 
-**Statement**: System shall do X.
+**STATEMENT**: System shall do X.
 """
 
     document = SDMarkdownReader.read(doc_markdown, file_path=None)
@@ -482,7 +482,7 @@ def test_010_markdown_writer_injects_mid_into_section_nodes_when_grammar_declare
 
     lines = output_markdown.splitlines()
 
-    # The SECTION node must receive TYPE and MID injection.
+    # The SECTION node must receive Type and MID injection.
     section_idx = next(
         i for i, line in enumerate(lines) if "Section heading" in line
     )
@@ -492,14 +492,14 @@ def test_010_markdown_writer_injects_mid_into_section_nodes_when_grammar_declare
             break
         section_block_lines.append(line)
     section_block = "\n".join(section_block_lines)
-    assert "**TYPE**: SECTION" in section_block, (
-        f"TYPE: SECTION not found in section block: {section_block!r}"
+    assert "**Type**: SECTION" in section_block, (
+        f"Type: SECTION not found in section block: {section_block!r}"
     )
     assert "**MID**:" in section_block, (
         f"MID not injected into section block: {section_block!r}"
     )
 
-    # The REQUIREMENT node must also receive TYPE and MID injection.
+    # The REQUIREMENT node must also receive Type and MID injection.
     req_idx = next(
         i
         for i, line in enumerate(lines)
@@ -532,7 +532,7 @@ def test_011_markdown_grammar_reader_and_writer_roundtrip_reverse_role():
 #### Relation: Parent
 
 **Role**: Refines
-**Reverse Role**: Refined by
+**Reverse role**: Refined by
 """
 
     grammar = MarkdownGrammarReader.read(grammar_markdown)
@@ -542,7 +542,7 @@ def test_011_markdown_grammar_reader_and_writer_roundtrip_reverse_role():
 
     output_markdown = MarkdownGrammarWriter.write(grammar)
     assert "**Role**: Refines" in output_markdown
-    assert "**Reverse Role**: Refined by" in output_markdown
+    assert "**Reverse role**: Refined by" in output_markdown
 
     roundtrip_grammar = MarkdownGrammarReader.read(output_markdown)
     roundtrip_relation = roundtrip_grammar.elements_by_type[
@@ -550,3 +550,138 @@ def test_011_markdown_grammar_reader_and_writer_roundtrip_reverse_role():
     ].relations[0]
     assert roundtrip_relation.relation_role == "Refines"
     assert roundtrip_relation.reverse_relation_role == "Refined by"
+
+
+def test_012_markdown_grammar_field_declared_in_camel_case():
+    """
+    A custom grammar is free to declare an arbitrary (non-reserved) field
+    name in ALL_CAPS, Camel-Case, or Camel Case. SDMarkdownReader no longer
+    normalizes parsed field names, so a document must write such a field
+    using the exact casing declared by the grammar for it to be recognised;
+    that casing is also what the writer reproduces on write-back.
+    """
+    grammar_markdown = """\
+# StrictDoc Markdown Grammar
+
+## Element: REQUIREMENT
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: Name
+
+**Type**: String
+**Required**: False
+"""
+    doc_markdown = """\
+# Document
+
+**Grammar**: `requirements.gra.md`
+
+## Requirement title
+
+**UID**: REQ-1
+**Name**: Some name text.
+"""
+
+    document = SDMarkdownReader.read(doc_markdown, file_path=None)
+    resolved_grammar = MarkdownGrammarReader.read(grammar_markdown)
+    resolved_grammar.import_from_file = "requirements.gra.md"
+    resolved_grammar.parent = document
+    document.grammar = resolved_grammar
+
+    requirement_element = resolved_grammar.elements_by_type["REQUIREMENT"]
+    assert "Name" in requirement_element.fields_map
+
+    requirement = document.section_contents[0]
+    assert "Name" in requirement.ordered_fields_lookup
+
+    output_markdown = SDMarkdownWriter.write(document)
+    assert "**Name**: Some name text." in output_markdown
+
+
+def test_013_markdown_grammar_reserved_field_declared_in_title_case():
+    """
+    The 8 reserved field roles (Title, Statement, Rationale, Comment, Level,
+    Status, Tags, Prefix) back shared SDocNode accessors (reserved_title,
+    reserved_statement, rationale, etc.) that hardcode the exact ALL_CAPS
+    key, for the default AND any custom grammar (SDocNode has no
+    per-markup subclass). A custom grammar may declare one of these fields
+    using the readable surface name; it is canonicalized to the required
+    internal key so that those accessors keep working, and the declared
+    surface name becomes the default human title (round-tripped by the
+    writer).
+
+    Regression test: an earlier version of this canonicalization was
+    reader/writer-only and left the grammar's own field.title as the
+    declared surface name, which silently broke node.rationale (and
+    node.reserved_statement / GrammarElement.content_field detection, which
+    also hardcode "STATEMENT") for any custom grammar declaring these
+    fields in a non-ALL_CAPS casing.
+    """
+    grammar_markdown = """\
+# StrictDoc Markdown Grammar
+
+## Element: REQUIREMENT
+
+### Field: UID
+
+**Type**: String
+**Required**: False
+
+### Field: Statement
+
+**Type**: String
+**Required**: False
+
+### Field: Rationale
+
+**Type**: String
+**Required**: False
+"""
+    doc_markdown = """\
+# Document
+
+**Grammar**: `requirements.gra.md`
+
+## Requirement title
+
+**UID**: REQ-1
+**Statement**: Some statement text.
+**Rationale**: Some rationale text.
+"""
+
+    document = SDMarkdownReader.read(doc_markdown, file_path=None)
+    resolved_grammar = MarkdownGrammarReader.read(grammar_markdown)
+    resolved_grammar.import_from_file = "requirements.gra.md"
+    resolved_grammar.parent = document
+    document.grammar = resolved_grammar
+
+    requirement_element = resolved_grammar.elements_by_type["REQUIREMENT"]
+    # The internal key stays ALL_CAPS regardless of the declared casing.
+    assert "STATEMENT" in requirement_element.fields_map
+    assert "RATIONALE" in requirement_element.fields_map
+    assert requirement_element.content_field == ("STATEMENT", 1)
+    assert (
+        requirement_element.fields_map["STATEMENT"].get_field_human_name()
+        == "Statement"
+    )
+    assert (
+        requirement_element.fields_map["RATIONALE"].get_field_human_name()
+        == "Rationale"
+    )
+
+    requirement = document.section_contents[0]
+    assert "STATEMENT" in requirement.ordered_fields_lookup
+    assert "RATIONALE" in requirement.ordered_fields_lookup
+
+    # The shared SDocNode accessors must actually work, not just the raw
+    # field lookup (this is what the earlier, broken version got wrong).
+    assert requirement.reserved_statement == "Some statement text."
+    assert requirement.rationale == "Some rationale text."
+
+    output_markdown = SDMarkdownWriter.write(document)
+    assert "**Statement**: Some statement text." in output_markdown
+    assert "**Rationale**: Some rationale text." in output_markdown

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
@@ -198,7 +198,7 @@ def test_012_markdown_reader_preserves_multiline_crlf_field_value():
         "\r\n"
         "**UID**: REQ-1\r\n"
         "\r\n"
-        "**Statement**:\r\n"
+        "**STATEMENT**:\r\n"
         "\r\n"
         "Line 1\r\n"
         "Line 2\r\n"
@@ -263,7 +263,7 @@ def test_015_document_level_prefix_sets_requirement_prefix():
     markdown_content = """\
 # Requirements specification
 
-**PREFIX**: MYDOC-
+**Prefix**: MYDOC-
 
 ## Requirement
 
@@ -519,7 +519,7 @@ def test_017_section_immediately_followed_by_child_section_has_no_empty_text_nod
 **MID**: aabbccdd11223344aabbccdd11223344 \\
 **UID**: REQ-1
 
-**Statement**: Some statement.
+**STATEMENT**: Some statement.
 """
 
     reader = SDMarkdownReader()
@@ -550,7 +550,7 @@ def test_025_markdown_reader_empty_heading_produces_no_title_field():
 
 ##
 
-**TYPE**: REQUIREMENT \\
+**Type**: REQUIREMENT \\
 **UID**: REQ-1
 """
 

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_roundtrip.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_roundtrip.py
@@ -406,11 +406,6 @@ System shall do X.
     assert requirement.reserved_statement.strip() == "System shall do X."
     assert requirement.rationale == "Because it is needed."
 
-    requirement_element = document.grammar.elements_by_type["REQUIREMENT"]
-    assert (
-        requirement_element.fields_map["RATIONALE"].human_title == "Rationale"
-    )
-
 
 def test_015b_roundtrip_relation_with_role():
     input_markdown = """\
@@ -460,7 +455,7 @@ Parent requirement statement.
 ## Child requirement
 
 **UID**: REQ-CHILD
-**RELATIONS**:
+**Relations**:
 - **Type**: Parent
   **ID**: REQ-PARENT
 
@@ -469,7 +464,7 @@ Child requirement statement.
 ## Parent with child relation
 
 **UID**: REQ-PARENT-EXPLICIT-CHILD
-**RELATIONS**:
+**Relations**:
 - **Type**: Child
   **ID**: REQ-CHILD
 
@@ -478,7 +473,7 @@ Parent with explicit child relation.
 ## File relation C function
 
 **UID**: REQ-FILE-C
-**RELATIONS**:
+**Relations**:
 - **Type**: File
   **Path**: file.c
   **Element**: function
@@ -489,7 +484,7 @@ File relation to C function.
 ## File relation Python class
 
 **UID**: REQ-FILE-PY
-**RELATIONS**:
+**Relations**:
 - **Type**: File
   **Path**: file.py
   **Element**: class
@@ -500,7 +495,7 @@ File relation to Python class.
 ## File relation Rust no element
 
 **UID**: REQ-FILE-RUST
-**RELATIONS**:
+**Relations**:
 - **Type**: File
   **Path**: file.rs
   **ID**: my_function
@@ -510,7 +505,7 @@ File relation to Rust function without element annotation.
 ## File relation line range
 
 **UID**: REQ-FILE-LINE-RANGE
-**RELATIONS**:
+**Relations**:
 - **Type**: File
   **Path**: file.c
   **Lines**: `10, 20`
@@ -520,7 +515,7 @@ File relation to a line range.
 ## Requirement with multiple relations
 
 **UID**: REQ-MULTI
-**RELATIONS**:
+**Relations**:
 - **Type**: Parent
   **ID**: REQ-PARENT
 - **Type**: Parent
@@ -638,7 +633,7 @@ STATEMENT: System shall do X.
 
 **UID**: REQ-1
 
-**STATEMENT**: System shall do X.
+**Statement**: System shall do X.
 """,
         ),
         (
@@ -658,9 +653,9 @@ STATEMENT: System shall do X.
 ## Requirement title
 
 **UID**: REQ-1 \\
-**STATUS**: Draft
+**Status**: Draft
 
-**STATEMENT**: System shall do X.
+**Statement**: System shall do X.
 """,
         ),
         (
@@ -690,7 +685,7 @@ RELATIONS:
 - **Type**: `Parent` \\
   **ID**: `REQ-2`
 
-**STATEMENT**: Child requirement shall do B.
+**Statement**: Child requirement shall do B.
 """,
         ),
         (
@@ -718,7 +713,7 @@ RELATIONS:
   **ID**: `REQ-2` \\
   **Role**: `Refines`
 
-**STATEMENT**: Parent requirement shall do A.
+**Statement**: Parent requirement shall do A.
 """,
         ),
     ],
@@ -735,13 +730,13 @@ def test_017_sdoc_to_markdown_roundtrip(
 
 
 def test_018_type_section_input_is_parsed_as_section():
-    """**TYPE**: SECTION in input creates a SECTION; writer drops TYPE for default grammar."""
+    """**Type**: SECTION in input creates a SECTION; writer drops TYPE for default grammar."""
     input_markdown = """\
 # Document title
 
 ## Test Section
 
-**TYPE**: SECTION
+**Type**: SECTION
 """
     # With the default grammar, TYPE is never written back by the writer.
     expected_markdown = """\
@@ -755,18 +750,18 @@ def test_018_type_section_input_is_parsed_as_section():
     assert isinstance(section, SDocNode)
     assert section.node_type == "SECTION"
     assert section.reserved_title == "Test Section"
-    # No TEXT child: the **TYPE**: line must not become prose.
+    # No TEXT child: the **Type**: line must not become prose.
     assert len(section.section_contents) == 0
 
 
 def test_019_type_section_with_body_strips_type_line():
-    """**TYPE**: SECTION with a body: TYPE is dropped in output, body text is preserved."""
+    """**Type**: SECTION with a body: TYPE is dropped in output, body text is preserved."""
     input_markdown = """\
 # Document title
 
 ## Test Section
 
-**TYPE**: SECTION
+**Type**: SECTION
 
 Informative text.
 """
@@ -789,13 +784,13 @@ Informative text.
     assert text_node.node_type == "TEXT"
     assert text_node.reserved_statement is not None
     assert "Informative text." in text_node.reserved_statement
-    # The raw **TYPE**: line must not appear in the text body.
+    # The raw **Type**: line must not appear in the text body.
     assert "**TYPE**" not in text_node.reserved_statement
 
 
 def test_020_type_requirement_in_default_grammar_strips_type():
     """
-    **TYPE**: REQUIREMENT in a default-grammar doc is accepted by the reader
+    **Type**: REQUIREMENT in a default-grammar doc is accepted by the reader
     but not written back (TYPE is only emitted for custom-grammar documents).
     """
     input_markdown = """\
@@ -803,7 +798,7 @@ def test_020_type_requirement_in_default_grammar_strips_type():
 
 ## Requirement title
 
-**TYPE**: REQUIREMENT \\
+**Type**: REQUIREMENT \\
 **UID**: REQ-1
 
 System shall do X.
@@ -834,7 +829,7 @@ def test_021_type_custom_grammar_preserves_node_type():
 
 ## Some Assumption
 
-**TYPE**: ASSUMPTION \\
+**Type**: ASSUMPTION \\
 **UID**: ASM-1
 
 Some assumption text.
@@ -849,9 +844,9 @@ Some assumption text.
 
 ## Some Assumption
 
-**TYPE**: ASSUMPTION \\
+**Type**: ASSUMPTION \\
 **UID**: ASM-1 \\
-**STATEMENT**: Some assumption text.
+**Statement**: Some assumption text.
 """
     document, _ = _assert_markdown_roundtrip(input_markdown, expected_markdown)
 
@@ -863,7 +858,7 @@ Some assumption text.
 
 def test_022_type_section_emitted_in_custom_grammar():
     """
-    With a custom grammar, the writer emits **TYPE**: SECTION for SECTION nodes.
+    With a custom grammar, the writer emits **Type**: SECTION for SECTION nodes.
 
     Without the TYPE field the reader would treat any heading that has a meta
     block (e.g. auto-generated MID) as a typed node and mis-classify it as a
@@ -876,11 +871,11 @@ def test_022_type_section_emitted_in_custom_grammar():
 
 ## Test Section
 
-**TYPE**: SECTION
+**Type**: SECTION
 
 ### Some Assumption
 
-**TYPE**: ASSUMPTION \\
+**Type**: ASSUMPTION \\
 **UID**: ASM-1
 
 Some assumption text.
@@ -892,13 +887,13 @@ Some assumption text.
 
 ## Test Section
 
-**TYPE**: SECTION
+**Type**: SECTION
 
 ### Some Assumption
 
-**TYPE**: ASSUMPTION \\
+**Type**: ASSUMPTION \\
 **UID**: ASM-1 \\
-**STATEMENT**: Some assumption text.
+**Statement**: Some assumption text.
 """
     document, _ = _assert_markdown_roundtrip(input_markdown, expected_markdown)
 
@@ -922,7 +917,7 @@ def test_023_type_section_mid_preserved():
 
 ## Introduction
 
-**TYPE**: SECTION \\
+**Type**: SECTION \\
 **MID**: 11111111111111111111111111111111
 
 **STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
@@ -934,7 +929,7 @@ def test_023_type_section_mid_preserved():
 
 ## Introduction
 
-**TYPE**: SECTION \\
+**Type**: SECTION \\
 **MID**: 11111111111111111111111111111111
 
 **STATEMENT**: This is a TEXT node statement, not a SECTION node statement.
@@ -960,7 +955,7 @@ def test_023_type_section_mid_preserved():
 
 def test_024_type_section_mid_with_text_mid_body():
     r"""
-    SECTION MID is preserved; **TYPE**: TEXT \\ **MID**: ... prefix in the section
+    SECTION MID is preserved; **Type**: TEXT \\ **MID**: ... prefix in the section
     body is parsed as the TEXT node's machine identifier (MD-28).
 
     With an unresolved grammar the writer does not re-emit the TEXT TYPE/MID
@@ -974,10 +969,10 @@ def test_024_type_section_mid_with_text_mid_body():
 
 ## Introduction
 
-**TYPE**: SECTION \\
+**Type**: SECTION \\
 **MID**: 11111111111111111111111111111111
 
-**TYPE**: TEXT \\
+**Type**: TEXT \\
 **MID**: 22222222222222222222222222222222
 
 **STATEMENT**: This is a text statement.
@@ -991,7 +986,7 @@ def test_024_type_section_mid_with_text_mid_body():
 
 ## Introduction
 
-**TYPE**: SECTION \\
+**Type**: SECTION \\
 **MID**: 11111111111111111111111111111111
 
 **STATEMENT**: This is a text statement.
@@ -1028,22 +1023,22 @@ def test_025_statement_body_with_fenced_code_block_containing_field_patterns():
 
 **UID**: REQ-1
 
-**STATEMENT**:
+**Statement**:
 
 The heading meta block uses the following syntax:
 
 ```
-**TYPE**: SECTION \\
+**Type**: SECTION \\
 **MID**: 11111111111111111111111111111111
 ```
 
 A second example shows the TEXT prefix:
 
 ```
-**TYPE**: TEXT \\
+**Type**: TEXT \\
 **MID**: 22222222222222222222222222222222
 
-**STATEMENT**: Body text here.
+**Statement**: Body text here.
 ```
 """
     reader = SDMarkdownReader()
@@ -1062,7 +1057,7 @@ def test_026_document_level_prefix_roundtrips():
     input_markdown = """\
 # Requirements specification
 
-**PREFIX**: MYDOC-
+**Prefix**: MYDOC-
 
 ## Requirement
 
@@ -1081,7 +1076,7 @@ def test_027_section_prefix_without_type_roundtrips():
 
 ## Chapter 2
 
-**PREFIX**: LEVEL2-REQ-
+**Prefix**: LEVEL2-REQ-
 
 ### Requirement
 
@@ -1114,8 +1109,8 @@ def test_028_section_prefix_with_type_drops_type_on_output():
 
 ## Chapter 2
 
-**TYPE**: SECTION \\
-**PREFIX**: LEVEL2-REQ-
+**Type**: SECTION \\
+**Prefix**: LEVEL2-REQ-
 
 ### Requirement
 
@@ -1128,7 +1123,7 @@ def test_028_section_prefix_with_type_drops_type_on_output():
 
 ## Chapter 2
 
-**PREFIX**: LEVEL2-REQ-
+**Prefix**: LEVEL2-REQ-
 
 ### Requirement
 


### PR DESCRIPTION

WHY: As defined in the `task.md` of this changeset:

> Compared to the SDoc conventions, where the `ALL_CAPS` style is used everywhere, we want maximum readability and ease-of-use for Markdown. The WHAT changes are supposed to bring Markdown a little away from SDoc/ALL_CAPS style adding better readability.