### PR TITLE
perf(export/html): pool initializer for parallel document export

### DIFF
--- a/strictdoc/export/html/html_generator.py
+++ b/strictdoc/export/html/html_generator.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 from collections import defaultdict
-from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -55,7 +54,7 @@ from strictdoc.helpers.file_modification_time import get_file_modification_time
 from strictdoc.helpers.file_system import sync_dir
 from strictdoc.helpers.git_client import GitClient
 from strictdoc.helpers.mid import MID
-from strictdoc.helpers.parallelizer import Parallelizer
+from strictdoc.helpers.parallelizer import Parallelizer, get_worker_context
 from strictdoc.helpers.paths import SDocRelativePath, path_to_posix_path
 from strictdoc.helpers.timing import measure_performance, timing_decorator
 
@@ -67,19 +66,45 @@ def render_favicon_svg(
     # Deliberately not using html_templates.jinja_environment(): for large
     # projects it is a CompiledHTMLTemplates instance that lazily caches a
     # ModuleLoader-backed Environment (holding unpicklable compiled
-    # _TemplateModule objects) on first call. HTMLGenerator instances are
-    # captured by the closure passed to the document-export parallelizer,
-    # so populating that cache here, in the main process, before parallel
-    # export starts, makes the whole HTMLGenerator (and its html_templates)
-    # unpicklable for the worker pool. A standalone, uncached environment
-    # sidesteps that entirely; favicon.svg.jinja is small enough that
-    # skipping template compilation has no measurable cost.
+    # _TemplateModule objects) on first call. The HTMLGenerator instance is
+    # sent once to each worker process via the document-export parallelizer's
+    # pool initializer (see export_complete_tree()), so populating that cache
+    # here, in the main process, before parallel export starts, would make
+    # the whole HTMLGenerator (and its html_templates) unpicklable for the
+    # worker pool. A standalone, uncached environment sidesteps that
+    # entirely; favicon.svg.jinja is small enough that skipping template
+    # compilation has no measurable cost.
     variant = project_config.get_favicon_variant()
     return (
         NormalHTMLTemplates()
         .jinja_environment()
         .get_template("_shared/favicon.svg.jinja")
         .render(variant=variant)
+    )
+
+
+def _export_single_document_worker(document_mid: MID) -> None:
+    """
+    Module-level (picklable-by-reference) task function for the document
+    export parallelizer. The (HTMLGenerator, TraceabilityIndex) pair is not
+    passed as an argument here: it is sent to each worker process exactly
+    once via run_parallel_with_context()'s pool initializer, instead of
+    being pickled fresh into every submitted document's task.
+
+    Only the document's MID travels per-task, not the SDocDocument object
+    itself: the document is looked up in this worker's own copy of
+    traceability_index instead. Nodes reachable from a document that was
+    pickled separately (e.g. as a direct task argument) would not be the
+    same Python objects as the ones inside the worker's traceability_index
+    (a different, earlier pickle/unpickle of the same content) - and
+    identity-sensitive lookups, such as NodeFilter's blacklist (a plain
+    `set`, hashed/compared by object identity), would then silently fail
+    to recognize them.
+    """
+    html_generator, traceability_index = get_worker_context()
+    document = traceability_index.get_node_by_mid(document_mid)
+    html_generator.export_single_document_with_performance(
+        document, traceability_index
     )
 
 
@@ -114,12 +139,6 @@ class HTMLGenerator:
             traceability_index=traceability_index
         )
 
-        # Export all documents in parallel.
-        export_binding = partial(
-            self.export_single_document_with_performance,
-            traceability_index=traceability_index,
-        )
-
         # By default, do not export included documents. Only, if the option to
         # include is provided.
         documents_to_export: List[SDocDocument] = []
@@ -151,15 +170,11 @@ class HTMLGenerator:
                 documents_to_export.append(document_)
 
         if len(documents_to_export) > 0:
-            if len(traceability_index.document_tree.document_list) <= 25:
-                parallelizer.run_parallel(documents_to_export, export_binding)
-            else:
-                print(  # noqa: T201
-                    "NOTE: Running document export without parallelization "
-                    "because the document tree contains more than 25 documents."
-                )
-                for document_ in documents_to_export:
-                    export_binding(document_)
+            parallelizer.run_parallel_with_context(
+                [document_.reserved_mid for document_ in documents_to_export],
+                _export_single_document_worker,
+                (self, traceability_index),
+            )
 
         # Export document tree.
         # FIXME: It is important that this export is **after** the parallelized

--- a/strictdoc/helpers/parallelizer.py
+++ b/strictdoc/helpers/parallelizer.py
@@ -18,6 +18,17 @@ from strictdoc.helpers.exception import (
 
 MultiprocessingLambdaType = Callable[[Any], Any]
 
+# Where run_parallel_with_context() cannot use the fork+copy-on-write fast
+# path (Windows, always - or a caller that is not single-threaded when it
+# runs), this caps how many tasks it will still dispatch via the
+# pool-initializer mechanism before falling back to running in-process
+# instead. Task count is only a rough proxy for the size of the shared
+# `context` object actually being duplicated per worker, but this is the
+# same document-count cutoff (25) html_generator.py used to apply
+# unconditionally before the fork+COW path existed - see
+# run_parallel_with_context() below for the measurements behind it.
+_LARGE_CONTEXT_FALLBACK_THRESHOLD = 25
+
 # Set once per worker process by _init_worker_context() (either via a pool
 # initializer under multiprocessing, or directly in-process under
 # NullParallelizer). run_parallel_with_context() exists so that a large,
@@ -207,17 +218,32 @@ class MultiprocessingParallelizer(Parallelizer):
                 max_workers=self.process_number,
                 mp_context=multiprocessing.get_context("fork"),
             )
-        else:
-            # Not safe to fork here (other threads are alive) or fork isn't
-            # available (Windows). Fall back to sending `context` once per
-            # worker via the pool initializer - still only process_number
-            # pickles instead of one per task, just not copy-on-write-free.
+            return self.run_parallel(contents, processing_func)
+
+        # Not safe to fork here (other threads are alive), or fork isn't
+        # available at all (Windows - the measured regression above is not
+        # a POSIX-only curiosity, it applies there unconditionally, every
+        # time, regardless of tree size). Below a modest number of tasks,
+        # sending `context` once per worker via the pool initializer is
+        # still fine (process_number pickles, not one per task). Above it,
+        # skip multiprocessing for this call entirely and run in-process:
+        # this is the same safety net this parallelizer relied on (as a
+        # document-count cutoff one level up, in html_generator.py) before
+        # the fork+COW path existed, now scoped to exactly the cases that
+        # cannot use that path.
+        if len(contents) > _LARGE_CONTEXT_FALLBACK_THRESHOLD:
             self.executor = ProcessPoolExecutor(
-                max_workers=self.process_number,
-                mp_context=self.mp_context,
-                initializer=_init_worker_context,
-                initargs=(context,),
+                max_workers=self.process_number, mp_context=self.mp_context
             )
+            _init_worker_context(context)
+            return [processing_func(item) for item in contents]
+
+        self.executor = ProcessPoolExecutor(
+            max_workers=self.process_number,
+            mp_context=self.mp_context,
+            initializer=_init_worker_context,
+            initargs=(context,),
+        )
         return self.run_parallel(contents, processing_func)
 
     def shutdown(self) -> None:

--- a/strictdoc/helpers/parallelizer.py
+++ b/strictdoc/helpers/parallelizer.py
@@ -5,6 +5,7 @@ Run StrictDoc child tasks as separate processes.
 """
 
 import multiprocessing
+import threading
 from abc import ABC, abstractmethod
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from typing import Any, Callable, Iterable, List, Optional, Tuple
@@ -39,6 +40,18 @@ def get_worker_context() -> Any:
     main process) by a processing_func passed to run_parallel_with_context().
     """
     return _worker_context_box[0]
+
+
+def _can_fork_safely() -> bool:
+    """
+    Forking a *multithreaded* process risks a deadlock (a lock held by a
+    thread that doesn't exist in the child), not forking per se. "fork" is
+    also simply unavailable on some platforms (Windows).
+    """
+    return (
+        threading.active_count() == 1
+        and "fork" in multiprocessing.get_all_start_methods()
+    )
 
 
 def processing_func_wrapper(
@@ -162,18 +175,49 @@ class MultiprocessingParallelizer(Parallelizer):
         processing_func: MultiprocessingLambdaType,
         context: Any,
     ) -> Iterable[Any]:
-        # A pool initializer only runs once, when a worker process starts.
-        # Recreate the pool so that every worker (fork/forkserver/spawn
-        # alike) is (re)started with the initializer bound to this call's
-        # context, instead of relying on each submitted task to carry its
-        # own copy of `context` to be pickled and sent individually.
+        # shutdown(wait=True) joins the previous pool's management/feeder
+        # threads. In the common case (a one-shot CLI export) that leaves
+        # the process single-threaded, which is what _can_fork_safely()
+        # needs to be true. But this parallelizer can also be reused inside
+        # a long-lived process (e.g. the dev server, or a test suite that
+        # keeps other threads around), where that does not hold - hence
+        # checking rather than assuming.
         self.executor.shutdown(wait=True)
-        self.executor = ProcessPoolExecutor(
-            max_workers=self.process_number,
-            mp_context=self.mp_context,
-            initializer=_init_worker_context,
-            initargs=(context,),
-        )
+
+        # `context` (e.g. a whole traceability index) can be large - tens to
+        # hundreds of MB for a big documentation tree. Pickling it into every
+        # worker via a pool initializer (initargs) means each worker pays a
+        # full deserialization of that payload, and under "forkserver"/
+        # "spawn" those deserializations happen independently and
+        # concurrently in every worker, which for a large enough payload
+        # turns into severe memory/CPU contention - worse than not
+        # parallelizing at all (measured: a 138MB index caused a 12-worker
+        # export to run ~3.5x SLOWER than sequential on one real, large
+        # document tree).
+        #
+        # Where it's safe to fork, sidestep this entirely: set the context
+        # in this (parent) process, then fork. Forked children share the
+        # already-built object graph via copy-on-write - no pickling of
+        # `context` at all, and no redundant per-worker reconstruction.
+        # Measured effect on the same 138MB-index tree: export dropped from
+        # ~98s to ~15s, faster than not parallelizing.
+        if _can_fork_safely():
+            _init_worker_context(context)
+            self.executor = ProcessPoolExecutor(
+                max_workers=self.process_number,
+                mp_context=multiprocessing.get_context("fork"),
+            )
+        else:
+            # Not safe to fork here (other threads are alive) or fork isn't
+            # available (Windows). Fall back to sending `context` once per
+            # worker via the pool initializer - still only process_number
+            # pickles instead of one per task, just not copy-on-write-free.
+            self.executor = ProcessPoolExecutor(
+                max_workers=self.process_number,
+                mp_context=self.mp_context,
+                initializer=_init_worker_context,
+                initargs=(context,),
+            )
         return self.run_parallel(contents, processing_func)
 
     def shutdown(self) -> None:

--- a/strictdoc/helpers/parallelizer.py
+++ b/strictdoc/helpers/parallelizer.py
@@ -17,6 +17,29 @@ from strictdoc.helpers.exception import (
 
 MultiprocessingLambdaType = Callable[[Any], Any]
 
+# Set once per worker process by _init_worker_context() (either via a pool
+# initializer under multiprocessing, or directly in-process under
+# NullParallelizer). run_parallel_with_context() exists so that a large,
+# shared, read-only value (e.g. a whole traceability index) is sent to each
+# worker process exactly once, instead of being pickled fresh into every
+# submitted task's closure/arguments.
+#
+# A single-item box, rather than a rebound module-level name, so that
+# _init_worker_context() can set it without a `global` statement.
+_worker_context_box: List[Any] = [None]
+
+
+def _init_worker_context(context: Any) -> None:
+    _worker_context_box[0] = context
+
+
+def get_worker_context() -> Any:
+    """
+    Called from within a worker process (or, under NullParallelizer, the
+    main process) by a processing_func passed to run_parallel_with_context().
+    """
+    return _worker_context_box[0]
+
 
 def processing_func_wrapper(
     func: MultiprocessingLambdaType, input_arg: Any
@@ -41,6 +64,21 @@ class Parallelizer(ABC):
         contents: List[Any],
         processing_func: MultiprocessingLambdaType,
     ) -> Iterable[Any]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def run_parallel_with_context(
+        self,
+        contents: List[Any],
+        processing_func: MultiprocessingLambdaType,
+        context: Any,
+    ) -> Iterable[Any]:
+        """
+        Like run_parallel(), but `context` is sent to each worker process
+        exactly once instead of being pickled into every task. `processing_func`
+        must be a plain, module-level function (not a bound method or a
+        closure) that retrieves the context via get_worker_context().
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -87,9 +125,10 @@ class MultiprocessingParallelizer(Parallelizer):
                 if "forkserver" in multiprocessing.get_all_start_methods()
                 else "spawn"
             )
-        mp_context = multiprocessing.get_context(start_method)
+        self.process_number = process_number
+        self.mp_context = multiprocessing.get_context(start_method)
         self.executor = ProcessPoolExecutor(
-            max_workers=process_number, mp_context=mp_context
+            max_workers=self.process_number, mp_context=self.mp_context
         )
 
     def run_parallel(
@@ -117,6 +156,26 @@ class MultiprocessingParallelizer(Parallelizer):
         except Exception as e:
             raise e
 
+    def run_parallel_with_context(
+        self,
+        contents: List[Any],
+        processing_func: MultiprocessingLambdaType,
+        context: Any,
+    ) -> Iterable[Any]:
+        # A pool initializer only runs once, when a worker process starts.
+        # Recreate the pool so that every worker (fork/forkserver/spawn
+        # alike) is (re)started with the initializer bound to this call's
+        # context, instead of relying on each submitted task to carry its
+        # own copy of `context` to be pickled and sent individually.
+        self.executor.shutdown(wait=True)
+        self.executor = ProcessPoolExecutor(
+            max_workers=self.process_number,
+            mp_context=self.mp_context,
+            initializer=_init_worker_context,
+            initargs=(context,),
+        )
+        return self.run_parallel(contents, processing_func)
+
     def shutdown(self) -> None:
         self.executor.shutdown(wait=True)
 
@@ -131,6 +190,15 @@ class NullParallelizer(Parallelizer):
         for content in contents:
             results.append(processing_func(content))
         return results
+
+    def run_parallel_with_context(
+        self,
+        contents: List[Any],
+        processing_func: MultiprocessingLambdaType,
+        context: Any,
+    ) -> Iterable[Any]:
+        _init_worker_context(context)
+        return self.run_parallel(contents, processing_func)
 
     def shutdown(self) -> None:
         pass

--- a/tests/unit/strictdoc/helpers/test_parallelizer.py
+++ b/tests/unit/strictdoc/helpers/test_parallelizer.py
@@ -3,6 +3,7 @@ import signal
 import sys
 from concurrent.futures.process import BrokenProcessPool
 from time import sleep
+from unittest import mock
 
 import pytest
 
@@ -10,6 +11,7 @@ from strictdoc.helpers.exception import StrictDocChildProcessException
 from strictdoc.helpers.parallelizer import (
     MultiprocessingParallelizer,
     NullParallelizer,
+    _can_fork_safely,
     get_worker_context,
 )
 
@@ -91,6 +93,60 @@ def test_run_parallel_with_context_can_be_called_again_with_a_new_context():
 
         assert list(first_result) == ["first"]
         assert list(second_result) == ["second"]
+    finally:
+        parallelizer.shutdown()
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="fork is not available on Windows"
+)
+def test_can_fork_safely_true_when_single_threaded():
+    with mock.patch(
+        "strictdoc.helpers.parallelizer.threading.active_count",
+        return_value=1,
+    ):
+        assert _can_fork_safely() is True
+
+
+def test_can_fork_safely_false_when_not_single_threaded():
+    # A live background thread makes forking unsafe: a lock it holds could
+    # be left permanently locked (and never released) in the forked child,
+    # which only inherits a frozen snapshot of the parent's memory, not
+    # the thread that was about to release that lock.
+    with mock.patch(
+        "strictdoc.helpers.parallelizer.threading.active_count",
+        return_value=2,
+    ):
+        assert _can_fork_safely() is False
+
+
+def test_can_fork_safely_false_when_fork_unavailable():
+    with mock.patch(
+        "strictdoc.helpers.parallelizer.threading.active_count",
+        return_value=1,
+    ), mock.patch(
+        "strictdoc.helpers.parallelizer.multiprocessing.get_all_start_methods",
+        return_value=["spawn"],
+    ):
+        assert _can_fork_safely() is False
+
+
+def test_run_parallel_with_context_falls_back_when_not_safe_to_fork():
+    parallelizer = MultiprocessingParallelizer()
+
+    try:
+        with mock.patch(
+            "strictdoc.helpers.parallelizer._can_fork_safely",
+            return_value=False,
+        ):
+            output_items = parallelizer.run_parallel_with_context(
+                [1, 2, 3],
+                child_process_that_reads_the_worker_context,
+                "fallback-context",
+            )
+
+        assert list(output_items) == ["fallback-context"] * 3
+        assert parallelizer.executor._mp_context.get_start_method() != "fork"
     finally:
         parallelizer.shutdown()
 

--- a/tests/unit/strictdoc/helpers/test_parallelizer.py
+++ b/tests/unit/strictdoc/helpers/test_parallelizer.py
@@ -151,6 +151,35 @@ def test_run_parallel_with_context_falls_back_when_not_safe_to_fork():
         parallelizer.shutdown()
 
 
+def test_run_parallel_with_context_runs_in_process_when_not_safe_to_fork_and_many_tasks():
+    # Without fork+COW (Windows, always - or a caller that isn't
+    # single-threaded), sending a large `context` to every worker via the
+    # pool initializer doesn't scale (see run_parallel_with_context()'s
+    # comments for the measurements). Above the task-count threshold used
+    # as a size proxy, this must skip multiprocessing for the call
+    # entirely rather than duplicate `context` into a whole pool of
+    # workers - the same protection html_generator.py's now-removed
+    # document-count cutoff used to provide unconditionally.
+    parallelizer = MultiprocessingParallelizer()
+
+    try:
+        many_items = list(range(30))
+
+        with mock.patch(
+            "strictdoc.helpers.parallelizer._can_fork_safely",
+            return_value=False,
+        ):
+            output_items = parallelizer.run_parallel_with_context(
+                many_items,
+                child_process_that_reads_the_worker_context,
+                "large-fallback-context",
+            )
+
+        assert output_items == ["large-fallback-context"] * len(many_items)
+    finally:
+        parallelizer.shutdown()
+
+
 def test_run_parallel_with_context_null_parallelizer():
     parallelizer = NullParallelizer()
 

--- a/tests/unit/strictdoc/helpers/test_parallelizer.py
+++ b/tests/unit/strictdoc/helpers/test_parallelizer.py
@@ -7,7 +7,11 @@ from time import sleep
 import pytest
 
 from strictdoc.helpers.exception import StrictDocChildProcessException
-from strictdoc.helpers.parallelizer import MultiprocessingParallelizer
+from strictdoc.helpers.parallelizer import (
+    MultiprocessingParallelizer,
+    NullParallelizer,
+    get_worker_context,
+)
 
 
 def child_process_that_multiplies_by_two(input_number):
@@ -21,6 +25,10 @@ def child_process_that_fails(_):
 def child_that_sigterms_itself_and_hangs(_):
     os.kill(os.getpid(), signal.SIGTERM)
     sleep(120)
+
+
+def child_process_that_reads_the_worker_context(_):
+    return get_worker_context()
 
 
 def test_nominal_use_case():
@@ -53,6 +61,48 @@ def test_if_child_process_fails_then_parallelizer_exits_with_non_zero():
         )
     finally:
         parallelizer.shutdown()
+
+
+def test_run_parallel_with_context_sends_context_once_per_worker():
+    parallelizer = MultiprocessingParallelizer()
+
+    try:
+        output_items = parallelizer.run_parallel_with_context(
+            [1, 2, 3],
+            child_process_that_reads_the_worker_context,
+            "shared-context",
+        )
+
+        assert list(output_items) == ["shared-context"] * 3
+    finally:
+        parallelizer.shutdown()
+
+
+def test_run_parallel_with_context_can_be_called_again_with_a_new_context():
+    parallelizer = MultiprocessingParallelizer()
+
+    try:
+        first_result = parallelizer.run_parallel_with_context(
+            [1], child_process_that_reads_the_worker_context, "first"
+        )
+        second_result = parallelizer.run_parallel_with_context(
+            [1], child_process_that_reads_the_worker_context, "second"
+        )
+
+        assert list(first_result) == ["first"]
+        assert list(second_result) == ["second"]
+    finally:
+        parallelizer.shutdown()
+
+
+def test_run_parallel_with_context_null_parallelizer():
+    parallelizer = NullParallelizer()
+
+    output_items = parallelizer.run_parallel_with_context(
+        [1, 2], child_process_that_reads_the_worker_context, "null-context"
+    )
+
+    assert output_items == ["null-context", "null-context"]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary
- `export_complete_tree()` built a `functools.partial` closure over the whole `traceability_index` (and the whole `HTMLGenerator`, including `project_config`/`html_templates`) and passed it to `parallelizer.run_parallel()`. `ProcessPoolExecutor` pickles the submitted callable and its arguments per task, so every one of N documents re-pickled the entire index. A "more than 25 documents" cutoff existed specifically to fall back to sequential export once that per-task cost got large enough to matter.
- `Parallelizer` gains `run_parallel_with_context()`: a value is sent to each worker process exactly once instead of being pickled into every task, and workers retrieve it via `get_worker_context()`.
- `export_complete_tree()` now sends `(self, traceability_index)` once per worker and submits only each document's MID per task, so **the 25-document cutoff is no longer needed and has been removed**.

## A regression found while benchmarking, and its fix
Benchmarking against a real 139-document tree (ECSS EARM-scale, ~12MB source / 138MB pickled index) showed the pool-initializer approach alone made large-tree export **~3.5x slower**, not faster: sending the 138MB index via a pool initializer means every worker independently deserializes its own full copy, concurrently, at pool startup - severe memory/CPU contention that got monotonically worse with more workers (1 worker: ~31s, 3: ~37s, 6: ~57s, 12: ~98-104s, vs ~29s sequential).

Fix: exploit `fork`'s copy-on-write instead of pickling the context at all, but only where it's actually safe to fork (forking a *multithreaded* process risks a deadlock; `_can_fork_safely()` checks `threading.active_count() == 1` at the actual call site, degrading to the pickle-based path whenever that doesn't hold - e.g. a long-lived server process, or the pytest process itself, which genuinely has a background thread from plugin infrastructure and exercised this fallback while writing tests).

Result on the same tree, with the real production code: export step dropped to **~15s**, reproduced multiple times - faster than sequential, not just faster than the broken parallel-only version.

## Windows / fork-unavailable safety net
`fork` is unconditionally unavailable on Windows, so `_can_fork_safely()` is always `False` there - removing the 25-document cutoff unconditionally would have left Windows users exporting a large tree exposed to the exact ~3.5x regression above, with no protection at all (worse than before this PR). Restored the same protection as a task-count threshold scoped to exactly the cases that can't fork: above it, skip multiprocessing for the call entirely and run in-process (same as the old cutoff's effect); below it, the pool-initializer path is still fine. Verified by forcing `_can_fork_safely()` to always return `False` (a "Windows" simulation) and re-running the export against the same 139-document tree: export step ~28s, matching the sequential baseline, not the ~98-104s regression.

## Also fixed along the way
Only the document's MID travels per task, not the `SDocDocument` object itself. Passing the document directly surfaced a real correctness bug: `NodeFilter`'s blacklist is a plain `set`, hashed/compared by object identity. Sending `traceability_index` via the initializer/fork and each document via a *separate* per-task pickle stream produced two distinct (though content-identical) copies of the same document's nodes, so `node not in blacklisted_nodes` silently stopped recognizing blacklisted nodes - `--filter-nodes` integration tests caught this immediately. Workers now resolve the document from their own copy of `traceability_index` via `get_node_by_mid()`.

## Test plan
- [x] New unit tests in `test_parallelizer.py`: `run_parallel_with_context()` correctness for both `MultiprocessingParallelizer` and `NullParallelizer`; `_can_fork_safely()` decision logic (single-threaded, multi-threaded, fork-unavailable) as a pure, directly-testable function; the large-tree fallback-to-in-process behavior when forking isn't safe.
- [x] `invoke tu` - 690 unit tests pass.
- [x] `invoke lint` - ruff format/check + mypy strict clean.
- [x] `invoke ti --focus parallelization` and `invoke ti --focus features/html` - all relevant tests pass (59/59 in the html subset).
- [x] Manual, real-world benchmark against a 139-document ECSS tree (~12MB source): export step ~15s with fork+COW vs ~98-104s with pool-initializer-only vs ~29s sequential baseline vs ~28s simulated-Windows fallback. Reproduced multiple times.
- [x] Correctness: diffed all 279 output HTML files between old and new mechanism - byte-identical except for content already non-deterministic between any two independent parses (auto-generated MIDs on nodes without an explicit MID, a timestamp meta tag), confirmed by diffing two runs of the unmodified baseline against each other.
- [x] Manual: exported a 30-document tree (above the old 25-doc cutoff) with parallelization on, confirmed correct output for all 30 docs; re-ran as a no-op (skip logic still works); re-ran with `--no-parallelization` (`NullParallelizer` path still works).