### PR TITLE
feat(tasks): invoke server auto-detects and offers to replace its own previous instance

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -19,6 +19,8 @@ from strictdoc.core.environment import (
     HTML_STATIC_DIRS,
     HTML_TEMPLATE_DIRS,
 )
+from strictdoc.core.project_config import ProjectConfigDefault
+from tools.server_check import free_strictdoc_port
 
 # Specifying encoding because Windows crashes otherwise when running Invoke
 # tasks below:
@@ -136,11 +138,26 @@ def clean(context):
 
 
 @task(aliases=["s"])
-def server(context, input_path=".", config=None):
+def server(context, input_path=".", config=None, port=None):
     assert os.path.isdir(input_path), input_path
     if config is not None:
         assert os.path.isfile(config), config
     config_argument = f"--config {config}" if config is not None else ""
+    port_argument = f"--port {port}" if port is not None else ""
+
+    try:
+        should_continue = free_strictdoc_port(
+            port
+            if port is not None
+            else ProjectConfigDefault.DEFAULT_SERVER_PORT
+        )
+    except OSError as error:
+        print(error, file=sys.stderr)  # noqa: T201
+        return
+
+    if not should_continue:
+        return
+
     run_invoke_with_tox(
         context,
         ToxEnvironment.DEVELOPMENT,
@@ -149,6 +166,7 @@ def server(context, input_path=".", config=None):
                 --debug
                 server {input_path} {config_argument}
                     --host 127.0.0.1
+                    {port_argument}
                     --reload
                     --watch
         """,

--- a/tests/unit/tools/test_server_check.py
+++ b/tests/unit/tools/test_server_check.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for tools/server_check.py: detecting who occupies a port, and
+safely stopping only strictdoc's own server process tree while leaving
+unrelated processes alone.
+
+These fake `lsof`/`ps`/`pgrep`/`kill` instead of touching real OS
+processes, so they run the exact same branching logic that `invoke server`
+uses when its port is already taken.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from tools import server_check
+
+
+class FakeProcessTree:
+    """
+    Fakes the `lsof`/`ps`/`pgrep` commands server_check.py shells out to,
+    for a small hand-built set of PIDs, parents, and children.
+    """
+
+    def __init__(self) -> None:
+        self.port_pids: list[int] = []
+        self.commands: dict[int, str] = {}
+        self.parents: dict[int, int] = {}
+        self.children: dict[int, list[int]] = {}
+        self.killed: list[tuple[int, int]] = []
+        self.dead: set = set()
+
+    def run(self, cmd: list[str], **_kwargs) -> subprocess.CompletedProcess:
+        if cmd[0] == "lsof":
+            stdout = "\n".join(str(pid) for pid in self.port_pids)
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        if cmd[0] == "ps" and cmd[-1] == "command=":
+            pid = int(cmd[2])
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=self.commands.get(pid, ""), stderr=""
+            )
+
+        if cmd[0] == "ps" and cmd[-1] == "ppid=":
+            pid = int(cmd[2])
+            parent = self.parents.get(pid)
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=str(parent) if parent else "", stderr=""
+            )
+
+        if cmd[0] == "pgrep":
+            pid = int(cmd[2])
+            kids = self.children.get(pid, [])
+            return subprocess.CompletedProcess(
+                cmd,
+                0 if kids else 1,
+                stdout="\n".join(str(kid) for kid in kids),
+                stderr="",
+            )
+
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    def kill(self, pid: int, sig: int) -> None:
+        self.killed.append((pid, sig))
+        if sig == 0:
+            if pid in self.dead:
+                raise ProcessLookupError
+            return
+        self.dead.add(pid)
+
+
+@pytest.fixture
+def fake_tree(monkeypatch) -> FakeProcessTree:
+    tree = FakeProcessTree()
+    monkeypatch.setattr(server_check.subprocess, "run", tree.run)
+    monkeypatch.setattr(server_check.os, "kill", tree.kill)
+    monkeypatch.setattr(server_check.time, "sleep", lambda _seconds: None)
+    return tree
+
+
+def fake_input(answer: str):
+    def _input(prompt: str = "") -> str:
+        print(prompt, end="")  # noqa: T201
+        return answer
+
+    return _input
+
+
+def test_is_strictdoc_server_pid_detects_via_ancestor(fake_tree):
+    fake_tree.commands[300] = (
+        "/path/python -m strictdoc.cli.main --debug server . --reload"
+    )
+    fake_tree.commands[301] = (
+        "/path/python -c "
+        "from multiprocessing.spawn import spawn_main; spawn_main()"
+    )
+    fake_tree.parents[301] = 300
+
+    assert server_check.is_strictdoc_server_pid(300) is True
+    assert server_check.is_strictdoc_server_pid(301) is True
+
+
+def test_is_strictdoc_server_pid_false_for_unrelated_process(fake_tree):
+    fake_tree.commands[400] = "/usr/bin/python3 -m http.server 5111"
+
+    assert server_check.is_strictdoc_server_pid(400) is False
+
+
+def test_free_strictdoc_port_when_port_is_free(fake_tree):
+    fake_tree.port_pids = []
+
+    assert server_check.free_strictdoc_port(5111) is True
+    assert fake_tree.killed == []
+
+
+def test_free_strictdoc_port_refuses_foreign_process(fake_tree):
+    fake_tree.port_pids = [111]
+    fake_tree.commands[111] = "/usr/bin/python3 -m http.server 5111"
+
+    with pytest.raises(OSError) as excinfo:
+        server_check.free_strictdoc_port(5111)
+
+    message = str(excinfo.value)
+    assert "occupied by another process" in message
+    assert "PID 111" in message
+    assert fake_tree.killed == []
+
+
+def test_free_strictdoc_port_own_server_keep_existing(fake_tree, monkeypatch):
+    fake_tree.port_pids = [200]
+    fake_tree.commands[200] = (
+        "/path/python -m strictdoc.cli.main --debug server . "
+        "--host 127.0.0.1 --reload --watch"
+    )
+    monkeypatch.setattr("builtins.input", fake_input("n"))
+
+    result = server_check.free_strictdoc_port(5111)
+
+    assert result is False
+    assert fake_tree.killed == []
+
+
+def test_free_strictdoc_port_own_server_replace(fake_tree, monkeypatch):
+    fake_tree.port_pids = [200]
+    fake_tree.commands[200] = (
+        "/path/python -m strictdoc.cli.main --debug server . "
+        "--host 127.0.0.1 --reload --watch"
+    )
+    fake_tree.children[200] = [201]
+    fake_tree.commands[201] = (
+        "/path/python -c "
+        "from multiprocessing.spawn import spawn_main; spawn_main()"
+    )
+    monkeypatch.setattr("builtins.input", fake_input("y"))
+
+    result = server_check.free_strictdoc_port(5111)
+
+    assert result is True
+    assert (200, server_check.signal.SIGTERM) in fake_tree.killed
+    assert (201, server_check.signal.SIGTERM) in fake_tree.killed

--- a/tools/server_check.py
+++ b/tools/server_check.py
@@ -1,0 +1,166 @@
+"""
+Checks whether a port is occupied by a previous strictdoc.cli.main server
+process (walking process ancestry, so a --reload supervisor's
+multiprocessing worker/tracker children count too), and offers to stop it.
+A foreign (non-strictdoc) process on the port is never touched
+automatically.
+
+Used by `invoke server` (see tasks.py) before starting a new server.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import time
+
+BOLD = "\033[1m"
+RESET = "\033[0m"
+
+
+def find_pids_on_port(port: int) -> list[int]:
+    result = subprocess.run(
+        ["lsof", "-ti", f"tcp:{port}"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+    return [int(pid) for pid in result.stdout.split()]
+
+
+def describe_pid(pid: int) -> str:
+    result = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "command="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    command = result.stdout.strip()
+    return command if command else "(no longer running)"
+
+
+def get_ppid(pid: int) -> int | None:
+    result = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "ppid="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    text = result.stdout.strip()
+    return int(text) if text else None
+
+
+def command_is_strictdoc_server(command: str) -> bool:
+    return "strictdoc.cli.main" in command and " server " in f" {command} "
+
+
+def is_strictdoc_server_pid(pid: int) -> bool:
+    """
+    True if `pid` is a strictdoc.cli.main server process, or a descendant
+    of one (e.g. a --reload supervisor's multiprocessing worker/tracker,
+    which doesn't have "strictdoc.cli.main" in its own command line but is
+    still part of that server's process tree).
+    """
+
+    current: int | None = pid
+    for _ in range(10):
+        if current is None or current <= 1:
+            return False
+        if command_is_strictdoc_server(describe_pid(current)):
+            return True
+        current = get_ppid(current)
+    return False
+
+
+def collect_pid_tree(pid: int) -> list[int]:
+    result = subprocess.run(
+        ["pgrep", "-P", str(pid)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    children = [int(child_pid) for child_pid in result.stdout.split()]
+    pids = [pid]
+    for child_pid in children:
+        pids.extend(collect_pid_tree(child_pid))
+    return pids
+
+
+def pid_is_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def stop_pids(pids: list[int]) -> None:
+    all_pids: list[int] = []
+    for pid in pids:
+        all_pids.extend(collect_pid_tree(pid))
+
+    for pid in all_pids:
+        print(f"  ⏹️  stopping PID {pid} ({describe_pid(pid)})")  # noqa: T201
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            continue
+
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if not any(pid_is_alive(pid) for pid in all_pids):
+            return
+        time.sleep(0.1)
+
+    for pid in all_pids:
+        if pid_is_alive(pid):
+            print(f"  ⚠️  {pid} did not stop, sending SIGKILL")  # noqa: T201
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                continue
+
+
+def free_strictdoc_port(port: int) -> bool:
+    """
+    If `port` is occupied by a previous strictdoc.cli.main server process,
+    ask whether to stop it (and its child processes) and returns whether
+    the caller should proceed with starting a new server. If it's occupied
+    by anything else, raise instead of touching it.
+    """
+
+    pids = find_pids_on_port(port)
+    if not pids:
+        return True
+
+    foreign_pids = [pid for pid in pids if not is_strictdoc_server_pid(pid)]
+    if foreign_pids:
+        details = "\n".join(
+            f"  PID {pid}: {describe_pid(pid)}" for pid in foreign_pids
+        )
+        raise OSError(
+            f"⚠️  Port {port} is occupied by another process, not a "
+            f"strictdoc server:\n{details}\n"
+            "Stop it yourself if you want to reuse this port."
+        )
+
+    details = "\n".join(f"  PID {pid}: {describe_pid(pid)}" for pid in pids)
+    print(  # noqa: T201
+        f"🔁 A previous strictdoc server is running on port {port}:\n{details}"
+    )
+    answer = (
+        input(f"{BOLD}Stop it and start a new one? [y/n]:{RESET} ")
+        .strip()
+        .lower()
+    )
+    if answer != "y":
+        print(  # noqa: T201
+            f"ℹ️  Keeping the existing server on port {port}. Not starting a new one."
+        )
+        return False
+
+    stop_pids(pids)
+    return True


### PR DESCRIPTION
## Summary

`invoke server` now checks its target port before starting:

- if it's held by a **previous strictdoc.cli.main server** (matched by walking
  the process's ancestry, not just its own command line — a `--reload`
  supervisor's multiprocessing worker/tracker children don't have
  `strictdoc.cli.main` in their own command line but are still part of that
  server's process tree), it asks:


```
A previous strictdoc server is running on port 5111:
PID ...: ...
Stop it and start a new one? [y/n]:
```




`y` stops it (and its child processes) and starts a new one; `n` leaves
the existing server running and aborts without starting a duplicate.

- if it's held by **anything else** (a foreign, non-strictdoc process), it's
never touched automatically — the command reports what's there and refuses
to start, instead of failing later with a cryptic "Address already in use".

Adds an optional `--port` to `invoke server` (defaults to StrictDoc's own
`ProjectConfigDefault.DEFAULT_SERVER_PORT`, 5111) so the pre-check knows
which port to look at. It's only forwarded to the underlying CLI command
when explicitly given, so existing configs with a custom `server_port` are
unaffected.

The port-check logic lives in `tools/server_check.py` (following the
existing `tools/` convention), imported by `tasks.py`'s `server` task.

## Why

Previously, if a leftover strictdoc dev server (or anything else) was still
bound to the default port, `invoke server` would just fail with
`ERROR: [Errno 48] Address already in use` — no indication of what was
occupying the port or how to resolve it, and no safe way to recover without
manually finding and killing PIDs (including `--reload`'s
multiprocessing/resource_tracker children, which regular `kill <pid>` often
doesn't fully stop).

## Test plan

- [x] Unit tests (`tests/unit/tools/test_server_check.py`) covering
    `is_strictdoc_server_pid`/`free_strictdoc_port`: port free, foreign
    process (refused), own previous server + `n` (kept), own previous
    server + `y` (stopped and replaced) — faking `lsof`/`ps`/`pgrep`/`kill`,
    no real OS process spawning.
- [x] Manually verified against a real `invoke server --reload` process
    tree (parent + `resource_tracker` + `spawn_main` children): correctly
    detected, prompted, and fully stopped on `y`; left untouched on `n`.
- [x] Manually verified a genuine foreign process (unrelated to strictdoc)
    on the port is reported and never touched.
