### PR TITLE
fix(export/html): defer initial MathJax/Mermaid rendering to browser idle time

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -64,6 +64,10 @@ This release contains the following enhancements:
 2\) A section-level ``UID`` declared in a Markdown heading's metadata block
 (``**UID**: ...``) is now registered correctly, so that it can be linked to
 via ``[LINK <uid>]``.
+
+3\) The web interface renders large documents faster. The initial MathJax
+typesetting and Mermaid diagram rendering are deferred to browser idle time so
+they no longer block the first paint of the document.
 <<<
 
 [[/SECTION]]

--- a/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
@@ -520,7 +520,7 @@ class DocumentScreenViewObject:
         Get a stable link for a given node.
 
         An example of a link produced: ../../#SDOC_UG_CONTACT
-        The copy_to_clipboard.js consumes this link and
+        The copy_to_clipboard.js script consumes this link and
         transforms it into a link like: http://127.0.0.1:5111/?a=SDOC_UG_CONTACT.
         """
 

--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -44,8 +44,37 @@
   window.MathJax = {
     tex: {
       tags: 'ams',
-    },   
+    },
+    startup: {
+      // Defer the initial typeset off the critical render path:
+      // it is kicked at browser idle time below.
+      typeset: false,
+    },
   };
+  // Typeset when the browser is idle instead of blocking first paint.
+  // Race handling: the MathJax script is loaded async, so when the idle
+  // callback fires it can be in one of three states:
+  // 1. fully started:    typesetPromise exists -> typeset directly;
+  // 2. loaded, starting: startup.promise exists -> typeset once startup
+  //                      is complete;
+  // 3. not executed yet: window.MathJax is still the plain config object
+  //                      above (no startup.promise) -> re-check shortly.
+  window.addEventListener('load', () => {
+    const kickMathJax = () => {
+      if (window.MathJax?.typesetPromise) {
+        MathJax.typesetPromise().catch(console.error);
+      } else if (window.MathJax?.startup?.promise) {
+        MathJax.startup.promise
+          .then(() => MathJax.typesetPromise())
+          .catch(console.error);
+      } else {
+        setTimeout(kickMathJax, 100);
+      }
+    };
+    ('requestIdleCallback' in window)
+      ? requestIdleCallback(kickMathJax, { timeout: 2000 })
+      : setTimeout(kickMathJax, 0);
+  });
   </script>
   <script id="MathJax-script" async src="{{ view_object.render_static_url('mathjax/tex-mml-chtml.js') }}"></script>
   {%- if view_object.is_running_on_server -%}
@@ -85,7 +114,17 @@
   {%- if view_object.project_config.is_activated_mermaid() -%}
     <script src="{{ view_object.render_static_url('mermaid/mermaid.min.js') }}"></script>
     <script type="module">
-      mermaid.initialize({ startOnLoad: true });
+      // Defer the initial diagram rendering off the critical render path.
+      // mermaid.min.js is a classic script loaded before this module, so
+      // the mermaid global is guaranteed to exist here (no load race,
+      // unlike the async MathJax script above).
+      mermaid.initialize({ startOnLoad: false });
+      window.addEventListener('load', () => {
+        const kickMermaid = () => mermaid.run().catch(console.error);
+        ('requestIdleCallback' in window)
+          ? requestIdleCallback(kickMermaid, { timeout: 2000 })
+          : setTimeout(kickMermaid, 0);
+      });
     </script>
   {%- if view_object.is_running_on_server -%}
     <script>

--- a/tests/integration/features/mathjax/03_mathjax_enabled_math_block/test.itest
+++ b/tests/integration/features/mathjax/03_mathjax_enabled_math_block/test.itest
@@ -10,6 +10,8 @@ RUN: %check_exists --file "%T/html/_static/mathjax/output/chtml/fonts/tex.js"
 
 RUN: %cat %T/html/03_mathjax_enabled_math_block/input.html | filecheck %s --check-prefix CHECK-HTML
 
+CHECK-HTML: window.MathJax = {
+CHECK-HTML: typeset: false,
 CHECK-HTML: <span class="math notranslate nohighlight">\( a^2 + b^2 = c^2 \)</span>
 CHECK-HTML: <div class="math notranslate nohighlight">\[ \begin{align*}\begin{aligned}(a + b)^2 = a^2 + 2ab + b^2 \\ (a - b)^2 = a^2 - 2ab + b^2\end{aligned}\end{align*} \]</div>
 CHECK-HTML: <div class="math notranslate nohighlight">\[ \begin{equation}\label{euler}\begin{aligned} e^{i\pi} + 1 = 0 \end{aligned}\end{equation} \]</div>

--- a/tests/integration/features/mermaid/01_enabled/test.itest
+++ b/tests/integration/features/mermaid/01_enabled/test.itest
@@ -7,8 +7,13 @@ CHECK: Published: Hello world doc
 
 RUN: %check_exists --file "%T/html/_static/mermaid/mermaid.min.js"
 
-RUN: cat %T/html/01_enabled/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/01_enabled/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-DOC
 RUN: cat %T/html/01_enabled/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
 RUN: cat %T/html/01_enabled/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
 RUN: cat %T/html/01_enabled/input-DEEP-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
 CHECK-HTML: mermaid.initialize({ startOnLoad: true });
+
+The document screen defers the initial Mermaid rendering to browser idle
+time, so it initializes with startOnLoad: false and calls mermaid.run() later.
+CHECK-HTML-DOC: mermaid.initialize({ startOnLoad: false });
+CHECK-HTML-DOC: mermaid.run()


### PR DESCRIPTION


WHY: Ensures that the rendering of MathJax/Mermaid does not block the first paint. This change will be useful for rendering large documents when we implement lazy loading in the editable UI (coming in the next PR #3049).