### PR TITLE
feat(toc): keep current-section highlighting correct when content loads without a TOC update

### DIFF
--- a/developer/tasks/20260726_toc_highlight_improvement/task.md
+++ b/developer/tasks/20260726_toc_highlight_improvement/task.md
@@ -17,6 +17,11 @@ Success criteria:
 - No regression to existing highlighting behavior: node creation,
   update, deletion, and folder expand/collapse continue to update the
   current-section highlight exactly as today.
+- Fixes, as a side effect, a pre-existing and independent case of the
+  same underlying gap: canceling a node edit (Cancel, without saving)
+  re-inserts the node's read-view anchor without updating the TOC
+  frame, so the highlighting for that node went stale after any Cancel
+  before this task.
 - The fix must not depend on the specific mechanism, naming
   convention, or markup used by any given content-loading feature
   (e.g., must not assume a particular turbo-frame id pattern or a
@@ -64,14 +69,27 @@ This task addresses that gap ahead of the lazy-chunk-loading feature
 landing, so that TOC highlighting is already correct once it does,
 without requiring changes to the incoming feature itself.
 
+The same class of gap already exists today, independently of chunking:
+canceling a node edit (`cancel_edit_requirement`) calls
+`render_updated_nodes_and_toc([requirement], node_updated=False)` -
+with `node_updated=False`, the `frame-toc` update is skipped, so only
+the node's read-view content (with a freshly re-inserted anchor) is
+streamed back. This is the same "content changed, TOC frame did not"
+shape as the chunking case, just triggered by a different, already-
+shipped feature - and the fix in this task closes it too.
+
 ## HOW
 
-Add a second `MutationObserver`, alongside the existing one on
-`frame-toc`, targeting the stable content container
-(`[js-toc_highlighting-content_root]`), configured for
-`childList: true, subtree: true`. On a triggering mutation
-(coalesced via `requestAnimationFrame`, matching the existing
-debouncing pattern used elsewhere in the file), re-run
+React to new content anchors via the shared `StrictDoc.onInsert(selector,
+callback)` contract (`app_core.js`, introduced by
+`developer/tasks/20260724_stimulus_free/task.md`), registering for
+`CONTENT_ELEMENT_SELECTOR` (`sdoc-anchor`), instead of a dedicated
+`MutationObserver` on the content container — per that contract, feature
+scripts must not each run their own subtree-wide `MutationObserver` for
+this purpose. On a triggering call (coalesced via
+`requestAnimationFrame`, matching the existing debouncing pattern used
+elsewhere in the file — necessary here since `onInsert` calls back once
+per matched element, not once per mutation batch), re-run
 `processAnchorList()` for the content frame and recompute currently
 visible sections, without resetting the TOC link mappings
 (`processLinkList()` / `resetState()`).
@@ -83,11 +101,31 @@ appeared in the DOM. When `processAnchorList()` later discovers a new
 anchor id, it merges the newly found anchor element into the existing
 entry for that id, which already carries the correct TOC link.
 
-Given the coupling described above, this change is a no-op under all
-current (non-lazy-loading) content-mutation paths, since those already
-trigger the existing `frame-toc` observer. It only becomes active once
-a mechanism exists that inserts content without mutating `frame-toc`
-— which is exactly the case this task is meant to prepare for.
+The new `onInsert` registration fires only for elements matching
+`CONTENT_ELEMENT_SELECTOR` (`sdoc-anchor`) - either the inserted node
+itself or a descendant of it - and does not fire for removals or for
+unrelated markup changes. Concretely, for the existing edit flow:
+
+- Opening a node's edit form replaces its read view (turbo-stream
+  `replace`) with form markup that contains no `sdoc-anchor` at all -
+  this observer never fires while a node is being edited.
+- Saving a node re-inserts its read view (with a fresh anchor) *and*
+  updates `frame-toc` in the same response, so this observer's firing
+  here is redundant with the existing `frame-toc` observer - both run,
+  `processAnchorList()`'s own `anchorsCount`/`anchorsSig` check finds
+  nothing changed on the second pass, so the net effect is one extra
+  cheap, coalesced no-op pass.
+- Canceling a node's edit re-inserts its read view (with a fresh
+  anchor) *without* touching `frame-toc` (see WHY) - this is the one
+  existing-feature path where this observer is not redundant: it is
+  the only thing that re-associates the `IntersectionObserver` with
+  the newly-inserted anchor element, fixing the stale-highlight-after-
+  Cancel bug described above.
+
+Beyond today's existing flows, this observer is also what activates
+once a mechanism exists that inserts content without mutating
+`frame-toc` at all on initial insertion - which is the
+lazy-chunk-loading case this task is meant to prepare for.
 
 Open implementation consideration: `processAnchorList()` performs a
 full re-scan and signature computation over all anchors currently in
@@ -98,3 +136,16 @@ present. Start with the full re-scan approach; if measurement shows
 this to be a performance concern on large documents, consider
 processing `MutationRecord.addedNodes`/`removedNodes` directly for an
 incremental update instead of a full re-scan.
+
+Out of scope: the pre-existing `MutationObserver` on `frame-toc` is not
+migrated to `StrictDoc.onInsert` as part of this task. It reacts to the
+TOC container being replaced wholesale, not to a specific new element
+of interest appearing — a different kind of reaction than what
+`onInsert` is designed for. `TOC_ELEMENT_SELECTOR` (`'a'`) is also too
+generic to register page-wide via `onInsert` without matching unrelated
+links elsewhere on the page, and doing so would call back once per
+matched link instead of once per replace event, requiring a new
+coalescing wrapper that does not exist for this path today (unlike
+`scheduleAnchorRescan`/`scheduleHighlightRefresh`). Migrating it is a
+possible separate future cleanup, not required by this task's success
+criteria.

--- a/developer/tasks/20260726_toc_highlight_improvement/task.md
+++ b/developer/tasks/20260726_toc_highlight_improvement/task.md
@@ -1,0 +1,100 @@
+# TOC current-section highlighting: track anchors added by content-only DOM updates
+
+## WHAT
+
+Extend the TOC "current section" highlighting mechanism
+(`strictdoc/export/html/_static/toc_highlighting.js`) so that it
+correctly tracks document nodes whose anchors are inserted into the
+content area after the initial page load, through any DOM update that
+does not also update the TOC frame (`frame-toc`).
+
+Success criteria:
+
+- When a document node that was not present in the DOM at initial page
+  load later appears in the content area and is scrolled into view,
+  its corresponding TOC entry is marked as the current section, with
+  the same behavior as for a node that was present at initial load.
+- No regression to existing highlighting behavior: node creation,
+  update, deletion, and folder expand/collapse continue to update the
+  current-section highlight exactly as today.
+- The fix must not depend on the specific mechanism, naming
+  convention, or markup used by any given content-loading feature
+  (e.g., must not assume a particular turbo-frame id pattern or a
+  particular JS event). It must generalize to "content appeared in the
+  DOM," regardless of cause.
+- The fix relies on the following invariant, which must continue to
+  hold: the TOC (`frame-toc`) is always rendered in full on initial
+  page load, listing every document node, regardless of whether that
+  node's content is present in the DOM at that time. Any future
+  content-loading feature must not turn the TOC itself into a
+  partially or lazily rendered structure, or this mechanism breaks.
+
+## WHY
+
+`toc_highlighting.js` determines which section is "current" using an
+`IntersectionObserver` over content anchors (`sdoc-anchor` elements).
+The set of anchors under observation is (re)built by
+`processAnchorList()`, which only runs in two situations: once on the
+page's `load` event, and whenever the TOC frame's own DOM mutates
+(tracked via a `MutationObserver` on `frame-toc`).
+
+This is sufficient today because, on the server side, every operation
+that changes document content (creating, updating, or deleting a node)
+always re-renders and streams a full TOC update to `frame-toc` in the
+same turbo-stream response as the content change
+(`DocumentScreenViewObject.render_updated_nodes_and_toc()`: the TOC
+partial is always re-rendered and pushed to `frame-toc` whenever
+`node_updated` is true, alongside the turbo-stream updates for the
+affected node content). As a result, content mutation and TOC mutation
+are always coupled in the current system, and observing `frame-toc` is
+enough to catch every case where the set of visible anchors changes.
+
+An upcoming feature renders large documents in lazily-loaded chunks:
+additional document nodes are fetched and inserted into the content
+area via independent turbo-frame requests, well after the initial page
+load. The TOC is rendered in full up front and is not re-streamed when
+a chunk loads — this is the first scenario where document content
+changes without any corresponding mutation of `frame-toc`. The current
+highlighting mechanism has no path that reacts to this, so once a user
+scrolls into a node that was not present in the DOM at initial load,
+the current-section highlight stops updating and remains stuck on the
+last section that was tracked.
+
+This task addresses that gap ahead of the lazy-chunk-loading feature
+landing, so that TOC highlighting is already correct once it does,
+without requiring changes to the incoming feature itself.
+
+## HOW
+
+Add a second `MutationObserver`, alongside the existing one on
+`frame-toc`, targeting the stable content container
+(`[js-toc_highlighting-content_root]`), configured for
+`childList: true, subtree: true`. On a triggering mutation
+(coalesced via `requestAnimationFrame`, matching the existing
+debouncing pattern used elsewhere in the file), re-run
+`processAnchorList()` for the content frame and recompute currently
+visible sections, without resetting the TOC link mappings
+(`processLinkList()` / `resetState()`).
+
+This is safe without a full state reset because `processLinkList()`
+already captures a `link` reference for every node's anchor id from
+the initial full TOC scan, including nodes whose content has not yet
+appeared in the DOM. When `processAnchorList()` later discovers a new
+anchor id, it merges the newly found anchor element into the existing
+entry for that id, which already carries the correct TOC link.
+
+Given the coupling described above, this change is a no-op under all
+current (non-lazy-loading) content-mutation paths, since those already
+trigger the existing `frame-toc` observer. It only becomes active once
+a mechanism exists that inserts content without mutating `frame-toc`
+— which is exactly the case this task is meant to prepare for.
+
+Open implementation consideration: `processAnchorList()` performs a
+full re-scan and signature computation over all anchors currently in
+the DOM on each run. Under frequent content-only mutations (e.g.,
+scrolling through many lazily-loaded chunks in quick succession), the
+cost of this re-scan grows with the total number of anchors already
+present. Start with the full re-scan approach; if measurement shows
+this to be a performance concern on large documents, consider
+processing `MutationRecord.addedNodes`/`removedNodes` directly for an
+incremental update instead of a full re-scan.

--- a/strictdoc/export/html/_static/toc_highlighting.js
+++ b/strictdoc/export/html/_static/toc_highlighting.js
@@ -98,16 +98,25 @@ window.addEventListener("load",function(){
   // * lazily-loaded document chunk inserting nodes whose anchors were not
   // * present at initial load. The TOC frame observer above does not see
   // * this case (see toc_highlighting.js task notes), so anchors are
-  // * re-scanned directly off content-frame mutations as well.
-  new MutationObserver(function () {
+  // * re-scanned via StrictDoc.onInsert as well, instead of a dedicated
+  // * MutationObserver - see the onInsert contract in app_core.js.
+  // * scheduleAnchorRescan() coalesces via requestAnimationFrame, since
+  // * onInsert calls back once per matched element, not once per batch.
+  // *
+  // * Fires only for CONTENT_ELEMENT_SELECTOR (sdoc-anchor) matches - the
+  // * inserted node itself or a descendant of it, per the onInsert
+  // * contract. Unaffected by mutations that don't insert an anchor:
+  // * opening a node's edit form replaces it with form markup that has no
+  // * sdoc-anchor at all, so this never fires while editing. It does fire
+  // * when a node's read view (with its anchor) is re-inserted afterwards -
+  // * both on save (already covered anyway by the TOC frame observer,
+  // * since saving also updates frame-toc) and on Cancel (which does not
+  // * touch frame-toc: previously this meant the observed anchor element
+  // * for that node stayed stale/detached after any Cancel, independently
+  // * of chunking - this re-scan fixes that case too).
+  strictDoc.onInsert(CONTENT_ELEMENT_SELECTOR, function () {
     scheduleAnchorRescan(contentFrame, anchorObserver);
-  }).observe(
-    contentFrame,
-    {
-      childList: true,
-      subtree: true,
-    }
-  );
+  });
 
   // * Refresh TOC highlights when collapsible_toc.js changes branch visibility.
   strictDoc.bus.on(TOC_STATE_CHANGED_EVENT, () => {

--- a/strictdoc/export/html/_static/toc_highlighting.js
+++ b/strictdoc/export/html/_static/toc_highlighting.js
@@ -38,6 +38,7 @@ let tocHighlightingState = {
   folderSet: new Set(),
 };
 let tocRefreshRaf = null;
+let anchorRescanRaf = null;
 
 function resetState() {
   // * Keep anchorsCount/anchorsSig to detect changes across TOC mutations.
@@ -92,6 +93,21 @@ window.addEventListener("load",function(){
   if (tocList && tocList.querySelector(TOC_ELEMENT_SELECTOR)) {
     highlightTOC(tocFrame, contentFrame, anchorObserver);
   }
+
+  // * Content can also change without the TOC frame mutating - e.g. a
+  // * lazily-loaded document chunk inserting nodes whose anchors were not
+  // * present at initial load. The TOC frame observer above does not see
+  // * this case (see toc_highlighting.js task notes), so anchors are
+  // * re-scanned directly off content-frame mutations as well.
+  new MutationObserver(function () {
+    scheduleAnchorRescan(contentFrame, anchorObserver);
+  }).observe(
+    contentFrame,
+    {
+      childList: true,
+      subtree: true,
+    }
+  );
 
   // * Refresh TOC highlights when collapsible_toc.js changes branch visibility.
   strictDoc.bus.on(TOC_STATE_CHANGED_EVENT, () => {
@@ -336,6 +352,23 @@ function handleIntersect(entries, observer) {
   });
 
   updateVisibleSectionItems(topBound, bottomBound);
+}
+
+// Coalesce multiple content-frame mutations (e.g. all nodes inserted by one
+// lazily-loaded chunk) into a single anchor re-scan.
+function scheduleAnchorRescan(contentFrame, anchorObserver) {
+  if (anchorRescanRaf !== null) {
+    return;
+  }
+  anchorRescanRaf = requestAnimationFrame(() => {
+    anchorRescanRaf = null;
+    // * Deliberately not resetState()+processLinkList(): the TOC link for
+    // * every node id was already captured by the initial full scan, so
+    // * merging newly found anchors into the existing data[id] entries is
+    // * enough - see toc_highlighting.js task notes.
+    processAnchorList(contentFrame, anchorObserver);
+    refreshHighlightFromCurrentState();
+  });
 }
 
 // Coalesce multiple TOC state changes into a single frame refresh.

--- a/tests/end2end/navigation/toc/toc_highlighting_lazy_chunks/input/document.sdoc
+++ b/tests/end2end/navigation/toc/toc_highlighting_lazy_chunks/input/document.sdoc
@@ -1,0 +1,177 @@
+[DOCUMENT]
+TITLE: TOC Highlighting Lazy Chunks Document
+
+[REQUIREMENT]
+UID: TOCLZ-001
+TITLE: Requirement 1
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-001 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-002
+TITLE: Requirement 2
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-002 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-003
+TITLE: Requirement 3
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-003 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-004
+TITLE: Requirement 4
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-004 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-005
+TITLE: Requirement 5
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-005 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-006
+TITLE: Requirement 6
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-006 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-007
+TITLE: Requirement 7
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-007 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-008
+TITLE: Requirement 8
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-008 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-009
+TITLE: Requirement 9
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-009 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-010
+TITLE: Requirement 10
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-010 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-011
+TITLE: Requirement 11
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-011 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-012
+TITLE: Requirement 12
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-012 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-013
+TITLE: Requirement 13
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-013 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-014
+TITLE: Requirement 14
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-014 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-015
+TITLE: Requirement 15
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-015 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-016
+TITLE: Requirement 16
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-016 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-017
+TITLE: Requirement 17
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-017 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-018
+TITLE: Requirement 18
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-018 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-019
+TITLE: Requirement 19
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-019 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-020
+TITLE: Requirement 20
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-020 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-021
+TITLE: Requirement 21
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-021 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-022
+TITLE: Requirement 22
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-022 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-023
+TITLE: Requirement 23
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-023 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-024
+TITLE: Requirement 24
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-024 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-025
+TITLE: Requirement 25
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-025 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-026
+TITLE: Requirement 26
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-026 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-027
+TITLE: Requirement 27
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-027 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-028
+TITLE: Requirement 28
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-028 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-029
+TITLE: Requirement 29
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-029 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-030
+TITLE: Requirement 30
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-030 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-031
+TITLE: Requirement 31
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-031 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-032
+TITLE: Requirement 32
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-032 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-033
+TITLE: Requirement 33
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-033 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-034
+TITLE: Requirement 34
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-034 must appear exactly once.
+
+[REQUIREMENT]
+UID: TOCLZ-035
+TITLE: Requirement 35
+STATEMENT: The toc-lazy fixture statement TOCLZSTMT-035 must appear exactly once.

--- a/tests/end2end/navigation/toc/toc_highlighting_lazy_chunks/input/strictdoc_config.py
+++ b/tests/end2end/navigation/toc/toc_highlighting_lazy_chunks/input/strictdoc_config.py
@@ -1,0 +1,9 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_title="TOC Highlighting Lazy Chunks Test",
+        chunked_documents_threshold=10,
+    )
+    return config

--- a/tests/end2end/navigation/toc/toc_highlighting_lazy_chunks/test_case.py
+++ b/tests/end2end/navigation/toc/toc_highlighting_lazy_chunks/test_case.py
@@ -1,0 +1,85 @@
+import unittest
+
+from selenium.webdriver.common.by import By
+
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.toc import TOC
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+# The document has 35 requirements, and strictdoc_config.py sets
+# chunked_documents_threshold = 10, so the document is rendered as four
+# chunks: 0, 1, 2, 3. The last chunk sits several thousand pixels below the
+# viewport, so it is guaranteed to stay lazy (not eagerly loaded by Turbo)
+# until the page is scrolled down to it - see
+# tests/end2end/screens/document/lazy_loading/test_case.py, which relies on
+# the same guarantee.
+LAST_CHUNK_XPATH = "//turbo-frame[@id='document-chunk-3']"
+
+
+class Test(E2ECase):
+    @unittest.skip(
+        "Disabled on this branch: chunked_documents_threshold and "
+        "server-side lazy chunk loading do not exist here yet (see "
+        "developer/tasks/20260726_toc_highlight_improvement/task.md). "
+        "Re-enable this test on the branch that adds lazy-loaded document "
+        "chunks, to verify TOC current-section highlighting keeps working "
+        "correctly once that feature lands."
+    )
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+
+            screen_document = (
+                screen_project_index.do_click_on_the_document_with_title(
+                    "TOC Highlighting Lazy Chunks Document"
+                )
+            )
+            screen_document.assert_on_screen_document()
+
+            toc: TOC = screen_document.get_toc()
+
+            # The last chunk (and TOCLZ-035, its only requirement's anchor)
+            # is not loaded yet: its content must not be in the DOM.
+            self.assert_element_not_present(
+                f"{LAST_CHUNK_XPATH}//sdoc-node",
+                by=By.XPATH,
+            )
+
+            # Scrolling the last chunk's placeholder into view makes Turbo
+            # lazily load it - this is the scenario where content appears
+            # in the DOM without any corresponding mutation of the TOC
+            # frame (see developer/tasks/20260726_toc_highlight_improvement/
+            # task.md for why this matters for TOC highlighting).
+            self.sdoc_do_scroll_to_element_by_xpath(LAST_CHUNK_XPATH)
+            self.assert_element_present(
+                f"{LAST_CHUNK_XPATH}//sdoc-node",
+                by=By.XPATH,
+                timeout=20,
+            )
+
+            # Scroll the now-loaded last requirement into the center of the
+            # viewport so it is unambiguously the "current" section.
+            self.execute_script(
+                "document.getElementById('TOCLZ-035')"
+                ".scrollIntoView({block: 'center'});"
+            )
+            self.sleep(1)
+
+            # The TOC entry for the newly-loaded requirement must be marked
+            # as the current section.
+            toc.assert_toc_link_has_attribute("TOCLZ-035", "intersected")
+
+            # The TOC entry for the first requirement, now scrolled far out
+            # of view, must not be marked as current.
+            toc.assert_toc_link_has_not_attribute("TOCLZ-001", "intersected")


### PR DESCRIPTION
## Summary

Fixes a gap in TOC "current section" highlighting: it doesn't track
content inserted without a matching TOC update (e.g., the upcoming
lazy-chunk-loading feature, and - as a bonus fix - canceling a node
edit today). Full problem/solution writeup:
`developer/tasks/20260726_toc_highlight_improvement/task.md`.

## Changes

- `toc_highlighting.js`: react to newly-inserted content anchors via
  `StrictDoc.onInsert` (the shared, page-wide `MutationObserver`
  contract from `app_core.js`). Re-scans anchors and recomputes visible
  sections without resetting existing TOC link mappings.

- New (currently skipped) e2e test,
`tests/end2end/navigation/toc/toc_highlighting_lazy_chunks/`, covering
  the scenario this fix targets. It's skipped because
  `chunked_documents_threshold` / lazy chunk loading don't exist on
  this branch yet - see the skip reason for what to do once they land.


## Testing

- Existing TOC highlighting e2e tests (`toc_highlighting`,
  `toc_highlighting_table`) pass unchanged.
- New e2e test, disabled on this branch with a
  skip reason pointing at when to re-enable it.

## Follow-up

Whoever lands the lazy-chunk-loading feature should remove the
`@unittest.skip` on `toc_highlighting_lazy_chunks` and confirm it
passes.
