### PR TITLE
fix(features/table): fix(features/table): stop losing inline-cell corrections made before a save responds

### DIFF
--- a/strictdoc/export/html/_static/table_view_edit.js
+++ b/strictdoc/export/html/_static/table_view_edit.js
@@ -79,6 +79,29 @@
         return new URLSearchParams(new FormData(form))
     }
 
+    // Form data for a cell's save request: the field's own form, with
+    // active_form_key/active_field_name overridden from the cell's own
+    // hidden inputs when present. A shared custom-metadata form can hold
+    // several passive-open rows with identically-named hidden inputs, so a
+    // plain form read could pick up another row's value instead of this
+    // cell's; this is what actually determines which row's target is saved.
+    function buildCellSaveFormData(cell, form) {
+        const formData = createFormData(form);
+        const activeFormKey = cell.querySelector(
+            'input[name="active_form_key"]'
+        )?.value;
+        if (activeFormKey !== undefined) {
+            formData.set('active_form_key', activeFormKey);
+        }
+        const activeFieldName = cell.querySelector(
+            'input[name="active_field_name"]'
+        )?.value;
+        if (activeFieldName !== undefined) {
+            formData.set('active_field_name', activeFieldName);
+        }
+        return formData;
+    }
+
     function getCellState(cell) {
         let state = cellStates.get(cell);
         if (!state) {
@@ -89,6 +112,10 @@
                 originalFormData: undefined,
                 // Shared by duplicate save triggers for this cell.
                 savePromise: null,
+                // Serialized form data as of the in-flight save's dispatch,
+                // so a save queued behind it can tell a real duplicate
+                // trigger from a correction typed before the response landed.
+                dispatchedFormData: undefined,
                 // Delayed blur save used by autocomplete dropdown interaction.
                 autocompleteBlurTimer: null,
                 // Bumped on every initInlineCellState() call for this cell so a
@@ -466,8 +493,33 @@
         const state = getCellState(cell);
         if (state.savePromise) {
             // Blur, outside-click, and keyboard handlers may request the same
-            // logical save. Reuse the in-flight request for this cell only.
-            return state.savePromise;
+            // logical save while one is already in flight for this cell.
+            // Wait for it, then decide whether this call still needs to do
+            // anything: Turbo defers applying a successful response by at
+            // least one animation frame, so the field being unedited here is
+            // not proof the in-flight request already covered it — compare
+            // against the data that request actually dispatched instead.
+            await state.savePromise;
+            const dispatchedData = state.dispatchedFormData;
+            const form = getFieldForm(cell);
+            const currentData = form
+                ? buildCellSaveFormData(cell, form).toString()
+                : undefined;
+            if (
+                currentData !== undefined &&
+                dispatchedData !== undefined &&
+                currentData === dispatchedData
+            ) {
+                // Same data the in-flight request already sent — a genuine
+                // duplicate trigger for one logical save. Nothing changed
+                // since, so there's nothing new to submit.
+                return;
+            }
+            // The field was edited again since the in-flight request was
+            // dispatched (e.g. a validation error corrected before the
+            // server responded). That correction must still reach the
+            // server — run this save for real against the current data.
+            return runCellSave(cell, saveOperation);
         }
 
         state.savePromise = saveOperation();
@@ -868,22 +920,11 @@
         // Clear only errors belonging to the field being submitted.
         clearFieldErrors(cell);
 
-        const formData = createFormData(form);
-        const activeFormKey = cell.querySelector(
-            'input[name="active_form_key"]'
-        )?.value;
-        if (activeFormKey !== undefined) {
-            // A shared custom-metadata form may contain several passive-open
-            // rows, each with its own active_form_key input. The cell being
-            // saved must determine which row receives the validation stream.
-            formData.set('active_form_key', activeFormKey);
-        }
-        const activeFieldName = cell.querySelector(
-            'input[name="active_field_name"]'
-        )?.value;
-        if (activeFieldName !== undefined) {
-            formData.set('active_field_name', activeFieldName);
-        }
+        const formData = buildCellSaveFormData(cell, form);
+        // Recorded so a save queued behind this one (see runCellSave) can
+        // tell a real duplicate trigger from a correction typed before this
+        // request's response landed.
+        state.dispatchedFormData = formData.toString();
 
         try {
             const { response, html } = await postTurboStream(form.action, formData);


### PR DESCRIPTION
**Resubmit inline-cell edits typed while the previous save was still pending**

The inline-cell save path deduplicated overlapping save triggers by returning the in-flight promise unchanged. If a field was edited again before that request resolved (e.g. a validation error corrected before the server responded), the correction never reached the server: only the original, stale submission's response applied, so the same error kept reappearing no matter what the user typed next.

runCellSave() now waits for the in-flight save, then compares the cell's current form data against what that request actually dispatched. Unchanged data is treated as a genuine duplicate trigger (no second request); changed data is submitted for real. Turbo defers applying a successful response by an animation frame, so comparing against the dispatched snapshot, not just whether the form element is still in the DOM, was needed to avoid a spurious second POST for true duplicates (covered by
edit_table_cell_statement_save_by_cmd_enter/test_case.py).

---

What the flaky test did:

Typed an empty value into the field → saved → server returned "Value must not be empty" — expected, that's fine. Clicked the field again, typed "1" then backspace (empty again) → saved. Immediately, with no pause, clicked the same field again and typed "Corrected value" → saved. Checked: the error should be gone, and the cell should show "Corrected value". What was actually happening in the JS (the bug):
When the user triggers "save" a second time while the first request is still in flight (server hasn't answered yet), runCellSave() said: "a save is already running for this cell — just return that same promise, don't send anything new."

The problem: that "same promise" was built from the old data (the empty value). If the user managed to type "Corrected value" before the first request finished, the second save call just piggybacked on the first one and never actually sent "Corrected value" to the server.

So only the first (invalid, empty) request ever reached the server, its error response came back, and that error stayed on screen forever — because the corrected value never made it to the server at all.

Why it failed on CI but not locally:
This is a race condition: step 3 (click + type + outside-click) has to happen faster than the server responds to step 2. On a local machine the server usually answers faster than Selenium can click again, so the race never triggered. On CI (typically slower, more loaded), the browser actions sometimes outran the network response, so the bug showed up.

The fix: on a second save trigger, the code now waits for the first request to finish, then compares what was actually sent with what's currently in the field. If the data changed (like in the test — "Corrected value" instead of empty), it sends a real new request. If it didn't change, it skips sending a redundant duplicate.