### PR TITLE
feat(plantuml): add PlantUML diagram rendering support

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -3961,6 +3961,69 @@ diagrams.
 [[/SECTION]]
 
 [[SECTION]]
+MID: 241e0e27e1c74262a97a9aaaefda6064
+TITLE: PlantUML diagramming tool
+
+[TEXT]
+MID: 6bd707bcbc2b4e77b65a8d7d02607daa
+STATEMENT: >>>
+PlantUML diagrams can be created inside of StrictDoc/RST markup as follows:
+
+.. code:: strictdoc
+
+    [TEXT]
+    STATEMENT: >>>
+    .. raw:: html
+
+        <pre class="plantuml">
+        @startuml
+        Alice -> Bob: Hello
+        @enduml
+        </pre>
+    <<<
+
+Markdown documents can use a fenced code block tagged ``plantuml`` instead:
+
+.. code:: markdown
+
+    ```plantuml
+    @startuml
+    Alice -> Bob: Hello
+    @enduml
+    ```
+
+Unlike Mermaid, PlantUML diagrams are not rendered in the browser: the
+diagram source is sent to a PlantUML server, which renders it to an SVG
+image. Because of this, PlantUML support is disabled by default and must be
+enabled explicitly by setting the ``plantuml_server_url`` option to a
+PlantUML server, for example the public server at
+``https://www.plantuml.com/plantuml``:
+
+.. code:: python
+
+    from strictdoc.core.project_config import ProjectConfig
+
+
+    def create_config() -> ProjectConfig:
+        config = ProjectConfig(
+            plantuml_server_url="https://www.plantuml.com/plantuml",
+        )
+        return config
+
+If ``plantuml_server_url`` is not set, ``pre.plantuml``/``` ```plantuml ```
+blocks are left as-is and no diagram is rendered.
+
+.. warning::
+
+    When using the public server, the text of every PlantUML diagram is sent
+    to a third party (plantuml.com) for rendering. Projects with
+    confidential diagram content should self-host a PlantUML server and
+    point ``plantuml_server_url`` at it instead.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
 MID: 17a8adb92c8d4e7992e869355e73912d
 TITLE: Configuration
 
@@ -4238,6 +4301,40 @@ server.
 The path must be relative to the project root and point to an existing file.
 The referenced CSS file is applied on top of StrictDoc's own stylesheets, so
 only the rules that need to be changed have to be specified.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
+MID: c94bf61401bb4dabb337427f47b6d876
+UID: SECTION-UG-PlantUML-server-URL
+TITLE: PlantUML server URL
+
+[TEXT]
+MID: 9493b1051cdc45bb9887264d5d3f75b0
+STATEMENT: >>>
+PlantUML support is disabled unless a ``plantuml_server_url`` is configured
+(see [LINK: SDOC_UG_OPTIONS_PROJECT_LEVEL]). This can point to the public
+server at ``https://www.plantuml.com/plantuml``, or to a self-hosted
+instance:
+
+.. code:: python
+
+    from strictdoc.core.project_config import ProjectConfig
+
+
+    def create_config() -> ProjectConfig:
+        config = ProjectConfig(
+            plantuml_server_url="https://plantuml.example.com/plantuml",
+        )
+        return config
+
+.. note::
+
+    There is no default ``plantuml_server_url``. Rendering a PlantUML diagram
+    requires sending its source to a PlantUML server, so StrictDoc leaves the
+    feature off until a project explicitly opts in and chooses a server it
+    trusts with that content.
 <<<
 
 [[/SECTION]]

--- a/docs/strictdoc_04_release_notes.sdoc
+++ b/docs/strictdoc_04_release_notes.sdoc
@@ -50,6 +50,26 @@ releases:
 <<<
 
 [[SECTION]]
+MID: 5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e
+TITLE: Unreleased
+
+[TEXT]
+MID: c42d4f9213c04aac9ff29a2ed2fcb6c8
+STATEMENT: >>>
+This release contains the following enhancements:
+
+1\) StrictDoc now supports PlantUML diagrams. SDoc/RST documents can embed a
+``<pre class="plantuml">`` block via the ``.. raw:: html`` directive, and
+Markdown documents can use a fenced code block labeled ``plantuml``. Diagram
+text is rendered to an SVG image by a PlantUML server. PlantUML is disabled
+by default; set the new ``plantuml_server_url`` option to enable it, e.g. to
+the public server at ``https://www.plantuml.com/plantuml`` or to a
+self-hosted instance.
+<<<
+
+[[/SECTION]]
+
+[[SECTION]]
 MID: f4a1c9b3e5d64f7a8b9c0d1e2f3a4b5c
 TITLE: 0.28.3 (2026-08-25)
 

--- a/strictdoc/backend/markdown/markdown_to_html_fragment_writer.py
+++ b/strictdoc/backend/markdown/markdown_to_html_fragment_writer.py
@@ -33,10 +33,13 @@ def _render_fence(
     info = unescapeAll(token.info).strip() if token.info else ""
     lang_name = info.split(maxsplit=1)[0] if info else ""
 
-    if lang_name.lower() != "mermaid":
-        return _DEFAULT_FENCE_RENDERER(tokens, idx, options, env)
+    if lang_name.lower() == "mermaid":
+        return f'<pre class="mermaid">{escapeHtml(token.content)}</pre>\n'
 
-    return f'<pre class="mermaid">{escapeHtml(token.content)}</pre>\n'
+    if lang_name.lower() == "plantuml":
+        return f'<pre class="plantuml">{escapeHtml(token.content)}</pre>\n'
+
+    return _DEFAULT_FENCE_RENDERER(tokens, idx, options, env)
 
 
 def _math_inline_rule(state: StateInline, silent: bool) -> bool:

--- a/strictdoc/core/environment.py
+++ b/strictdoc/core/environment.py
@@ -35,6 +35,7 @@ HTML_STATIC_DIRS = [
     os.path.join("strictdoc", "features", "mathjax", "assets"),
     os.path.join("strictdoc", "features", "mermaid", "assets"),
     os.path.join("strictdoc", "features", "nestor", "assets"),
+    os.path.join("strictdoc", "features", "plantuml", "assets"),
     os.path.join("strictdoc", "features", "project_index", "assets"),
     os.path.join("strictdoc", "features", "source_coverage", "assets"),
     os.path.join("strictdoc", "features", "source_file_view", "assets"),

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -42,7 +42,7 @@ from strictdoc.helpers.exception import StrictDocException
 from strictdoc.helpers.file_modification_time import get_file_modification_time
 from strictdoc.helpers.md5 import get_md5
 from strictdoc.helpers.module import import_from_path
-from strictdoc.helpers.net import is_valid_host
+from strictdoc.helpers.net import is_valid_host, is_valid_url
 from strictdoc.helpers.path_filter import validate_mask
 
 if TYPE_CHECKING:
@@ -222,6 +222,10 @@ class ProjectConfig:
         # override StrictDoc's default stylesheets in the HTML export and
         # on the server.
         custom_css_path: Optional[str] = None,
+        # PlantUML server URL used to render '.. raw:: html'/Markdown
+        # 'plantuml' diagram blocks. PlantUML is disabled unless this is set,
+        # e.g. to the public server: "https://www.plantuml.com/plantuml".
+        plantuml_server_url: Optional[str] = None,
         user_plugin: Optional[StrictDocPlugin] = None,
         # Optional custom Python function for defining a node's UID prefix.
         custom_node_prefix_function: Optional[CustomNodePrefixFunction] = None,
@@ -516,6 +520,9 @@ class ProjectConfig:
         # Optional custom CSS path, project-relative. Validated and
         # resolved to an absolute path in validate_and_finalize().
         self.custom_css_path: Optional[str] = custom_css_path
+
+        # PlantUML server URL. Validated in validate_and_finalize().
+        self.plantuml_server_url: Optional[str] = plantuml_server_url
 
         self.config_last_update: Optional[datetime.datetime] = (
             _config_last_update
@@ -879,6 +886,16 @@ class ProjectConfig:
             self.custom_css_path = custom_css_path
 
         #
+        # Validate PlantUML server URL.
+        #
+        if self.plantuml_server_url is not None:
+            assert is_valid_url(self.plantuml_server_url), (
+                "config: plantuml_server_url: invalid URL: "
+                f"'{self.plantuml_server_url}'."
+            )
+            self.plantuml_server_url = self.plantuml_server_url.rstrip("/")
+
+        #
         # Validate path to Chrome Driver.
         #
         if (
@@ -1039,6 +1056,13 @@ class ProjectConfig:
         # flag, since Mermaid is now a stable feature that is always included
         # in the static assets.
         return True
+
+    def is_activated_plantuml(self) -> bool:
+        return self.plantuml_server_url is not None
+
+    def get_plantuml_server_url(self) -> str:
+        assert self.plantuml_server_url is not None
+        return self.plantuml_server_url
 
     def get_project_root_path(self) -> str:
         if self.input_paths is not None and len(self.input_paths) > 0:
@@ -1327,6 +1351,7 @@ class ProjectConfigLoader:
         html2pdf_strict: bool = False
         html2pdf_template: Optional[str] = None
         custom_css_path: Optional[str] = None
+        plantuml_server_url: Optional[str] = None
         bundle_document_version = (
             ProjectConfigDefault.DEFAULT_BUNDLE_DOCUMENT_VERSION
         )
@@ -1393,6 +1418,10 @@ class ProjectConfigLoader:
 
             custom_css_path = project_content.get(
                 "custom_css_path", custom_css_path
+            )
+
+            plantuml_server_url = project_content.get(
+                "plantuml_server_url", plantuml_server_url
             )
 
             bundle_document_version = project_content.get(
@@ -1497,6 +1526,7 @@ class ProjectConfigLoader:
             html2pdf_strict=html2pdf_strict,
             html2pdf_template=html2pdf_template,
             custom_css_path=custom_css_path,
+            plantuml_server_url=plantuml_server_url,
             bundle_document_version=bundle_document_version,
             bundle_document_date=bundle_document_date,
             traceability_matrix_relation_columns=traceability_matrix_relation_columns,

--- a/strictdoc/export/html/templates/screens/document/document/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/document/index.jinja
@@ -185,6 +185,31 @@
     </script>
   {%- endif -%}
   {%- endif -%}
+  {%- if view_object.project_config.is_activated_plantuml() -%}
+    <script src="{{ view_object.render_static_url('plantuml/plantuml.js') }}"></script>
+    <script type="module">
+      const plantumlServerUrl = {{ view_object.project_config.get_plantuml_server_url() | tojson }};
+      const kickPlantUML = () => window.strictdocRenderPlantUML(plantumlServerUrl).catch(console.error);
+      window.addEventListener('load', () => {
+        ('requestIdleCallback' in window)
+          ? requestIdleCallback(kickPlantUML, { timeout: 2000 })
+          : setTimeout(kickPlantUML, 0);
+      });
+  {%- if view_object.is_running_on_server -%}
+      // Re-render PlantUML diagrams after node updates (i.e. after saving)...
+      document.addEventListener("turbo:before-stream-render", () => {
+        requestAnimationFrame(kickPlantUML);
+      });
+
+      // Lazily loaded document chunks (see frame_document_content.jinja.html)
+      // arrive after the initial idle-time rendering; re-run when one loads.
+      document.addEventListener("turbo:frame-load", (event) => {
+        if (!event.target.id?.startsWith("document-chunk-")) return;
+        requestAnimationFrame(kickPlantUML);
+      });
+  {%- endif -%}
+    </script>
+  {%- endif -%}
   {{ super() }}
 {% endblock head_scripts %}
 {% block title %}{{ view_object.document.title }} - {{ view_object.get_page_title() }}{% endblock title %}

--- a/strictdoc/export/html/templates/screens/document/table/index.jinja
+++ b/strictdoc/export/html/templates/screens/document/table/index.jinja
@@ -36,6 +36,12 @@
       mermaid.initialize({ startOnLoad: true });
     </script>
   {%- endif -%}
+  {%- if view_object.project_config.is_activated_plantuml() -%}
+    <script src="{{ view_object.render_static_url('plantuml/plantuml.js') }}"></script>
+    <script type="module">
+      window.strictdocRenderPlantUML({{ view_object.project_config.get_plantuml_server_url() | tojson }}).catch(console.error);
+    </script>
+  {%- endif -%}
   {{ super() }}
 {% endblock head_scripts %}
 {% block title %}{{ view_object.document.title }} - {{ view_object.document_type.get_page_title() }}{% endblock title %}

--- a/strictdoc/features/deep_trace/templates/features/deep_trace/index.jinja
+++ b/strictdoc/features/deep_trace/templates/features/deep_trace/index.jinja
@@ -32,6 +32,12 @@
       mermaid.initialize({ startOnLoad: true });
     </script>
   {%- endif -%}
+  {%- if view_object.project_config.is_activated_plantuml() -%}
+    <script src="{{ view_object.render_static_url('plantuml/plantuml.js') }}"></script>
+    <script type="module">
+      window.strictdocRenderPlantUML({{ view_object.project_config.get_plantuml_server_url() | tojson }}).catch(console.error);
+    </script>
+  {%- endif -%}
   {# only for deep-trace: #}
   <script src="{{ view_object.render_static_url('zoomable.js') }}"></script>
   {{ super() }}

--- a/strictdoc/features/html2pdf/templates/features/html2pdf/index.jinja
+++ b/strictdoc/features/html2pdf/templates/features/html2pdf/index.jinja
@@ -22,6 +22,12 @@
       mermaid.initialize({ startOnLoad: true });
     </script>
   {%- endif -%}
+  {%- if view_object.project_config.is_activated_plantuml() -%}
+    <script src="{{ view_object.render_static_url('plantuml/plantuml.js') }}"></script>
+    <script type="module">
+      window.strictdocRenderPlantUML({{ view_object.project_config.get_plantuml_server_url() | tojson }}).catch(console.error);
+    </script>
+  {%- endif -%}
   {%- if view_object.project_config.is_activated_html2pdf() -%}
   <script
   defer

--- a/strictdoc/features/plantuml/assets/plantuml/plantuml.js
+++ b/strictdoc/features/plantuml/assets/plantuml/plantuml.js
@@ -1,0 +1,88 @@
+/*
+ * Finds <pre class="plantuml"> blocks, encodes their text content using
+ * PlantUML's text-encoding format (raw DEFLATE + a custom 6-bit alphabet),
+ * and replaces each block with an <img> pointing at a PlantUML server that
+ * renders the diagram to SVG.
+ */
+(function () {
+  "use strict";
+
+  function encode6bit(b) {
+    if (b < 10) {
+      return String.fromCharCode(48 + b);
+    }
+    b -= 10;
+    if (b < 26) {
+      return String.fromCharCode(65 + b);
+    }
+    b -= 26;
+    if (b < 26) {
+      return String.fromCharCode(97 + b);
+    }
+    b -= 26;
+    if (b === 0) {
+      return "-";
+    }
+    if (b === 1) {
+      return "_";
+    }
+    return "?";
+  }
+
+  function append3bytes(b1, b2, b3) {
+    var c1 = b1 >> 2;
+    var c2 = ((b1 & 0x3) << 4) | (b2 >> 4);
+    var c3 = ((b2 & 0xf) << 2) | (b3 >> 6);
+    var c4 = b3 & 0x3f;
+    return (
+      encode6bit(c1 & 0x3f) +
+      encode6bit(c2 & 0x3f) +
+      encode6bit(c3 & 0x3f) +
+      encode6bit(c4 & 0x3f)
+    );
+  }
+
+  function encode64(data) {
+    var result = "";
+    for (var i = 0; i < data.length; i += 3) {
+      if (i + 2 === data.length) {
+        result += append3bytes(data[i], data[i + 1], 0);
+      } else if (i + 1 === data.length) {
+        result += append3bytes(data[i], 0, 0);
+      } else {
+        result += append3bytes(data[i], data[i + 1], data[i + 2]);
+      }
+    }
+    return result;
+  }
+
+  async function deflateRaw(bytes) {
+    var stream = new Blob([bytes])
+      .stream()
+      .pipeThrough(new CompressionStream("deflate-raw"));
+    var buffer = await new Response(stream).arrayBuffer();
+    return new Uint8Array(buffer);
+  }
+
+  async function encodePlantUML(text) {
+    var utf8Bytes = new TextEncoder().encode(text);
+    var deflated = await deflateRaw(utf8Bytes);
+    return encode64(deflated);
+  }
+
+  async function renderPlantUMLBlocks(serverUrl) {
+    var blocks = document.querySelectorAll("pre.plantuml");
+    for (var i = 0; i < blocks.length; i++) {
+      var block = blocks[i];
+      var diagramText = block.textContent;
+      var encoded = await encodePlantUML(diagramText);
+      var img = document.createElement("img");
+      img.className = "plantuml";
+      img.src = serverUrl.replace(/\/$/, "") + "/svg/" + encoded;
+      img.alt = "PlantUML diagram";
+      block.replaceWith(img);
+    }
+  }
+
+  window.strictdocRenderPlantUML = renderPlantUMLBlocks;
+})();

--- a/strictdoc/features/trace/templates/features/trace/index.jinja
+++ b/strictdoc/features/trace/templates/features/trace/index.jinja
@@ -33,6 +33,12 @@
       mermaid.initialize({ startOnLoad: true });
     </script>
   {%- endif -%}
+  {%- if view_object.project_config.is_activated_plantuml() -%}
+    <script src="{{ view_object.render_static_url('plantuml/plantuml.js') }}"></script>
+    <script type="module">
+      window.strictdocRenderPlantUML({{ view_object.project_config.get_plantuml_server_url() | tojson }}).catch(console.error);
+    </script>
+  {%- endif -%}
   {{ super() }}
 {% endblock head_scripts %}
 {% block title %}{{ view_object.document.title }} - {{ view_object.get_page_title() }}{% endblock title %}

--- a/strictdoc/helpers/net.py
+++ b/strictdoc/helpers/net.py
@@ -1,5 +1,6 @@
 import ipaddress
 import re
+from urllib.parse import urlparse
 
 # Regex for a valid hostname (RFC 1034/1035)
 HOSTNAME_REGEX = re.compile(
@@ -18,3 +19,14 @@ def is_valid_host(host: str) -> bool:
     except ValueError:
         # If not an IP, check if it's a valid hostname.
         return bool(HOSTNAME_REGEX.fullmatch(host)) and len(host) <= 253
+
+
+def is_valid_url(url: str) -> bool:
+    """
+    Validate that a string is a well-formed absolute http(s) URL.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)

--- a/tests/end2end/screens/document/view_document/view_document_with_markdown_plantuml/document.md
+++ b/tests/end2end/screens/document/view_document/view_document_with_markdown_plantuml/document.md
@@ -1,0 +1,13 @@
+# Document 1
+
+## Requirement title
+
+**MID**: abcdef123456
+
+Requirement statement.
+
+```plantuml
+@startuml
+Alice -> Bob: Hello
+@enduml
+```

--- a/tests/end2end/screens/document/view_document/view_document_with_markdown_plantuml/strictdoc_config.py
+++ b/tests/end2end/screens/document/view_document/view_document_with_markdown_plantuml/strictdoc_config.py
@@ -1,0 +1,8 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        plantuml_server_url="https://www.plantuml.com/plantuml",
+    )
+    return config

--- a/tests/end2end/screens/document/view_document/view_document_with_markdown_plantuml/test_case.py
+++ b/tests/end2end/screens/document/view_document/view_document_with_markdown_plantuml/test_case.py
@@ -1,0 +1,39 @@
+"""
+@relation(SDOC-SRS-54, scope=file)
+"""
+
+import os
+
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+path_to_this_test_file_folder = os.path.dirname(os.path.abspath(__file__))
+
+
+class Test(E2ECase):
+    def test(self):
+        with SDocTestServer(
+            input_path=path_to_this_test_file_folder
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+
+            screen_project_index.assert_on_screen()
+            screen_project_index.assert_contains_document("Document 1")
+
+            screen_document = screen_project_index.do_click_on_first_document()
+
+            screen_document.assert_on_screen_document()
+            screen_document.assert_header_document_title("Document 1")
+            screen_document.assert_not_empty_document()
+
+            screen_document.assert_text("abcdef123456")
+
+            self.assert_element("img.plantuml")
+            self.assert_element_absent("pre.plantuml")
+            plantuml_image_src = self.get_attribute("img.plantuml", "src")
+            assert "/svg/" in plantuml_image_src

--- a/tests/integration/features/plantuml/01_enabled/input.sdoc
+++ b/tests/integration/features/plantuml/01_enabled/input.sdoc
@@ -1,0 +1,13 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[TEXT]
+STATEMENT: >>>
+.. raw:: html
+
+    <pre class="plantuml">
+    @startuml
+    Alice -> Bob: Hello
+    @enduml
+    </pre>
+<<<

--- a/tests/integration/features/plantuml/01_enabled/strictdoc_config.py
+++ b/tests/integration/features/plantuml/01_enabled/strictdoc_config.py
@@ -1,0 +1,13 @@
+from strictdoc.core.project_config import ProjectConfig
+
+
+def create_config() -> ProjectConfig:
+    config = ProjectConfig(
+        project_features=[
+            "TABLE_SCREEN",
+            "TRACEABILITY_SCREEN",
+            "DEEP_TRACEABILITY_SCREEN",
+        ],
+        plantuml_server_url="https://www.plantuml.com/plantuml",
+    )
+    return config

--- a/tests/integration/features/plantuml/01_enabled/test.itest
+++ b/tests/integration/features/plantuml/01_enabled/test.itest
@@ -1,0 +1,21 @@
+#
+# Verify that PlantUML is available in the HTML export when
+# plantuml_server_url is configured.
+#
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Export completed.
+
+RUN: %check_exists --file "%T/html/_static/plantuml/plantuml.js"
+
+RUN: cat %T/html/01_enabled/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML-DOC
+RUN: cat %T/html/01_enabled/input-TABLE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/01_enabled/input-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+RUN: cat %T/html/01_enabled/input-DEEP-TRACE.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+CHECK-HTML: window.strictdocRenderPlantUML("https://www.plantuml.com/plantuml")
+
+The document screen defers the initial PlantUML rendering to browser idle
+time via requestIdleCallback/setTimeout instead of calling it eagerly.
+CHECK-HTML-DOC: const plantumlServerUrl = "https://www.plantuml.com/plantuml";
+CHECK-HTML-DOC: const kickPlantUML = () => window.strictdocRenderPlantUML(plantumlServerUrl)
+CHECK-HTML-DOC: requestIdleCallback(kickPlantUML, { timeout: 2000 })

--- a/tests/integration/features/plantuml/02_disabled_by_default/input.sdoc
+++ b/tests/integration/features/plantuml/02_disabled_by_default/input.sdoc
@@ -1,0 +1,13 @@
+[DOCUMENT]
+TITLE: Hello world doc
+
+[TEXT]
+STATEMENT: >>>
+.. raw:: html
+
+    <pre class="plantuml">
+    @startuml
+    Alice -> Bob: Hello
+    @enduml
+    </pre>
+<<<

--- a/tests/integration/features/plantuml/02_disabled_by_default/test.itest
+++ b/tests/integration/features/plantuml/02_disabled_by_default/test.itest
@@ -1,0 +1,12 @@
+#
+# Verify that PlantUML is disabled when plantuml_server_url is not
+# configured: no PlantUML script tag or init call is emitted into the
+# generated HTML.
+#
+
+RUN: %strictdoc export %S --output-dir %T | filecheck %s --dump-input=fail
+CHECK: Export completed.
+
+RUN: cat %T/html/02_disabled_by_default/input.html | filecheck %s --dump-input=fail --check-prefix=CHECK-HTML
+CHECK-HTML-NOT: strictdocRenderPlantUML
+CHECK-HTML-NOT: plantuml.js

--- a/tests/unit/strictdoc/export/markdown/test_markdown_to_html_fragment_writer.py
+++ b/tests/unit/strictdoc/export/markdown/test_markdown_to_html_fragment_writer.py
@@ -55,6 +55,16 @@ def test_05_writes_mermaid_fence_as_mermaid_pre_block():
     )
 
 
+def test_05a_writes_plantuml_fence_as_plantuml_pre_block():
+    markdown_input = "```plantuml\n@startuml\nAlice -> Bob\n@enduml\n```\n"
+
+    html_output = MarkdownToHtmlFragmentWriter().write(markdown_input)
+
+    assert html_output == (
+        '<pre class="plantuml">@startuml\nAlice -&gt; Bob\n@enduml\n</pre>\n'
+    )
+
+
 def test_06_writes_regular_fence_as_code_block():
     markdown_input = "```python\nprint(1)\n```\n"
 


### PR DESCRIPTION
Mirrors the existing Mermaid fence-rendering pattern (client-side JS injection replacing pre.plantuml/```plantuml blocks) for consistency with how diagramming tools are already integrated.

No default plantuml_server_url is configured: unlike Mermaid, which renders entirely in the browser, PlantUML rendering requires sending diagram source to a server, so the feature stays off until a project explicitly opts in and chooses a server it trusts with that content. Making it opt in with explicit server configuration prevents accidental information leakage.

Closes: https://github.com/strictdoc-project/strictdoc/issues/2791