### PR TITLE
fix(markdown): register section-level UID for LINK resolution

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -51,14 +51,18 @@ releases:
 
 [[SECTION]]
 MID: a7ffb392d48244969318ec115e4695bd
-TITLE: 0.??.? (2026-??-??)
+TITLE: Unreleased
 
 [TEXT]
 MID: 0046268453bf439b8a826ecc57abbe91
 STATEMENT: >>>
 This release contains the following enhancements:
 
-?\) The Markdown format now supports ``Version``, ``Date`` and ``Classification`` as document config fields.
+1\) The Markdown format now supports ``Version``, ``Date`` and ``Classification`` as document config fields.
+
+2\) A section-level ``UID`` declared in a Markdown heading's metadata block
+(``**UID**: ...``) is now registered correctly, so that it can be linked to
+via ``[LINK <uid>]``.
 <<<
 
 [[/SECTION]]

--- a/strictdoc/backend/markdown/reader.py
+++ b/strictdoc/backend/markdown/reader.py
@@ -482,36 +482,55 @@ class SDMarkdownReader:
                 section_node.ng_including_document_reference = (
                     including_document_reference
                 )
+                uid_values: List[str] = []
+                mid_value: Optional[str] = None
+                prefix_value: Optional[str] = None
+                for field_ in parsed_node.fields:
+                    if field_.name == "UID":
+                        uid_values.append(field_.value)
+                    elif field_.name == "MID" and mid_value is None:
+                        mid_value = field_.value
+                    elif field_.name == "PREFIX" and prefix_value is None:
+                        prefix_value = field_.value
+
+                # Preserve UID from the section meta block for LINK resolution.
+                # Must run before the MID block so field order ends up MID, UID, PREFIX, TITLE.
+                # A duplicated UID is skipped; the raw-body fallback below preserves it instead.
+                if len(uid_values) == 1:
+                    uid_sdoc_field = SDocNodeField.create_from_string(
+                        parent=section_node,
+                        field_name="UID",
+                        field_value=uid_values[0],
+                        multiline=False,
+                    )
+                    existing = list(section_node.ordered_fields_lookup.items())
+                    section_node.ordered_fields_lookup.clear()
+                    section_node.ordered_fields_lookup["UID"] = [uid_sdoc_field]
+                    section_node.ordered_fields_lookup.update(existing)
                 # Preserve MID from the section meta block (e.g. **Type**: SECTION \ **MID**: ...).
                 # create_section does not accept fields, so we patch it in afterwards.
                 # MID must be inserted before TITLE to match the grammar field order.
-                mid_field = next(
-                    (f for f in parsed_node.fields if f.name == "MID"), None
-                )
-                if mid_field is not None:
+                if mid_value is not None:
                     mid_sdoc_field = SDocNodeField.create_from_string(
                         parent=section_node,
                         field_name="MID",
-                        field_value=mid_field.value,
+                        field_value=mid_value,
                         multiline=False,
                     )
                     existing = list(section_node.ordered_fields_lookup.items())
                     section_node.ordered_fields_lookup.clear()
                     section_node.ordered_fields_lookup["MID"] = [mid_sdoc_field]
                     section_node.ordered_fields_lookup.update(existing)
-                    section_node.reserved_mid = MID(mid_field.value)
+                    section_node.reserved_mid = MID(mid_value)
                     section_node.mid_permanent = True
                 # Preserve Prefix from the section meta block.
                 # The internal PREFIX key is inserted before TITLE (after
                 # MID) to keep the field order: MID, LEVEL, PREFIX, TITLE.
-                prefix_field = next(
-                    (f for f in parsed_node.fields if f.name == "PREFIX"), None
-                )
-                if prefix_field is not None:
+                if prefix_value is not None:
                     prefix_sdoc_field = SDocNodeField.create_from_string(
                         parent=section_node,
                         field_name="PREFIX",
-                        field_value=prefix_field.value,
+                        field_value=prefix_value,
                         multiline=False,
                     )
                     title_entry = section_node.ordered_fields_lookup.pop(
@@ -803,14 +822,18 @@ class SDMarkdownReader:
 
         # Use body_lines_without_meta (meta block stripped) as processed_body
         # only when the meta block contains section-specific fields (Type, MID,
-        # Prefix) so those lines do not reappear as prose in the TEXT child.
-        # For ambiguous meta blocks (e.g. duplicate UID fields in an invalid
-        # requirement node) fall back to None so _create_document_tree uses the
-        # raw heading body and preserves the content.
+        # Prefix, an unambiguous UID) so those lines do not reappear as prose
+        # in the TEXT child. For ambiguous meta blocks (e.g. duplicate UID
+        # fields in an invalid requirement node) fall back to None so
+        # _create_document_tree uses the raw heading body and preserves the
+        # content.
         _parsed_field_names: Set[str] = {f.name for f in parsed_fields}
+        uid_field_count = sum(1 for f in parsed_fields if f.name == "UID")
         processed_body: Optional[str] = None
         if explicit_node_type is not None or (
-            "MID" in _parsed_field_names or "PREFIX" in _parsed_field_names
+            "MID" in _parsed_field_names
+            or "PREFIX" in _parsed_field_names
+            or uid_field_count == 1
         ):
             processed_body = "".join(body_lines_without_meta)
 

--- a/tests/integration/features/markdown/25_document_level_uid_link/input1.md
+++ b/tests/integration/features/markdown/25_document_level_uid_link/input1.md
@@ -3,3 +3,18 @@
 **UID**: DOC-1
 
 Read [LINK: DOC-2].
+
+## Section A
+
+**Type**: SECTION \
+**UID**: SEC-1
+
+Read [LINK: SEC-2].
+
+## Section C
+
+**UID**: SEC-3
+
+### Notes
+
+Read [LINK: SEC-4].

--- a/tests/integration/features/markdown/25_document_level_uid_link/input2.md
+++ b/tests/integration/features/markdown/25_document_level_uid_link/input2.md
@@ -3,3 +3,18 @@
 **UID**: DOC-2
 
 Read [LINK: DOC-1].
+
+## Section B
+
+**Type**: SECTION \
+**UID**: SEC-2
+
+Read [LINK: SEC-1].
+
+## Section D
+
+**UID**: SEC-4
+
+### Notes
+
+Read [LINK: SEC-3].

--- a/tests/integration/features/markdown/25_document_level_uid_link/test.itest
+++ b/tests/integration/features/markdown/25_document_level_uid_link/test.itest
@@ -1,4 +1,4 @@
-# A document-level **UID**: in a Markdown H1 must be linkable via [LINK: uid].
+# A document-level or section-level **UID**: in Markdown must be linkable via [LINK: uid].
 
 RUN: %strictdoc export %S --formats=html --output-dir %T | filecheck %s --dump-input=fail
 CHECK: Published: Document
@@ -6,7 +6,11 @@ CHECK: Published: Document
 RUN: %cat %T/html/%THIS_TEST_FOLDER/input1.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC1
 
 CHECK-HTML-DOC1: <a href="../25_document_level_uid_link/input2.html#DOC-2">{{.*}}Document 2
+CHECK-HTML-DOC1: <a href="../25_document_level_uid_link/input2.html#SEC-2">{{.*}}Section B
+CHECK-HTML-DOC1: <a href="../25_document_level_uid_link/input2.html#SEC-4">{{.*}}Section D
 
 RUN: %cat %T/html/%THIS_TEST_FOLDER/input2.html | filecheck %s --dump-input=fail --check-prefix CHECK-HTML-DOC2
 
 CHECK-HTML-DOC2: <a href="../25_document_level_uid_link/input1.html#DOC-1">{{.*}}Document 1
+CHECK-HTML-DOC2: <a href="../25_document_level_uid_link/input1.html#SEC-1">{{.*}}Section A
+CHECK-HTML-DOC2: <a href="../25_document_level_uid_link/input1.html#SEC-3">{{.*}}Section C

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
@@ -594,3 +594,57 @@ def test_025_markdown_reader_empty_heading_produces_no_title_field():
     assert requirement.reserved_uid == "REQ-1"
     assert requirement.reserved_title is None
     assert "TITLE" not in requirement.ordered_fields_lookup
+
+
+def test_027_section_level_fields():
+    markdown_content = """\
+# Document title
+
+## Chapter 2
+
+**Type**: SECTION \\
+**MID**: aabbccdd11223344aabbccdd11223344 \\
+**UID**: SEC-1 \\
+**PREFIX**: LEVEL2-REQ-
+
+Some prose.
+"""
+
+    reader = SDMarkdownReader()
+    document = reader.read(markdown_content, file_path=None)
+
+    section = document.section_contents[0]
+    assert isinstance(section, SDocNode)
+    assert section.node_type == "SECTION"
+    assert section.reserved_uid == "SEC-1"
+    assert str(section.reserved_mid) == "aabbccdd11223344aabbccdd11223344"
+    assert section.get_prefix() == "LEVEL2-REQ-"
+    assert list(section.ordered_fields_lookup.keys()) == [
+        "MID",
+        "UID",
+        "PREFIX",
+        "TITLE",
+    ]
+
+
+def test_028_section_level_uid_without_explicit_type_has_no_duplicated_prose():
+    markdown_content = """\
+# Document title
+
+## Chapter 2
+
+**UID**: SEC-1
+
+### Notes
+
+Some prose.
+"""
+
+    reader = SDMarkdownReader()
+    document = reader.read(markdown_content, file_path=None)
+
+    section = document.section_contents[0]
+    assert isinstance(section, SDocNode)
+    assert section.node_type == "SECTION"
+    assert section.reserved_uid == "SEC-1"
+    assert [c.node_type for c in section.section_contents] == ["SECTION"]


### PR DESCRIPTION
What: Make section-level UIDs from markdown traceable.

Why: The markdown reader already parsed a section's `**UID**:` meta field, but did add it into the section node, so `[LINK]` could not resolve it.

How: Insert the parsed UID field into the section node's field lookup, same as for MID/PREFIX. Skip ambiguous duplicate UIDs (is it a field or is it prose?) so the existing raw-body fallback preserves them unchanged.