### PR TITLE
fix(backend/markdown): populate the node location correctly

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -131,6 +131,9 @@ ignore = [
     # Too many statements
     "PLR0915",
 
+    # Too many positional arguments
+    "PLR0917",
+
     # FIXME: Enable: Use `sys.exit()` instead of `exit`
     "PLR1722",
 

--- a/strictdoc/backend/markdown/reader.py
+++ b/strictdoc/backend/markdown/reader.py
@@ -374,6 +374,7 @@ class SDMarkdownReader:
                 statement=root_text,
                 document_reference=document_reference,
                 including_document_reference=including_document_reference,
+                line_start=root_heading.line_start,
             )
             document.section_contents.append(root_text_node)
 
@@ -527,6 +528,7 @@ class SDMarkdownReader:
                 file_path=file_path,
                 project_config=project_config,
                 node_type=parsed_node.explicit_node_type or "REQUIREMENT",
+                line_start=heading_line_start,
             )
             parent_node.section_contents.append(requirement_node)
 
@@ -550,6 +552,8 @@ class SDMarkdownReader:
             document,
             title,
         )
+        section_node.ng_line_start = heading_line_start
+        section_node.ng_col_start = 1
         section_node.ng_including_document_reference = (
             including_document_reference
         )
@@ -690,6 +694,7 @@ class SDMarkdownReader:
                 document_reference=document_reference,
                 including_document_reference=including_document_reference,
                 mid=text_mid,
+                line_start=heading_line_start,
             )
             section_node.section_contents.append(text_node)
 
@@ -1443,6 +1448,7 @@ class SDMarkdownReader:
         file_path: Optional[str] = None,
         project_config: Optional[ProjectConfig] = None,
         node_type: str = "REQUIREMENT",
+        line_start: Optional[int] = None,
     ) -> SDocNode:
         """Build a SDocNode from parsed fields, attaching relations and document references."""
         parsed_meta_fields: List[ParsedField] = []
@@ -1491,6 +1497,8 @@ class SDMarkdownReader:
             fields=requirement_fields,
             relations=[],
         )
+        requirement.ng_line_start = line_start
+        requirement.ng_col_start = 1
         SDMarkdownReader._wire_node_field_parents(requirement)
         if relations_field is not None:
             requirement.relations = SDMarkdownReader._build_references(
@@ -1550,6 +1558,7 @@ class SDMarkdownReader:
         document_reference: DocumentReference,
         including_document_reference: DocumentReference,
         mid: Optional[str] = None,
+        line_start: Optional[int] = None,
     ) -> SDocNode:
         """Build a TEXT SDocNode wrapping raw Markdown prose."""
         fields = []
@@ -1576,6 +1585,8 @@ class SDMarkdownReader:
             fields=fields,
             relations=[],
         )
+        text_node.ng_line_start = line_start
+        text_node.ng_col_start = 1
         SDMarkdownReader._wire_node_field_parents(text_node)
         text_node.ng_document_reference = document_reference
         text_node.ng_including_document_reference = including_document_reference

--- a/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
+++ b/tests/unit/strictdoc/backend/markdown/test_markdown_reader.py
@@ -3,8 +3,14 @@ import pytest
 from strictdoc.backend.markdown.reader import SDMarkdownReader
 from strictdoc.backend.sdoc.error_handling import StrictDocSemanticError
 from strictdoc.backend.sdoc.models.anchor import Anchor
+from strictdoc.backend.sdoc.models.document_grammar import DocumentGrammar
+from strictdoc.backend.sdoc.models.grammar_element import (
+    GrammarElement,
+    GrammarElementFieldString,
+)
 from strictdoc.backend.sdoc.models.inline_link import InlineLink
 from strictdoc.backend.sdoc.models.node import SDocNode
+from strictdoc.backend.sdoc.validations.sdoc_validator import SDocValidator
 
 
 def test_001_markdown_reader_requires_h1_heading_first():
@@ -930,3 +936,70 @@ def test_031_markdown_reader_rejects_forward_jump_beyond_h6():
     with pytest.raises(StrictDocSemanticError) as exc_info:
         reader.read(markdown_content, file_path=None)
     assert "forward jumps" in str(exc_info.value.title)
+
+
+def test_036_markdown_reader_unregistered_field_error_reports_correct_location():
+    # Regression test: a semantic error raised against a Markdown-derived
+    # node used to always report "Location: file:None:None" because
+    # SDMarkdownReader never populated SDocNode.ng_line_start/ng_col_start
+    # (unlike the SDoc/textX backend, which sets them via ParserFromTextX).
+    markdown_content = """\
+# Document title
+
+Some intro text.
+
+## Section with a stray UID
+
+**Type**: SECTION \\
+**UID**: SECTION-1
+
+Section body text.
+"""
+    section_heading_line = 5
+
+    reader = SDMarkdownReader()
+    document = reader.read(markdown_content, file_path="test.md")
+
+    section_node = document.section_contents[1]
+    assert isinstance(section_node, SDocNode)
+    assert section_node.node_type == "SECTION"
+    assert "UID" in section_node.ordered_fields_lookup
+
+    # A custom grammar (as in the reported bug) whose SECTION element only
+    # declares MID and TITLE, i.e., it does not register UID.
+    custom_section_element = GrammarElement(
+        parent=None,
+        tag="SECTION",
+        property_is_composite="True",
+        property_prefix="",
+        property_view_style="",
+        fields=[
+            GrammarElementFieldString(
+                parent=None, title="MID", human_title=None, required="False"
+            ),
+            GrammarElementFieldString(
+                parent=None, title="TITLE", human_title=None, required="True"
+            ),
+        ],
+        relations=[],
+    )
+    custom_grammar = DocumentGrammar(
+        parent=None, elements=[custom_section_element], import_from_file=None
+    )
+
+    with pytest.raises(StrictDocSemanticError) as exc_info:
+        SDocValidator.validate_node(
+            section_node,
+            custom_grammar,
+            path_to_sdoc_file="test.md",
+        )
+
+    error = exc_info.value
+    assert "UID" in error.title
+    assert error.file_path == "test.md"
+    assert error.line == section_heading_line
+    assert error.col is not None
+    assert (
+        f"Location: test.md:{section_heading_line}:{error.col}"
+        in error.to_print_message()
+    )


### PR DESCRIPTION
WHY: This is useful for error reporting.