### PR TITLE
feat(export/html): stabilize scroll position for lazy chunks in static export

### DIFF
--- a/strictdoc/export/html/_static/toc_chunk_navigation.js
+++ b/strictdoc/export/html/_static/toc_chunk_navigation.js
@@ -31,15 +31,21 @@
   // DocumentHTMLGenerator._export_static_chunks) - only loadStaticChunk()
   // and its two call sites differ; TOC click/hashchange handling, scrolling,
   // and the turbo:frame-load cleanup listener below are delivery-agnostic.
+  // loadStaticChunk() also dispatches a synthetic "turbo:before-fetch-response"
+  // that real Turbo frame loads emit natively, so content_viewport_restoration.js
+  // (loaded for both modes when the document is chunked) treats both delivery
+  // paths the same.
   const IS_STATIC_EXPORT = document.querySelector(
     'meta[name="strictdoc-export-type"]'
   )?.content === "static";
 
   // Load a static chunk's .js file, splice its rendered HTML into the
-  // placeholder, and dispatch the same "turbo:frame-load" event Turbo fires
-  // for server-mode frame loads, so every existing listener (the preload
-  // observer's unobserve, the placeholder-class cleanup below, and this
-  // file's own onFrameLoad handlers) keeps working unchanged.
+  // placeholder, and dispatch the same "turbo:before-fetch-response" and
+  // "turbo:frame-load" events Turbo fires around a server-mode frame load,
+  // so every existing listener (content_viewport_restoration.js's geometry
+  // snapshot/compensation, the preload observer's unobserve, the
+  // placeholder-class cleanup below, and this file's own onFrameLoad
+  // handlers) keeps working unchanged.
   async function loadStaticChunk(frame) {
     const src = frame.dataset.chunkSrc;
     const key = frame.dataset.chunkKey;
@@ -54,6 +60,13 @@
     // rest of this file dispatches/observes events on.
     const template = document.createElement("template");
     template.innerHTML = html.trim();
+    // Fired before the placeholder's content changes so
+    // content_viewport_restoration.js can snapshot the pre-load viewport
+    // geometry, exactly as it does for the real fetch response server mode
+    // gets from Turbo before that library inserts a frame's content.
+    frame.dispatchEvent(
+      new Event("turbo:before-fetch-response", { bubbles: true })
+    );
     frame.innerHTML = template.content.firstElementChild.innerHTML;
     frame.dispatchEvent(new Event("turbo:frame-load", { bubbles: true }));
   }

--- a/strictdoc/export/html/templates/screens/document/document/document_chunk_lazy_placeholder_static.jinja.html
+++ b/strictdoc/export/html/templates/screens/document/document/document_chunk_lazy_placeholder_static.jinja.html
@@ -17,11 +17,11 @@
     validates the document-chunk-* id, eagerly preloads them near
     the viewport, and removes the class once the chunk has loaded.
 
-  LIMITATION: unlike server mode, static export does not load
-  content_viewport_restoration.js (it is edit-focused and gated on
-  is_running_on_server), so a background-preloaded chunk above the reading
-  position that resolves from its estimated height to its real height can
-  still cause a small, uncompensated scroll jump. Accepted for now.
+  content_viewport_restoration.js is loaded for chunked static documents too
+  (see document/index.jinja) and compensates the scroll position when a
+  background-preloaded chunk above the reading position resolves from its
+  estimated height to its real height; toc_chunk_navigation.js's
+  loadStaticChunk() dispatches the synthetic events it listens for.
 #}
 <turbo-frame
   id="document-chunk-{{ chunk.index }}"

--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -17,7 +17,19 @@
   {%- if view_object.is_chunked_rendering() %}
   <script src="{{ view_object.render_static_url('toc_chunk_navigation.js') }}"></script>
   {%- endif %}
-  {%- if view_object.is_running_on_server -%}
+  {#- content_viewport_restoration.js conditions:
+      * is_chunked_rendering()
+      In static export, the script is only needed for chunked documents —
+      to stabilize scroll position while chunks load.
+      * is_running_on_server
+      On the server, the script is needed for all documents, chunked or not —
+      beyond scroll stabilization, it also positions the viewport precisely
+      after create/delete/move/grammar-edit operations, more precisely than
+      the browser does on its own.
+      Removing the script for non-chunked server documents wouldn't cause errors,
+      but this precise positioning would be lost.
+  -#}
+  {%- if view_object.is_running_on_server or view_object.is_chunked_rendering() -%}
   <script src="{{ view_object.render_static_url('content_viewport_restoration.js') }}"></script>
   {%- endif -%}
 


### PR DESCRIPTION

Enabled scroll stabilization for chunked static documents. To do this, we manually dispatch a `turbo:before-fetch-response`  event before splicing in the chunk content - `content_viewport_restoration.js` needs it to snapshot the viewport position before geometry changes.