### PR TITLE
feat(query): add quantified list membership queries

### DIFF
--- a/developer/tasks/20260708_query_list_membership/task.md
+++ b/developer/tasks/20260708_query_list_membership/task.md
@@ -1,0 +1,74 @@
+# Add quantified list membership expressions to the query language
+
+## WHAT
+
+Adds support for quantified list membership expressions in the StrictDoc query language:
+
+Example:
+```
+any(["tag_a", "tag_b"]) in node["TAGS"]
+all(["tag_a", "tag_b"]) in node["TAGS"]
+none(["excluded_a", "excluded_b"]) in node["TAGS"]
+```
+
+The existing scalar membership expression remains supported:
+```
+"System" in node["TITLE"]
+```
+
+## WHY
+
+StrictDoc already supports substring-style membership checks such as `"System" in node["TITLE"]`. When filtering nodes by tags or other fields, users currently have to repeat this expression with explicit boolean operators:
+
+```
+("tag_a" in node["TAGS"] or "tag_b" in node["TAGS"])
+```
+
+This becomes noisy for product-line filters and other searches that need to match against a list of accepted values. Quantified list membership keeps the existing `in` mental model while making these filters shorter and easier to read.
+
+## HOW
+
+### Proposed behavior
+
+- `any(["A", "B"]) in X` matches when at least one listed string is contained in `X`.
+- `all(["A", "B"]) in X` matches when every listed string is contained in `X`.
+- `none(["A", "B"]) in X` matches when none of the listed strings are contained in `X`.
+- When `X` is `node["TAGS"]`, matching is exact against comma-space-separated tag values instead of substring-based.
+- The order of strings in the list does not affect matching.
+- Existing scalar `in` and `not in` expressions keep their current behavior.
+- The first implementation supports string lists on the left-hand side only.
+- Bare tag list syntax such as `any([tag_a, tag_b]) in node["TAGS"]` is intentionally not supported in this first step, keeping list items consistent with the existing quoted string syntax.
+- Reverse list-field semantics such as `all(node["TAGS"]) in ["A", "B"]` are intentionally not supported in this first step.
+
+### Implementation details
+
+- Extend the query grammar with `StringListExpression`.
+- Add `AnyInExpression`, `AllInExpression`, and `NoneInExpression` grammar rules.
+- Add corresponding query object model classes.
+- Register the new expression classes in the query reader.
+- Reuse the existing scalar `in` substring evaluation for each string in the list, except for `node["TAGS"]` where matching is exact against comma-space-separated tag values.
+- Add parser tests for the new expression types.
+- Add evaluator tests for positive matches, negative matches, order-independent matching, and exact tag matching.
+- Add evaluator coverage proving scalar `in` on `node["TAGS"]` keeps its existing substring behavior.
+- Add parser rejection tests for intentionally unsupported bare-list and reverse-list-field syntaxes.
+- Add integration tests covering `--filter-nodes` with `any([...])`, `all([...])`, and `none([...])` in `node["TAGS"]`.
+- Add user guide documentation for quantified list membership expressions.
+
+### Future work
+
+- Consider first-class list-valued fields so expressions such as `all(node["TAGS"]) in ["tag_a", "tag_b"]` can be supported.
+- Consider subset/equality-style operators if users need reverse checks such as "all node tags are in this allowed set".
+
+### Verification
+
+- Parser support for `any([...]) in ...`.
+- Parser support for `all([...]) in ...`.
+- Parser support for `none([...]) in ...`.
+- Positive evaluator behavior for all three quantifiers.
+- Negative evaluator behavior for all three quantifiers.
+- Order-independent evaluator behavior.
+- Exact `node["TAGS"]` matching that does not match tag substrings.
+- Scalar `in` compatibility for `node["TAGS"]` substring checks.
+- Parser rejection for intentionally unsupported syntaxes.
+- `--filter-nodes` integration behavior for `any([...])`, `all([...])`, and `none([...])` tag filters.
+- User guide examples for `any([...])`, `all([...])`, and `none([...])` tag filters.

--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -5028,9 +5028,16 @@ that converts search queries into corresponding Python expressions.
 
 Important rules:
 
-- Every query component shall start with ``node.``.
+- Node properties and functions are accessed through ``node.`` or
+  ``node["FIELD"]`` expressions.
 - ``and`` and ``or`` expressions must be grouped using round brackets.
 - Only double quotes are accepted for strings.
+- For text fields, ``"text" in node["FIELD"]`` checks substring membership. The
+  quantified forms ``any([...]) in node["FIELD"]``, ``all([...]) in
+  node["FIELD"]``, and ``none([...]) in node["FIELD"]`` apply the same substring
+  check to each listed string.
+- For ``node["TAGS"]``, quantified list membership checks exact
+  comma-space-separated tag values.
 
 .. list-table:: Query examples
    :widths: 50 50
@@ -5049,13 +5056,22 @@ Important rules:
      - Find all requirements or sections from documents with ``ROOT: True``. See [LINK: SECTION-UG-Document] for the description of the ``ROOT`` option.
 
    * - ``(node.is_requirement and "System" in node["TITLE"])``
-     - Find all requirements with a TITLE that equals to "System".
+     - Find all requirements with a TITLE that contains "System".
 
    * - ``(node.is_requirement and node.has_parent_requirements)``
      - Find all requirements which have parent requirements.
 
    * - ``(node.is_requirement and node.has_child_requirements)``
      - Find all requirements which have child requirements.
+
+   * - ``any(["tag_a", "tag_b"]) in node["TAGS"]``
+     - Find all nodes that have at least one of the listed tags.
+
+   * - ``all(["tag_a", "tag_b"]) in node["TAGS"]``
+     - Find all nodes that have every listed tag.
+
+   * - ``none(["excluded_a", "excluded_b"]) in node["TAGS"]``
+     - Find all nodes that have none of the listed tags.
 <<<
 
 [[/SECTION]]
@@ -5079,6 +5095,10 @@ Example:
 .. code:: text
 
     strictdoc export . --filter-nodes '"System" in node["TITLE"]'
+
+.. code:: text
+
+    strictdoc export . --filter-nodes 'any(["tag_a", "tag_b"]) in node["TAGS"]'
 <<<
 
 [[/SECTION]]

--- a/strictdoc/core/query_engine/grammar.py
+++ b/strictdoc/core/query_engine/grammar.py
@@ -37,6 +37,12 @@ BooleanExpression:
   |
   NodeHasChildRequirementsExpression
   |
+  AnyInExpression
+  |
+  AllInExpression
+  |
+  NoneInExpression
+  |
   InExpression
   |
   NotInExpression
@@ -70,6 +76,10 @@ StringExpression:
 
 NoneExpression:
   _ = 'None'
+;
+
+StringListExpression:
+  '[' strings += StringExpression[','] ']'
 ;
 
 NodeFieldExpression:
@@ -138,6 +148,18 @@ InExpression:
 
 NotInExpression:
   lhs_expr = InableLHSExpression 'not in' rhs_expr = InableRHSExpression
+;
+
+AnyInExpression:
+  'any' '(' lhs_expr = StringListExpression ')' 'in' rhs_expr = InableRHSExpression
+;
+
+AllInExpression:
+  'all' '(' lhs_expr = StringListExpression ')' 'in' rhs_expr = InableRHSExpression
+;
+
+NoneInExpression:
+  'none' '(' lhs_expr = StringListExpression ')' 'in' rhs_expr = InableRHSExpression
 ;
 
 InableLHSExpression:

--- a/strictdoc/core/query_engine/query_object.py
+++ b/strictdoc/core/query_engine/query_object.py
@@ -35,6 +35,12 @@ class NoneExpression:
         self.parent: Any = parent
 
 
+class StringListExpression:
+    def __init__(self, parent: Any, strings: List[StringExpression]):
+        self.parent: Any = parent
+        self.strings: List[StringExpression] = strings
+
+
 class NodeFieldExpression:
     def __init__(self, parent: Any, field_name: str):
         self.parent: Any = parent
@@ -143,6 +149,42 @@ class NotInExpression:
         self.rhs_expr: Expression = rhs_expr
 
 
+class AnyInExpression:
+    def __init__(
+        self,
+        parent: Any,
+        lhs_expr: StringListExpression,
+        rhs_expr: Expression,
+    ):
+        self.parent: Any = parent
+        self.lhs_expr: StringListExpression = lhs_expr
+        self.rhs_expr: Expression = rhs_expr
+
+
+class AllInExpression:
+    def __init__(
+        self,
+        parent: Any,
+        lhs_expr: StringListExpression,
+        rhs_expr: Expression,
+    ):
+        self.parent: Any = parent
+        self.lhs_expr: StringListExpression = lhs_expr
+        self.rhs_expr: Expression = rhs_expr
+
+
+class NoneInExpression:
+    def __init__(
+        self,
+        parent: Any,
+        lhs_expr: StringListExpression,
+        rhs_expr: Expression,
+    ):
+        self.parent: Any = parent
+        self.lhs_expr: StringListExpression = lhs_expr
+        self.rhs_expr: Expression = rhs_expr
+
+
 class Query:
     def __init__(self, root_expression: Any):
         self.root_expression: Any = root_expression
@@ -236,7 +278,43 @@ class QueryObject:
             ) is not None:
                 return lhs_value not in rhs_value
             return False
+        if isinstance(expression, AnyInExpression):
+            return any(
+                self._evaluate_list_in(node, lhs_expr_, expression.rhs_expr)
+                for lhs_expr_ in expression.lhs_expr.strings
+            )
+        if isinstance(expression, AllInExpression):
+            return all(
+                self._evaluate_list_in(node, lhs_expr_, expression.rhs_expr)
+                for lhs_expr_ in expression.lhs_expr.strings
+            )
+        if isinstance(expression, NoneInExpression):
+            return not any(
+                self._evaluate_list_in(node, lhs_expr_, expression.rhs_expr)
+                for lhs_expr_ in expression.lhs_expr.strings
+            )
         assert 0, expression
+
+    def _evaluate_list_in(
+        self,
+        node: SDocExtendedElementIF,
+        lhs_expr: StringExpression,
+        rhs_expr: Expression,
+    ) -> bool:
+        if (rhs_value := self._evaluate_value(node, rhs_expr)) is not None and (
+            lhs_value := self._evaluate_value(node, lhs_expr)
+        ) is not None:
+            if (
+                isinstance(rhs_expr, NodeFieldExpression)
+                and rhs_expr.field_name == "TAGS"
+            ):
+                return lhs_value in self._split_list_field_value(rhs_value)
+            return lhs_value in rhs_value
+        return False
+
+    @staticmethod
+    def _split_list_field_value(field_value: str) -> List[str]:
+        return field_value.split(", ")
 
     def _evaluate_equal(
         self, node: SDocExtendedElementIF, expression: EqualExpression

--- a/strictdoc/core/query_engine/query_reader.py
+++ b/strictdoc/core/query_engine/query_reader.py
@@ -8,7 +8,9 @@ from textx import metamodel_from_str
 
 from strictdoc.core.query_engine.grammar import QUERY_GRAMMAR
 from strictdoc.core.query_engine.query_object import (
+    AllInExpression,
     AndExpression,
+    AnyInExpression,
     EqualExpression,
     InExpression,
     NodeContainsAnyFreeTextExpression,
@@ -24,16 +26,20 @@ from strictdoc.core.query_engine.query_object import (
     NodeIsSourceFileWithNoCoverageExpression,
     NodeIsSourceFileWithPartialCoverageExpression,
     NoneExpression,
+    NoneInExpression,
     NotEqualExpression,
     NotExpression,
     NotInExpression,
     OrExpression,
     Query,
     StringExpression,
+    StringListExpression,
 )
 
 QUERY_MODELS = [
+    AllInExpression,
     AndExpression,
+    AnyInExpression,
     EqualExpression,
     InExpression,
     NodeContainsExpression,
@@ -49,12 +55,14 @@ QUERY_MODELS = [
     NodeIsSourceFileWithPartialCoverageExpression,
     NodeIsSourceFileWithNoCoverageExpression,
     NoneExpression,
+    NoneInExpression,
     NotEqualExpression,
     NotExpression,
     NotInExpression,
     OrExpression,
     Query,
     StringExpression,
+    StringListExpression,
 ]
 
 

--- a/tests/integration/features/node_filters/02_export_to_sdoc_format_with_any_in_filter/expected/output.sdoc
+++ b/tests/integration/features/node_filters/02_export_to_sdoc_format_with_any_in_filter/expected/output.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: Query filter list membership
+
+[REQUIREMENT]
+TAGS: tag_a
+TITLE: Requirement #1
+STATEMENT: Statement #1
+
+[REQUIREMENT]
+TAGS: tag_b
+TITLE: Requirement #2
+STATEMENT: Statement #2

--- a/tests/integration/features/node_filters/02_export_to_sdoc_format_with_any_in_filter/input.sdoc
+++ b/tests/integration/features/node_filters/02_export_to_sdoc_format_with_any_in_filter/input.sdoc
@@ -1,0 +1,22 @@
+[DOCUMENT]
+TITLE: Query filter list membership
+
+[REQUIREMENT]
+TAGS: tag_a
+TITLE: Requirement #1
+STATEMENT: Statement #1
+
+[REQUIREMENT]
+TAGS: tag_b
+TITLE: Requirement #2
+STATEMENT: Statement #2
+
+[REQUIREMENT]
+TAGS: tag_c
+TITLE: Requirement #3
+STATEMENT: Statement #3
+
+[REQUIREMENT]
+TAGS: tag
+TITLE: Requirement #4
+STATEMENT: Statement #4

--- a/tests/integration/features/node_filters/02_export_to_sdoc_format_with_any_in_filter/test.itest
+++ b/tests/integration/features/node_filters/02_export_to_sdoc_format_with_any_in_filter/test.itest
@@ -1,0 +1,4 @@
+RUN: %expect_exit 0 %strictdoc export %S/input.sdoc --formats=sdoc --output-dir=%T --filter-nodes 'any(["tag_a", "tag_b"]) in node["TAGS"]' | filecheck %s --dump-input=fail
+CHECK: Reading SDOC: input.sdoc
+
+RUN: %diff %S/expected/output.sdoc %T/sdoc/input.sdoc

--- a/tests/integration/features/node_filters/03_export_to_sdoc_format_with_all_in_filter/expected/output.sdoc
+++ b/tests/integration/features/node_filters/03_export_to_sdoc_format_with_all_in_filter/expected/output.sdoc
@@ -1,0 +1,7 @@
+[DOCUMENT]
+TITLE: Query filter all list membership
+
+[REQUIREMENT]
+TAGS: tag_b, tag_a
+TITLE: Requirement #1
+STATEMENT: Statement #1

--- a/tests/integration/features/node_filters/03_export_to_sdoc_format_with_all_in_filter/input.sdoc
+++ b/tests/integration/features/node_filters/03_export_to_sdoc_format_with_all_in_filter/input.sdoc
@@ -1,0 +1,17 @@
+[DOCUMENT]
+TITLE: Query filter all list membership
+
+[REQUIREMENT]
+TAGS: tag_b, tag_a
+TITLE: Requirement #1
+STATEMENT: Statement #1
+
+[REQUIREMENT]
+TAGS: tag_a
+TITLE: Requirement #2
+STATEMENT: Statement #2
+
+[REQUIREMENT]
+TAGS: tag_b
+TITLE: Requirement #3
+STATEMENT: Statement #3

--- a/tests/integration/features/node_filters/03_export_to_sdoc_format_with_all_in_filter/test.itest
+++ b/tests/integration/features/node_filters/03_export_to_sdoc_format_with_all_in_filter/test.itest
@@ -1,0 +1,4 @@
+RUN: %expect_exit 0 %strictdoc export %S/input.sdoc --formats=sdoc --output-dir=%T --filter-nodes 'all(["tag_a", "tag_b"]) in node["TAGS"]' | filecheck %s --dump-input=fail
+CHECK: Reading SDOC: input.sdoc
+
+RUN: %diff %S/expected/output.sdoc %T/sdoc/input.sdoc

--- a/tests/integration/features/node_filters/04_export_to_sdoc_format_with_none_in_filter/expected/output.sdoc
+++ b/tests/integration/features/node_filters/04_export_to_sdoc_format_with_none_in_filter/expected/output.sdoc
@@ -1,0 +1,12 @@
+[DOCUMENT]
+TITLE: Query filter none list membership
+
+[REQUIREMENT]
+TAGS: tag_a
+TITLE: Requirement #1
+STATEMENT: Statement #1
+
+[REQUIREMENT]
+TAGS: tag_b
+TITLE: Requirement #4
+STATEMENT: Statement #4

--- a/tests/integration/features/node_filters/04_export_to_sdoc_format_with_none_in_filter/input.sdoc
+++ b/tests/integration/features/node_filters/04_export_to_sdoc_format_with_none_in_filter/input.sdoc
@@ -1,0 +1,22 @@
+[DOCUMENT]
+TITLE: Query filter none list membership
+
+[REQUIREMENT]
+TAGS: tag_a
+TITLE: Requirement #1
+STATEMENT: Statement #1
+
+[REQUIREMENT]
+TAGS: excluded_a
+TITLE: Requirement #2
+STATEMENT: Statement #2
+
+[REQUIREMENT]
+TAGS: excluded_b
+TITLE: Requirement #3
+STATEMENT: Statement #3
+
+[REQUIREMENT]
+TAGS: tag_b
+TITLE: Requirement #4
+STATEMENT: Statement #4

--- a/tests/integration/features/node_filters/04_export_to_sdoc_format_with_none_in_filter/test.itest
+++ b/tests/integration/features/node_filters/04_export_to_sdoc_format_with_none_in_filter/test.itest
@@ -1,0 +1,4 @@
+RUN: %expect_exit 0 %strictdoc export %S/input.sdoc --formats=sdoc --output-dir=%T --filter-nodes 'none(["excluded_a", "excluded_b"]) in node["TAGS"]' | filecheck %s --dump-input=fail
+CHECK: Reading SDOC: input.sdoc
+
+RUN: %diff %S/expected/output.sdoc %T/sdoc/input.sdoc

--- a/tests/unit/strictdoc/core/query_engine/test_query_object.py
+++ b/tests/unit/strictdoc/core/query_engine/test_query_object.py
@@ -1,0 +1,96 @@
+from strictdoc.backend.sdoc.models.object_factory import SDocObjectFactory
+from strictdoc.core.query_engine.query_object import QueryObject
+from strictdoc.core.query_engine.query_reader import QueryReader
+from tests.unit.helpers.document_builder import DocumentBuilder
+
+
+def evaluate_query(query: str) -> bool:
+    parsed_query = QueryReader.read(query)
+    return QueryObject(parsed_query, None).evaluate(None)
+
+
+def evaluate_node_query(query: str, node) -> bool:
+    parsed_query = QueryReader.read(query)
+    return QueryObject(parsed_query, None).evaluate(node)
+
+
+def test_10_any_all_none_in_expressions_evaluate_string_rhs():
+    assert evaluate_query('any(["X", "B"]) in "ABC"') is True
+    assert evaluate_query('all(["A", "B"]) in "ABC"') is True
+    assert evaluate_query('none(["X", "Y"]) in "ABC"') is True
+
+
+def test_20_any_all_none_in_expressions_evaluate_string_rhs_no_match():
+    assert evaluate_query('any(["X", "Y"]) in "ABC"') is False
+    assert evaluate_query('all(["A", "X"]) in "ABC"') is False
+    assert evaluate_query('none(["X", "A"]) in "ABC"') is False
+
+
+def test_30_in_expressions_evaluate_string_rhs_order_independent():
+    assert evaluate_query('any(["X", "B", "A"]) in "ABC"') is True
+    assert evaluate_query('all(["B", "A"]) in "ABC"') is True
+    assert evaluate_query('none(["Y", "X"]) in "ABC"') is True
+
+
+def test_40_any_in_expression_matches_tags_exactly():
+    builder = DocumentBuilder()
+    node = SDocObjectFactory.create_requirement(
+        parent=builder.document,
+        tags="tag_a, tag_b",
+    )
+
+    assert evaluate_node_query('any(["tag_a"]) in node["TAGS"]', node) is True
+    assert evaluate_node_query('any(["tag"]) in node["TAGS"]', node) is False
+
+
+def test_45_scalar_in_expression_matches_tags_by_substring():
+    builder = DocumentBuilder()
+    node = SDocObjectFactory.create_requirement(
+        parent=builder.document,
+        tags="tag_a, tag_b",
+    )
+
+    assert evaluate_node_query('"tag" in node["TAGS"]', node) is True
+
+
+def test_50_all_in_expression_matches_tags_exactly():
+    builder = DocumentBuilder()
+    node = SDocObjectFactory.create_requirement(
+        parent=builder.document,
+        tags="tag_a, tag_b",
+    )
+
+    assert (
+        evaluate_node_query('all(["tag_a", "tag_b"]) in node["TAGS"]', node)
+        is True
+    )
+    assert evaluate_node_query('all(["tag"]) in node["TAGS"]', node) is False
+
+
+def test_60_none_in_expression_matches_tags_exactly():
+    builder = DocumentBuilder()
+    node = SDocObjectFactory.create_requirement(
+        parent=builder.document,
+        tags="tag_a, tag_b",
+    )
+
+    assert evaluate_node_query('none(["tag"]) in node["TAGS"]', node) is True
+    assert evaluate_node_query('none(["tag_a"]) in node["TAGS"]', node) is False
+
+
+def test_70_any_all_none_in_expressions_evaluate_node_text_field():
+    builder = DocumentBuilder()
+    node = SDocObjectFactory.create_requirement(
+        parent=builder.document,
+        title="System ABC",
+    )
+
+    assert (
+        evaluate_node_query('any(["System", "Other"]) in node["TITLE"]', node)
+        is True
+    )
+    assert (
+        evaluate_node_query('all(["System", "ABC"]) in node["TITLE"]', node)
+        is True
+    )
+    assert evaluate_node_query('none(["Other"]) in node["TITLE"]', node) is True

--- a/tests/unit/strictdoc/core/query_engine/test_query_reader.py
+++ b/tests/unit/strictdoc/core/query_engine/test_query_reader.py
@@ -1,4 +1,6 @@
 from strictdoc.core.query_engine.query_object import (
+    AllInExpression,
+    AnyInExpression,
     EqualExpression,
     InExpression,
     NodeContainsAnyFreeTextExpression,
@@ -6,6 +8,7 @@ from strictdoc.core.query_engine.query_object import (
     NodeHasParentRequirementsExpression,
     NodeIsRequirementExpression,
     NodeIsSectionExpression,
+    NoneInExpression,
     NotEqualExpression,
     NotExpression,
     OrExpression,
@@ -13,6 +16,14 @@ from strictdoc.core.query_engine.query_object import (
     StringExpression,
 )
 from strictdoc.core.query_engine.query_reader import QueryReader
+
+
+def assert_query_rejected(query: str) -> None:
+    try:
+        QueryReader.read(query)
+    except Exception:
+        return
+    raise AssertionError(f"Query was expected to be rejected: {query}")
 
 
 def test_30_equal_expression_two_node_field_expressions():
@@ -109,6 +120,65 @@ def test_52_in_expression_with_string_and_node_field_expression():
         query_object.root_expression.rhs_expr, NodeFieldExpression
     )
     assert query_object.root_expression.rhs_expr.field_name == "TITLE"
+
+
+def test_53_any_in_expression_with_string_list_and_node_field_expression():
+    query = """\
+any(["A", "B"]) in node["TAGS"]\
+"""
+    query_object = QueryReader.read(query)
+    assert isinstance(query_object, Query)
+    assert isinstance(query_object.root_expression, AnyInExpression)
+    assert [
+        string_expression.string
+        for string_expression in query_object.root_expression.lhs_expr.strings
+    ] == ["A", "B"]
+    assert isinstance(
+        query_object.root_expression.rhs_expr, NodeFieldExpression
+    )
+    assert query_object.root_expression.rhs_expr.field_name == "TAGS"
+
+
+def test_54_all_in_expression_with_string_list_and_node_field_expression():
+    query = """\
+all(["A", "B"]) in node["TAGS"]\
+"""
+    query_object = QueryReader.read(query)
+    assert isinstance(query_object, Query)
+    assert isinstance(query_object.root_expression, AllInExpression)
+    assert [
+        string_expression.string
+        for string_expression in query_object.root_expression.lhs_expr.strings
+    ] == ["A", "B"]
+    assert isinstance(
+        query_object.root_expression.rhs_expr, NodeFieldExpression
+    )
+    assert query_object.root_expression.rhs_expr.field_name == "TAGS"
+
+
+def test_55_none_in_expression_with_string_list_and_node_field_expression():
+    query = """\
+none(["A", "B"]) in node["TAGS"]\
+"""
+    query_object = QueryReader.read(query)
+    assert isinstance(query_object, Query)
+    assert isinstance(query_object.root_expression, NoneInExpression)
+    assert [
+        string_expression.string
+        for string_expression in query_object.root_expression.lhs_expr.strings
+    ] == ["A", "B"]
+    assert isinstance(
+        query_object.root_expression.rhs_expr, NodeFieldExpression
+    )
+    assert query_object.root_expression.rhs_expr.field_name == "TAGS"
+
+
+def test_56_bare_list_items_are_not_supported():
+    assert_query_rejected('any([A, B]) in node["TAGS"]')
+
+
+def test_57_reverse_list_field_semantics_are_not_supported():
+    assert_query_rejected('all(node["TAGS"]) in ["A", "B"]')
 
 
 def test_61_node_has_parent_requirements():


### PR DESCRIPTION
Add any/all/none query expressions for matching quoted string lists against fields.

Quantified matching keeps scalar in/not in behavior unchanged. For node["TAGS"], the new list forms match exact comma-space-separated tag values instead of substrings.

Includes parser, evaluator, documentation, and --filter-nodes integration coverage.