### PR TITLE
fix: keep node dropdown menus fully visible near the bottom of the scroll area

### DIFF
--- a/strictdoc/export/html/_static/content.css
+++ b/strictdoc/export/html/_static/content.css
@@ -85,7 +85,6 @@
 [data-viewtype="document"] .content {
   display: block;
   max-width: 900px;
-  /* margin-bottom: 300px; */
   margin-left: auto;
   margin-right: auto;
 }

--- a/strictdoc/export/html/_static/dropdown_menu.js
+++ b/strictdoc/export/html/_static/dropdown_menu.js
@@ -33,12 +33,51 @@
       t.setAttribute('aria-expanded', isThis);
       content.setAttribute('aria-hidden', !isThis);
     });
+    positionMenu(toggle);
   }
 
   function hide(toggle) {
     const content = contentOf(toggle);
     toggle.setAttribute('aria-expanded', false);
-    if (content) content.setAttribute('aria-hidden', true);
+    if (content) {
+      content.setAttribute('aria-hidden', true);
+      content.classList.remove('is-flipped');
+    }
+  }
+
+  // A menu that opens downward from a node near the bottom of the scroll
+  // area can render past the visible edge and become unreachable - there is
+  // no CSS-only way to detect that, so this measures the menu after it's
+  // shown and, if it would overflow, flips it to open upward instead
+  // (mirrors the CSS `top: 0` anchor to `bottom: 0` via `.is-flipped`, see
+  // element.css). If even the flipped position doesn't fully fit inside the
+  // scroll container, nudge the scroll position so the whole menu stays
+  // reachable rather than being clipped.
+  function positionMenu(toggle) {
+    const content = contentOf(toggle);
+    if (!content) return;
+
+    content.classList.remove('is-flipped');
+
+    const container = content.closest('.main');
+    const containerRect = container
+      ? container.getBoundingClientRect()
+      : { top: 0, bottom: window.innerHeight };
+
+    if (content.getBoundingClientRect().bottom > containerRect.bottom) {
+      content.classList.add('is-flipped');
+    }
+
+    if (!container) return;
+
+    const rect = content.getBoundingClientRect();
+    const overflowBelow = rect.bottom - containerRect.bottom;
+    const overflowAbove = containerRect.top - rect.top;
+    if (overflowBelow > 0) {
+      container.scrollTop += overflowBelow;
+    } else if (overflowAbove > 0) {
+      container.scrollTop -= overflowAbove;
+    }
   }
 
   window.StrictDoc.onInsert('[data-dropdown-handler]', (toggle) => {

--- a/strictdoc/export/html/_static/element.css
+++ b/strictdoc/export/html/_static/element.css
@@ -1166,6 +1166,13 @@ sdoc-menu menu {
 
 }
 
+/* Set by dropdown_menu.js when the menu would otherwise overflow past the
+   bottom of the scroll area - opens upward instead of downward. */
+sdoc-menu menu.is-flipped {
+  top: auto;
+  bottom: 0;
+}
+
 sdoc-menu.add_node menu {
   display: grid;
   grid-template-columns:  minmax(min-content, max-content)


### PR DESCRIPTION


Replaces the static margin-bottom: 300px hack on .content (which reserved scroll space unconditionally, causing an unwanted jump-to-bottom on fragment links even on short pages) with actual collision detection: dropdown_menu.js now measures the menu against the .main scroll container's bottom edge when it opens, flips it upward (.is-flipped in element.css) if it would overflow, and nudges the container's scroll position if the flipped menu still doesn't fully fit.

Closes #3051
Connected to old problem #1114