### PR TITLE
feat: add UID restore button for rejected relation-blocked renames

### DIFF
--- a/developer/tasks/20260731_3083_restore_deleted_uid/task.md
+++ b/developer/tasks/20260731_3083_restore_deleted_uid/task.md
@@ -1,0 +1,129 @@
+# Restore-UID button on "renaming UID with relations" validation error
+
+## WHAT
+
+- When a user edits a requirement's `UID` field and submits the form while
+  the requirement still has parent or child relations, validation currently
+  rejects the change with an inline error:
+  > Not supported yet: Renaming a requirement UID when the requirement has
+  > parent requirement relations. For now, manually delete the relations,
+  > rename the UID, recreate the relations.
+  (a sibling message exists for child relations).
+- Today the form re-renders with the `UID` field still showing the new
+  (rejected) value the user typed, alongside the error message, with no way
+  to get back to the previous, valid UID short of closing the form.
+- When this specific validation error fires, show a "restore" button next
+  to the `UID` field, in `sdoc-form-row-aside`, next to where the existing
+  reset button (`data-action-type="reset"`, tooltip "Generate default UID")
+  lives for the empty-UID case. Clicking it puts the requirement's original
+  UID (the value it had when the form was opened) back into the field, in
+  place, without submitting or closing the form, and clears the now-stale
+  validation error(s) shown for that field.
+- This applies to both the parent-relations and child-relations variants of
+  this error.
+- The existing "reset" button's tooltip was renamed from "Reset UID to
+  default" to "Generate default UID": once both buttons can appear side by
+  side (empty UID + relations-blocked rename), "Reset" read as too close in
+  meaning to the new "Restore UID" even though it does something different
+  (invents a new auto-numbered UID vs. bringing back the prior one).
+- Out of scope: changing the underlying rule that UID renaming is blocked
+  while relations exist; any change to how relations themselves are
+  deleted/recreated; the reset button's behavior itself (unrelated — it
+  generates a new auto-numbered UID for an empty field, it does not
+  restore a prior value; only its tooltip text changed).
+
+### Test case
+
+- Open the edit form for a requirement that has a parent relation.
+- Change `UID` to a new value and submit.
+- The form re-renders with the parent-relations error message, the `UID`
+  field still showing the rejected value, and a restore button next to it.
+- Clicking the restore button puts the requirement's original UID back into
+  the field (in place, no submit) and removes the error message(s) shown
+  for that field.
+- Same behavior for a requirement with a child relation and the
+  child-relations error message.
+- The restore button must not appear on an otherwise-normal edit (no such
+  error).
+- Same behavior when the UID was cleared to empty (not just retyped) while
+  relations exist — a different template/code path (see HOW).
+
+## WHY
+
+- The error message tells the user the rename cannot proceed as submitted,
+  but the form still shows the rejected new UID as if it were accepted,
+  which is misleading and leaves the field in a value that cannot actually
+  be saved without further action (deleting relations first).
+- A restore action lets the user get back to a known-good value without
+  closing the form (losing the rest of their in-progress edits) or having
+  to remember/retype the original UID themselves.
+
+## HOW (implemented)
+
+- `strictdoc/export/html/form_objects/requirement_form_object.py`:
+  `RequirementFormObject.__init__` gained
+  `self.uid_rename_blocked_by_relations: bool = False`; `validate()` sets
+  it to `True` at both `add_error("UID", "Not supported yet: ...")` call
+  sites (parent-relations branch and child-relations branch). The `UID`
+  field's `field_value` itself is left untouched (still shows what the
+  user typed) — restoring is a manual, explicit user action, not implicit.
+- `strictdoc/export/html/templates/screens/document/document/frame_requirement_form.jinja`:
+  passes `text_field_row_context.existing_requirement_uid =
+  form_object.existing_requirement_uid` and
+  `text_field_row_context.uid_restore_available =
+  form_object.uid_rename_blocked_by_relations` into the single-line field
+  loop (harmless for non-UID fields, only read by the UID row).
+- `strictdoc/export/html/templates/components/form/row/row_with_text_field.jinja`:
+  `row_right` block now renders an `<a data-js-restore-field-action
+  data-restore-value="{{ existing_requirement_uid }}"
+  data-testid="restore-uid-field-action">` when
+  `field.field_name == "UID"` and `uid_restore_available` is true.
+- `strictdoc/export/html/templates/components/form/row/row_uid_with_reset/frame.jinja`:
+  same restore button, added next to the existing reset button. Needed
+  separately: when the UID is cleared to an **empty** string (not renamed
+  to another value), `frame_requirement_form.jinja` renders this template
+  instead of `row_with_text_field.jinja` (the `field_.field_value == ""`
+  branch) — an empty UID with parent/child relations still triggers
+  `uid_rename_blocked_by_relations` (alongside the separate "must have a
+  UID" error), so the restore button has to exist on this code path too.
+  Missed in the first pass; found via manual testing, not by the e2e
+  tests below (they only covered the "rename to another value" path).
+- `strictdoc/export/html/templates/icons/ico16_restore.svg`: new icon —
+  a single undo-style arrow, using the same top arc as `ico16_reset.svg`'s
+  first path (`M5,4 C8.5,1.5 13,4 13,9`) but with a custom arrowhead
+  attached at the arc's start (left/top) instead of its end, so the arrow
+  reads as "go back" rather than "go forward".
+- `strictdoc/export/html/_static/restorable_field.js`: new vanilla-JS
+  delegated click listener (same pattern as `deletable_field.js` /
+  `movable_field.js`) for `[data-js-restore-field-action]`. Pure
+  client-side: no server round-trip, since the original value is already
+  embedded in the button's `data-restore-value` at render time. Sets both
+  the visible `[data-js-editable-field]` element's `textContent` and its
+  hidden mirror input's `.value` (mirroring what `editable_field.js` keeps
+  in sync on user typing), and removes all `<sdoc-form-error>` elements
+  inside the field's `sdoc-form-row` — the errors described why the
+  rejected value was invalid, which no longer applies once restored.
+- `strictdoc/export/html/templates/screens/document/document/index.jinja`:
+  registered the new script alongside `deletable_field.js` /
+  `movable_field.js`.
+- `strictdoc/export/html/templates/components/form/row/row_uid_with_reset/frame.jinja`:
+  the pre-existing reset button's `title` changed from
+  "Reset UID to default" to "Generate default UID" (text only — same
+  `data-testid="reset-uid-field-action"`, same behavior).
+- Tests extended:
+  `tests/end2end/helpers/screens/document/form_edit_requirement.py` gained
+  `assert_uid_field_has_restore_button`,
+  `assert_uid_field_has_not_restore_button`, `do_restore_uid_field`
+  (mirroring the existing `..._reset_button`/`do_reset_uid_field` helpers).
+  `tests/end2end/helpers/form/form.py` gained `assert_error_not_present`.
+  `tests/end2end/screens/document/_cross_cutting/RELATIONS/update_node/update_requirement_renaming_uid_when_parent_links_exist/test_case.py`
+  and the `..._when_child_links_exist` sibling now also assert the button
+  appears, click it, assert the field shows the original UID again, and
+  assert the error message is no longer present.
+  The parent-links test additionally covers the empty-UID variant (clear
+  the field entirely instead of typing a replacement), which is what
+  caught the `row_uid_with_reset/frame.jinja` gap above.
+- Verified against manual reverts (stashing one fix file at a time,
+  including just the error-clearing line in `restorable_field.js` and just
+  the `row_uid_with_reset/frame.jinja` addition): every extended e2e test
+  fails on the corresponding pre-fix code and passes with the fix.

--- a/strictdoc/export/html/_static/restorable_field.js
+++ b/strictdoc/export/html/_static/restorable_field.js
@@ -1,0 +1,30 @@
+// One delegated click listener for every "restore this field's previous
+// value" button. Sets both the visible contenteditable and its hidden
+// mirror input (editable_field.js keeps them in sync on user input, but a
+// programmatic value change needs to update both explicitly), and clears
+// the field's validation errors: they described why the rejected value
+// was invalid, which no longer applies once the field is back to its
+// known-good value.
+
+(() => {
+
+  document.addEventListener('click', (event) => {
+    const btn = event.target.closest?.('[data-js-restore-field-action]');
+    if (!btn) return;
+    event.preventDefault();
+
+    const row = btn.closest('sdoc-form-row');
+    if (!row) return;
+    const editable = row.querySelector('[data-js-editable-field]');
+    if (!editable) return;
+
+    const restoreValue = btn.dataset.restoreValue;
+    const hidden = editable.nextElementSibling;
+
+    editable.textContent = restoreValue;
+    hidden.value = restoreValue;
+
+    row.querySelectorAll('sdoc-form-error').forEach((errorEl) => errorEl.remove());
+  });
+
+})();

--- a/strictdoc/export/html/form_objects/requirement_form_object.py
+++ b/strictdoc/export/html/form_objects/requirement_form_object.py
@@ -280,6 +280,10 @@ class RequirementFormObject(ErrorObject):
         self.existing_requirement_uid: Optional[str] = existing_requirement_uid
         self.grammar: DocumentGrammar = grammar
         self.relation_types: List[str] = relation_types
+        # Set by validate() when a UID rename is rejected because the
+        # requirement still has parent/child relations, so the template can
+        # offer a button to restore existing_requirement_uid into the field.
+        self.uid_rename_blocked_by_relations: bool = False
 
     @staticmethod
     def create_from_request(
@@ -879,6 +883,7 @@ class RequirementFormObject(ErrorObject):
                     "parent requirement relations. For now, manually delete the "
                     "relations, rename the UID, recreate the relations.",
                 )
+                self.uid_rename_blocked_by_relations = True
 
             existing_node = assert_cast(
                 traceability_index.get_node_by_uid_weak(
@@ -895,6 +900,7 @@ class RequirementFormObject(ErrorObject):
                     "child requirement relations. For now, manually delete the "
                     "relations, rename the UID, recreate the relations.",
                 )
+                self.uid_rename_blocked_by_relations = True
                 return
 
         if requirement_uid is not None:

--- a/strictdoc/export/html/templates/components/form/row/row_uid_with_reset/frame.jinja
+++ b/strictdoc/export/html/templates/components/form/row/row_uid_with_reset/frame.jinja
@@ -55,11 +55,25 @@
 {% endblock row_content %}
 
 {% block row_right scoped %}
+  {%- if
+    text_field_row_context.uid_restore_available is defined
+    and text_field_row_context.uid_restore_available
+  -%}
+    <a
+      class="field_action"
+      href="#"
+      title="Restore UID"
+      data-action-type="restore"
+      data-js-restore-field-action
+      data-restore-value="{{ text_field_row_context.existing_requirement_uid }}"
+      data-testid="restore-uid-field-action"
+    >{% include "icons/ico16_restore.svg" %}</a>
+  {%- endif -%}
     <a
       class="field_action"
       href="/reset_uid?reference_mid={{ text_field_row_context.reference_mid }}"
       mid="{{ text_field_row_context.field.field_mid }}"
-      title="Reset UID to default"
+      title="Generate default UID"
       data-action-type="reset"
       data-turbo-action="replace"
       data-turbo="true"

--- a/strictdoc/export/html/templates/components/form/row/row_with_text_field.jinja
+++ b/strictdoc/export/html/templates/components/form/row/row_with_text_field.jinja
@@ -71,5 +71,19 @@
 {% endblock row_content %}
 
 {% block row_right %}
-  {# Explicitly nothing. #}
+  {%- if
+    text_field_row_context.field.field_name == "UID"
+    and text_field_row_context.uid_restore_available is defined
+    and text_field_row_context.uid_restore_available
+  -%}
+    <a
+      class="field_action"
+      href="#"
+      title="Restore UID"
+      data-action-type="restore"
+      data-js-restore-field-action
+      data-restore-value="{{ text_field_row_context.existing_requirement_uid }}"
+      data-testid="restore-uid-field-action"
+    >{% include "icons/ico16_restore.svg" %}</a>
+  {%- endif -%}
 {% endblock row_right %}

--- a/strictdoc/export/html/templates/icons/ico16_restore.svg
+++ b/strictdoc/export/html/templates/icons/ico16_restore.svg
@@ -1,0 +1,12 @@
+<svg
+  class="svg_icon"
+  viewBox="0 0 16 16"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="1.5"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5,4 C8.5,1.5 13,4 13,9"/>
+  <polyline points="7 5 4.2 4.6 4.7 1.8" />
+</svg>

--- a/strictdoc/export/html/templates/screens/document/document/frame_requirement_form.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/frame_requirement_form.jinja
@@ -52,6 +52,8 @@
       {% set text_field_row_context.field_editable = field_.is_editable %}
       {% set text_field_row_context.field_type = "singleline" %}
       {% set text_field_row_context.reference_mid = form_object.requirement_mid %}
+      {% set text_field_row_context.existing_requirement_uid = form_object.existing_requirement_uid %}
+      {% set text_field_row_context.uid_restore_available = form_object.uid_rename_blocked_by_relations %}
       {%- if form_object.element_type != "TEXT" and field_.field_name == "UID" and field_.field_value == "" -%}
         <turbo-frame id="uid_with_reset-{{ text_field_row_context.reference_mid }}">
           {# this template is turbo-frame and has a button to reset to the default value: #}

--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -32,6 +32,7 @@
   <script src="{{ view_object.render_static_url('editable_field.js') }}"></script>
   <script src="{{ view_object.render_static_url('deletable_field.js') }}"></script>
   <script src="{{ view_object.render_static_url('movable_field.js') }}"></script>
+  <script src="{{ view_object.render_static_url('restorable_field.js') }}"></script>
   <script src="{{ view_object.render_static_url('modal.js') }}"></script>
   <script src="{{ view_object.render_static_url('scroll_into_view.js') }}"></script>
   <script src="{{ view_object.render_static_url('tabs.js') }}"></script>

--- a/tests/end2end/helpers/form/form.py
+++ b/tests/end2end/helpers/form/form.py
@@ -38,6 +38,11 @@ class Form:  # pylint: disable=invalid-name
             f"//sdoc-form-error[contains(., '{message}')]", by=By.XPATH
         )
 
+    def assert_error_not_present(self, message: str) -> None:
+        self.test_case.assert_element_not_present(
+            f"//sdoc-form-error[contains(., '{message}')]", by=By.XPATH
+        )
+
     def assert_contenteditable_contains(self, text: str) -> None:
         self.test_case.assert_element(
             f"//sdoc-contenteditable[contains(., '{text}')]", by=By.XPATH

--- a/tests/end2end/helpers/screens/document/form_edit_requirement.py
+++ b/tests/end2end/helpers/screens/document/form_edit_requirement.py
@@ -218,6 +218,28 @@ class Form_EditRequirement(Form):  # pylint: disable=invalid-name
             staleness_of(field_element_before_reset)
         )
 
+    # Restore UID button
+
+    def assert_uid_field_has_restore_button(self) -> None:
+        self.test_case.assert_element_present(
+            "//*[@data-testid='restore-uid-field-action']",
+            by=By.XPATH,
+        )
+
+    def assert_uid_field_has_not_restore_button(self) -> None:
+        self.test_case.assert_element_not_present(
+            "//*[@data-testid='restore-uid-field-action']",
+            by=By.XPATH,
+        )
+
+    def do_restore_uid_field(self) -> None:
+        # Unlike the reset button, restoring is a plain client-side DOM
+        # update (restorable_field.js), no server round-trip: no need to
+        # wait for a DOM swap, only for the field's text to change.
+        self.test_case.click_xpath(
+            "//*[@data-testid='restore-uid-field-action']"
+        )
+
     def assert_field_is_readonly(self, field_name: str) -> None:
         """Verifies that a specific field has contenteditable set to false."""
         selector = (

--- a/tests/end2end/screens/document/_cross_cutting/RELATIONS/update_node/update_requirement_renaming_uid_when_child_links_exist/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/RELATIONS/update_node/update_requirement_renaming_uid_when_child_links_exist/test_case.py
@@ -36,6 +36,8 @@ class Test(E2ECase):
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )
+            form_edit_requirement.assert_uid_field_has_not_restore_button()
+
             form_edit_requirement.do_fill_in_field_uid("Modified UID")
 
             form_edit_requirement.do_form_submit_and_catch_error(
@@ -43,6 +45,21 @@ class Test(E2ECase):
                 "Renaming a requirement UID when the requirement has child "
                 "requirement relations. For now, manually delete the relations,"
                 " rename the UID, recreate the relations.",
+            )
+
+            form_edit_requirement.assert_uid_field_contains("Modified UID")
+            form_edit_requirement.assert_uid_field_has_restore_button()
+
+            form_edit_requirement.do_restore_uid_field()
+
+            form_edit_requirement.assert_uid_field_contains("REQ-001")
+            form_edit_requirement.assert_uid_field_does_not_contain(
+                "Modified UID"
+            )
+            form_edit_requirement.assert_error_not_present(
+                "Not supported yet: "
+                "Renaming a requirement UID when the requirement has child "
+                "requirement relations."
             )
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/document/_cross_cutting/RELATIONS/update_node/update_requirement_renaming_uid_when_parent_links_exist/test_case.py
+++ b/tests/end2end/screens/document/_cross_cutting/RELATIONS/update_node/update_requirement_renaming_uid_when_parent_links_exist/test_case.py
@@ -37,6 +37,8 @@ class Test(E2ECase):
             form_edit_requirement: Form_EditRequirement = (
                 requirement.do_open_form_edit_requirement()
             )
+            form_edit_requirement.assert_uid_field_has_not_restore_button()
+
             form_edit_requirement.do_fill_in_field_uid("Modified UID")
 
             form_edit_requirement.do_form_submit_and_catch_error(
@@ -44,6 +46,54 @@ class Test(E2ECase):
                 "Renaming a requirement UID when the requirement has parent "
                 "requirement relations. For now, manually delete the relations,"
                 " rename the UID, recreate the relations."
+            )
+
+            form_edit_requirement.assert_uid_field_contains("Modified UID")
+            form_edit_requirement.assert_uid_field_has_restore_button()
+
+            form_edit_requirement.do_restore_uid_field()
+
+            form_edit_requirement.assert_uid_field_contains("REQ-002")
+            form_edit_requirement.assert_uid_field_does_not_contain(
+                "Modified UID"
+            )
+            form_edit_requirement.assert_error_not_present(
+                "Not supported yet: "
+                "Renaming a requirement UID when the requirement has parent "
+                "requirement relations."
+            )
+
+            # Clearing the UID entirely (instead of typing a replacement) is
+            # a separate code path: an empty UID field is rendered via
+            # components/form/row/row_uid_with_reset/frame.jinja, not
+            # row_with_text_field.jinja, and triggers both the "must have a
+            # UID" and the "renaming blocked" errors at once.
+            form_edit_requirement.do_clear_field("UID")
+
+            form_edit_requirement.do_form_submit_and_catch_error(
+                "Requirement with parent relations must have an UID. "
+                "Either provide a parent UID, or "
+                "delete the parent requirement relations."
+            )
+            form_edit_requirement.do_form_submit_and_catch_error(
+                "Not supported yet: "
+                "Renaming a requirement UID when the requirement has parent "
+                "requirement relations. For now, manually delete the relations,"
+                " rename the UID, recreate the relations."
+            )
+
+            form_edit_requirement.assert_uid_field_has_restore_button()
+
+            form_edit_requirement.do_restore_uid_field()
+
+            form_edit_requirement.assert_uid_field_contains("REQ-002")
+            form_edit_requirement.assert_error_not_present(
+                "Requirement with parent relations must have an UID."
+            )
+            form_edit_requirement.assert_error_not_present(
+                "Not supported yet: "
+                "Renaming a requirement UID when the requirement has parent "
+                "requirement relations."
             )
 
         assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
Renaming a requirement's UID while it still has parent/child relations is rejected, but the field kept showing the rejected value with no way back except retyping or closing the form.

Adds a "Restore UID" button next to the field (both the normal and the empty-UID/"reset" row variants) that puts the original UID back in place and clears the now-stale errors for that field. Renamed the existing "Reset UID to default" button's tooltip to "Generate default UID" to avoid it reading as a synonym for the new restore action.

<img width="643" height="378" alt="image" src="https://github.com/user-attachments/assets/1da5ae32-6a9b-44e8-855e-31404160d67b" />


Closes #3083 