### PR TITLE
feat(nix): build and run StrictDoc from the flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.idea/
 /.venv/
-/.venv-nix/
+/.direnv/
 /.vscode/
 /build/
 /developer/tasks/**/Context.md

--- a/bootstrap_nix.sh
+++ b/bootstrap_nix.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 #
-# Enters the Nix dev shell defined in flake.nix, which provides the
-# system-level dependencies (Python, libtidy, a browser for
-# end2end/screencast tests, Ruby for the changelog generator) that the
-# existing .envrc + .venv + invoke workflow does not install by itself.
+# Enters the Nix dev shell defined in flake.nix. That shell provides a Python
+# interpreter with the runtime dependencies of pyproject.toml and with Invoke
+# and Tox, plus the tools that are not Python packages: libtidy (integration
+# tests), Chromium and a matching driver (end2end and screencast tests), and
+# github_changelog_generator.
 #
-# Uses its own .venv-nix/ (separate from .envrc's .venv/) so switching
-# between the system Python and Nix's Python never corrupts either venv.
+# Tox still creates its own virtual environments under build/tox/, but it
+# installs only the development dependencies of tox.ini there. The runtime
+# dependencies of pyproject.toml come from the Nix shell.
+#
+# This is an alternative to the .envrc + .venv + invoke workflow, which keeps
+# working unchanged. The two do not share a virtual environment.
 #
 # Usage:
 #   ./bootstrap_nix.sh        # enter an interactive dev shell

--- a/developer/pip_install_strictdoc_deps.py
+++ b/developer/pip_install_strictdoc_deps.py
@@ -1,9 +1,7 @@
 import importlib.metadata as importlib_metadata
 import os
-import shutil
 import subprocess
 import sys
-import sysconfig
 import tempfile
 
 import toml
@@ -18,44 +16,6 @@ class PackageVersionConflict(Exception):
     pass
 
 
-def link_nix_numpy_stack_if_available() -> None:
-    """
-    If STRICTDOC_NIX_NUMPY_STACK is set (only ever done by flake.nix's
-    devShell, never on a non-Nix setup), symlink those Nix-built
-    packages (numpy, pandas, ...) into this venv's site-packages instead
-    of leaving them to be pip-installed from PyPI below. This avoids
-    pip-installed manylinux wheels for numpy/pandas needing libstdc++.so.6
-    at runtime, which Nix's own dynamic linker won't find unpatched --
-    see flake.nix for the full explanation.
-    """
-    nix_stack_paths = os.environ.get("STRICTDOC_NIX_NUMPY_STACK")
-    if not nix_stack_paths:
-        return
-
-    site_packages = sysconfig.get_path("purelib")
-    python_dir = f"python{sys.version_info.major}.{sys.version_info.minor}"
-
-    for nix_pkg_path in nix_stack_paths.split():
-        nix_site_packages = os.path.join(
-            nix_pkg_path, "lib", python_dir, "site-packages"
-        )
-        if not os.path.isdir(nix_site_packages):
-            continue
-        for entry in os.listdir(nix_site_packages):
-            source = os.path.join(nix_site_packages, entry)
-            target = os.path.join(site_packages, entry)
-            if os.path.islink(target) and os.readlink(target) == source:
-                # Already linked to this exact Nix store path.
-                continue
-            if os.path.isdir(target) and not os.path.islink(target):
-                # A real (e.g. pip-installed) copy from before -- replace
-                # it so this is self-healing on an existing venv.
-                shutil.rmtree(target)
-            elif os.path.exists(target) or os.path.islink(target):
-                os.remove(target)
-            os.symlink(source, target)
-
-
 # A simplified version inspired by:
 # https://github.com/HansBug/hbutils/blob/37879186c489bced2791309c43d131f1703b7bd4/hbutils/system/python/package.py#L171
 def check_if_package_installed(package_name: str):
@@ -67,8 +27,6 @@ def check_if_package_installed(package_name: str):
     if not requirement.specifier.contains(version):
         raise PackageVersionConflict(version)
 
-
-link_nix_numpy_stack_if_available()
 
 print(  # noqa: T201
     "pip_install_strictdoc_deps.py: "

--- a/flake.lock
+++ b/flake.lock
@@ -34,10 +34,31 @@
         "type": "github"
       }
     },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786031528,
+        "narHash": "sha256-cROiHKO3UbIKqF5FG5NikvydzlfIj4EcR1Cty9qOVt4=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "1b1485546d85f6f6c7aadb10c4923dbc09633263",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pyproject-nix": "pyproject-nix"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,90 +4,191 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+
+    pyproject-nix = {
+      url = "github:pyproject-nix/pyproject.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      nixpkgs,
+      flake-utils,
+      pyproject-nix,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs { inherit system; };
 
-        # Built by nixpkgs itself -- numpy/pandas's compiled extensions
-        # are already correctly linked against Nix's own libstdc++ (no
-        # patchelf needed for these specifically). Symlinked directly
-        # into .venv-nix's site-packages in shellHook below, instead of
-        # pip-installing this whole stack from PyPI. six/python-dateutil/
-        # pytz/tzdata are pandas's own runtime deps, pulled in the same
-        # way so pip never needs to touch any of this.
-        nixNumpyStack = with pkgs.python312Packages; [
-          numpy
-          pandas
-          six
-          python-dateutil
-          pytz
-          tzdata
-        ];
+        # This pulls in all of the python dependencies defined by
+        # pyproject.toml, but none from tox.ini. This means we have enough
+        # to run strictdoc, but not the developer tooling.
+        project = pyproject-nix.lib.project.loadPyproject { projectRoot = ./.; };
+
+        # Use 3.13 for the environment because the nixpkgs cache contains
+        # cached builds for some of the larger python dependencies like
+        # scipy. When using 3.12, it requires building scipy from source.
+        python = pkgs.python313.override {
+          self = python;
+          packageOverrides = pkgs.lib.composeExtensions treeSitterOverrides versionOverrides;
+        };
+
+        # pyproject.toml pins versions that are not in nixpkgs, so we override
+        # the versions with the following. If strictdoc adopts uv, then the
+        # uv2nix project (which is a subproject of pyproject-nix), can use
+        # the uv.lock to automatically resolve these versions.
+        versionOverrides = final: prev: {
+          reqif = prev.reqif.overrideAttrs (_old: rec {
+            version = "0.1.0";
+            # From the repository rather than the sdist, because nixpkgs' own
+            # derivation patches a file under tests/, which the sdist omits.
+            src = pkgs.fetchFromGitHub {
+              owner = "strictdoc-project";
+              repo = "reqif";
+              tag = version;
+              hash = "sha256-aMjq2x9/aC7HRDL2T2v/yvz+TP+AAKSY3e/TmboKq9Q=";
+            };
+          });
+
+          python-datauri = prev.python-datauri.overrideAttrs (_old: rec {
+            version = "2.2.0";
+            src = final.fetchPypi {
+              inherit version;
+              pname = "python_datauri";
+              hash = "sha256-j6WCIpdf7lQc455rC51WU878wkga0mKe/AN41IsT9Ds=";
+            };
+
+            # tests/assets holds fixture files, one of which is EBCDIC-encoded
+            # and named test_*, so pytest tries to collect it as a module and
+            # fails to decode it. In 2.2.0 that directory is not excluded for us.
+            disabledTestPaths = [ "tests/assets" ];
+          });
+        };
+
+        treeSitterOverrides = final: _prev: {
+          # nixpkgs packages most of the tree-sitter grammars for Python, but
+          # not these two. Both are built the same way as their siblings there,
+          # from the grammar's own repository.
+          tree-sitter-c = final.buildPythonPackage rec {
+            pname = "tree-sitter-c";
+            version = "0.24.2";
+            pyproject = true;
+
+            src = pkgs.fetchFromGitHub {
+              owner = "tree-sitter";
+              repo = "tree-sitter-c";
+              tag = "v${version}";
+              hash = "sha256-Juuf57GQI7OAP6O03KtSzyKJAoXtGKjyYJ+sTM1A4mU=";
+            };
+
+            build-system = [ final.setuptools ];
+            doCheck = false; # The grammar carries no Python tests.
+            pythonImportsCheck = [ "tree_sitter_c" ];
+          };
+
+          tree-sitter-cpp = final.buildPythonPackage rec {
+            pname = "tree-sitter-cpp";
+            version = "0.23.4";
+            pyproject = true;
+
+            src = pkgs.fetchFromGitHub {
+              owner = "tree-sitter";
+              repo = "tree-sitter-cpp";
+              tag = "v${version}";
+              hash = "sha256-tP5Tu747V8QMCEBYwOEmMQUm8OjojpJdlRmjcJTbe2k=";
+            };
+
+            build-system = [ final.setuptools ];
+            doCheck = false;
+            pythonImportsCheck = [ "tree_sitter_cpp" ];
+          };
+        };
+
+        # The runtime dependencies plus the "development" extra.
+        # Everything else the tox environments need is still installed by tox
+        # itself, from PyPI, into build/tox/.
+        pythonEnv = python.withPackages (
+          project.renderers.withPackages {
+            inherit python;
+            extras = [ "development" ];
+          }
+        );
+
+        # nixpkgs' invoke wrapper puts its own `bin/` first on PATH and drops
+        # `NIX_PYTHONPATH`, so the `invoke ...` that tasks.py spawns runs a bare
+        # invoke with no access to our Python environment.
+        # `python -m invoke` skips that wrapper.
+        invokeWrapper = pkgs.writeShellScriptBin "invoke" ''
+          exec ${pythonEnv}/bin/python3 -m invoke "$@"
+        '';
+
+        # pyproject.toml declares the version dynamic, so the renderer below
+        # cannot supply one. hatchling reads it out of this file. Read it the
+        # same way rather than repeating the number here.
+        version =
+          let
+            match = builtins.match ''.*__version__ = "([^"]+)".*'' (builtins.readFile ./strictdoc/__init__.py);
+          in
+          if match == null then
+            throw "flake.nix: no __version__ found in strictdoc/__init__.py"
+          else
+            builtins.head match;
+
+        strictdoc = python.pkgs.buildPythonPackage (
+          project.renderers.buildPythonPackage { inherit python; } // { inherit version; }
+        );
       in
       {
-        # `nix develop` (or ./bootstrap_nix.sh) gives a shell with the
-        # system-level dependencies that pip cannot install: a Python
-        # interpreter, libtidy (used by pytidylib in integration tests),
-        # a browser (seleniumbase/playwright end2end + screencast tests),
-        # and Ruby (`gem install github_changelog_generator`).
-        #
-        # All Python dependencies themselves are still installed via pip,
-        # exactly as the existing `.envrc` workflow already does -- this
-        # flake does not attempt to map them onto nixpkgs' own Python
-        # package set.
-        #
-        # This shell uses its own `.venv-nix/`, separate from `.envrc`'s
-        # `.venv/`. Sharing one venv between Nix's Python and the system
-        # Python is unsafe: re-running `python -m venv` against an
-        # existing venv rewrites pyvenv.cfg to point at whichever python3
-        # is currently first on PATH, but does NOT repoint the bin/python
-        # symlink -- so alternating between the two providers leaves
-        # compiled stdlib extensions (_ssl, termios, ...) mismatched
-        # against the running interpreter's glibc, breaking imports with
-        # GLIBC_* errors. Separate venv directories avoid that entirely.
+        # This shell provides the Python environment the project declares,
+        # plus the system-level tools that are not Python packages at all:
+        # libtidy (pytidylib, integration tests), a browser and a matching
+        # driver, both of which seleniumbase picks up from PATH
+        # (end2end and screencast tests), and github_changelog_generator.
         devShells.default = pkgs.mkShell {
           packages = [
-            pkgs.python312
+            invokeWrapper # Must come before pythonEnv, to shadow its `invoke`.
+            pythonEnv
             pkgs.html-tidy
             pkgs.chromium
-            pkgs.ruby
+            pkgs.chromedriver
+            pkgs.github-changelog-generator
           ];
 
-          shellHook = ''
-            export PYTHONPYCACHEPREFIX=build/pycache
-            # Read by developer/pip_install_strictdoc_deps.py: when set,
-            # it symlinks these store paths' packages into whichever venv
-            # it's running in (e.g. tox's build/tox/py312-check) instead
-            # of pip-installing numpy/pandas from PyPI there too. Only
-            # ever set inside this Nix shell, so it's a complete no-op
-            # for anyone not using Nix.
-            export STRICTDOC_NIX_NUMPY_STACK="${toString nixNumpyStack}"
-            echo "strictdoc: activating virtual environment (.venv-nix)."
-            # Pip-install the project's own bootstrap set (toml, invoke,
-            # packaging, ...) once, right when .venv-nix is first created,
-            # so `invoke` and scripts like
-            # developer/pip_install_strictdoc_deps.py work immediately
-            # without a manual step.
-            #
-            # numpy/pandas and pandas's own runtime deps are NOT
-            # pip-installed at all -- symlinked in from nixNumpyStack
-            # instead (module dir + .dist-info, so pip still recognizes
-            # them as installed and won't try to pull its own).
-            if [ ! -d .venv-nix ]; then
-              python3 -m venv .venv-nix/
-              site_packages=".venv-nix/lib/python3.12/site-packages"
-              for nix_pkg_path in ${toString nixNumpyStack}; do
-                for entry in "$nix_pkg_path"/lib/python3.12/site-packages/*; do
-                  ln -s "$entry" "$site_packages/$(basename "$entry")"
-                done
-              done
-              .venv-nix/bin/pip install --quiet -r requirements.bootstrap.txt
-            fi
-            source .venv-nix/bin/activate
-          '';
+          # Keep __pycache__ out of the source tree.
+          PYTHONPYCACHEPREFIX = "build/pycache";
+
+          # The packages that tox installs from PyPI load shared libraries the
+          # way a normal FHS distribution provides them: pytidylib dlopen()s
+          # libtidy.so.58 by name, and manylinux wheels link their C extensions
+          # against libstdc++/libz. A Nix interpreter does not search any of the
+          # usual locations for them, so point the dynamic linker at the
+          # Nix-provided copies. Without this, `import numpy` inside a tox
+          # environment fails with
+          # "libstdc++.so.6: cannot open shared object file".
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+            pkgs.stdenv.cc.cc.lib
+            pkgs.zlib
+            pkgs.html-tidy
+          ];
+
+          # tasks.py runs every task through tox, and tox creates its own
+          # virtualenvs under build/tox. Put this environment's site-packages
+          # on their PYTHONPATH, so that the runtime dependencies of
+          # pyproject.toml come from Nix and tox installs only the development
+          # dependencies of tox.ini.
+          TOX_OVERRIDE = "testenv.set_env+=PYTHONPATH=${pythonEnv}/${python.sitePackages};testenv.pass_env+=LD_LIBRARY_PATH";
         };
-      });
+
+        # `nix build` and, through the app below, `nix run <this flake>`.
+        packages.default = strictdoc;
+
+        apps.default = {
+          type = "app";
+          program = "${strictdoc}/bin/strictdoc";
+        };
+      }
+    );
 }

--- a/tests/integration/self_testing/nix_flake/01_dev_shell_smoke_test/test.itest
+++ b/tests/integration/self_testing/nix_flake/01_dev_shell_smoke_test/test.itest
@@ -5,18 +5,22 @@ REQUIRES: NIX_AVAILABLE
 # Small smoke test for the project's Nix flake (flake.nix): verifies that
 # `nix flake check` passes, that `nix develop` produces a working shell
 # with the expected Python interpreter, and that StrictDoc's own CLI
-# actually runs inside that shell (exercising the full pip-installed
-# environment, including the numpy/pandas + patchelf RPATH fix in
-# flake.nix's shellHook -- see flake.nix for why that's needed).
+# actually runs inside that shell.
 #
 
 RUN: cd "%strictdoc_root" && nix --extra-experimental-features "nix-command flakes" flake check --no-build
 
 RUN: cd "%strictdoc_root" && nix --extra-experimental-features "nix-command flakes" develop --command python3 --version | filecheck %s --check-prefix=CHECK-PYTHON
 
-CHECK-PYTHON: Python 3.12
+CHECK-PYTHON: Python 3.13
+
+# A dependency from nixpkgs, and one built by flake.nix because nixpkgs does not
+# carry it.
+RUN: cd "%strictdoc_root" && nix --extra-experimental-features "nix-command flakes" develop --command python3 -c "import pandas, tree_sitter_c; print('dependencies ok')" | filecheck %s --check-prefix=CHECK-DEPS
+
+CHECK-DEPS: dependencies ok
 
 # strictdoc has no literal "help" subcommand -- --help is its help flag.
-RUN: cd "%strictdoc_root" && nix --extra-experimental-features "nix-command flakes" develop --command bash -c "pip install --quiet -e '.[development]' && python -m strictdoc.cli.main --help" | filecheck %s --check-prefix=CHECK-HELP
+RUN: cd "%strictdoc_root" && nix --extra-experimental-features "nix-command flakes" develop --command python3 -m strictdoc.cli.main --help | filecheck %s --check-prefix=CHECK-HELP
 
 CHECK-HELP: usage: strictdoc

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ package = "skip"
 skip_install = true
 pass_env =
     PYTHONPYCACHEPREFIX
-    STRICTDOC_NIX_NUMPY_STACK
 deps =
     -rrequirements.bootstrap.txt
     # Reload files when changed (used by 'invoke watch')
@@ -34,7 +33,6 @@ pass_env=
     PYTHONPYCACHEPREFIX
     CHROMEWEBDRIVER
     STRICTDOC_CACHE_DIR
-    STRICTDOC_NIX_NUMPY_STACK
     # Pass the desktop session through tox so headed Chrome can open
     # end-to-end tests in a visible browser window on Ubuntu/Linux.
     DBUS_SESSION_BUS_ADDRESS
@@ -52,7 +50,6 @@ package = "skip"
 skip_install = true
 pass_env =
     PYTHONPYCACHEPREFIX
-    STRICTDOC_NIX_NUMPY_STACK
 allowlist_externals =
     cd
     cp
@@ -88,7 +85,6 @@ package = "skip"
 skip_install = true
 pass_env =
     PYTHONPYCACHEPREFIX
-    STRICTDOC_NIX_NUMPY_STACK
 allowlist_externals =
     rm
 deps =
@@ -114,7 +110,6 @@ package = "skip"
 skip_install = true
 pass_env =
     PYTHONPYCACHEPREFIX
-    STRICTDOC_NIX_NUMPY_STACK
 deps =
     -rrequirements.bootstrap.txt
     pyinstaller


### PR DESCRIPTION
Before this change, the flake gave a Python interpreter and system libraries, but not the Python dependencies. The shell installed those with pip each time it started, into a virtual environment .venv-nix. The file .envrc made a second virtual environment, .venv. The result was a different environment for each way to enter the directory.

Now pyproject.nix reads pyproject.toml and finds each dependency in nixpkgs. The shell gives the environment that the project declares. The pip step and both virtual environments are no longer necessary. The file .envrc contains only `use flake`, thus direnv and `nix develop` give the same environment.

The flake also builds StrictDoc. Thus you can run it without a copy of the source:

    nix run github:strictdoc-project/strictdoc -- --help

The flake contains four package definitions. nixpkgs does not have tree-sitter-c and tree-sitter-cpp. It has reqif and python-datauri, but with a version that pyproject.toml does not permit.

The interpreter is Python 3.13, and not 3.12. nixpkgs supplies binaries for its default interpreter and for the one below it. With 3.12, many of the python packages would need to built from source.

The shell installs github_changelog_generator directly in place of ruby, since it was already available in nixpkgs.

---

You can test this off of my fork with:

    nix run github:adamatom/strictdoc/complete_flake -- --help