### PR TITLE
feat(traceability): preserve verification result provenance

### DIFF
--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -63,6 +63,10 @@ fields on generated ``TEST_RESULT`` nodes.
 
 4\) Fixed: the TABLE VIEW now renders the Relation cell as non-editable for node
 types whose grammar does not declare relations.
+
+5\) The traceability index now preserves whether each result verifies the
+selected requirement or one of its descendants, and whether a generated test
+case mediates the link.
 <<<
 
 [[/SECTION]]

--- a/strictdoc/core/traceability_index.py
+++ b/strictdoc/core/traceability_index.py
@@ -4,6 +4,7 @@
 
 import datetime
 from copy import copy, deepcopy
+from dataclasses import dataclass
 from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 from strictdoc.backend.sdoc.document_reference import DocumentReference
@@ -23,7 +24,7 @@ from strictdoc.backend.sdoc_source_code.models.source_file_info import (
     SourceFileTraceabilityInfo,
 )
 from strictdoc.core.asset_manager import AssetManager
-from strictdoc.core.constants import GraphLinkType
+from strictdoc.core.constants import GraphEdgeLabel, GraphLinkType
 from strictdoc.core.document_iterator import SDocDocumentIterator
 from strictdoc.core.document_meta import DocumentMeta
 from strictdoc.core.document_tree import DocumentTree
@@ -46,6 +47,13 @@ from strictdoc.helpers.mid import MID
 from strictdoc.helpers.ordered_set import OrderedSet
 from strictdoc.helpers.paths import SDocRelativePath
 from strictdoc.helpers.sorting import alphanumeric_sort
+
+
+@dataclass(frozen=True)
+class VerificationResultProvenance:
+    verified_requirement: SDocNode
+    test_case: Optional[SDocNode]
+    test_result: SDocNode
 
 
 class TraceabilityIndex:
@@ -353,6 +361,57 @@ class TraceabilityIndex:
                 edge=role,
             )
         )
+
+    def get_verification_result_provenance(
+        self, requirement: SDocNode
+    ) -> List[VerificationResultProvenance]:
+        assert isinstance(requirement, SDocNode)
+
+        result_provenance: List[VerificationResultProvenance] = []
+        visited_requirements: OrderedSet[SDocNode] = OrderedSet()
+        requirements_to_visit: List[SDocNode] = [requirement]
+
+        while len(requirements_to_visit) > 0:
+            current_requirement: SDocNode = requirements_to_visit.pop()
+            if current_requirement in visited_requirements:
+                continue
+            visited_requirements.add(current_requirement)
+
+            hierarchy_children: List[SDocNode] = []
+            for child_node_, edge_label_ in self.get_child_relations_with_roles(
+                current_requirement
+            ):
+                if edge_label_ == GraphEdgeLabel.IS_SATISFIED_BY:
+                    result_provenance.append(
+                        VerificationResultProvenance(
+                            verified_requirement=current_requirement,
+                            test_case=None,
+                            test_result=child_node_,
+                        )
+                    )
+                    continue
+
+                if edge_label_ == GraphEdgeLabel.IS_VERIFIED_BY:
+                    for (
+                        test_result_,
+                        test_case_edge_label_,
+                    ) in self.get_child_relations_with_roles(child_node_):
+                        if test_case_edge_label_ == GraphEdgeLabel.HAS_RESULT:
+                            result_provenance.append(
+                                VerificationResultProvenance(
+                                    verified_requirement=current_requirement,
+                                    test_case=child_node_,
+                                    test_result=test_result_,
+                                )
+                            )
+                    continue
+
+                if not isinstance(edge_label_, GraphEdgeLabel):
+                    hierarchy_children.append(child_node_)
+
+            requirements_to_visit.extend(reversed(hierarchy_children))
+
+        return result_provenance
 
     def get_display_role_for_parent_relation(
         self,

--- a/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/.gitignore
+++ b/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/.gitignore
@@ -1,0 +1,1 @@
+!reports/

--- a/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/check_provenance.py
+++ b/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/check_provenance.py
@@ -1,0 +1,170 @@
+import os
+from typing import Optional
+
+from strictdoc.backend.sdoc.models.node import SDocNode
+from strictdoc.core.constants import GraphEdgeLabel
+from strictdoc.core.project_config import ProjectConfig, ProjectConfigLoader
+from strictdoc.core.traceability_index import TraceabilityIndex
+from strictdoc.core.traceability_index_builder import TraceabilityIndexBuilder
+from strictdoc.helpers.parallelizer import Parallelizer
+
+
+def get_only_child_node_with_edge(
+    traceability_index: TraceabilityIndex,
+    parent_node: SDocNode,
+    edge_label: GraphEdgeLabel,
+) -> SDocNode:
+    matching_child_nodes = [
+        child_node_
+        for child_node_, child_edge_label_ in (
+            traceability_index.get_child_relations_with_roles(parent_node)
+        )
+        if child_edge_label_ == edge_label
+    ]
+    assert len(matching_child_nodes) == 1, matching_child_nodes
+    return matching_child_nodes[0]
+
+
+def get_child_relation_uids(
+    traceability_index: TraceabilityIndex,
+    parent_node: SDocNode,
+) -> set[tuple[str, Optional[str]]]:
+    child_relations = traceability_index.get_child_relations_with_roles(
+        parent_node
+    )
+    return {
+        (child_node_.reserved_uid, child_edge_label_)
+        for child_node_, child_edge_label_ in child_relations
+    }
+
+
+def get_child_relation_types(
+    traceability_index: TraceabilityIndex,
+    parent_node: SDocNode,
+) -> list[tuple[str, Optional[str]]]:
+    return [
+        (child_node_.node_type, child_edge_label_)
+        for child_node_, child_edge_label_ in (
+            traceability_index.get_child_relations_with_roles(parent_node)
+        )
+    ]
+
+
+def get_verification_result_provenance_signature(
+    traceability_index: TraceabilityIndex,
+    requirement: SDocNode,
+) -> list[tuple[SDocNode, Optional[SDocNode], SDocNode]]:
+    return [
+        (
+            provenance_.verified_requirement,
+            provenance_.test_case,
+            provenance_.test_result,
+        )
+        for provenance_ in (
+            traceability_index.get_verification_result_provenance(requirement)
+        )
+    ]
+
+
+def main() -> None:
+    project_root: str = os.getcwd()
+    project_config: ProjectConfig = (
+        ProjectConfigLoader.load_from_path_or_get_default(
+            path_to_config=project_root
+        )
+    )
+    project_config.input_paths = [project_root]
+    project_config.source_root_path = project_root
+    project_config.validate_and_finalize()
+    parallelizer: Parallelizer = Parallelizer.create(parallelize=False)
+    try:
+        traceability_index: TraceabilityIndex = TraceabilityIndexBuilder.create(
+            project_config=project_config,
+            parallelizer=parallelizer,
+        )
+    finally:
+        parallelizer.shutdown()
+
+    grandparent_requirement = traceability_index.get_node_by_uid(
+        "REQ-GRANDPARENT"
+    )
+    parent_requirement = traceability_index.get_node_by_uid("REQ-PARENT")
+    direct_requirement = traceability_index.get_node_by_uid("REQ-DIRECT")
+    mediated_requirement = traceability_index.get_node_by_uid("REQ-MEDIATED")
+    assert isinstance(grandparent_requirement, SDocNode)
+    assert isinstance(parent_requirement, SDocNode)
+    assert isinstance(direct_requirement, SDocNode)
+    assert isinstance(mediated_requirement, SDocNode)
+
+    assert get_child_relation_uids(
+        traceability_index, grandparent_requirement
+    ) == {("REQ-PARENT", None)}
+    assert get_child_relation_uids(traceability_index, parent_requirement) == {
+        ("REQ-DIRECT", None),
+        ("REQ-MEDIATED", None),
+    }
+
+    assert get_child_relation_types(traceability_index, direct_requirement) == [
+        ("TEST_RESULT", GraphEdgeLabel.IS_SATISFIED_BY)
+    ]
+    direct_result = get_only_child_node_with_edge(
+        traceability_index,
+        direct_requirement,
+        GraphEdgeLabel.IS_SATISFIED_BY,
+    )
+    assert direct_result.node_type == "TEST_RESULT"
+    assert direct_result.reserved_status == "FAILED"
+
+    assert get_child_relation_types(
+        traceability_index, mediated_requirement
+    ) == [("TEST_CASE", GraphEdgeLabel.IS_VERIFIED_BY)]
+    test_case = get_only_child_node_with_edge(
+        traceability_index,
+        mediated_requirement,
+        GraphEdgeLabel.IS_VERIFIED_BY,
+    )
+    assert test_case.node_type == "TEST_CASE"
+
+    assert get_child_relation_types(traceability_index, test_case) == [
+        ("TEST_RESULT", GraphEdgeLabel.HAS_RESULT)
+    ]
+    mediated_result = get_only_child_node_with_edge(
+        traceability_index,
+        test_case,
+        GraphEdgeLabel.HAS_RESULT,
+    )
+    assert mediated_result.node_type == "TEST_RESULT"
+    assert mediated_result.reserved_status == "FAILED"
+
+    assert get_verification_result_provenance_signature(
+        traceability_index,
+        parent_requirement,
+    ) == [
+        (direct_requirement, None, direct_result),
+        (mediated_requirement, test_case, mediated_result),
+    ]
+    assert get_verification_result_provenance_signature(
+        traceability_index,
+        grandparent_requirement,
+    ) == [
+        (direct_requirement, None, direct_result),
+        (mediated_requirement, test_case, mediated_result),
+    ]
+    assert get_verification_result_provenance_signature(
+        traceability_index,
+        direct_requirement,
+    ) == [(direct_requirement, None, direct_result)]
+    assert get_verification_result_provenance_signature(
+        traceability_index,
+        mediated_requirement,
+    ) == [(mediated_requirement, test_case, mediated_result)]
+
+    assert direct_result is not mediated_result
+    assert grandparent_requirement.reserved_status is None
+    assert parent_requirement.reserved_status is None
+    assert direct_requirement.reserved_status is None
+    assert mediated_requirement.reserved_status is None
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/reports/tests_unit.ctest.junit.xml
+++ b/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/reports/tests_unit.ctest.junit.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="verification result provenance"
+           tests="2"
+           failures="2"
+           disabled="0"
+           skipped="0"
+           time="0">
+  <testcase name="DirectSuite.Failure"
+            classname="DirectSuite.Failure"
+            time="0.1"
+            status="run">
+    <failure>Direct test failure.</failure>
+  </testcase>
+  <testcase name="MediatedSuite.Failure"
+            classname="MediatedSuite.Failure"
+            time="0.1"
+            status="run">
+    <failure>Mediated test failure.</failure>
+  </testcase>
+</testsuite>

--- a/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/requirements.sdoc
+++ b/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/requirements.sdoc
@@ -1,0 +1,31 @@
+[DOCUMENT]
+TITLE: Verification result provenance
+
+[REQUIREMENT]
+UID: REQ-GRANDPARENT
+TITLE: Grandparent requirement
+STATEMENT: The system shall provide a capability group.
+
+[REQUIREMENT]
+UID: REQ-PARENT
+TITLE: Parent requirement
+STATEMENT: The system shall provide a verified capability.
+RELATIONS:
+- TYPE: Parent
+  VALUE: REQ-GRANDPARENT
+
+[REQUIREMENT]
+UID: REQ-DIRECT
+TITLE: Directly verified requirement
+STATEMENT: The system shall provide a directly tested behavior.
+RELATIONS:
+- TYPE: Parent
+  VALUE: REQ-PARENT
+
+[REQUIREMENT]
+UID: REQ-MEDIATED
+TITLE: Test-case-verified requirement
+STATEMENT: The system shall provide a behavior tested through a test case.
+RELATIONS:
+- TYPE: Parent
+  VALUE: REQ-PARENT

--- a/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/strictdoc_config.py
+++ b/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/strictdoc_config.py
@@ -1,0 +1,16 @@
+from strictdoc.core.project_config import ProjectConfig, SourceNodesEntry
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=["REQUIREMENT_TO_SOURCE_TRACEABILITY"],
+        include_source_paths=["tests/**.cpp"],
+        source_nodes=[
+            SourceNodesEntry(
+                path="tests/mediated/",
+                uid="TEST_DOCUMENT",
+                node_type="TEST_CASE",
+            )
+        ],
+    )
+    return config

--- a/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/test.itest
+++ b/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/test.itest
@@ -1,0 +1,6 @@
+# Verify that result links retain whether a failure is direct or mediated by a
+# generated test case. The parent requirement has only hierarchical child links,
+# so both failures remain downstream effects rather than direct failures.
+
+RUN: cd %S
+RUN: python %S/check_provenance.py

--- a/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/test_cases.sdoc
+++ b/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/test_cases.sdoc
@@ -1,0 +1,29 @@
+[DOCUMENT]
+TITLE: Test cases
+UID: TEST_DOCUMENT
+
+[GRAMMAR]
+ELEMENTS:
+- TAG: SECTION
+  PROPERTIES:
+    IS_COMPOSITE: True
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+- TAG: TEST_CASE
+  FIELDS:
+  - TITLE: UID
+    TYPE: String
+    REQUIRED: False
+  - TITLE: TITLE
+    TYPE: String
+    REQUIRED: True
+  - TITLE: OBJECTIVE
+    TYPE: String
+    REQUIRED: False
+  RELATIONS:
+  - TYPE: File

--- a/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/tests/direct.cpp
+++ b/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/tests/direct.cpp
@@ -1,0 +1,6 @@
+/**
+ * @relation(REQ-DIRECT, scope=function)
+ */
+TEST(DirectSuite, Failure)
+{
+}

--- a/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/tests/mediated/test.cpp
+++ b/tests/integration/features/test_reports/verification_result_provenance/01_direct_and_downstream/tests/mediated/test.cpp
@@ -1,0 +1,8 @@
+/**
+ * @relation(REQ-MEDIATED, scope=function)
+ *
+ * OBJECTIVE: Verify the mediated requirement.
+ */
+TEST(MediatedSuite, Failure)
+{
+}


### PR DESCRIPTION
This adds a narrow traceability query that preserves where verification results came from. It is a foundation for #2232, without choosing result aggregation or presentation semantics yet.

The new `VerificationResultProvenance` record keeps the requirement actually verified, an optional generated test case, and the raw result node. `TraceabilityIndex.get_verification_result_provenance()` follows the two graph shapes StrictDoc already creates:

- `IS_SATISFIED_BY` for a direct requirement-to-result link;
- `IS_VERIFIED_BY` followed by `HAS_RESULT` for a generated test-case link.

The query also traverses ordinary requirement hierarchy in deterministic order. This lets a consumer distinguish a result attached to the selected requirement from one attached to a descendant. It deliberately does not normalize producer-specific statuses, mutate a requirement's own `STATUS`, aggregate pass/fail state, or add HTML indicators.

The integration fixture builds the real SDoc, C++, and CTest/JUnit graph. It covers direct and mediated links, a two-level requirement hierarchy, exact ordering, duplicate prevention, raw failed-result preservation, and unchanged requirement statuses.

Validation:

- `invoke test-integration --focus verification_result_provenance --no-parallelization`
- `invoke test-unit --path tests/unit/strictdoc/core/test_traceability_index.py`
- targeted Ruff format and lint checks
- `invoke lint-mypy`
- `invoke lint-commit`