### PR TITLE
fix: count invalid fields, not error messages, in form tab badge

### DIFF
--- a/developer/tasks/20260731_3058_form_validation_ui/task.md
+++ b/developer/tasks/20260731_3058_form_validation_ui/task.md
@@ -1,0 +1,67 @@
+# Per-tab error badge must count invalid fields, not error messages
+
+## WHAT
+
+- In the node-edit popup form (tabs: `Fields`, `Relations`, `Comments`), each
+  tab with at least one invalid field shows a red numeric badge.
+- The badge must show the number of **distinct fields** on that tab that have
+  at least one validation error.
+- It currently shows the total number of validation **error messages** on
+  that tab, which over-counts whenever a single field accumulates more than
+  one error message (e.g. the `UID` field can carry up to three messages at
+  once: uniqueness, "requires an UID because it has parent relations",
+  "renaming with parent/child relations not supported").
+- Individual field-level error display is out of scope and already correct:
+  each error message must keep rendering in its own `<sdoc-form-error>` tag
+  under its field, one tag per message, even when a field has several.
+- Applies uniformly to all fields/tabs, not just `UID`.
+
+### Test case
+
+- Trigger a validation failure where one field (e.g. `UID`) ends up with two
+  error messages and another field on the same tab (e.g. `STATEMENT`) ends
+  up with one error message.
+- The tab badge must read `2` (two invalid fields), not `3` (three error
+  messages).
+- Both `UID` error messages must still each render in their own
+  `<sdoc-form-error>` tag.
+
+## WHY
+
+- The badge is meant to tell the user how many fields need attention on a
+  tab, so they know how much work is left before the form can be submitted.
+- Reporting the message count instead misleads the user: e.g. a badge
+  reading "3" for what is actually one problem field (with 3 stacked
+  messages) plus one other field overstates the number of things to fix,
+  and doesn't match the number of fields actually shown as invalid.
+
+## HOW
+
+- The count is currently computed entirely client-side, in
+  `strictdoc/export/html/_static/tabs.js`, via
+  `contentEl.querySelectorAll('sdoc-form-error').length` — one entry per
+  `<sdoc-form-error>` DOM node, i.e. per error message, not per field.
+  The badge itself is pure CSS
+  (`strictdoc/export/html/_static/element.css`), driven by the
+  `data-errors` attribute that `tabs.js` sets on `<sdoc-tab>`.
+- Field-level error messages are rendered by the row/field partials under
+  `strictdoc/export/html/templates/components/form/...`
+  (e.g. `row/row_with_text_field.jinja`, `field/contenteditable/index.jinja`,
+  `field/autocompletable/index.jinja`, `row/row_with_relation.jinja`,
+  `row/row_with_comment.jinja`, `row/row_uid_with_reset/frame.jinja`), each
+  looping over its own field's error list and emitting one
+  `<sdoc-form-error>` per message — this part is unchanged.
+- Fix direction (to be confirmed during implementation): count distinct
+  error-owning field containers per tab instead of raw `<sdoc-form-error>`
+  nodes — e.g. in `tabs.js`, count elements that carry a field-level wrapper
+  attribute/class and have at least one `sdoc-form-error` descendant, rather
+  than counting the `sdoc-form-error` descendants themselves. No Python
+  changes appear necessary since error grouping by field name already
+  exists server-side in `strictdoc/server/error_object.py`
+  (`ErrorObject.errors: Dict[str, List[str]]`).
+- No existing automated test asserts on the badge's `data-errors` value.
+  Add end2end coverage for a field with multiple stacked error messages
+  (e.g. the `UID` "must be unique" + "parent relations" combination, or a
+  synthetic case) confirming the badge equals the number of invalid fields;
+  extend `tests/end2end/helpers/form/form.py` with an assertion helper for
+  the tab badge count if none exists.

--- a/strictdoc/export/html/_static/tabs.js
+++ b/strictdoc/export/html/_static/tabs.js
@@ -29,9 +29,19 @@
     const tabs = {};
     const errorTabs = [];
 
+    // A field can carry more than one <sdoc-form-error> (e.g. a UID field
+    // failing both the uniqueness check and the rename-with-relations
+    // check at once). The badge must count invalid fields, not messages,
+    // so errors are deduplicated by their closest field-owning ancestor.
+    const FIELD_WRAPPER_SELECTOR = 'sdoc-form-row, sdoc-form-field-group, sdoc-form-field';
+
     sdocTabContent.forEach((contentEl, index) => {
       const key = contentEl.id;
-      const errors = contentEl.querySelectorAll('sdoc-form-error');
+      const errorFields = new Set(
+        [...contentEl.querySelectorAll('sdoc-form-error')].map(
+          (errorEl) => errorEl.closest(FIELD_WRAPPER_SELECTOR) || errorEl
+        )
+      );
 
       const tabEl = document.createElement('sdoc-tab');
       tabEl.style.order = index;
@@ -39,8 +49,8 @@
       tabEl.setAttribute('data-testid', `form-tab-${key}`);
       tabEl.addEventListener('mouseup', () => activateTab(tabs, key));
       if (contentEl.hasAttribute('active')) tabEl.setAttribute('active', '');
-      if (errors.length) {
-        tabEl.setAttribute('data-errors', errors.length);
+      if (errorFields.size) {
+        tabEl.setAttribute('data-errors', errorFields.size);
         errorTabs.push(key);
       }
 

--- a/tests/end2end/helpers/form/form.py
+++ b/tests/end2end/helpers/form/form.py
@@ -84,6 +84,16 @@ class Form:  # pylint: disable=invalid-name
             f"//*[@data-testid='form-tab-{tab_name}']"
         )
 
+    def assert_tab_error_count(self, tab_name: str, count: int) -> None:
+        assert isinstance(tab_name, str)
+        assert isinstance(count, int)
+        self.test_case.assert_attribute(
+            f"//*[@data-testid='form-tab-{tab_name}']",
+            "data-errors",
+            str(count),
+            by=By.XPATH,
+        )
+
     #
     # Work with fields containers.
     #

--- a/tests/end2end/screens/document/update_node/_validation/update_requirement_error_badge_counts_invalid_fields_not_messages/expected_output/document.sdoc
+++ b/tests/end2end/screens/document/update_node/_validation/update_requirement_error_badge_counts_invalid_fields_not_messages/expected_output/document.sdoc
@@ -1,0 +1,45 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+  RELATIONS:
+  - TYPE: Parent
+
+[REQUIREMENT]
+UID: REQ-001
+TITLE: Requirement title #1
+STATEMENT: >>>
+Requirement statement #1.
+<<<
+
+[REQUIREMENT]
+UID: REQ-002
+TITLE: Requirement title #2
+STATEMENT: >>>
+Requirement statement #2.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: REQ-001
+
+[REQUIREMENT]
+UID: REQ-003
+TITLE: Requirement title #3
+STATEMENT: >>>
+Requirement statement #3.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: REQ-002

--- a/tests/end2end/screens/document/update_node/_validation/update_requirement_error_badge_counts_invalid_fields_not_messages/input/document.sdoc
+++ b/tests/end2end/screens/document/update_node/_validation/update_requirement_error_badge_counts_invalid_fields_not_messages/input/document.sdoc
@@ -1,0 +1,45 @@
+[DOCUMENT]
+TITLE: Document 1
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: REQUIREMENT
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: False
+  - TITLE: STATEMENT
+    TYPE: String
+    REQUIRED: True
+  RELATIONS:
+  - TYPE: Parent
+
+[REQUIREMENT]
+UID: REQ-001
+TITLE: Requirement title #1
+STATEMENT: >>>
+Requirement statement #1.
+<<<
+
+[REQUIREMENT]
+UID: REQ-002
+TITLE: Requirement title #2
+STATEMENT: >>>
+Requirement statement #2.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: REQ-001
+
+[REQUIREMENT]
+UID: REQ-003
+TITLE: Requirement title #3
+STATEMENT: >>>
+Requirement statement #3.
+<<<
+RELATIONS:
+- TYPE: Parent
+  VALUE: REQ-002

--- a/tests/end2end/screens/document/update_node/_validation/update_requirement_error_badge_counts_invalid_fields_not_messages/test_case.py
+++ b/tests/end2end/screens/document/update_node/_validation/update_requirement_error_badge_counts_invalid_fields_not_messages/test_case.py
@@ -1,0 +1,70 @@
+"""
+@relation(SDOC-SRS-55, scope=file)
+"""
+
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.screens.document.form_edit_requirement import (
+    Form_EditRequirement,
+)
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+
+            # REQ-002 has both an outgoing Parent relation (to REQ-001) and
+            # an incoming Child relation (from REQ-003), so renaming its UID
+            # adds two separate error messages to the same UID field.
+            requirement = screen_document.get_node(2)
+            form_edit_requirement: Form_EditRequirement = (
+                requirement.do_open_form_edit_requirement()
+            )
+
+            form_edit_requirement.do_fill_in_field_uid("Modified UID")
+            form_edit_requirement.do_clear_field("STATEMENT")
+
+            form_edit_requirement.do_form_submit_and_catch_error(
+                "Not supported yet: "
+                "Renaming a requirement UID when the requirement has parent "
+                "requirement relations. For now, manually delete the relations,"
+                " rename the UID, recreate the relations."
+            )
+            form_edit_requirement.do_form_submit_and_catch_error(
+                "Not supported yet: "
+                "Renaming a requirement UID when the requirement has child "
+                "requirement relations. For now, manually delete the relations,"
+                " rename the UID, recreate the relations."
+            )
+            form_edit_requirement.do_form_submit_and_catch_error(
+                "Node's STATEMENT must not be empty. "
+                "If there is no appropriate value for this field yet, "
+                "enter TBD (to be done) or TBC (to be confirmed)."
+            )
+
+            # 3 error messages (2 on UID, 1 on STATEMENT) but only 2 fields
+            # are actually invalid: the "Fields" tab badge must show 2.
+            form_edit_requirement.assert_tab_error_count("Fields", 2)
+
+            form_edit_requirement.do_form_cancel()
+
+        assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
The per-tab error badge in the node-edit form counted <sdoc-form-error> message tags instead of distinct invalid fields, overstating the count whenever one field (e.g. UID) collected several messages at once.

tabs.js now dedupes error tags by their closest field-owning ancestor. Adds an e2e test and a form-helper assertion for the tab badge count.

Closes #3058 