### PR TITLE
feat(test-reports): map JUnit testcase properties

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -50,6 +50,21 @@ releases:
 <<<
 
 [[SECTION]]
+MID: 295e21753ef346d88c2ccb0ceecd0657
+TITLE: Unreleased
+
+[TEXT]
+MID: c9ceba5f4cc74d04b7f389962b1f127a
+STATEMENT: >>>
+This release contains the following enhancements:
+
+1\) The JUnit XML test report reader now maps testcase ``<properties>`` to
+fields on generated ``TEST_RESULT`` nodes.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
 MID: a7ffb392d48244969318ec115e4695bd
 TITLE: 0.27.1 (2026-07-26)
 

--- a/strictdoc/backend/sdoc/models/document_grammar.py
+++ b/strictdoc/backend/sdoc/models/document_grammar.py
@@ -160,7 +160,11 @@ class DocumentGrammar(SDocGrammarIF):
         return grammar
 
     @staticmethod
-    def create_for_test_report(parent: SDocDocumentIF) -> "DocumentGrammar":
+    def create_for_test_report(
+        parent: SDocDocumentIF,
+        *,
+        additional_fields: Optional[List[GrammarElementFieldString]] = None,
+    ) -> "DocumentGrammar":
         section_element: GrammarElement = (
             DocumentGrammar.create_default_section_element(
                 parent=None, enable_mid=parent.config.enable_mid == True
@@ -203,19 +207,25 @@ class DocumentGrammar(SDocGrammarIF):
                 human_title=None,
                 required="True",
             ),
-            GrammarElementFieldString(
-                parent=None,
-                title=RequirementFieldName.TITLE,
-                human_title=None,
-                required="True",
-            ),
-            GrammarElementFieldString(
-                parent=None,
-                title=RequirementFieldName.STATEMENT,
-                human_title=None,
-                required="False",
-            ),
         ]
+        if additional_fields is not None:
+            fields.extend(additional_fields)
+        fields.extend(
+            [
+                GrammarElementFieldString(
+                    parent=None,
+                    title=RequirementFieldName.TITLE,
+                    human_title=None,
+                    required="True",
+                ),
+                GrammarElementFieldString(
+                    parent=None,
+                    title=RequirementFieldName.STATEMENT,
+                    human_title=None,
+                    required="False",
+                ),
+            ]
+        )
         requirement_element = GrammarElement(
             parent=None,
             tag="TEST_RESULT",

--- a/strictdoc/backend/sdoc_source_code/test_reports/junit_xml_reader.py
+++ b/strictdoc/backend/sdoc_source_code/test_reports/junit_xml_reader.py
@@ -3,8 +3,9 @@
 """
 
 import os
+import re
 from enum import IntEnum
-from typing import Any, List, Optional, Type
+from typing import Any, Dict, List, Optional, Set, Type
 
 import bs4
 from bs4 import BeautifulSoup
@@ -12,6 +13,9 @@ from bs4 import BeautifulSoup
 from strictdoc.backend.sdoc.document_reference import DocumentReference
 from strictdoc.backend.sdoc.models.document import SDocDocument
 from strictdoc.backend.sdoc.models.document_grammar import DocumentGrammar
+from strictdoc.backend.sdoc.models.grammar_element import (
+    GrammarElementFieldString,
+)
 from strictdoc.backend.sdoc.models.node import SDocNode, SDocNodeField
 from strictdoc.backend.sdoc.models.reference import (
     FileEntry,
@@ -23,6 +27,7 @@ from strictdoc.core.project_config import ProjectConfig
 from strictdoc.helpers.cast import assert_cast, assert_optional_cast
 from strictdoc.helpers.file_system import file_open_read_utf8
 from strictdoc.helpers.paths import path_to_posix_path
+from strictdoc.helpers.string import is_uppercase_underscore_string
 
 
 class JUnitXMLDialect(IntEnum):
@@ -48,6 +53,17 @@ class JUnitXMLDialect(IntEnum):
 
 
 class JUnitXMLReader:
+    _SAFE_SDOC_FIELD_NAME_REGEX: re.Pattern[str] = re.compile(r"[^A-Za-z0-9]")
+    _TEST_RESULT_RESERVED_FIELD_NAMES: Set[str] = {
+        "UID",
+        "TEST_PATH",
+        "TEST_FUNCTION",
+        "DURATION",
+        "STATUS",
+        "TITLE",
+        "STATEMENT",
+    }
+
     @classmethod
     def read_from_file(
         cls: Type["JUnitXMLReader"],
@@ -87,10 +103,6 @@ class JUnitXMLReader:
             autogen=True,
         )
         document.ng_including_document_reference = DocumentReference()
-        grammar = DocumentGrammar.create_for_test_report(document)
-        document.grammar = grammar
-        document.config.requirement_style = "Table"
-
         xml_testsuite_list: List[bs4.element.Tag]
 
         xml_testsuites: Optional[bs4.element.Tag] = assert_optional_cast(
@@ -115,6 +127,24 @@ class JUnitXMLReader:
             document.title = "Test report: " + assert_cast(
                 xml_testsuite_list[0]["name"], str
             )
+
+        property_field_names: Dict[str, str] = (
+            cls._collect_property_field_names(xml_testsuite_list)
+        )
+        additional_fields: List[GrammarElementFieldString] = [
+            GrammarElementFieldString(
+                parent=None,
+                title=field_name_,
+                human_title=property_name_,
+                required="False",
+            )
+            for property_name_, field_name_ in property_field_names.items()
+        ]
+        grammar = DocumentGrammar.create_for_test_report(
+            document, additional_fields=additional_fields
+        )
+        document.grammar = grammar
+        document.config.requirement_style = "Table"
 
         for xml_testsuite_ in xml_testsuite_list:
             assert isinstance(xml_testsuite_, bs4.element.Tag)
@@ -392,6 +422,26 @@ class JUnitXMLReader:
                         multiline__=None,
                     ),
                 )
+                for xml_property_ in cls._get_xml_property_list(xml_testcase_):
+                    property_name: str = cls._get_xml_property_attribute(
+                        xml_property_, "name"
+                    )
+                    property_value: str = cls._get_xml_property_attribute(
+                        xml_property_, "value"
+                    )
+                    property_field_name: str = property_field_names[
+                        property_name
+                    ]
+                    testcase_node.set_field_value(
+                        field_name=property_field_name,
+                        form_field_index=0,
+                        value=SDocNodeField(
+                            parent=testcase_node,
+                            field_name=property_field_name,
+                            parts=[property_value],
+                            multiline__=None,
+                        ),
+                    )
                 testcase_node.set_field_value(
                     field_name="TITLE",
                     form_field_index=0,
@@ -434,3 +484,101 @@ class JUnitXMLReader:
                 test_suite_section.section_contents.append(testcase_node)
 
         return document
+
+    @classmethod
+    def _collect_property_field_names(
+        cls: Type["JUnitXMLReader"],
+        xml_testsuite_list: List[bs4.element.Tag],
+    ) -> Dict[str, str]:
+        property_field_names: Dict[str, str] = {}
+        property_names_by_field_name: Dict[str, str] = {}
+
+        for xml_testsuite_ in xml_testsuite_list:
+            xml_testcase_list: List[Any] = xml_testsuite_.find_all(
+                "testcase", recursive=False
+            )
+            for xml_testcase_ in xml_testcase_list:
+                assert isinstance(xml_testcase_, bs4.element.Tag)
+                property_names_for_testcase: Set[str] = set()
+                for xml_property_ in cls._get_xml_property_list(xml_testcase_):
+                    property_name: str = cls._get_xml_property_attribute(
+                        xml_property_, "name"
+                    )
+                    if property_name in property_names_for_testcase:
+                        raise RuntimeError(
+                            "JUnit testcase contains duplicate property name: "
+                            f"{property_name!r}."
+                        )
+                    property_names_for_testcase.add(property_name)
+                    field_name: str = cls._create_sdoc_field_name(property_name)
+                    if not is_uppercase_underscore_string(field_name):
+                        raise RuntimeError(
+                            "JUnit property name cannot be mapped to a "
+                            "StrictDoc field name: "
+                            f"{property_name!r}."
+                        )
+                    if field_name in cls._TEST_RESULT_RESERVED_FIELD_NAMES:
+                        raise RuntimeError(
+                            "JUnit property name maps to a reserved "
+                            "TEST_RESULT field: "
+                            f"{property_name!r} -> {field_name!r}."
+                        )
+                    existing_property_name: Optional[str] = (
+                        property_names_by_field_name.get(field_name)
+                    )
+                    if (
+                        existing_property_name is not None
+                        and existing_property_name != property_name
+                    ):
+                        raise RuntimeError(
+                            "JUnit property names map to the same StrictDoc "
+                            "field: "
+                            f"{existing_property_name!r}, {property_name!r} "
+                            f"-> {field_name!r}."
+                        )
+                    property_names_by_field_name[field_name] = property_name
+                    property_field_names[property_name] = field_name
+
+        return property_field_names
+
+    @staticmethod
+    def _get_xml_property_list(
+        xml_testcase: bs4.element.Tag,
+    ) -> List[bs4.element.Tag]:
+        xml_properties_or_none: Optional[bs4.element.Tag] = (
+            assert_optional_cast(
+                xml_testcase.find("properties", recursive=False),
+                bs4.element.Tag,
+            )
+        )
+        if xml_properties_or_none is None:
+            return []
+        return [
+            assert_cast(xml_property_, bs4.element.Tag)
+            for xml_property_ in xml_properties_or_none.find_all(
+                "property", recursive=False
+            )
+        ]
+
+    @staticmethod
+    def _get_xml_property_attribute(
+        xml_property: bs4.element.Tag, attribute_name: str
+    ) -> str:
+        attribute_value: Any = xml_property.get(attribute_name)
+        if attribute_value is None:
+            raise RuntimeError(
+                "JUnit property is missing required "
+                f"{attribute_name!r} attribute."
+            )
+        if not isinstance(attribute_value, str):
+            raise RuntimeError(
+                "JUnit property attribute must be a string: "
+                f"{attribute_name!r}."
+            )
+        return attribute_value
+
+    @classmethod
+    def _create_sdoc_field_name(
+        cls: Type["JUnitXMLReader"], property_name: str
+    ) -> str:
+        return cls._SAFE_SDOC_FIELD_NAME_REGEX.sub("_", property_name).upper()

--- a/tests/integration/features/test_reports/junit_xml/ctest/06_testcase_properties/docs/input.sdoc
+++ b/tests/integration/features/test_reports/junit_xml/ctest/06_testcase_properties/docs/input.sdoc
@@ -1,0 +1,6 @@
+[DOCUMENT]
+TITLE: Testcase properties
+
+[REQUIREMENT]
+UID: REQ-1
+STATEMENT: Test statement.

--- a/tests/integration/features/test_reports/junit_xml/ctest/06_testcase_properties/reports/tests_unit.ctest.junit.xml
+++ b/tests/integration/features/test_reports/junit_xml/ctest/06_testcase_properties/reports/tests_unit.ctest.junit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="testcase properties"
+           tests="1"
+           failures="0"
+           disabled="0"
+           skipped="0"
+           time="0">
+  <testcase name="TestSuite.Test1"
+            classname="TestSuite.Test1"
+            time="0.1"
+            status="run">
+    <properties>
+      <property name="requirement" value="REQ-1"/>
+      <property name="strictdoc:image" value="test1.png"/>
+    </properties>
+  </testcase>
+</testsuite>

--- a/tests/integration/features/test_reports/junit_xml/ctest/06_testcase_properties/strictdoc_config.py
+++ b/tests/integration/features/test_reports/junit_xml/ctest/06_testcase_properties/strictdoc_config.py
@@ -1,0 +1,8 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=["REQUIREMENT_TO_SOURCE_TRACEABILITY"],
+    )
+    return config

--- a/tests/integration/features/test_reports/junit_xml/ctest/06_testcase_properties/test.itest
+++ b/tests/integration/features/test_reports/junit_xml/ctest/06_testcase_properties/test.itest
@@ -1,0 +1,12 @@
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+
+# Ensure that the test report document is generated.
+CHECK: Published: Test report: testcase properties
+RUN: %check_exists --file "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html"
+
+# Ensure that testcase properties are rendered as TEST_RESULT fields.
+RUN: %cat "%T/html/%THIS_TEST_FOLDER/reports/tests_unit.ctest.junit.html" | filecheck %s --check-prefix CHECK-TEST-REPORT
+CHECK-TEST-REPORT: <sdoc-node-field-label>requirement:</sdoc-node-field-label>
+CHECK-TEST-REPORT: <sdoc-autogen>REQ-1</sdoc-autogen>
+CHECK-TEST-REPORT: <sdoc-node-field-label>strictdoc:image:</sdoc-node-field-label>
+CHECK-TEST-REPORT: <sdoc-autogen>test1.png</sdoc-autogen>

--- a/tests/integration/features/test_reports/junit_xml/ctest/06_testcase_properties/tests/test.cpp
+++ b/tests/integration/features/test_reports/junit_xml/ctest/06_testcase_properties/tests/test.cpp
@@ -1,0 +1,6 @@
+/**
+ * @relation(REQ-1, scope=function)
+ */
+TEST(TestSuite, Test1)
+{
+}

--- a/tests/unit/strictdoc/backend/sdoc_source_code/test_reports/test_junit_xml_reader_ctest.py
+++ b/tests/unit/strictdoc/backend/sdoc_source_code/test_reports/test_junit_xml_reader_ctest.py
@@ -63,6 +63,163 @@ def test_01_ctest():
         )
 
 
+def test_02_testcase_properties_are_mapped_to_fields():
+    source_input = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Test suite" tests="1" failures="0" skipped="0">
+  <testcase name="TestSuite.Test1"
+            classname="TestSuite.Test1"
+            time="0.1">
+    <properties>
+      <property name="requirement" value="REQ1"/>
+      <property name="strictdoc:image" value="test1.png"/>
+    </properties>
+  </testcase>
+</testsuite>
+"""
+
+    project_config: ProjectConfig = ProjectConfig.default_config()
+
+    with tempfile.NamedTemporaryFile(
+        mode="w+", delete=True, suffix=".ctest.junit.xml"
+    ) as temp_file:
+        doc_file: File = File(
+            0,
+            temp_file.name,
+            SDocRelativePath(os.path.basename(temp_file.name)),
+        )
+        document: SDocDocument = JUnitXMLReader.read_from_string(
+            source_input, doc_file, project_config
+        )
+
+        test_result_grammar = document.grammar.elements_by_type["TEST_RESULT"]
+        assert (
+            test_result_grammar.fields_map["REQUIREMENT"].human_title
+            == "requirement"
+        )
+        assert (
+            test_result_grammar.fields_map["STRICTDOC_IMAGE"].human_title
+            == "strictdoc:image"
+        )
+        assert not test_result_grammar.is_field_multiline("REQUIREMENT")
+        assert not test_result_grammar.is_field_multiline("STRICTDOC_IMAGE")
+
+        test_result_node: SDocNode = assert_cast(
+            document.section_contents[0].section_contents[1], SDocNode
+        )
+        assert (
+            test_result_node.get_meta_field_value_by_title("REQUIREMENT")
+            == "REQ1"
+        )
+        assert (
+            test_result_node.get_meta_field_value_by_title("STRICTDOC_IMAGE")
+            == "test1.png"
+        )
+
+
+def test_03_property_names_may_repeat_across_testcases():
+    source_input = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Test suite" tests="2" failures="0" skipped="0">
+  <testcase name="TestSuite.Test1"
+            classname="TestSuite.Test1"
+            time="0.1">
+    <properties>
+      <property name="requirement" value="REQ1"/>
+    </properties>
+  </testcase>
+  <testcase name="TestSuite.Test2"
+            classname="TestSuite.Test2"
+            time="0.1">
+    <properties>
+      <property name="requirement" value="REQ2"/>
+    </properties>
+  </testcase>
+</testsuite>
+"""
+
+    document: SDocDocument = _read_ctest_source(source_input)
+    first_test_result: SDocNode = assert_cast(
+        document.section_contents[0].section_contents[1], SDocNode
+    )
+    second_test_result: SDocNode = assert_cast(
+        document.section_contents[0].section_contents[2], SDocNode
+    )
+    assert (
+        first_test_result.get_meta_field_value_by_title("REQUIREMENT") == "REQ1"
+    )
+    assert (
+        second_test_result.get_meta_field_value_by_title("REQUIREMENT")
+        == "REQ2"
+    )
+
+
+@pytest.mark.parametrize(
+    ("property_xml", "expected_error"),
+    [
+        (
+            '<property name="requirement--id" value="REQ1"/>',
+            (
+                "JUnit property name cannot be mapped to a StrictDoc field "
+                "name: 'requirement--id'."
+            ),
+        ),
+        (
+            '<property name="status" value="ignored"/>',
+            (
+                "JUnit property name maps to a reserved TEST_RESULT field: "
+                "'status' -> 'STATUS'."
+            ),
+        ),
+        (
+            """\
+<property name="strictdoc:image" value="test1.png"/>
+<property name="strictdoc-image" value="test2.png"/>\
+""",
+            (
+                "JUnit property names map to the same StrictDoc field: "
+                "'strictdoc:image', 'strictdoc-image' -> "
+                "'STRICTDOC_IMAGE'."
+            ),
+        ),
+        (
+            """\
+<property name="requirement" value="REQ1"/>
+<property name="requirement" value="REQ2"/>\
+""",
+            ("JUnit testcase contains duplicate property name: 'requirement'."),
+        ),
+        (
+            '<property value="REQ1"/>',
+            "JUnit property is missing required 'name' attribute.",
+        ),
+        (
+            '<property name="requirement"/>',
+            "JUnit property is missing required 'value' attribute.",
+        ),
+    ],
+)
+def test_04_invalid_testcase_properties_are_rejected(
+    property_xml: str, expected_error: str
+):
+    source_input = f"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Test suite" tests="1" failures="0" skipped="0">
+  <testcase name="TestSuite.Test1"
+            classname="TestSuite.Test1"
+            time="0.1">
+    <properties>
+      {property_xml}
+    </properties>
+  </testcase>
+</testsuite>
+"""
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _ = _read_ctest_source(source_input)
+    assert expected_error == str(exc_info.value)
+
+
 def test__90__error_handling__empty_xml():
     source_input = ""
 
@@ -83,3 +240,19 @@ def test__90__error_handling__empty_xml():
         assert """\
 Document is empty, line 1, column 1 (<string>, line 1)\
 """ == str(exc_info.value)
+
+
+def _read_ctest_source(source_input: str) -> SDocDocument:
+    project_config: ProjectConfig = ProjectConfig.default_config()
+
+    with tempfile.NamedTemporaryFile(
+        mode="w+", delete=True, suffix=".ctest.junit.xml"
+    ) as temp_file:
+        doc_file: File = File(
+            0,
+            temp_file.name,
+            SDocRelativePath(os.path.basename(temp_file.name)),
+        )
+        return JUnitXMLReader.read_from_string(
+            source_input, doc_file, project_config
+        )


### PR DESCRIPTION
## What changed

- Map testcase `<properties>` into generated `TEST_RESULT` fields.
- Normalize property names to valid uppercase StrictDoc field identifiers while
  preserving the original names as human-readable field titles.
- Reject invalid, reserved, normalization-colliding, and duplicate property
  names with actionable errors.
- Add focused unit and HTML integration coverage.
- Add an Unreleased note.

## Why

StrictDoc previously discarded testcase properties during JUnit XML ingestion,
so test-runner metadata could not appear in generated reports. This implements
the generic metadata portion of #3050 without defining attachment copying or
special rendering semantics.

Duplicate property names remain valid across different testcases. They are
rejected within one testcase because StrictDoc fields are single-valued and a
silent last-value-wins mapping would lose metadata emitted by runners such as
pytest.

## User impact

JUnit metadata such as requirement identifiers and `strictdoc:image` now appears
as ordinary string fields in generated test-result reports. Existing reports
without testcase properties are unchanged.

## Validation

- `invoke test-unit`: 655 passed, 1 skipped.
- `invoke lint-mypy`: passed.
- `invoke lint-ruff`: passed.
- `invoke test-integration --focus 06_testcase_properties
  --no-parallelization` under WSL: 1 selected test passed.
- `invoke docs`: the changed release notes parsed successfully; the export then
  stopped on the existing Windows path-length limitation.
