### PR TITLE
chore: scope hatch build include to per-target (sdist vs wheel)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,12 @@ build-backend = "hatchling.build"
 path = "strictdoc/__init__.py"
 
 [tool.hatch.build]
+exclude = [
+    # Without this, the folder is still included to the output tar.gz because it has a Markdown file.
+    "/developer",
+]
+
+[tool.hatch.build.targets.sdist]
 include = [
     "/strictdoc/",
     "LICENSE",
@@ -18,9 +24,9 @@ include = [
     "pyproject.toml"
 ]
 
-exclude = [
-    # Without this, the folder is still included to the output tar.gz because it has a Markdown file.
-    "/developer",
+[tool.hatch.build.targets.wheel]
+include = [
+    "/strictdoc/",
 ]
 
 [project]
@@ -87,7 +93,7 @@ dependencies = [
 
     # ReqIF
     # @relation(SDOC-SRS-73, scope=line)
-    "reqif >= 0.0.39, == 0.*",
+    "reqif >= 0.1.0, == 0.1.*",
 
     # SPDX
     "spdx-tools >= 0.8.5",


### PR DESCRIPTION
LICENSE, NOTICE, README.md, and pyproject.toml were included via a single top-level [tool.hatch.build] include list, which hatchling applies to both the sdist and the wheel. This put those files as loose entries at the wheel root, so every install spilled them into site-packages/ alongside the strictdoc package.

Move the include list under [tool.hatch.build.targets.sdist] and restrict [tool.hatch.build.targets.wheel] to /strictdoc/ only. As a side effect, hatchling now places LICENSE/NOTICE in strictdoc-*.dist-info/licenses/, the PEP 639-correct location.

Also clamp the reqif dependency to the 0.1.x line
(>= 0.1.0, == 0.1.*), since the wheel packaging bug is also present in reqif's release and pinning avoids picking up an affected version unexpectedly.