### PR TITLE
Validate document extension against editable formats on creation

### DIFF
--- a/developer/tasks/20260722_3053_formats_edit_validation/task.md
+++ b/developer/tasks/20260722_3053_formats_edit_validation/task.md
@@ -118,6 +118,14 @@ established by the `Format` abstraction (see prior tasks
   `tests/unit/strictdoc/core/test_project_config.py` (numbered
   `test_NN_description` functions, direct `ProjectConfig(...)`
   instantiation, no mocking framework).
+- Fixing this revealed 3 pre-existing e2e tests that silently depended
+  on the removed auto-append-`.sdoc` behavior (a `docs/document`-style
+  path with no extension, previously expected to succeed):
+  `create_document_normal_flow`,
+  `create_document_validate_document_path_outside_of_include_filter`,
+  `create_document_validate_document_path_inside_of_exclude_filter`.
+  Updated each to use an explicit `.sdoc` path (no fixture/
+  expected_output changes needed — same resulting file content).
 
 ## Known limitation (out of scope for this task)
 
@@ -134,3 +142,5 @@ this hardcoded fallback. Not fixing this now — it would turn a validation
 fix into a writer-dispatch refactor — but flagging it as a follow-up
 since `Format` has no "write an edited document back to disk" method yet
 (`write_converted_document` is for `convert`, not this save path).
+A `FIXME` pointing at this mismatch was added directly at
+`write_document_to_file()` for discoverability.

--- a/developer/tasks/20260722_3053_formats_edit_validation/task.md
+++ b/developer/tasks/20260722_3053_formats_edit_validation/task.md
@@ -126,6 +126,21 @@ established by the `Format` abstraction (see prior tasks
   `create_document_validate_document_path_inside_of_exclude_filter`.
   Updated each to use an explicit `.sdoc` path (no fixture/
   expected_output changes needed — same resulting file content).
+- End-to-end coverage: added
+  `tests/end2end/screens/project_index/create_document/_validation/create_document_validate_document_path_unsupported_extension/`,
+  following the existing `_validation` sibling tests' structure
+  (input/expected_output/`.sandbox`, `End2EndTestSetup`,
+  `Form_AddDocument`). On standard server settings (no
+  `include_doc_paths`/`exclude_doc_paths` restriction), it submits
+  `document.pdf` and asserts the exact rendered error text ("Document path
+  must end with one of the supported document extensions: .sdoc, .md,
+  .markdown."), then submits `document.sdoc` and asserts the document is
+  created. The expected extensions list was confirmed live via
+  `ProjectConfig.default_config().get_editable_document_extensions()`.
+  - Verified with `invoke test-end2end --headless
+    --test-path=screens/project_index/create_document` (7/7 passed) and
+    the LINK_and_ANCHOR create-document e2e test (1/1 passed), against a
+    real headless browser/server.
 
 ## Known limitation (out of scope for this task)
 

--- a/developer/tasks/20260722_3053_formats_edit_validation/task.md
+++ b/developer/tasks/20260722_3053_formats_edit_validation/task.md
@@ -1,0 +1,136 @@
+# Validate document path extension against editable formats on document creation
+
+## WHAT
+
+When a user creates a new document via the web UI ("Add Document" on the
+project home page), `document_path` validation and file-extension handling
+must change as follows:
+
+- Remove the current auto-append-`.sdoc`-if-missing behavior in
+  `document_tree__create_document()`
+  (`strictdoc/server/routers/main_router.py`). The extension is no longer
+  silently added; the user must supply it explicitly as part of
+  `document_path`.
+- Add a new, separate validation step: `document_path` must end with an
+  extension that belongs to one of the project's *editable* formats, i.e. a
+  `Format` in `project_config.formats` whose `supports_edit()` is `True`.
+  The set of allowed extensions is the union of `supported_extensions()`
+  from every such format.
+- This "format is allowed" validation is distinct from the existing
+  `include_doc_paths` / `exclude_doc_paths` path-filter validation:
+  - Different concern: one validates *where* the file may live, the other
+    validates *what kind* of file it may be.
+  - Different, non-overlapping error message, so the user can tell why the
+    save was rejected.
+  - Both may fire independently for the same submission (e.g. a path
+    outside `include_doc_paths` *and* an unsupported/missing extension).
+- The allowed-extensions list must never be hardcoded. It is computed at
+  request time from `project_config.formats`, so any format added or
+  removed from the project config (now or in the future) is reflected
+  automatically in both the validation and the user-facing hint, with no
+  further code changes.
+- Provide the same dynamically computed extensions list (and/or a
+  ready-to-render string) to the "Add Document" form template, to back a
+  TIP telling the user which extensions are accepted. The final visual
+  design of the TIP will be done separately; the backend should hand the
+  template a reasonable placeholder value (list/string of allowed
+  extensions) it can render.
+- Remove the current decorative `.sdoc` suffix hint
+  (`singleline_suffix='.sdoc'` in
+  `strictdoc/features/project_index/templates/features/project_index/frame_form_new_document.jinja.html`),
+  since it is misleading now that more than one extension can be valid and
+  it visually duplicates an extension the user already typed (producing an
+  apparent `name.sdoc.sdoc`).
+
+## WHY
+
+Reported bug: entering a document name without an extension and clicking
+Save produces the error `Document path is not a valid path according to
+the project config's setting 'include_doc_paths': [...]`, even though the
+only actual problem is the missing extension. Investigation
+(`strictdoc/server/routers/main_router.py:2935-2983`) showed the root
+cause: `include_doc_paths`/`exclude_doc_paths` filters run against the raw
+`document_path`, and the `.sdoc` extension is only appended afterwards, if
+validation already passed. In addition, the UI shows a decorative orange
+`.sdoc` hint next to the input that is never merged into the submitted
+value, so a user who *does* type `.sdoc` sees a confusing
+`name.sdoc.sdoc`.
+
+A minimal fix (move the extension-append earlier) would only paper over
+the symptom. The real cause is architectural: StrictDoc's document-edit
+path is no longer single-format. `Format.supports_edit()` /
+`Format.supported_extensions()` already exist
+(`strictdoc/core/format.py`), and both `SDocFormat` (`.sdoc`) and
+`MarkdownFormat` (`.md`, `.markdown`) currently report
+`supports_edit() == True`; `write_document_to_file()`
+(`strictdoc/server/routers/main_router.py:299-325`) already branches on
+the file extension to pick the right writer. Silently forcing `.sdoc` onto
+every new document is actively wrong in a project that also allows
+Markdown documents — it would create a `.sdoc` file when the user asked
+for `.md`, with no way to disambiguate. More editable formats are
+expected to be added over time, so the create-document validation and
+UI hint need to be driven by the live, configured list of editable
+formats rather than a hardcoded extension, matching the pattern already
+established by the `Format` abstraction (see prior tasks
+`20260711_1_format_abstraction`, `20260711_2_connect_import_to_formats`).
+
+## HOW
+
+- Add a helper that computes the allowed extensions for document creation,
+  e.g. `ProjectConfig.get_editable_document_extensions() -> List[str]` in
+  `strictdoc/core/project_config.py`: iterate `self.formats`, keep formats
+  where `format_.supports_edit()` is `True`, extend the result with each
+  format's `supported_extensions()`, dedupe while preserving order.
+- In `document_tree__create_document()`
+  (`strictdoc/server/routers/main_router.py`):
+  - Delete the `if not document_path.endswith(".sdoc"): document_path =
+    document_path + ".sdoc"` block (currently lines 2982-2983).
+  - After the existing `include_doc_paths`/`exclude_doc_paths` checks, add
+    a new check: if `document_path` does not end with any extension from
+    `project_config.get_editable_document_extensions()`, call
+    `error_object.add_error("document_path", ...)` with a message that
+    names the allowed extensions and is clearly distinct from the
+    path-filter error text (e.g. "Document path must end with one of the
+    supported extensions: .sdoc, .md, .markdown." vs. the existing
+    "Document path is not a valid path according to ... 'include_doc_paths'").
+  - Pass the computed extensions (or a formatted string) into both
+    `stream_new_document.jinja.html` (error re-render path) and the
+    initial `frame_form_new_document.jinja.html` render, alongside the
+    existing `include_doc_paths` context variable.
+- Template changes (`frame_form_new_document.jinja.html`): remove the
+  `singleline_suffix='.sdoc'` argument; add a TIP block analogous to the
+  existing `include_doc_paths` `<sdoc-form-hint>`, driven by the new
+  extensions variable. Actual visual/UX polish of the TIP is out of scope
+  here and will be done separately.
+- Testing: the goal is to verify the *mechanism* (format iteration →
+  `supports_edit()` filter → `supported_extensions()` collection →
+  validation/error), not which formats happen to be registered. Write a
+  unit test that constructs a `ProjectConfig` with `formats=[SDocFormat()]`
+  only (overriding the default list) and asserts
+  `get_editable_document_extensions() == [".sdoc"]`, plus a test that adds
+  `HTML2PDFFormat()` (`supports_edit() == False`,
+  `supported_extensions() == [".pdf"]`) to the list and asserts `.pdf` is
+  *not* included in the result. `HTML2PDFFormat` is used instead of a
+  fake/stub `Format` because it is a real, permanently non-editable format
+  (PDF export is not and will not become UI-editable) with a trivial
+  no-arg constructor — add a short comment in the test explaining this
+  choice and why a stub was not used. Follow the existing conventions in
+  `tests/unit/strictdoc/core/test_project_config.py` (numbered
+  `test_NN_description` functions, direct `ProjectConfig(...)`
+  instantiation, no mocking framework).
+
+## Known limitation (out of scope for this task)
+
+`write_document_to_file()`
+(`strictdoc/server/routers/main_router.py:299-325`) picks the writer by
+hardcoding `document.meta.input_doc_full_path.lower().endswith((".md",
+".markdown"))`, falling back to the SDoc writer otherwise. It is not
+derived from `project_config.formats`/`Format.supports_edit()` at all
+(there is already a `FIXME: Factorize this into an OOP class` comment on
+it). Once this task makes document-path validation dynamically accept any
+editable format's extensions, a project that adds a third editable format
+in the future would pass validation but still get silently mis-written by
+this hardcoded fallback. Not fixing this now — it would turn a validation
+fix into a writer-dispatch refactor — but flagging it as a follow-up
+since `Format` has no "write an edited document back to disk" method yet
+(`write_converted_document` is for `convert`, not this save path).

--- a/strictdoc/backend/excel/export/excel_format.py
+++ b/strictdoc/backend/excel/export/excel_format.py
@@ -55,6 +55,10 @@ class ExcelFormat(Format):
         return False
 
     @staticmethod
+    def supports_edit() -> bool:
+        return False
+
+    @staticmethod
     def supports_grammar() -> bool:
         return False
 

--- a/strictdoc/backend/gcov/gcov_format.py
+++ b/strictdoc/backend/gcov/gcov_format.py
@@ -36,6 +36,10 @@ class GCovJSONFormat(Format):
         return True
 
     @staticmethod
+    def supports_edit() -> bool:
+        return False
+
+    @staticmethod
     def read_extensions() -> List[str]:
         return [".gcov.json"]
 

--- a/strictdoc/backend/json/json_format.py
+++ b/strictdoc/backend/json/json_format.py
@@ -28,6 +28,10 @@ class JSONFormat(Format):
         return False
 
     @staticmethod
+    def supports_edit() -> bool:
+        return False
+
+    @staticmethod
     def supports_grammar() -> bool:
         return False
 

--- a/strictdoc/backend/markdown/markdown_format.py
+++ b/strictdoc/backend/markdown/markdown_format.py
@@ -39,6 +39,10 @@ class MarkdownFormat(Format):
         return True
 
     @staticmethod
+    def supports_edit() -> bool:
+        return True
+
+    @staticmethod
     def read_extensions() -> List[str]:
         return [".md", ".markdown"]
 

--- a/strictdoc/backend/reqif/reqif_format.py
+++ b/strictdoc/backend/reqif/reqif_format.py
@@ -66,6 +66,10 @@ class ReqIFFormat(Format):
         return True
 
     @staticmethod
+    def supports_edit() -> bool:
+        return False
+
+    @staticmethod
     def read_extensions() -> List[str]:
         # Only ".reqif" is auto-discovered as native tree-building input
         # today, not ".reqifz" (even though both are listed in

--- a/strictdoc/backend/rst/rst_format.py
+++ b/strictdoc/backend/rst/rst_format.py
@@ -28,6 +28,10 @@ class RSTFormat(Format):
         return False
 
     @staticmethod
+    def supports_edit() -> bool:
+        return False
+
+    @staticmethod
     def supports_grammar() -> bool:
         return False
 

--- a/strictdoc/backend/sdoc/sdoc_format.py
+++ b/strictdoc/backend/sdoc/sdoc_format.py
@@ -58,6 +58,10 @@ class SDocFormat(Format):
         return True
 
     @staticmethod
+    def supports_edit() -> bool:
+        return True
+
+    @staticmethod
     def read_extensions() -> List[str]:
         return [".sdoc"]
 

--- a/strictdoc/backend/sdoc_source_code/test_reports/junit_xml_format.py
+++ b/strictdoc/backend/sdoc_source_code/test_reports/junit_xml_format.py
@@ -38,6 +38,10 @@ class JUnitXMLFormat(Format):
         return True
 
     @staticmethod
+    def supports_edit() -> bool:
+        return False
+
+    @staticmethod
     def read_extensions() -> List[str]:
         return [".junit.xml"]
 

--- a/strictdoc/backend/sdoc_source_code/test_reports/robot_xml_format.py
+++ b/strictdoc/backend/sdoc_source_code/test_reports/robot_xml_format.py
@@ -38,6 +38,10 @@ class RobotXMLFormat(Format):
         return True
 
     @staticmethod
+    def supports_edit() -> bool:
+        return False
+
+    @staticmethod
     def read_extensions() -> List[str]:
         return [".robot.xml"]
 

--- a/strictdoc/backend/spdx/spdx_format.py
+++ b/strictdoc/backend/spdx/spdx_format.py
@@ -28,6 +28,10 @@ class SPDXFormat(Format):
         return False
 
     @staticmethod
+    def supports_edit() -> bool:
+        return False
+
+    @staticmethod
     def supports_grammar() -> bool:
         return False
 

--- a/strictdoc/core/format.py
+++ b/strictdoc/core/format.py
@@ -69,6 +69,11 @@ class Format(ABC):
         raise NotImplementedError
 
     @staticmethod
+    @abstractmethod
+    def supports_edit() -> bool:
+        raise NotImplementedError
+
+    @staticmethod
     def read_extensions() -> List[str]:
         """
         Extensions this Format auto-discovers/reads as native DocumentFinder

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -549,6 +549,23 @@ class ProjectConfig:
                 return feature
         return None
 
+    def get_editable_document_extensions(self) -> List[str]:
+        """
+        File extensions a new/edited document may use, i.e. the union of
+        supported_extensions() from every format in self.formats that
+        supports_edit(). Computed live from self.formats so that adding or
+        removing a format changes the accepted extensions without any
+        further code changes.
+        """
+        extensions: List[str] = []
+        for format_ in self.formats:
+            if not format_.supports_edit():
+                continue
+            for extension in format_.supported_extensions():
+                if extension not in extensions:
+                    extensions.append(extension)
+        return extensions
+
     # Some server command settings can override the project config settings.
     def integrate_server_config(
         self, server_config: ServerCommandConfig

--- a/strictdoc/export/html/html_format.py
+++ b/strictdoc/export/html/html_format.py
@@ -30,6 +30,10 @@ class HTMLFormat(Format):
         return False
 
     @staticmethod
+    def supports_edit() -> bool:
+        return False
+
+    @staticmethod
     def supports_grammar() -> bool:
         return False
 

--- a/strictdoc/features/doxygen/doxygen_format.py
+++ b/strictdoc/features/doxygen/doxygen_format.py
@@ -27,6 +27,10 @@ class DoxygenFormat(Format):
         return False
 
     @staticmethod
+    def supports_edit() -> bool:
+        return False
+
+    @staticmethod
     def supports_grammar() -> bool:
         return False
 

--- a/strictdoc/features/html2pdf/html2pdf_format.py
+++ b/strictdoc/features/html2pdf/html2pdf_format.py
@@ -28,6 +28,10 @@ class HTML2PDFFormat(Format):
         return False
 
     @staticmethod
+    def supports_edit() -> bool:
+        return False
+
+    @staticmethod
     def supports_grammar() -> bool:
         return False
 

--- a/strictdoc/features/project_index/templates/features/project_index/frame_form_new_document.jinja.html
+++ b/strictdoc/features/project_index/templates/features/project_index/frame_form_new_document.jinja.html
@@ -42,7 +42,6 @@ Add new document
             field_label="document path and filename",
             field_placeholder="Enter document path and filename here...",
             field_type="singleline",
-            singleline_suffix='.sdoc',
             field_value=document_path,
             testid_postfix="document_path",
             errors=error_object.get_errors("document_path")
@@ -54,6 +53,14 @@ Add new document
             ☞ Path must start with one of:
             {% for path in include_doc_paths -%}
               <code>{{ path }}</code>{% if not loop.last %}, {% endif %}
+            {%- endfor -%}
+          </sdoc-form-hint>
+          {%- endif -%}
+          {%- if editable_document_extensions -%}
+          <sdoc-form-hint>
+            ☞ File name must end with one of:
+            {% for extension in editable_document_extensions -%}
+              <code>{{ extension }}</code>{% if not loop.last %}, {% endif %}
             {%- endfor -%}
           </sdoc-form-hint>
           {%- endif -%}

--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -299,6 +299,13 @@ def create_main_router(
     def write_document_to_file(document: SDocDocument) -> None:
         """
         FIXME: Factorize this into an OOP class.
+
+        FIXME: The writer dispatch below is hardcoded to ".md"/".markdown"
+        vs. everything else, not derived from project_config.formats /
+        Format.supports_edit(). Document creation now accepts any editable
+        format's extension (see ProjectConfig.get_editable_document_extensions()),
+        so a third editable format would pass creation validation but get
+        silently mis-written here.
         """
 
         assert isinstance(document, SDocDocument)
@@ -2722,6 +2729,9 @@ def create_main_router(
             document_title="",
             document_path="",
             include_doc_paths=project_config.include_doc_paths,
+            editable_document_extensions=(
+                project_config.get_editable_document_extensions()
+            ),
         )
         return HTMLResponse(
             content=output,
@@ -2959,6 +2969,20 @@ def create_main_router(
                     ),
                 )
 
+        editable_document_extensions = (
+            project_config.get_editable_document_extensions()
+        )
+        if document_path is not None and len(document_path) > 0:
+            if not document_path.endswith(tuple(editable_document_extensions)):
+                error_object.add_error(
+                    "document_path",
+                    (
+                        "Document path must end with one of the supported "
+                        "document extensions: "
+                        f"{', '.join(editable_document_extensions)}."
+                    ),
+                )
+
         if error_object.any_errors():
             output = env().render_template_as_markup(
                 "actions/project_index/stream_new_document.jinja.html",
@@ -2970,6 +2994,7 @@ def create_main_router(
                 if document_path is not None
                 else "",
                 include_doc_paths=project_config.include_doc_paths,
+                editable_document_extensions=editable_document_extensions,
             )
             return HTMLResponse(
                 content=output,
@@ -2978,9 +3003,6 @@ def create_main_router(
                     "Content-Type": "text/vnd.turbo-stream.html",
                 },
             )
-
-        if not document_path.endswith(".sdoc"):
-            document_path = document_path + ".sdoc"
 
         assert isinstance(project_config.input_paths, list)
         full_input_path = os.path.abspath(project_config.input_paths[0])

--- a/tests/end2end/screens/project_index/create_document/_validation/create_document_validate_document_path_inside_of_exclude_filter/test_case.py
+++ b/tests/end2end/screens/project_index/create_document/_validation/create_document_validate_document_path_inside_of_exclude_filter/test_case.py
@@ -39,7 +39,7 @@ class Test(E2ECase):
             )
 
             # Then, fill in a valid path.
-            form_add_document.do_fill_in_path("docs/document")
+            form_add_document.do_fill_in_path("docs/document.sdoc")
             form_add_document.do_form_submit()
 
             screen_project_index.assert_contains_document("Document 1")

--- a/tests/end2end/screens/project_index/create_document/_validation/create_document_validate_document_path_outside_of_include_filter/test_case.py
+++ b/tests/end2end/screens/project_index/create_document/_validation/create_document_validate_document_path_outside_of_include_filter/test_case.py
@@ -39,7 +39,7 @@ class Test(E2ECase):
             )
 
             # Then, fill in a valid path.
-            form_add_document.do_fill_in_path("docs/document")
+            form_add_document.do_fill_in_path("docs/document.sdoc")
             form_add_document.do_form_submit()
 
             screen_project_index.assert_contains_document("Document 1")

--- a/tests/end2end/screens/project_index/create_document/_validation/create_document_validate_document_path_unsupported_extension/expected_output/document.sdoc
+++ b/tests/end2end/screens/project_index/create_document/_validation/create_document_validate_document_path_unsupported_extension/expected_output/document.sdoc
@@ -1,0 +1,2 @@
+[DOCUMENT]
+TITLE: Document 1

--- a/tests/end2end/screens/project_index/create_document/_validation/create_document_validate_document_path_unsupported_extension/test_case.py
+++ b/tests/end2end/screens/project_index/create_document/_validation/create_document_validate_document_path_unsupported_extension/test_case.py
@@ -1,0 +1,53 @@
+"""
+@relation(SDOC-SRS-107, scope=function)
+"""
+
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.project_index.form_add_document import (
+    Form_AddDocument,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_empty_tree()
+
+            form_add_document: Form_AddDocument = (
+                screen_project_index.do_open_modal_form_add_document()
+            )
+            form_add_document.do_fill_in_title("Document 1")
+
+            # An extension that no editable format supports is rejected
+            # with a format-specific error. This project uses the default,
+            # unrestricted server settings (no include_doc_paths/
+            # exclude_doc_paths), so this error is distinct from -- and not
+            # to be confused with -- the include/exclude path-filter
+            # errors covered by the sibling tests in this folder.
+            form_add_document.do_fill_in_path("document.pdf")
+            form_add_document.do_form_submit_and_catch_error(
+                "Document path must end with one of the supported "
+                "document extensions: .sdoc, .md, .markdown."
+            )
+
+            # A supported extension (.sdoc) succeeds on the same, standard
+            # settings.
+            form_add_document.do_fill_in_path("document.sdoc")
+            form_add_document.do_form_submit()
+
+            screen_project_index.assert_contains_document("Document 1")
+
+        assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/project_index/create_document/create_document_normal_flow/test_case.py
+++ b/tests/end2end/screens/project_index/create_document/create_document_normal_flow/test_case.py
@@ -34,12 +34,13 @@ class Test(E2ECase):
             form_add_document.do_fill_in_path("docs/document1.sdoc")
             form_add_document.do_form_submit()
 
-            # Add file without .sdoc extension
+            # The extension is mandatory: add a second file with an
+            # explicit .sdoc extension.
             form_add_document: Form_AddDocument = (
                 screen_project_index.do_open_modal_form_add_document()
             )
             form_add_document.do_fill_in_title("Document 2")  # Empty document
-            form_add_document.do_fill_in_path("docs/document2")
+            form_add_document.do_fill_in_path("docs/document2.sdoc")
             form_add_document.do_form_submit()
 
             # Add file with a leading slash — slash must be stripped silently
@@ -47,7 +48,7 @@ class Test(E2ECase):
                 screen_project_index.do_open_modal_form_add_document()
             )
             form_add_document.do_fill_in_title("Document 3")
-            form_add_document.do_fill_in_path("/docs/document3")
+            form_add_document.do_fill_in_path("/docs/document3.sdoc")
             form_add_document.do_form_submit()
 
             screen_project_index.assert_contains_document("Document 3")

--- a/tests/integration/examples/python_api/custom_format_example_csv/csv_format.py
+++ b/tests/integration/examples/python_api/custom_format_example_csv/csv_format.py
@@ -115,6 +115,10 @@ class CSVFormat(Format):
         return False
 
     @staticmethod
+    def supports_edit() -> bool:
+        return False
+
+    @staticmethod
     def supports_grammar() -> bool:
         return False
 

--- a/tests/unit/strictdoc/core/test_project_config.py
+++ b/tests/unit/strictdoc/core/test_project_config.py
@@ -3,11 +3,13 @@ import tempfile
 
 import pytest
 
+from strictdoc.backend.sdoc.sdoc_format import SDocFormat
 from strictdoc.core.project_config import (
     ProjectConfig,
     ProjectConfigLoader,
     ProjectFeature,
 )
+from strictdoc.features.html2pdf.html2pdf_format import HTML2PDFFormat
 
 
 def test_01_default_config():
@@ -49,6 +51,31 @@ def test_32_include_source_paths_bad_mask():
 def test_33_exclude_source_paths_bad_mask():
     with pytest.raises(ValueError):
         _ = ProjectConfig(exclude_source_paths=[" "])
+
+
+#
+# Editable document extensions.
+#
+def test_40_editable_document_extensions_only_sdoc():
+    # SDocFormat is the base/always-available format, used here to test
+    # the get_editable_document_extensions() mechanism itself (iterate
+    # formats -> keep supports_edit() ones -> collect
+    # supported_extensions()), independent of which formats a real
+    # project happens to have configured.
+    project_config = ProjectConfig(formats=[SDocFormat()])
+    assert project_config.get_editable_document_extensions() == [".sdoc"]
+
+
+def test_41_editable_document_extensions_excludes_non_editable_format():
+    # HTML2PDFFormat is used (instead of a fake/stub Format) because it is
+    # a real, permanently non-editable format: PDF output is exported
+    # only, never edited through the UI, and supports_edit() is
+    # guaranteed to stay False. This keeps the test meaningful without
+    # inventing a throwaway Format subclass.
+    project_config = ProjectConfig(formats=[SDocFormat(), HTML2PDFFormat()])
+    extensions = project_config.get_editable_document_extensions()
+    assert extensions == [".sdoc"]
+    assert ".pdf" not in extensions
 
 
 def test_60_valid_host_and_port():


### PR DESCRIPTION
Closes #3053

## Summary

- Fixes a confusing UX bug: creating a document without a file extension
  produced an `include_doc_paths` path-filter error, even though the real
  problem was the missing extension. The old code auto-appended `.sdoc`
  only *after* path-filter validation had already passed.
- Replaces the hardcoded `.sdoc` auto-append with explicit validation
  driven by the project's configured formats: `document_path` must end
  with an extension belonging to a format that has `supports_edit() ==
  True` (e.g. `.sdoc`, `.md`, `.markdown`). The accepted-extensions list
  is computed live via a new `ProjectConfig.get_editable_document_extensions()`,
  so it stays correct as formats are added/removed, with no further code
  changes needed.
- This validation is a separate check with its own error message,
  distinct from the `include_doc_paths`/`exclude_doc_paths` path-filter
  errors, so users can tell why a save was actually rejected.
- The "Add Document" form now shows a hint listing the accepted
  extensions (replacing the old decorative, always-on ".sdoc" suffix,
  which was misleading once more than one extension became valid and
  visually duplicated an extension the user had already typed).
- Fixed 3 pre-existing e2e tests that silently relied on the removed
  auto-append behavior (extension-less paths that used to succeed).
  
  
<img width="638" height="407" alt="image" src="https://github.com/user-attachments/assets/8de2d4ce-0373-4293-a03f-ccdc56592a65" />

<img width="623" height="439" alt="image" src="https://github.com/user-attachments/assets/872c2b83-d488-489b-bc63-43b20e41cbe9" />

<img width="633" height="437" alt="image" src="https://github.com/user-attachments/assets/f2615367-c7b7-4170-9158-0507a73b2470" />


## Test plan

- [x] `tests/unit/strictdoc/core/test_project_config.py`: new unit tests
      for `get_editable_document_extensions()` (mechanism-level, using
      `SDocFormat` and `HTML2PDFFormat`).
- [x] New e2e test
      `create_document_validate_document_path_unsupported_extension`:
      `.pdf` rejected with the new error text, `.sdoc` succeeds, on
      default server settings.
- [x] `invoke test-end2end --headless
      --test-path=screens/project_index/create_document` — 7/7 passed.
- [x] `invoke lint-ruff` clean.