### PR TITLE
feat: introduce custom CSS option

### DIFF
--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -176,6 +176,10 @@ class ProjectConfig:
         # browser-tab favicon for a project's own (non-dev, non-test) server
         # or static export. Ignored for the dev/test favicon variants.
         favicon_path: Optional[str] = None,
+        # Custom CSS path can be set in the project config to extend or
+        # override StrictDoc's default stylesheets in the HTML export and
+        # on the server.
+        custom_css_path: Optional[str] = None,
         user_plugin: Optional[StrictDocPlugin] = None,
         formats: Optional[List["Format"]] = None,
         # Reserved for StrictDoc's internal use.
@@ -434,6 +438,10 @@ class ProjectConfig:
         # Optional custom favicon path, project-relative. Validated and
         # resolved to an absolute path in validate_and_finalize().
         self.favicon_path: Optional[str] = favicon_path
+
+        # Optional custom CSS path, project-relative. Validated and
+        # resolved to an absolute path in validate_and_finalize().
+        self.custom_css_path: Optional[str] = custom_css_path
 
         self.config_last_update: Optional[datetime.datetime] = (
             _config_last_update
@@ -723,6 +731,20 @@ class ProjectConfig:
             self.favicon_path = favicon_path
 
         #
+        # Validate custom CSS path.
+        #
+        if (custom_css_path := self.custom_css_path) is not None:
+            assert not os.path.isabs(custom_css_path)
+            if project_path is not None:
+                custom_css_path = os.path.join(project_path, custom_css_path)
+            if not os.path.isfile(custom_css_path):
+                raise ValueError(
+                    "config: custom_css_path: "
+                    f"invalid path to a CSS file: {custom_css_path}."
+                )
+            self.custom_css_path = custom_css_path
+
+        #
         # Validate path to Chrome Driver.
         #
         if (
@@ -820,6 +842,13 @@ class ProjectConfig:
             return "image/svg+xml"
         mime_type, _ = mimetypes.guess_type(custom_favicon_path)
         return mime_type or "application/octet-stream"
+
+    def get_custom_css_filename(self) -> str:
+        # The fixed name under which the custom CSS file (custom_css_path)
+        # is copied to the static assets output directory and linked from
+        # base.jinja.html. A fixed name avoids collisions with StrictDoc's
+        # own stylesheets.
+        return "custom.css"
 
     def is_activated_table_screen(self) -> bool:
         return ProjectFeature.TABLE_SCREEN in self.project_features
@@ -1160,6 +1189,7 @@ class ProjectConfigLoader:
         source_nodes: List[SourceNodesEntry] = []
         html2pdf_strict: bool = False
         html2pdf_template: Optional[str] = None
+        custom_css_path: Optional[str] = None
         bundle_document_version = (
             ProjectConfigDefault.DEFAULT_BUNDLE_DOCUMENT_VERSION
         )
@@ -1222,6 +1252,10 @@ class ProjectConfigLoader:
 
             html2pdf_template = project_content.get(
                 "html2pdf_template", html2pdf_template
+            )
+
+            custom_css_path = project_content.get(
+                "custom_css_path", custom_css_path
             )
 
             bundle_document_version = project_content.get(
@@ -1320,6 +1354,7 @@ class ProjectConfigLoader:
             source_nodes=source_nodes,
             html2pdf_strict=html2pdf_strict,
             html2pdf_template=html2pdf_template,
+            custom_css_path=custom_css_path,
             bundle_document_version=bundle_document_version,
             bundle_document_date=bundle_document_date,
             traceability_matrix_relation_columns=traceability_matrix_relation_columns,

--- a/strictdoc/export/html/html_generator.py
+++ b/strictdoc/export/html/html_generator.py
@@ -249,6 +249,18 @@ class HTMLGenerator:
             with open(favicon_output_path, "w", encoding="utf8") as output_file:
                 output_file.write(favicon_svg)
 
+        # Copy the project's custom CSS file, if configured. base.jinja.html
+        # links it after StrictDoc's own stylesheets so it can override them.
+        custom_css_path = project_config.custom_css_path
+        if custom_css_path is not None:
+            shutil.copyfile(
+                custom_css_path,
+                os.path.join(
+                    output_html_static_files,
+                    project_config.get_custom_css_filename(),
+                ),
+            )
+
         # Export HTML2PDF.
         if project_config.is_feature_activated(ProjectFeature.HTML2PDF):
             sync_dir(

--- a/strictdoc/export/html/templates/base.jinja.html
+++ b/strictdoc/export/html/templates/base.jinja.html
@@ -25,6 +25,9 @@
   <link rel="stylesheet" href="{{ view_object.render_static_url('requirement__temporary.css') }}"/>
   <link rel="stylesheet" href="{{ view_object.render_static_url('autogen.css') }}"/>
   <link rel="stylesheet" href="{{ view_object.render_static_url('pygments.css') }}"/>
+  {% if view_object.project_config.custom_css_path %}
+  <link rel="stylesheet" href="{{ view_object.render_static_url(view_object.project_config.get_custom_css_filename()) }}"/>
+  {% endif %}
   {% endblock head_css %}
 
   {% block head_scripts %}

--- a/tests/unit/strictdoc/export/html/test_custom_css.py
+++ b/tests/unit/strictdoc/export/html/test_custom_css.py
@@ -1,0 +1,63 @@
+import copy
+
+from strictdoc import environment as strictdoc_environment
+from strictdoc.core.project_config import ProjectConfig
+from strictdoc.export.html.html_generator import HTMLGenerator
+from strictdoc.export.html.html_templates import NormalHTMLTemplates
+
+
+def _project_config(
+    *,
+    custom_css_path: str | None = None,
+) -> ProjectConfig:
+    project_config = ProjectConfig()
+    # A shallow copy of the real environment singleton: keeps
+    # get_static_files_paths() etc. working, without mutating the shared
+    # global strictdoc.environment object that other tests may rely on.
+    project_config.environment = copy.copy(strictdoc_environment)
+    project_config.custom_css_path = custom_css_path
+    return project_config
+
+
+def test_custom_css_is_not_configured_by_default():
+    project_config = _project_config()
+    assert project_config.custom_css_path is None
+
+
+# Exercises the real HTMLGenerator.export_assets() and real filesystem
+# I/O (tmp_path), asserting on actual bytes written to disk rather than
+# mocked calls.
+def test_export_assets_copies_custom_css(tmp_path):
+    css_source = tmp_path / "my_styles.css"
+    css_source.write_text("body { background: hotpink; }")
+
+    project_config = _project_config(custom_css_path=str(css_source))
+    output_root = tmp_path / "output"
+    output_root.mkdir()
+
+    HTMLGenerator.export_assets(
+        traceability_index=None,
+        project_config=project_config,
+        html_templates=NormalHTMLTemplates(),
+        export_output_html_root=str(output_root),
+    )
+
+    static_dir = output_root / project_config.dir_for_sdoc_assets
+    custom_css_output = static_dir / project_config.get_custom_css_filename()
+    assert custom_css_output.read_text() == "body { background: hotpink; }"
+
+
+def test_export_assets_writes_no_custom_css_when_not_configured(tmp_path):
+    project_config = _project_config()
+    output_root = tmp_path / "output"
+    output_root.mkdir()
+
+    HTMLGenerator.export_assets(
+        traceability_index=None,
+        project_config=project_config,
+        html_templates=NormalHTMLTemplates(),
+        export_output_html_root=str(output_root),
+    )
+
+    static_dir = output_root / project_config.dir_for_sdoc_assets
+    assert not (static_dir / project_config.get_custom_css_filename()).exists()


### PR DESCRIPTION
Adds the ability for the user to supply a custom css file. In my instance this is useful to overwrite some of the default css supplied by strictdoc.

As this is a relatively small change I thought it would simpler to try and implement myself than create an issue etc. I've tried to mirror the implementation of custom favicon as much as possible.
- added custom_css_path to config
- updated HtmlGenerator to look for custom css if supplied
- updated base.jinja.html to add custom css conditionally
- added test file

Let me know if there is anything else you would want to add to this, or if there are any issues in the implementation.