### PR TITLE
fix(source_file_view): use cast() instead of list() to satisfy mypy

### DIFF
--- a/strictdoc/features/source_file_view/generator.py
+++ b/strictdoc/features/source_file_view/generator.py
@@ -4,7 +4,7 @@
 
 # mypy: disable-error-code="operator"
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, cast
 
 from markupsafe import Markup
 from pygments import highlight
@@ -220,8 +220,15 @@ class SourceFileViewHTMLGenerator:
         pygmented_source_file_content = pygmented_source_file_content[
             slice_start:slice_end
         ]
-        pygmented_source_file_lines: List[Union[str, SourceMarkerTuple]] = list(
-            pygmented_source_file_content.split("\n")
+        # cast() is required for mypy: split() returns List[str], and
+        # because List is invariant, mypy rejects assigning it directly to
+        # a List[Union[str, SourceMarkerTuple]] variable even with the
+        # annotation in place. cast() is a no-op at runtime, unlike
+        # wrapping in list(), which would silently allocate a second,
+        # unnecessary copy of the list just to satisfy the type checker.
+        pygmented_source_file_lines: List[Union[str, SourceMarkerTuple]] = cast(
+            List[Union[str, SourceMarkerTuple]],
+            pygmented_source_file_content.split("\n"),
         )
         if hack_first_line:
             pygmented_source_file_lines[0] = "<span></span>"


### PR DESCRIPTION
## Summary
- Replaces the `list()` wrap around `pygmented_source_file_content.split("\n")` with `typing.cast()` in `generator.py`.
- `split()` already returns a fresh `List[str]`; wrapping that in `list()` again allocated a redundant second copy of every source line, purely to route around mypy's list invariance check. `cast()` gives mypy the same type information with zero runtime cost, and matches the `cast()` pattern already used elsewhere in this codebase (`helpers/cast.py`, `backend/sdoc/processor.py`, `backend/sdoc_source_code/reader_rust.py`).
- Verified with a standalone mypy repro that both approaches satisfy the type checker identically; `cast()` just avoids the wasted allocation.

Small fix picked out of #2068.

## Test plan
- [x] `mypy` on the touched file shows no new errors (pre-existing unrelated errors in other files remain).
- [x] No behavior change — same runtime values, minus one redundant list copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)