### PR TITLE
feat(project_index): Hide external filesystem prefix in project index dashboard paths

### DIFF
--- a/strictdoc/features/project_index/assets/project_tree.css
+++ b/strictdoc/features/project_index/assets/project_tree.css
@@ -226,3 +226,27 @@
 .dashboard-path {
   overflow-wrap: anywhere;
 }
+
+.dashboard-path-external {
+  cursor: pointer;
+  padding: 0 0.2em;
+  border-radius: 3px;
+  background-color: rgba(0,0,0,0.06);
+}
+
+.dashboard-path-external:hover,
+.dashboard-path-external:focus {
+  background-color: rgba(0,0,0,0.12);
+}
+
+.dashboard-path-external-full {
+  display: none;
+}
+
+.dashboard-path.revealed .dashboard-path-external {
+  display: none;
+}
+
+.dashboard-path.revealed .dashboard-path-external-full {
+  display: inline;
+}

--- a/strictdoc/features/project_index/assets/project_tree.css
+++ b/strictdoc/features/project_index/assets/project_tree.css
@@ -170,7 +170,7 @@
 .dashboard {
   gap: var(--base-rhythm);
   display: grid;
-  grid-template-columns: 2fr 1fr;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
 }
 
 @media (max-width: 768px) {
@@ -221,4 +221,8 @@
   bottom: 0;
   background-color: rgba(0,0,0,0.025);
   border-bottom: var(--base-border);
+}
+
+.dashboard-path {
+  overflow-wrap: anywhere;
 }

--- a/strictdoc/features/project_index/assets/project_tree.js
+++ b/strictdoc/features/project_index/assets/project_tree.js
@@ -375,5 +375,25 @@ window.addEventListener("DOMContentLoaded", function(){
 
   projectTree.init();
 
+  document.addEventListener('click', function (event) {
+    const trigger = event.target.closest('.dashboard-path-external');
+    if (!trigger) {
+      return;
+    }
+    trigger.closest('.dashboard-path').classList.toggle('revealed');
+  });
+
+  document.addEventListener('keydown', function (event) {
+    if (event.key !== 'Enter' && event.key !== ' ') {
+      return;
+    }
+    const trigger = event.target.closest('.dashboard-path-external');
+    if (!trigger) {
+      return;
+    }
+    event.preventDefault();
+    trigger.closest('.dashboard-path').classList.toggle('revealed');
+  });
+
 },false);
 })();

--- a/strictdoc/features/project_index/templates/features/project_index/main.jinja
+++ b/strictdoc/features/project_index/templates/features/project_index/main.jinja
@@ -18,7 +18,7 @@
         {% if view_object.project_config.input_paths|length %}
           <b>Input paths:</b>
           {% for path_ in view_object.project_config.input_paths %}
-          <code style="word-wrap: break-word;">{{ path_ }}</code><br/>
+          <code class="dashboard-path">{{ path_ }}</code><br/>
           {% endfor %}
         {% endif %}
 
@@ -37,7 +37,7 @@
         {% if view_object.project_config.source_root_path is not none %}
           <b>Source root path:</b>
           <div>
-            <code style="word-wrap: break-word;">{{ view_object.project_config.source_root_path }}</code>
+            <code class="dashboard-path">{{ view_object.project_config.source_root_path }}</code>
           </div>
         {% endif %}
 

--- a/strictdoc/features/project_index/templates/features/project_index/main.jinja
+++ b/strictdoc/features/project_index/templates/features/project_index/main.jinja
@@ -18,7 +18,13 @@
         {% if view_object.project_config.input_paths|length %}
           <b>Input paths:</b>
           {% for path_ in view_object.project_config.input_paths %}
-          <code class="dashboard-path">{{ path_ }}</code><br/>
+          {% set external_, internal_ = view_object.split_path_for_display(path_) %}
+          <code class="dashboard-path">
+            {%- if external_ -%}
+            <span class="dashboard-path-external" tabindex="0" title="Click to reveal">…</span><span class="dashboard-path-external-full">{{ external_ }}</span>
+            {%- endif -%}
+            <span class="dashboard-path-internal">{{ internal_ }}</span>
+          </code><br/>
           {% endfor %}
         {% endif %}
 
@@ -35,10 +41,14 @@
         {% endif %}
 
         {% if view_object.project_config.source_root_path is not none %}
+          {% set external_, internal_ = view_object.split_path_for_display(view_object.project_config.source_root_path) %}
           <b>Source root path:</b>
-          <div>
-            <code class="dashboard-path">{{ view_object.project_config.source_root_path }}</code>
-          </div>
+            <code class="dashboard-path">
+              {%- if external_ -%}
+              <span class="dashboard-path-external" tabindex="0" title="Click to reveal">…</span><span class="dashboard-path-external-full">{{ external_ }}</span>
+              {%- endif -%}
+              <span class="dashboard-path-internal">{{ internal_ }}</span>
+            </code>
         {% endif %}
 
         {% if view_object.project_config.include_source_paths|length or view_object.project_config.exclude_source_paths|length %}

--- a/strictdoc/features/project_index/templates/features/project_index/main.jinja
+++ b/strictdoc/features/project_index/templates/features/project_index/main.jinja
@@ -19,9 +19,9 @@
           <b>Input paths:</b>
           {% for path_ in view_object.project_config.input_paths %}
           {% set external_, internal_ = view_object.split_path_for_display(path_) %}
-          <code class="dashboard-path">
+          <code class="dashboard-path" data-testid="dashboard-input-path">
             {%- if external_ -%}
-            <span class="dashboard-path-external" tabindex="0" title="Click to reveal">…</span><span class="dashboard-path-external-full">{{ external_ }}</span>
+            <span class="dashboard-path-external" data-testid="dashboard-input-path-external" tabindex="0" title="Click to reveal">…</span><span class="dashboard-path-external-full">{{ external_ }}</span>
             {%- endif -%}
             <span class="dashboard-path-internal">{{ internal_ }}</span>
           </code><br/>
@@ -43,9 +43,9 @@
         {% if view_object.project_config.source_root_path is not none %}
           {% set external_, internal_ = view_object.split_path_for_display(view_object.project_config.source_root_path) %}
           <b>Source root path:</b>
-            <code class="dashboard-path">
+            <code class="dashboard-path" data-testid="dashboard-source-root-path">
               {%- if external_ -%}
-              <span class="dashboard-path-external" tabindex="0" title="Click to reveal">…</span><span class="dashboard-path-external-full">{{ external_ }}</span>
+              <span class="dashboard-path-external" data-testid="dashboard-source-root-path-external" tabindex="0" title="Click to reveal">…</span><span class="dashboard-path-external-full">{{ external_ }}</span>
               {%- endif -%}
               <span class="dashboard-path-internal">{{ internal_ }}</span>
             </code>

--- a/strictdoc/features/project_index/view_object.py
+++ b/strictdoc/features/project_index/view_object.py
@@ -2,8 +2,9 @@
 @relation(SDOC-SRS-53, scope=file)
 """
 
+import os
 from dataclasses import dataclass
-from typing import Union
+from typing import Tuple, Union
 
 from markupsafe import Markup
 
@@ -81,6 +82,29 @@ class ProjectTreeViewObject:
 
     def get_document_level(self) -> int:
         return 0
+
+    def split_path_for_display(self, path: str) -> Tuple[str, str]:
+        """
+        Split an absolute path into an (external_prefix, remainder) pair,
+        so that the UI can hide the external_prefix (e.g. behind a
+        click-to-reveal "…") from screen recordings/screenshots.
+
+        If the path is inside the project root's parent directory, the
+        remainder keeps everything from the project root directory name
+        onward (e.g. "/strictdoc/some/src"). Otherwise the path lies
+        outside the project entirely, and only its last path segment is
+        kept in the remainder (e.g. remainder="/src" for
+        path="/opt/external-libs/src").
+        """
+        project_root_path = self.project_config.get_project_root_path()
+        external_prefix = os.path.dirname(project_root_path)
+        if external_prefix and path.startswith(external_prefix):
+            return external_prefix, path[len(external_prefix) :]
+
+        fallback_prefix = os.path.dirname(path)
+        if fallback_prefix and fallback_prefix != path:
+            return fallback_prefix, path[len(fallback_prefix) :]
+        return "", path
 
     def should_display_fragments_toggle(self) -> bool:
         return self.project_config.export_included_documents

--- a/tests/end2end/helpers/screens/project_index/screen_project_index.py
+++ b/tests/end2end/helpers/screens/project_index/screen_project_index.py
@@ -82,6 +82,76 @@ class Screen_ProjectIndex(Screen):  # pylint: disable=invalid-name
             by=By.XPATH,
         )
 
+    #
+    # Dashboard: external path prefix reveal/hide toggle.
+    #
+
+    def assert_dashboard_input_path_present(self) -> None:
+        self.test_case.assert_element(
+            '//*[@data-testid="dashboard-input-path"]',
+            by=By.XPATH,
+        )
+
+    def assert_dashboard_input_path_external_toggle_present(self) -> None:
+        self.test_case.assert_element(
+            '//*[@data-testid="dashboard-input-path-external"]',
+            by=By.XPATH,
+        )
+
+    def assert_dashboard_input_path_external_full_hidden(self) -> None:
+        self.test_case.assert_element_not_visible(
+            '//*[@data-testid="dashboard-input-path"]'
+            '//*[@class="dashboard-path-external-full"]',
+            by=By.XPATH,
+        )
+
+    def assert_dashboard_input_path_external_full_visible(self) -> None:
+        self.test_case.assert_element_visible(
+            '//*[@data-testid="dashboard-input-path"]'
+            '//*[@class="dashboard-path-external-full"]',
+            by=By.XPATH,
+        )
+
+    def do_click_on_dashboard_input_path_external_toggle(self) -> None:
+        self.test_case.click_xpath(
+            '//*[@data-testid="dashboard-input-path-external"]'
+        )
+
+    def assert_dashboard_source_root_path_present(self) -> None:
+        self.test_case.assert_element(
+            '//*[@data-testid="dashboard-source-root-path"]',
+            by=By.XPATH,
+        )
+
+    def assert_dashboard_source_root_path_external_toggle_present(
+        self,
+    ) -> None:
+        self.test_case.assert_element(
+            '//*[@data-testid="dashboard-source-root-path-external"]',
+            by=By.XPATH,
+        )
+
+    def assert_dashboard_source_root_path_external_full_hidden(self) -> None:
+        self.test_case.assert_element_not_visible(
+            '//*[@data-testid="dashboard-source-root-path"]'
+            '//*[@class="dashboard-path-external-full"]',
+            by=By.XPATH,
+        )
+
+    def assert_dashboard_source_root_path_external_full_visible(
+        self,
+    ) -> None:
+        self.test_case.assert_element_visible(
+            '//*[@data-testid="dashboard-source-root-path"]'
+            '//*[@class="dashboard-path-external-full"]',
+            by=By.XPATH,
+        )
+
+    def do_click_on_dashboard_source_root_path_external_toggle(self) -> None:
+        self.test_case.click_xpath(
+            '//*[@data-testid="dashboard-source-root-path-external"]'
+        )
+
     def assert_link_to_project_statistics_present(self) -> None:
         self.test_case.assert_element(
             '//a[@data-testid="project-tree-link-project-statistics"]',

--- a/tests/end2end/screens/project_index/view_dashboard_paths_reveal_external_prefix/test_case.py
+++ b/tests/end2end/screens/project_index/view_dashboard_paths_reveal_external_prefix/test_case.py
@@ -1,0 +1,39 @@
+"""
+@relation(SDOC-SRS-53, scope=file)
+"""
+
+import os
+
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+path_to_this_test_file_folder = os.path.dirname(os.path.abspath(__file__))
+
+
+class Test(E2ECase):
+    def test(self):
+        with SDocTestServer(
+            input_path=path_to_this_test_file_folder
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+
+            # Input paths: the external path prefix is hidden by default
+            # and gets revealed by clicking on the "…" toggle.
+            screen_project_index.assert_dashboard_input_path_present()
+            screen_project_index.assert_dashboard_input_path_external_toggle_present()
+            screen_project_index.assert_dashboard_input_path_external_full_hidden()
+            screen_project_index.do_click_on_dashboard_input_path_external_toggle()
+            screen_project_index.assert_dashboard_input_path_external_full_visible()
+
+            # Source root path: same reveal behavior.
+            screen_project_index.assert_dashboard_source_root_path_present()
+            screen_project_index.assert_dashboard_source_root_path_external_toggle_present()
+            screen_project_index.assert_dashboard_source_root_path_external_full_hidden()
+            screen_project_index.do_click_on_dashboard_source_root_path_external_toggle()
+            screen_project_index.assert_dashboard_source_root_path_external_full_visible()


### PR DESCRIPTION
- Input paths and Source root path on the Project tree configuration
  screen previously showed the full absolute filesystem path, leaking
  the user's local directory structure during screen sharing.
  Now the portion of the path outside the project (or, when a path lies
  entirely outside the project, everything but its last segment) is
  hidden behind a click-to-reveal "…" toggle; the project-internal part
  stays always visible.
- TEST: tests/end2end/screens/project_index/view_dashboard_paths_reveal_external_prefix

- The CSS that controls the column widths on the main screen has been fixed.