### PR TITLE
perf(backend/sdoc): stat-based fast path for the file pickle cache

### DIFF
--- a/strictdoc/backend/sdoc/pickle_cache.py
+++ b/strictdoc/backend/sdoc/pickle_cache.py
@@ -4,12 +4,21 @@
 
 import hashlib
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.helpers.md5 import get_file_md5
 from strictdoc.helpers.pickle import pickle_dump, pickle_load
+
+
+@dataclass
+class PickleCacheEntry:
+    mtime_ns: int
+    size: int
+    md5: str
+    content: Any
 
 
 class PickleCache:
@@ -20,19 +29,51 @@ class PickleCache:
         path_to_cached_file: str = PickleCache.get_cached_file_path(
             file_path, project_config, content_kind
         )
-        if os.path.isfile(path_to_cached_file):
-            with open(path_to_cached_file, "rb") as cache_file:
-                unpickled_content = cache_file.read()
-            try:
-                return pickle_load(unpickled_content)
-            except Exception as exception_:
-                raise AssertionError(
-                    "MUST NOT REACH HERE: "
-                    f"Error when unpickling a cache file: {path_to_cached_file}. "
-                    "To fix the issue, simply remove the cache file or the whole cache folder. "
-                    "Please report this exception to StrictDoc developers: "
-                    f"https://github.com/strictdoc-project/strictdoc/issues/new"
-                ) from exception_
+        if not os.path.isfile(path_to_cached_file):
+            return None
+
+        with open(path_to_cached_file, "rb") as cache_file:
+            pickled_entry = cache_file.read()
+        try:
+            entry = pickle_load(pickled_entry)
+        except Exception as exception_:
+            raise AssertionError(
+                "MUST NOT REACH HERE: "
+                f"Error when unpickling a cache file: {path_to_cached_file}. "
+                "To fix the issue, simply remove the cache file or the whole cache folder. "
+                "Please report this exception to StrictDoc developers: "
+                f"https://github.com/strictdoc-project/strictdoc/issues/new"
+            ) from exception_
+
+        # A None result (schema change, see pickle_load()) or an entry
+        # written by a previous, incompatible cache format both count as a
+        # cache miss.
+        if not isinstance(entry, PickleCacheEntry):
+            return None
+
+        # Fast path: if the file's mtime and size are unchanged since the
+        # entry was written, trust the cache without reading and hashing the
+        # file's content. This is the common case on a no-op re-run and
+        # turns the cache-freshness check into a single stat() call.
+        file_stat = os.stat(file_path)
+        if (
+            file_stat.st_mtime_ns == entry.mtime_ns
+            and file_stat.st_size == entry.size
+        ):
+            return entry.content
+
+        # Slow path: mtime/size changed (e.g., a git checkout touching the
+        # file's mtime without changing its content). Fall back to a content
+        # hash, like ccache/git do, before deciding the cache is stale.
+        if get_file_md5(file_path) == entry.md5:
+            # Content is unchanged: heal the entry so that the next read
+            # hits the fast path again.
+            entry.mtime_ns = file_stat.st_mtime_ns
+            entry.size = file_stat.st_size
+            with open(path_to_cached_file, "wb") as cache_file:
+                cache_file.write(pickle_dump(entry))
+            return entry.content
+
         return None
 
     @staticmethod
@@ -47,9 +88,17 @@ class PickleCache:
         )
         path_to_cached_file_dir: str = os.path.dirname(path_to_cached_file)
         Path(path_to_cached_file_dir).mkdir(parents=True, exist_ok=True)
-        pickled_content: Any = pickle_dump(content)
+
+        file_stat = os.stat(file_path)
+        entry = PickleCacheEntry(
+            mtime_ns=file_stat.st_mtime_ns,
+            size=file_stat.st_size,
+            md5=get_file_md5(file_path),
+            content=content,
+        )
+        pickled_entry: bytes = pickle_dump(entry)
         with open(path_to_cached_file, "wb") as cache_file:
-            cache_file.write(pickled_content)
+            cache_file.write(pickled_entry)
 
     @staticmethod
     def get_cached_file_path(
@@ -63,19 +112,25 @@ class PickleCache:
             else os.path.abspath(file_path)
         )
 
-        file_md5: str = get_file_md5(file_path)
-
         # File name contains an MD5 hash of its full path to ensure the
         # uniqueness of the cached items. Additionally, the unique file name
         # contains a full path to the output root to prevent collisions
         # between StrictDoc invocations running against the same set of SDoc
         # files in parallel.
+        #
+        # The file name is stable across content changes: unlike before, it
+        # no longer embeds a content hash, because computing that hash is
+        # exactly the per-run cost this cache is meant to avoid (see
+        # read_from_cache()'s stat-based fast path). One cache entry is
+        # reused and overwritten in place per input file, instead of
+        # accumulating one file per historical content version.
         unique_identifier = project_config.output_dir + full_path_to_file
         unique_identifier_md5 = hashlib.md5(
             unique_identifier.encode("utf-8")
         ).hexdigest()
-        file_name = os.path.basename(full_path_to_file)
-        file_name += "_" + unique_identifier_md5 + "_" + file_md5
+        file_name = (
+            os.path.basename(full_path_to_file) + "_" + unique_identifier_md5
+        )
 
         path_to_cached_file = os.path.join(
             path_to_tmp_dir,

--- a/tests/unit/strictdoc/backend/sdoc/test_pickle_cache.py
+++ b/tests/unit/strictdoc/backend/sdoc/test_pickle_cache.py
@@ -1,0 +1,102 @@
+import os
+from unittest import mock
+
+from strictdoc.backend.sdoc.pickle_cache import PickleCache
+from strictdoc.core.project_config import ProjectConfig
+from strictdoc.helpers.md5 import get_file_md5
+
+
+def create_project_config(tmp_path) -> ProjectConfig:
+    project_config = ProjectConfig.default_config()
+    project_config.output_dir = str(tmp_path / "output")
+    project_config.dir_for_sdoc_cache = str(tmp_path / "cache")
+    return project_config
+
+
+def test_01_cache_miss_when_no_cache_file_exists(tmp_path):
+    project_config = create_project_config(tmp_path)
+    input_file = tmp_path / "document.sdoc"
+    input_file.write_text("content")
+
+    assert (
+        PickleCache.read_from_cache(str(input_file), project_config, "sdoc")
+        is None
+    )
+
+
+def test_02_cache_hit_reuses_content_and_does_not_rehash_when_unchanged(
+    tmp_path,
+):
+    project_config = create_project_config(tmp_path)
+    input_file = tmp_path / "document.sdoc"
+    input_file.write_text("content")
+
+    PickleCache.save_to_cache(
+        "parsed-content", str(input_file), project_config, "sdoc"
+    )
+
+    with mock.patch(
+        "strictdoc.backend.sdoc.pickle_cache.get_file_md5"
+    ) as get_file_md5_mock:
+        result = PickleCache.read_from_cache(
+            str(input_file), project_config, "sdoc"
+        )
+
+    assert result == "parsed-content"
+    # The fast (stat-only) path must not need to hash the file's content.
+    get_file_md5_mock.assert_not_called()
+
+
+def test_03_cache_miss_when_file_content_changes(tmp_path):
+    project_config = create_project_config(tmp_path)
+    input_file = tmp_path / "document.sdoc"
+    input_file.write_text("content")
+
+    PickleCache.save_to_cache(
+        "parsed-content", str(input_file), project_config, "sdoc"
+    )
+
+    input_file.write_text("different content, different size")
+
+    assert (
+        PickleCache.read_from_cache(str(input_file), project_config, "sdoc")
+        is None
+    )
+
+
+def test_04_cache_hit_via_content_hash_when_mtime_changes_but_content_does_not(
+    tmp_path,
+):
+    project_config = create_project_config(tmp_path)
+    input_file = tmp_path / "document.sdoc"
+    input_file.write_text("content")
+
+    PickleCache.save_to_cache(
+        "parsed-content", str(input_file), project_config, "sdoc"
+    )
+
+    # Simulate a git checkout: mtime changes, content and size do not.
+    future_time = os.stat(input_file).st_mtime + 3600
+    os.utime(input_file, (future_time, future_time))
+
+    with mock.patch(
+        "strictdoc.backend.sdoc.pickle_cache.get_file_md5",
+        wraps=get_file_md5,
+    ) as get_file_md5_mock:
+        result = PickleCache.read_from_cache(
+            str(input_file), project_config, "sdoc"
+        )
+        assert result == "parsed-content"
+        # The mtime mismatch forces exactly one content-hash fallback check.
+        get_file_md5_mock.assert_called_once()
+
+    # The entry is healed after the content-hash fallback, so a subsequent
+    # read hits the fast (stat-only) path again.
+    with mock.patch(
+        "strictdoc.backend.sdoc.pickle_cache.get_file_md5"
+    ) as get_file_md5_mock:
+        result = PickleCache.read_from_cache(
+            str(input_file), project_config, "sdoc"
+        )
+        assert result == "parsed-content"
+        get_file_md5_mock.assert_not_called()


### PR DESCRIPTION
## Summary
- `PickleCache.get_cached_file_path()` called `get_file_md5()` — a full content read + hash — on every read *and* write, just to compute the cache key. Every command invocation paid this cost for every input file, even when nothing had changed.
- Cache entries now store `(mtime_ns, size, md5)` alongside the cached content. On read, if the file's current mtime/size match the entry, the cache is trusted without touching the file's content at all.
- Falls back to a content-hash comparison only when mtime/size differ (e.g. a git checkout touching mtimes without changing content) — the same technique ccache/git use. A match there heals the entry (rewrites mtime/size) so the next read hits the fast path again.
- Side effect: the cache file name no longer embeds a content hash (that hash is exactly the cost being removed), so one cache entry is reused/overwritten in place per input file instead of accumulating one file per historical content version.

## Benchmark
Simulated a 130-document tree (tiled from 8 real, distinct ECSS `.sdoc` files, ~31.7MB total), warm page cache (the realistic no-op re-run case):

| | current (`get_file_md5`) | fast path (`os.stat`) |
|---|---|---|
| median, 130 files | 43.08 ms | 0.14 ms |
| speedup | — | ~300x |

## Test plan
- [x] New unit tests in `tests/unit/strictdoc/backend/sdoc/test_pickle_cache.py`: cache miss with no entry, fast-path hit with zero `get_file_md5` calls, content-change invalidation, mtime-only-change fallback + healing.
- [x] `invoke tu` — 682 unit tests pass
- [x] `invoke lint` — ruff format/check + mypy strict clean
- [x] Manual end-to-end `strictdoc export`: verified fresh export, no-op re-export (cache hit, single reused cache file), and content-edit re-export (correctly picked up and reflected in output HTML)