### PR TITLE
fix(tools): filter server port check to LISTEN sockets only

### DIFF
--- a/tools/server_check.py
+++ b/tools/server_check.py
@@ -20,8 +20,14 @@ RESET = "\033[0m"
 
 
 def find_pids_on_port(port: int) -> list[int]:
+    # -sTCP:LISTEN restricts the match to sockets actually listening on
+    # `port`. Without it, lsof also matches processes that happen to be
+    # using `port` as the local (ephemeral) side of an unrelated outbound
+    # connection -- e.g. a browser with many open connections can land on
+    # this port purely by OS-assigned chance right after a strictdoc
+    # server released it, causing a false "port occupied" report.
     result = subprocess.run(
-        ["lsof", "-ti", f"tcp:{port}"],
+        ["lsof", "-ti", f"tcp:{port}", "-sTCP:LISTEN"],
         check=False,
         capture_output=True,
         text=True,


### PR DESCRIPTION
`invoke server`'s port-occupancy check used `lsof -ti tcp:<port>` without restricting to listening sockets, so it could match a completely unrelated process that happened to be using the port as the local (ephemeral) side of an outbound connection — e.g. a browser with many open connections landing on that port purely by OS-assigned chance right after a previous strictdoc server released it. This produced a false "port is occupied by another process" error and blocked starting the server even though the port was actually free.

Add `-sTCP:LISTEN` to the `lsof` call in `find_pids_on_port()` so only processes actually listening on the port are considered.