### PR TITLE
feat(markdown): map Version/Date/Classification to config

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -50,6 +50,20 @@ releases:
 <<<
 
 [[SECTION]]
+MID: a7ffb392d48244969318ec115e4695bd
+TITLE: 0.??.? (2026-??-??)
+
+[TEXT]
+MID: 0046268453bf439b8a826ecc57abbe91
+STATEMENT: >>>
+This release contains the following enhancements:
+
+?\) The Markdown format now supports ``Version``, ``Date`` and ``Classification`` as document config fields.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
 MID: 8a4b0e6f9d3c4c5b8e1a2f7d6c9b0a3e
 TITLE: 0.27.0 (2026-07-13)
 

--- a/strictdoc/backend/markdown/reader.py
+++ b/strictdoc/backend/markdown/reader.py
@@ -340,6 +340,12 @@ class SDMarkdownReader:
                     document.config.requirement_prefix = field_.value
                 if field_.name == "UID":
                     document.config.uid = field_.value
+                if field_.name == "Version":
+                    document.config.version = field_.value
+                if field_.name == "Date":
+                    document.config.date = field_.value
+                if field_.name == "Classification":
+                    document.config.classification = field_.value
                 metadata_entries.append(
                     DocumentCustomMetadataKeyValuePair(
                         key=field_.name,

--- a/tests/integration/features/markdown/26_document_config_and_meta_fields/input.md
+++ b/tests/integration/features/markdown/26_document_config_and_meta_fields/input.md
@@ -1,0 +1,9 @@
+# Hello world doc
+
+**Version**: @GIT_VERSION, @GIT_BRANCH \
+**Date**: @GIT_COMMIT_DATE, @GIT_COMMIT_DATETIME \
+**Classification**: Confidential \
+**GIT_VERSION**: @GIT_VERSION \
+**GIT_BRANCH**: @GIT_BRANCH \
+**GIT_COMMIT_DATE**: @GIT_COMMIT_DATE \
+**GIT_COMMIT_DATETIME**: @GIT_COMMIT_DATETIME

--- a/tests/integration/features/markdown/26_document_config_and_meta_fields/test.itest
+++ b/tests/integration/features/markdown/26_document_config_and_meta_fields/test.itest
@@ -1,0 +1,38 @@
+REQUIRES: PLATFORM_IS_NOT_WINDOWS
+
+# Test Markdown support for document config and metadata fields.
+
+# FIXME: git repository is not cleaned. But must be outside strictdoc folder to prevent git from reporting embedded git repositories.
+RUN: mkdir -p /tmp/strictdoc_itests
+RUN: THIS_TMP_DIR=$(mktemp -d %STRICTDOC_TMP_DIR/XXXXXX); cd $THIS_TMP_DIR
+RUN: THIS_TMP_DIR_NAME=$(basename "$THIS_TMP_DIR")
+RUN: echo $THIS_TMP_DIR
+RUN: cp %S/input.md $THIS_TMP_DIR/
+
+RUN: git init --initial-branch=main
+RUN: %strictdoc export . --output-dir Output/
+RUN: %cat "$THIS_TMP_DIR/Output/html/$THIS_TMP_DIR_NAME/input.html" | filecheck %s --dump-input=fail --check-prefix CHECK-1
+CHECK-1: N/A, N/A
+CHECK-1: N/A
+
+RUN: git config user.name "Test User"
+RUN: git config user.email "test@example.com"
+RUN: git add .
+RUN: git commit -m "Initial commit"
+RUN: rm -rf Output/
+RUN: %strictdoc export . --output-dir Output/
+RUN: %cat "$THIS_TMP_DIR/Output/html/$THIS_TMP_DIR_NAME/input.html" | filecheck %s --dump-input=fail --check-prefix CHECK-2
+CHECK-2: {{[a-f0-9]{7}}}, main
+CHECK-2: {{\d{4}-\d{2}-\d{2}}}, {{\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}}}
+
+CHECK-2: CLASSIFICATION:
+CHECK-2: Confidential
+
+CHECK-2: GIT_VERSION:
+CHECK-2: {{[a-f0-9]{7}}}
+CHECK-2: GIT_BRANCH:
+CHECK-2: main
+CHECK-2: GIT_COMMIT_DATE:
+CHECK-2: {{\d{4}-\d{2}-\d{2}}}
+CHECK-2: GIT_COMMIT_DATETIME:
+CHECK-2: {{\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}}}

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
@@ -535,13 +535,44 @@ def test_017_section_immediately_followed_by_child_section_has_no_empty_text_nod
     assert child.node_type == "REQUIREMENT"
 
 
-def test_024_markdown_reader_registers_document_level_uid():
-    markdown_content = "# Document title\n\n**UID**: DOC-1\n"
+def test_024_markdown_reader_registers_document_config():
+    markdown_content = """\
+# Document title
+
+**UID**: DOC-1 \\
+**Version**: Git commit: @GIT_VERSION, Git branch: @GIT_BRANCH \\
+**Date**: @GIT_COMMIT_DATETIME \\
+**Classification**: Confidential
+"""
 
     reader = SDMarkdownReader()
     document = reader.read(markdown_content, file_path=None)
 
     assert document.config.uid == "DOC-1"
+    assert (
+        document.config.version
+        == "Git commit: @GIT_VERSION, Git branch: @GIT_BRANCH"
+    )
+    assert document.config.date == "@GIT_COMMIT_DATETIME"
+    assert document.config.classification == "Confidential"
+    assert document.config.get_custom_metadata() == []
+
+
+def test_026_markdown_reader_registers_document_metadata():
+    markdown_content = """\
+# Document title
+
+**Author**: Jane \\
+**Checked-by**: Chuck Norris
+"""
+
+    reader = SDMarkdownReader()
+    document = reader.read(markdown_content, file_path=None)
+
+    assert document.config.get_custom_metadata() == [
+        ("Author", "Jane"),
+        ("Checked-by", "Chuck Norris"),
+    ]
 
 
 def test_025_markdown_reader_empty_heading_produces_no_title_field():

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_roundtrip.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_roundtrip.py
@@ -1098,6 +1098,50 @@ def test_027_section_prefix_without_type_roundtrips():
     )
 
 
+def test_029_document_config_roundtrip():
+    """
+    Document-level config data survives a full write-then-read cycle.
+    """
+    input_markdown = """\
+# Requirements specification
+
+**Version**: Git commit: @GIT_VERSION, Git branch: @GIT_BRANCH \\
+**Date**: @GIT_COMMIT_DATETIME \\
+**Classification**: Confidential
+"""
+    _, output_markdown = _assert_markdown_roundtrip(input_markdown)
+    document_from_output = SDMarkdownReader().read(
+        output_markdown, file_path=None
+    )
+    assert (
+        document_from_output.config.version
+        == "Git commit: @GIT_VERSION, Git branch: @GIT_BRANCH"
+    )
+    assert document_from_output.config.date == "@GIT_COMMIT_DATETIME"
+    assert document_from_output.config.classification == "Confidential"
+
+
+def test_030_document_level_metadata_roundtrip():
+    """
+    User-defined custom metadata survives a full write-then-read cycle.
+    """
+    input_markdown = """\
+# Requirements specification
+
+**Author**: Jane \\
+**Checked-by**: Chuck Norris
+"""
+    _, output_markdown = _assert_markdown_roundtrip(input_markdown)
+
+    document_from_output = SDMarkdownReader().read(
+        output_markdown, file_path=None
+    )
+    assert document_from_output.config.get_custom_metadata() == [
+        ("Author", "Jane"),
+        ("Checked-by", "Chuck Norris"),
+    ]
+
+
 def test_028_section_prefix_with_type_drops_type_on_output():
     """
     Section-level PREFIX written with explicit TYPE: SECTION is accepted;


### PR DESCRIPTION
What: Support `Version`, `Date` and `Classification` document config fields for markdown.

Why: Get closer to sdoc feature parity.

How: Recognize the keywords and store values in `DocumentConfig`.