### PR TITLE
feat(favicon, css): allow custom favicon in dev/test mode and fix custom.css load order

### DIFF
--- a/docs/strictdoc_01_user_guide.sdoc
+++ b/docs/strictdoc_01_user_guide.sdoc
@@ -4271,6 +4271,8 @@ A project can supply its own favicon file with the ``favicon_path`` option.
 
 The path must be relative to the project root and point to an existing file.
 Any common favicon format is supported (``.svg``, ``.ico``, ``.png``, etc.).
+``favicon_path`` applies in every mode, including StrictDoc's own
+development and test server, overriding the built-in favicon there too.
 <<<
 
 [[/SECTION]]

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -215,8 +215,8 @@ class ProjectConfig:
         # Logo path can be set in the project config to customize the launcher's appearance for a specific project.
         launcher_logo_path: Optional[str] = None,
         # Favicon path can be set in the project config to customize the
-        # browser-tab favicon for a project's own (non-dev, non-test) server
-        # or static export. Ignored for the dev/test favicon variants.
+        # browser-tab favicon. Applies in every mode, including the
+        # dev/test server, overriding the built-in favicon there too.
         favicon_path: Optional[str] = None,
         # Custom CSS path can be set in the project config to extend or
         # override StrictDoc's default stylesheets in the HTML export and
@@ -975,10 +975,6 @@ class ProjectConfig:
         )
 
     def get_custom_favicon_path(self) -> Optional[str]:
-        if self.favicon_path is None:
-            return None
-        if self.get_favicon_variant() in ("dev", "test"):
-            return None
         return self.favicon_path
 
     def get_favicon_filename(self) -> str:

--- a/strictdoc/export/html/html_generator.py
+++ b/strictdoc/export/html/html_generator.py
@@ -285,10 +285,10 @@ class HTMLGenerator:
                 message="Copying StrictDoc's assets",
             )
 
-        # Write the favicon: a project's own custom file (only for the
-        # "default" variant, see ProjectConfig.get_custom_favicon_path()),
-        # or else render it from the Jinja template so it can encode which
-        # kind of StrictDoc instance (dev/test/docs export) rendered it.
+        # Write the favicon: a project's own custom file if configured
+        # (see ProjectConfig.get_custom_favicon_path()), or else render it
+        # from the Jinja template so it can encode which kind of StrictDoc
+        # instance (dev/test/docs export) rendered it.
         favicon_output_path = os.path.join(
             output_html_static_files, project_config.get_favicon_filename()
         )

--- a/strictdoc/export/html/templates/base.jinja.html
+++ b/strictdoc/export/html/templates/base.jinja.html
@@ -25,10 +25,16 @@
   <link rel="stylesheet" href="{{ view_object.render_static_url('requirement__temporary.css') }}"/>
   <link rel="stylesheet" href="{{ view_object.render_static_url('autogen.css') }}"/>
   <link rel="stylesheet" href="{{ view_object.render_static_url('pygments.css') }}"/>
+  {% endblock head_css %}
+
+  {# Kept outside head_css so that a custom stylesheet always loads after
+     every screen-specific override, no matter what a child template adds
+     to head_css via super(). #}
+  {% block head_custom_css %}
   {% if view_object.project_config.custom_css_path %}
   <link rel="stylesheet" href="{{ view_object.render_static_url(view_object.project_config.get_custom_css_filename()) }}"/>
   {% endif %}
-  {% endblock head_css %}
+  {% endblock head_custom_css %}
 
   {% block head_scripts %}
   {# moved to docs templates #}

--- a/tests/unit/helpers/view_object_builder.py
+++ b/tests/unit/helpers/view_object_builder.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+from typing import Optional
+
+from strictdoc.core.document_tree import DocumentTree
+from strictdoc.core.traceability_index_builder import TraceabilityIndexBuilder
+from strictdoc.export.html.document_type import DocumentType
+from strictdoc.export.html.generators.view_objects.document_screen_view_object import (
+    DocumentScreenViewObject,
+)
+from strictdoc.export.html.html_templates import HTMLTemplates
+from strictdoc.export.html.renderers.link_renderer import LinkRenderer
+from strictdoc.export.html.renderers.markup_renderer import MarkupRenderer
+from strictdoc.helpers.git_client import GitClient
+from tests.unit.helpers.document_builder import DocumentBuilder
+
+
+def create_document_screen_view_object(
+    *,
+    node_count: int = 0,
+    threshold: int = 0,
+    is_running_on_server: bool = True,
+    document_type: DocumentType = DocumentType.DOCUMENT,
+    custom_css_path: Optional[str] = None,
+) -> DocumentScreenViewObject:
+    document_builder = DocumentBuilder()
+    for node_idx_ in range(node_count):
+        document_builder.add_requirement(f"REQ-{node_idx_:03d}")
+    document = document_builder.build()
+
+    project_config = document_builder.project_config
+    project_config.lazy_document_loading_threshold = threshold
+    project_config.is_running_on_server = is_running_on_server
+    project_config.custom_css_path = custom_css_path
+    # Required by get_project_hash(), which the page head calls into via
+    # static_search_head.jinja whenever a screen is actually rendered.
+    project_config.input_paths = ["/tmp/some/project"]
+
+    document_tree = DocumentTree(
+        file_tree=[],
+        document_list=[document],
+        map_docs_by_paths={},
+        map_docs_by_rel_paths={},
+        map_grammars_by_filenames={},
+    )
+    traceability_index = TraceabilityIndexBuilder.create_from_document_tree(
+        document_tree, project_config=project_config
+    )
+
+    link_renderer = LinkRenderer(root_path="", static_path="_static")
+    html_templates = HTMLTemplates.create(
+        project_config=project_config,
+        enable_caching=False,
+        strictdoc_last_update=datetime.today(),
+    )
+    markup_renderer = MarkupRenderer.create(
+        markup=document.config.get_markup(),
+        traceability_index=traceability_index,
+        link_renderer=link_renderer,
+        html_templates=html_templates,
+        config=project_config,
+        context_document=document,
+    )
+    return DocumentScreenViewObject(
+        document_type=document_type,
+        document=document,
+        traceability_index=traceability_index,
+        project_config=project_config,
+        link_renderer=link_renderer,
+        markup_renderer=markup_renderer,
+        jinja_environment=html_templates.jinja_environment(),
+        git_client=GitClient(),
+    )

--- a/tests/unit/strictdoc/export/html/test_custom_css.py
+++ b/tests/unit/strictdoc/export/html/test_custom_css.py
@@ -4,6 +4,9 @@ from strictdoc import environment as strictdoc_environment
 from strictdoc.core.project_config import ProjectConfig
 from strictdoc.export.html.html_generator import HTMLGenerator
 from strictdoc.export.html.html_templates import NormalHTMLTemplates
+from tests.unit.helpers.view_object_builder import (
+    create_document_screen_view_object,
+)
 
 
 def _project_config(
@@ -61,3 +64,20 @@ def test_export_assets_writes_no_custom_css_when_not_configured(tmp_path):
 
     static_dir = output_root / project_config.dir_for_sdoc_assets
     assert not (static_dir / project_config.get_custom_css_filename()).exists()
+
+
+# Regression test for custom.css needing to load after every other
+# stylesheet, including ones a screen-specific template adds to head_css
+# via super() (e.g. move_node_tree.css for the document screen). Renders
+# the actual document screen template rather than asserting on template
+# source, so it catches a future head_css/head_custom_css block reordering.
+def test_custom_css_loads_after_screen_specific_stylesheets():
+    view_object = create_document_screen_view_object(
+        custom_css_path="/tmp/some/custom.css",
+    )
+
+    html = str(view_object.render_screen())
+
+    move_node_tree_pos = html.index("move_node_tree.css")
+    custom_css_pos = html.index("custom.css")
+    assert move_node_tree_pos < custom_css_pos

--- a/tests/unit/strictdoc/export/html/test_document_screen_view_object.py
+++ b/tests/unit/strictdoc/export/html/test_document_screen_view_object.py
@@ -1,72 +1,10 @@
-from datetime import datetime
-
 import pytest
 
 from strictdoc.backend.sdoc.models.node import SDocNode
-from strictdoc.core.document_tree import DocumentTree
-from strictdoc.core.traceability_index_builder import TraceabilityIndexBuilder
 from strictdoc.export.html.document_type import DocumentType
-from strictdoc.export.html.generators.view_objects.document_screen_view_object import (
-    DocumentScreenViewObject,
+from tests.unit.helpers.view_object_builder import (
+    create_document_screen_view_object as create_view_object,
 )
-from strictdoc.export.html.html_templates import HTMLTemplates
-from strictdoc.export.html.renderers.link_renderer import LinkRenderer
-from strictdoc.export.html.renderers.markup_renderer import MarkupRenderer
-from strictdoc.helpers.git_client import GitClient
-from tests.unit.helpers.document_builder import DocumentBuilder
-
-
-def create_view_object(
-    *,
-    node_count,
-    threshold,
-    is_running_on_server=True,
-    document_type=DocumentType.DOCUMENT,
-) -> DocumentScreenViewObject:
-    document_builder = DocumentBuilder()
-    for node_idx_ in range(node_count):
-        document_builder.add_requirement(f"REQ-{node_idx_:03d}")
-    document = document_builder.build()
-
-    project_config = document_builder.project_config
-    project_config.lazy_document_loading_threshold = threshold
-    project_config.is_running_on_server = is_running_on_server
-
-    document_tree = DocumentTree(
-        file_tree=[],
-        document_list=[document],
-        map_docs_by_paths={},
-        map_docs_by_rel_paths={},
-        map_grammars_by_filenames={},
-    )
-    traceability_index = TraceabilityIndexBuilder.create_from_document_tree(
-        document_tree, project_config=project_config
-    )
-
-    link_renderer = LinkRenderer(root_path="", static_path="_static")
-    html_templates = HTMLTemplates.create(
-        project_config=project_config,
-        enable_caching=False,
-        strictdoc_last_update=datetime.today(),
-    )
-    markup_renderer = MarkupRenderer.create(
-        markup=document.config.get_markup(),
-        traceability_index=traceability_index,
-        link_renderer=link_renderer,
-        html_templates=html_templates,
-        config=project_config,
-        context_document=document,
-    )
-    return DocumentScreenViewObject(
-        document_type=document_type,
-        document=document,
-        traceability_index=traceability_index,
-        project_config=project_config,
-        link_renderer=link_renderer,
-        markup_renderer=markup_renderer,
-        jinja_environment=html_templates.jinja_environment(),
-        git_client=GitClient(),
-    )
 
 
 def test_threshold_zero_disables_chunked_rendering():

--- a/tests/unit/strictdoc/export/html/test_favicon.py
+++ b/tests/unit/strictdoc/export/html/test_favicon.py
@@ -69,10 +69,7 @@ def test_get_favicon_variant_static_export():
 
 
 # Checks get_favicon_filename()/get_favicon_mime_type() branching
-# (custom file vs. rendered SVG, per-variant override rule). Same
-# limitation as above: confirms the branching matches the code, not that
-# restricting custom favicons to the default variant is the correct
-# product requirement.
+# (custom file vs. rendered SVG default).
 def test_favicon_filename_and_mime_type_default_to_the_svg_template():
     project_config = _project_config(
         is_development_mode=False, is_test_env=False
@@ -93,16 +90,16 @@ def test_custom_favicon_is_used_for_the_default_variant():
     assert project_config.get_favicon_mime_type() == "image/png"
 
 
-def test_custom_favicon_is_ignored_for_dev_and_test_variants():
+def test_custom_favicon_overrides_dev_and_test_variants_too():
     for is_development_mode, is_test_env in ((True, False), (False, True)):
         project_config = _project_config(
             is_development_mode=is_development_mode,
             is_test_env=is_test_env,
             favicon_path="/tmp/some/logo.png",
         )
-        assert project_config.get_custom_favicon_path() is None
-        assert project_config.get_favicon_filename() == "favicon.svg"
-        assert project_config.get_favicon_mime_type() == "image/svg+xml"
+        assert project_config.get_custom_favicon_path() == "/tmp/some/logo.png"
+        assert project_config.get_favicon_filename() == "favicon.png"
+        assert project_config.get_favicon_mime_type() == "image/png"
 
 
 def _render_favicon_template(*, variant: str) -> str:
@@ -162,7 +159,7 @@ def test_export_assets_copies_custom_favicon_for_default_variant(tmp_path):
     assert not (static_dir / "favicon.svg").exists()
 
 
-def test_export_assets_ignores_custom_favicon_for_dev_variant(tmp_path):
+def test_export_assets_uses_custom_favicon_for_dev_variant_too(tmp_path):
     favicon_source = tmp_path / "logo.png"
     favicon_source.write_bytes(b"fake-png-bytes")
 
@@ -182,7 +179,5 @@ def test_export_assets_ignores_custom_favicon_for_dev_variant(tmp_path):
     )
 
     static_dir = output_root / project_config.dir_for_sdoc_assets
-    assert (
-        'data-testid="dev-favicon"' in (static_dir / "favicon.svg").read_text()
-    )
-    assert not (static_dir / "favicon.png").exists()
+    assert (static_dir / "favicon.png").read_bytes() == b"fake-png-bytes"
+    assert not (static_dir / "favicon.svg").exists()


### PR DESCRIPTION
- Make `favicon_path` apply in every mode, including StrictDoc's development and test server, where it previously fell back to the built-in favicon regardless of the setting.
- Move the custom.css link into its own `head_custom_css` block, declared after `head_css` in base.jinja.html, so it loads after every stylesheet regardless of what a child template overrides via `super()`.
- Extract a shared `create_document_screen_view_object()` test helper (tests/unit/helpers/view_object_builder.py) 