### PR TITLE
Add option to disable SSL certificate check

### DIFF
--- a/strictdoc/commands/export.py
+++ b/strictdoc/commands/export.py
@@ -256,6 +256,15 @@ class ExportCommand(BaseCommand):
             "strictdoc cache.",
         )
         command_parser_export.add_argument(
+            "--disable-ssl-check",
+            action="store_true",
+            default=False,
+            help=(
+                "Disable SSL certificate verification for HTML2PDF's "
+                "HTTP downloads."
+            ),
+        )
+        command_parser_export.add_argument(
             "--config",
             type=str,
             help="Path to the StrictDoc TOML config file.",

--- a/strictdoc/commands/export_config.py
+++ b/strictdoc/commands/export_config.py
@@ -31,6 +31,7 @@ class ExportCommandConfig:
         generate_diff_git: Optional[str],
         generate_diff_dirs: Optional[Tuple[str, str]],
         chromedriver: Optional[str],
+        disable_ssl_check: bool,
     ):
         assert isinstance(input_paths, list), f"{input_paths}"
         self.debug: bool = debug
@@ -54,6 +55,7 @@ class ExportCommandConfig:
         self.generate_diff_git: Optional[str] = generate_diff_git
         self.generate_diff_dirs: Optional[Tuple[str, str]] = generate_diff_dirs
         self.chromedriver: Optional[str] = chromedriver
+        self.disable_ssl_check: bool = disable_ssl_check
 
     def get_path_to_config(self) -> str:
         # FIXME: The control flow can be improved.

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -187,6 +187,7 @@ class ProjectConfig:
         html2pdf_strict: bool = False,
         html2pdf_template: Optional[str] = None,
         html2pdf_forced_page_break_nodes: Optional[List[str]] = None,
+        html2pdf_disable_ssl_check: bool = False,
         bundle_document_uid: Optional[str] = None,
         bundle_document_version: Optional[
             str
@@ -206,7 +207,6 @@ class ProjectConfig:
         diff_git_revisions: Optional[str] = None,
         diff_dir_revisions: Optional[Tuple[str, str]] = None,
         chromedriver: Optional[str] = None,
-        html2pdf_disable_ssl_check: bool = False,
         # FIXME: The section_behavior field will be removed by the end of 2025-Q4.
         section_behavior: Optional[
             str
@@ -433,6 +433,11 @@ class ProjectConfig:
         self.html2pdf_forced_page_break_nodes: List[str] = (
             html2pdf_forced_page_break_nodes or []
         )
+        assert isinstance(html2pdf_disable_ssl_check, bool), (
+            "config: html2pdf_disable_ssl_check: "
+            f"must be a True/False value: {html2pdf_disable_ssl_check}."
+        )
+        self.html2pdf_disable_ssl_check: bool = html2pdf_disable_ssl_check
 
         self.bundle_document_uid: Optional[str] = bundle_document_uid
         self.bundle_document_version: Optional[str] = bundle_document_version
@@ -485,11 +490,6 @@ class ProjectConfig:
         self.diff_page = False
 
         self.chromedriver: Optional[str] = chromedriver
-        assert isinstance(html2pdf_disable_ssl_check, bool), (
-            "config: html2pdf_disable_ssl_check: "
-            f"must be a True/False value: {html2pdf_disable_ssl_check}."
-        )
-        self.html2pdf_disable_ssl_check: bool = html2pdf_disable_ssl_check
         self.section_behavior: Optional[str] = section_behavior
 
         self.statistics_generator: Optional[str] = statistics_generator

--- a/strictdoc/core/project_config.py
+++ b/strictdoc/core/project_config.py
@@ -206,6 +206,7 @@ class ProjectConfig:
         diff_git_revisions: Optional[str] = None,
         diff_dir_revisions: Optional[Tuple[str, str]] = None,
         chromedriver: Optional[str] = None,
+        html2pdf_disable_ssl_check: bool = False,
         # FIXME: The section_behavior field will be removed by the end of 2025-Q4.
         section_behavior: Optional[
             str
@@ -484,6 +485,11 @@ class ProjectConfig:
         self.diff_page = False
 
         self.chromedriver: Optional[str] = chromedriver
+        assert isinstance(html2pdf_disable_ssl_check, bool), (
+            "config: html2pdf_disable_ssl_check: "
+            f"must be a True/False value: {html2pdf_disable_ssl_check}."
+        )
+        self.html2pdf_disable_ssl_check: bool = html2pdf_disable_ssl_check
         self.section_behavior: Optional[str] = section_behavior
 
         self.statistics_generator: Optional[str] = statistics_generator
@@ -776,6 +782,10 @@ class ProjectConfig:
                 self.diff_page = True
 
         self.chromedriver = export_config.chromedriver
+        # If enabled in project config, keep it enabled unless explicitly
+        # requested via CLI (which can only enable it as well).
+        if export_config.disable_ssl_check:
+            self.html2pdf_disable_ssl_check = True
 
         if (
             export_config.enable_mathjax
@@ -1344,6 +1354,7 @@ class ProjectConfigLoader:
         reqif_enable_mid = False
         reqif_import_markup: Optional[str] = None
         chromedriver: Optional[str] = None
+        html2pdf_disable_ssl_check: bool = False
 
         section_behavior: str = ProjectConfigDefault.DEFAULT_SECTION_BEHAVIOR
         statistics_generator: Optional[str] = None
@@ -1426,6 +1437,10 @@ class ProjectConfigLoader:
 
             chromedriver = project_content.get("chromedriver", chromedriver)
 
+            html2pdf_disable_ssl_check = project_content.get(
+                "html2pdf_disable_ssl_check", html2pdf_disable_ssl_check
+            )
+
             if (
                 test_report_root_dict_ := project_content.get(
                     "test_report_root_dict", None
@@ -1507,6 +1522,7 @@ class ProjectConfigLoader:
             reqif_enable_mid=reqif_enable_mid,
             reqif_import_markup=reqif_import_markup,
             chromedriver=chromedriver,
+            html2pdf_disable_ssl_check=html2pdf_disable_ssl_check,
             section_behavior=section_behavior,
             statistics_generator=statistics_generator,
             document_line_width=document_line_width,

--- a/strictdoc/features/html2pdf/pdf_print_driver.py
+++ b/strictdoc/features/html2pdf/pdf_print_driver.py
@@ -81,6 +81,8 @@ class PDFPrintDriver:
                     project_config.chromedriver,
                 ]
             )
+        if project_config.html2pdf_disable_ssl_check:
+            cmd.append("--disable-ssl-check")
         if project_config.html2pdf_strict:
             cmd.append("--strict")
         for path_to_print_ in paths_to_print:

--- a/tests/unit/strictdoc/cli/test_cli_arg_parser.py
+++ b/tests/unit/strictdoc/cli/test_cli_arg_parser.py
@@ -119,6 +119,22 @@ def test_export_09_config():
     assert args.command == "export"
 
 
+def test_export_10_disable_ssl_check_default_false():
+    parser = cli_args_parser()
+    args = parser.parse_args(["export", "docs"])
+
+    assert args.command == "export"
+    assert args.disable_ssl_check is False
+
+
+def test_export_11_disable_ssl_check_enabled():
+    parser = cli_args_parser()
+    args = parser.parse_args(["export", "docs", "--disable-ssl-check"])
+
+    assert args.command == "export"
+    assert args.disable_ssl_check is True
+
+
 def test_new_01_minimal():
     parser = cli_args_parser()
 


### PR DESCRIPTION
This PR adds an option to disable SSL certificate verification for downloads in environments that use custom or internally re-signed certificates. This is needed for corporate or restricted networks where HTTPS inspection can cause certificate validation to fail, even for trusted internal setups. SSL verification remains enabled by default, and disabling it is an explicit opt-in for exceptional cases only.