### PR TITLE
chore: consolidate pycache files in build/pycache folder

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -35,6 +35,11 @@ sys.stdout = open(1, "w", encoding="utf-8", closefd=False, buffering=1)
 STRICTDOC_TMP_DIR = os.path.join(tempfile.gettempdir(), "strictdoc_tmp_dir")
 TEST_REPORTS_DIR = "build/test_reports"
 
+# Redirect all __pycache__ output (from Invoke itself and every subprocess it
+# spawns: pytest, mypy, plain python invocations, etc.) into a single folder,
+# instead of littering __pycache__ directories across the source tree.
+os.environ["PYTHONPYCACHEPREFIX"] = os.path.abspath("build/pycache")
+
 
 def get_pyinstaller_html_template_data_options() -> str:
     return "\n".join(

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ commands =
 [testenv:{py310,py311,py312,py313,py314}-development]
 package = "skip"
 skip_install = true
+pass_env =
+    PYTHONPYCACHEPREFIX
 deps =
     -rrequirements.bootstrap.txt
     # Reload files when changed (used by 'invoke watch')
@@ -28,6 +30,7 @@ deps =
     -rrequirements.bootstrap.txt
     -rrequirements.check.txt
 pass_env=
+    PYTHONPYCACHEPREFIX
     CHROMEWEBDRIVER
     STRICTDOC_CACHE_DIR
     # Pass the desktop session through tox so headed Chrome can open
@@ -45,6 +48,8 @@ commands =
 [testenv:{py310,py311,py312,py313,py314}-documentation]
 package = "skip"
 skip_install = true
+pass_env =
+    PYTHONPYCACHEPREFIX
 allowlist_externals =
     cd
     cp
@@ -63,6 +68,7 @@ commands =
 package = "skip"
 skip_install = true
 pass_env =
+    PYTHONPYCACHEPREFIX
     TWINE_USERNAME
     TWINE_PASSWORD
 allowlist_externals =
@@ -77,6 +83,8 @@ commands =
 [testenv:{py310,py311,py312,py313,py314}-release-local]
 package = "skip"
 skip_install = true
+pass_env =
+    PYTHONPYCACHEPREFIX
 allowlist_externals =
     rm
 deps =
@@ -100,6 +108,8 @@ commands =
 [testenv:{py310,py311,py312,py313,py314}-pyinstaller]
 package = "skip"
 skip_install = true
+pass_env =
+    PYTHONPYCACHEPREFIX
 deps =
     -rrequirements.bootstrap.txt
     pyinstaller


### PR DESCRIPTION
WHY: Declutters the project structure (source and test files).