### PR TITLE
fix(tests/end2end): fix flaky test_created_node_stays_stable_when_chunk_above_loads

### DIFF
--- a/tests/end2end/helpers/screens/document/screen_document.py
+++ b/tests/end2end/helpers/screens/document/screen_document.py
@@ -187,6 +187,37 @@ class Screen_Document(Screen):  # pylint: disable=invalid-name
         )
         return top
 
+    def get_stable_node_containing_text_viewport_top(
+        self,
+        text: str,
+        *,
+        stable_duration: float = 0.3,
+        sample_interval: float = 0.05,
+        tolerance: float = 1,
+        timeout: int = 20,
+    ) -> float:
+        # Some production restorations correct a node's position over one or
+        # more async ticks after it first appears (e.g. a setTimeout()+rAF
+        # pair). Reading the position too early captures that transient
+        # value rather than the settled one a later assertion must compare
+        # against. Wait until consecutive samples stop moving instead of
+        # relying on a single read.
+        start_time = datetime.now()
+        last_top = self.get_node_containing_text_viewport_top(text)
+        stable_since = datetime.now()
+
+        while True:
+            self.test_case.sleep(sample_interval)
+            current_top = self.get_node_containing_text_viewport_top(text)
+            now = datetime.now()
+            if abs(current_top - last_top) > tolerance:
+                stable_since = now
+            elif (now - stable_since).total_seconds() >= stable_duration:
+                return current_top
+            last_top = current_top
+            if (now - start_time).total_seconds() >= timeout:
+                return current_top
+
     def assert_anchor_viewport_top_close(
         self,
         anchor: str,

--- a/tests/end2end/screens/document/lazy_loading_scroll_preservation/test_case.py
+++ b/tests/end2end/screens/document/lazy_loading_scroll_preservation/test_case.py
@@ -861,8 +861,18 @@ class Test(E2ECase):
             form.do_fill_in_field_title("Created Before Last Chunk Node")
             form.do_form_submit()
             self.assert_text("Created Before Last Chunk Node")
-            top_before = screen_document.get_node_containing_text_viewport_top(
-                "Created Before Last Chunk Node"
+            # Wait for the create operation's own restoration to settle
+            # before treating the current position as the reference. Reading
+            # it immediately can race the async setTimeout()+rAF correction
+            # in handleBeforeStreamRender(), producing a transient top_before
+            # that later shifts to the true locked position independently of
+            # chunk 1 loading. Unlike sibling create tests, the target here
+            # is not CONTENT_VIEWPORT_TOP, so wait for the measurement itself
+            # to stop moving rather than for a known coordinate.
+            top_before = (
+                screen_document.get_stable_node_containing_text_viewport_top(
+                    "Created Before Last Chunk Node"
+                )
             )
 
             # Loading the earlier chunk after create must preserve the


### PR DESCRIPTION
## Summary

- `test_created_node_stays_stable_when_chunk_above_loads` was flaky on macOS CI: the created node ended up about 100px away from the recorded reference position after chunk 1 loaded.
- The test read `top_before` right after `assert_text()`, before the create operation's own restoration had settled. `handleBeforeStreamRender()` corrects the new node's position through a `setTimeout(0)` + `requestAnimationFrame` pair, so on a slower runner the read can land mid-correction; the node then moves to its true position on its own, and the later stability assertion sees that unrelated shift as a failure.
- Added `get_stable_node_containing_text_viewport_top()`, which polls the node's position until it stops changing, and used it to capture `top_before`.

## Test plan

- [x] `invoke test-end2end --headless --focus test_created_node_stays_stable_when_chunk_above_loads` — ran 3 times in a row, all passed
- [x] `invoke test-end2end --headless --focus lazy_loading_scroll_preservation` — full 21-test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)