### PR TITLE
Fix editable Relation field for nodes without relations

### DIFF
--- a/developer/tasks/20260731_3059_table_view_wrong_field/task.md
+++ b/developer/tasks/20260731_3059_table_view_wrong_field/task.md
@@ -1,0 +1,48 @@
+# TABLE VIEW Relation field for unsupported node types
+
+## WHAT
+
+In TABLE VIEW, a Relation cell must be editable only when the grammar of the
+specific node type declares at least one relation type. For a node type without
+relations, the cell must be rendered as a dimmed, inactive cell like other
+grammar fields that are not declared for that node.
+
+The relation editing form must present diagnostics consistently: the file
+relation limitation belongs with form errors, and parent-relation UID
+validation must not be reported for file relations.
+
+The change is covered by an end-to-end regression fixture with a minimal
+SECTION without relations and a second node with a UID. The test enters TABLE
+VIEW edit mode and verifies that the SECTION Relation cell cannot be opened.
+
+## WHY
+
+The TABLE VIEW showed an active Relation editor for a NODE whose grammar did
+not support relations. Users could add a UID, but saving produced a 422 error
+instead of a meaningful result.
+
+The misleading UID error had a specific cause: when the relation type select
+had no options, the browser omitted the value and request parsing defaulted the
+relation type to `File`. Validation then checked only that a reference field
+existed, regardless of whether it was a Parent/Child relation, and emitted the
+parent-relation UID message.
+
+The file-relation warning was rendered as a standalone inline block instead of
+through the form error component, so it appeared in the wrong place relative
+to validation errors.
+
+## HOW
+
+The TABLE VIEW view object now treats `RELATIONS` as editable only when the
+grammar element has declared relations. The table template uses this check and
+renders the same dimmed-cell structure used by other unavailable fields.
+
+Requirement form validation now requires a UID only when at least one Parent or
+Child reference is present; File references do not trigger that diagnostic.
+The unsupported file-relation message is rendered with `sdoc-form-error` so it
+is grouped with the form's errors.
+
+The regression test lives under
+`tests/end2end/screens/table/view_table_edit/_relations/` and is run headless
+through the Invoke end-to-end task. Existing relation-editing and UID-validation
+tests remain unchanged and pass.

--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -60,6 +60,9 @@ This release contains the following enhancements:
 
 1\) The JUnit XML test report reader now maps testcase ``<properties>`` to
 fields on generated ``TEST_RESULT`` nodes.
+
+4\) Fixed: the TABLE VIEW now renders the Relation cell as non-editable for node
+types whose grammar does not declare relations.
 <<<
 
 [[/SECTION]]

--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -857,7 +857,15 @@ class RequirementFormObject(ErrorObject):
         requirement_uid: Optional[str] = (
             self.fields["UID"][0].field_value if "UID" in self.fields else None
         )
-        if len(self.reference_fields) > 0 and (
+        has_requirement_relations = any(
+            reference_field.field_type
+            in (
+                RequirementReferenceFormField.FieldType.PARENT,
+                RequirementReferenceFormField.FieldType.CHILD,
+            )
+            for reference_field in self.reference_fields
+        )
+        if has_requirement_relations and (
             requirement_uid is None or len(requirement_uid) == 0
         ):
             self.add_error(
@@ -871,7 +879,7 @@ class RequirementFormObject(ErrorObject):
             self.existing_requirement_uid is not None
             and self.existing_requirement_uid != requirement_uid
         ):
-            if len(self.reference_fields) > 0:
+            if has_requirement_relations:
                 self.add_error(
                     "UID",
                     "Not supported yet: "

--- a/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
+++ b/strictdoc/export/html/generators/view_objects/document_screen_view_object.py
@@ -671,6 +671,12 @@ class DocumentScreenViewObject:
         self, element_type: str, field_name: str
     ) -> bool:
         """Returns True if the field is declared in grammar and can be edited on TABLE screen."""
+        if field_name == "RELATIONS":
+            grammar = self.document.grammar
+            if grammar is None:
+                return False
+            element = grammar.elements_by_type.get(element_type)
+            return element is not None and len(element.relations) > 0
         return (
             self.get_table_cell_edit_mode(element_type, field_name)
             != TableCellEditMode.READONLY

--- a/strictdoc/export/html/templates/components/form/row/row_with_relation.jinja
+++ b/strictdoc/export/html/templates/components/form/row/row_with_relation.jinja
@@ -46,11 +46,10 @@
     {%- endfor -%}
   {%- endif -%}
 
-  {# FIXME: #}
   {% if relation_row_context.field.field_type == "File" %}
-    <div style="color: orange; margin-top: calc(var(--base-rhythm) * (-3)); font-size: 0.75em;">
-      <b>Warning: Editing file relations is not supported yet.</b>
-    </div>
+    <sdoc-form-error>
+      Warning: Editing file relations is not supported yet.
+    </sdoc-form-error>
   {% endif %}
 
   {%- with

--- a/strictdoc/export/html/templates/screens/document/table/body.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/body.jinja
@@ -37,6 +37,7 @@
 
         {%- if column == "RELATIONS" %}
           {%- set ns.past_reserved = true %}
+          {%- if view_object.is_table_cell_editable(node.node_type, "RELATIONS") %}
           <td class="content-view-td content-view-td-meta content-view-td-related"
               data-field-name="RELATIONS"
               {%- if is_server %}
@@ -51,6 +52,12 @@
               {%- include "screens/document/table/field_display_mode/relations.jinja" %}
             </div>
           </td>
+          {%- else %}
+          <td class="content-view-td content-view-td-meta content-view-td-related content-view-td--dimmed"
+              data-field-name="RELATIONS">
+            <div class="content-view-td--dimmed_tips"></div>
+          </td>
+          {%- endif %}
 
         {%- elif column == "TITLE" %}
           {%- set ns.past_reserved = true %}

--- a/tests/end2end/screens/table/view_table_edit/_relations/edit_table_cell_relations_not_declared/expected_output/document.sdoc
+++ b/tests/end2end/screens/table/view_table_edit/_relations/edit_table_cell_relations_not_declared/expected_output/document.sdoc
@@ -1,0 +1,31 @@
+[DOCUMENT]
+TITLE: Document
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: True
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  RELATIONS:
+  - TYPE: Parent
+
+[[SECTION]]
+TITLE: Section title
+
+[[/SECTION]]
+
+[REQUIREMENT]
+UID: REQ-001
+TITLE: Requirement title

--- a/tests/end2end/screens/table/view_table_edit/_relations/edit_table_cell_relations_not_declared/input/document.sdoc
+++ b/tests/end2end/screens/table/view_table_edit/_relations/edit_table_cell_relations_not_declared/input/document.sdoc
@@ -1,0 +1,31 @@
+[DOCUMENT]
+TITLE: Document
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: True
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  RELATIONS:
+  - TYPE: Parent
+
+[[SECTION]]
+TITLE: Section title
+
+[[/SECTION]]
+
+[REQUIREMENT]
+UID: REQ-001
+TITLE: Requirement title

--- a/tests/end2end/screens/table/view_table_edit/_relations/edit_table_cell_relations_not_declared/test_case.py
+++ b/tests/end2end/screens/table/view_table_edit/_relations/edit_table_cell_relations_not_declared/test_case.py
@@ -1,0 +1,45 @@
+from selenium.webdriver.common.by import By
+
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.viewtype_selector import ViewType_Selector
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_document = screen_project_index.do_click_on_first_document()
+            screen_document.assert_on_screen_document()
+
+            self.clear_local_storage()
+
+            viewtype_selector = ViewType_Selector(self)
+            screen_table = viewtype_selector.do_go_to_table()
+            screen_table.assert_on_screen_table()
+
+            section_mid = screen_table.get_node_mid_from_row(row_order=1)
+            assert section_mid is not None
+
+            screen_table.do_toggle_edit_mode()
+            screen_table.assert_edit_mode_on()
+
+            screen_table.assert_table_cell_is_dimmed("SECTION", "RELATIONS")
+            self.assert_element_not_present(
+                f'//tr[@data-node-mid="{section_mid}"]'
+                '//td[@data-field-name="RELATIONS"]'
+                '[@js-table_view_edit-field="relations"]',
+                by=By.XPATH,
+            )
+
+        assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION

- Disable Relation cells for node types whose grammar does not define any relations.
- Render such Relation cells as dimmed and non-editable, consistent with other unsupported fields.
- Run the UID-required validation only for Parent and Child relations, not for File relations.
- Display the unsupported File relation warning together with the form validation errors.
- Add end-to-end regression test.

Closes #3059