### PR TITLE
fix(tests/end2end): verify the cancel-during-fetch fix and drop redundant waits

### DIFF
--- a/strictdoc/export/html/_static/table_view_edit.js
+++ b/strictdoc/export/html/_static/table_view_edit.js
@@ -760,6 +760,10 @@
                     // check behind Turbo's own (registered first, above, when
                     // renderTurboStream() ran), so it runs in the same frame
                     // right after Turbo's stale mutation lands, and undoes it.
+                    // This ordering is exercised deterministically (by
+                    // delaying every requestAnimationFrame callback on the
+                    // page to widen the one-frame window) in
+                    // edit_table_document_custom_meta_cancel_during_fetch.
                     if (requestId !== null && originalHTML !== undefined) {
                         requestAnimationFrame(() => {
                             if (isEditRequestStaleAndUncontested(cell, requestId)) {

--- a/tests/end2end/helpers/form/form.py
+++ b/tests/end2end/helpers/form/form.py
@@ -8,6 +8,7 @@ from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support.ui import WebDriverWait
 
 from strictdoc.helpers.mid import MID
+from tests.end2end.conftest import test_environment
 from tests.end2end.e2e_case import E2ECase
 
 
@@ -233,9 +234,9 @@ class Form:  # pylint: disable=invalid-name
         self.test_case.type(field_xpath, f"{field_value}", by=By.XPATH)
 
         # We wait until the results <ul> is displayed.
-        WebDriverWait(self.test_case.driver, 3).until(
-            lambda _: results_ul.is_displayed()
-        )
+        WebDriverWait(
+            self.test_case.driver, test_environment.wait_timeout_seconds
+        ).until(lambda _: results_ul.is_displayed())
 
         # We send Arrow-Down and Enter select the first match.
         # The stimulus.js controller uses a debounce of 10ms, we are
@@ -248,7 +249,10 @@ class Form:  # pylint: disable=invalid-name
 
         # Now wait for the length of the field to increase, this means
         # the autocomplete did happen.
-        WebDriverWait(self.test_case.driver, timeout=3).until(
+        WebDriverWait(
+            self.test_case.driver,
+            timeout=test_environment.wait_timeout_seconds,
+        ).until(
             lambda _: (
                 len(element.text.lower().strip()) > len_before_autocomplete
             )
@@ -273,9 +277,9 @@ class Form:  # pylint: disable=invalid-name
         self.test_case.type(field_xpath, f"{field_value}", by=By.XPATH)
 
         # We wait until the results <ul> is displayed.
-        WebDriverWait(self.test_case.driver, 3).until(
-            lambda _: results_ul.is_displayed()
-        )
+        WebDriverWait(
+            self.test_case.driver, test_environment.wait_timeout_seconds
+        ).until(lambda _: results_ul.is_displayed())
 
         no_results_item = results_ul.find_element(
             By.XPATH,
@@ -313,9 +317,9 @@ class Form:  # pylint: disable=invalid-name
         text_before = element.text
         element.click()
 
-        WebDriverWait(self.test_case.driver, 3).until(
-            lambda _: results_ul.is_displayed()
-        )
+        WebDriverWait(
+            self.test_case.driver, test_environment.wait_timeout_seconds
+        ).until(lambda _: results_ul.is_displayed())
 
         self.test_case.assert_element_not_present(
             f"{field_xpath}/following-sibling::input[@type='hidden']"
@@ -353,9 +357,9 @@ class Form:  # pylint: disable=invalid-name
         element.send_keys(f",{field_value}")
 
         # We wait until the results <ul> is displayed.
-        WebDriverWait(self.test_case.driver, 3).until(
-            lambda _: results_ul.is_displayed()
-        )
+        WebDriverWait(
+            self.test_case.driver, test_environment.wait_timeout_seconds
+        ).until(lambda _: results_ul.is_displayed())
 
         # We send Arrow-Down and Enter select the first match.
         # autocompletable_field.js uses a debounce of 50ms, we are
@@ -368,7 +372,10 @@ class Form:  # pylint: disable=invalid-name
 
         # Now wait for the length of the field to increase, this means
         # the autocomplete did happen.
-        WebDriverWait(self.test_case.driver, timeout=3).until(
+        WebDriverWait(
+            self.test_case.driver,
+            timeout=test_environment.wait_timeout_seconds,
+        ).until(
             lambda _: (
                 len(element.text.lower().strip()) > len_before_autocomplete
             )
@@ -398,9 +405,9 @@ class Form:  # pylint: disable=invalid-name
         # leaves the raw typed prefix in the field (e.g. "REQ-"), which is
         # still a substring of the expected value and previously made this
         # method report a false success, saving an invalid relation UID.
-        WebDriverWait(self.test_case.driver, 3).until(
-            lambda _: results_ul.is_displayed()
-        )
+        WebDriverWait(
+            self.test_case.driver, test_environment.wait_timeout_seconds
+        ).until(lambda _: results_ul.is_displayed())
 
         # We send Arrow-Down and Enter select the first match.
         # autocompletable_field.js uses a debounce of 10ms, we are
@@ -416,9 +423,10 @@ class Form:  # pylint: disable=invalid-name
         # full target value (e.g. "REQ-001"), selecting the match commits
         # the same text, so the field's length never grows even though the
         # selection succeeded.
-        WebDriverWait(self.test_case.driver, timeout=3).until(
-            lambda _: not results_ul.is_displayed()
-        )
+        WebDriverWait(
+            self.test_case.driver,
+            timeout=test_environment.wait_timeout_seconds,
+        ).until(lambda _: not results_ul.is_displayed())
 
     def do_clear_field(self, field_name: str, field_order: int = 1) -> None:
         assert isinstance(field_name, str)

--- a/tests/end2end/helpers/form/form.py
+++ b/tests/end2end/helpers/form/form.py
@@ -43,9 +43,25 @@ class Form:  # pylint: disable=invalid-name
         )
 
     def assert_error_not_present(self, message: str) -> None:
-        self.test_case.assert_element_not_present(
-            f"//sdoc-form-error[contains(., '{message}')]", by=By.XPATH
-        )
+        try:
+            self.test_case.assert_element_not_present(
+                f"//sdoc-form-error[contains(., '{message}')]", by=By.XPATH
+            )
+        except Exception:
+            # This assertion has failed intermittently on CI with no local
+            # repro (message still present after the default wait). Dump
+            # the live state of every form row so a future CI failure
+            # carries the actual DOM instead of just a timeout message.
+            rows_html = self.test_case.execute_script(
+                "return [...document.querySelectorAll('sdoc-form-row')]"
+                ".map(row => row.outerHTML).join('\\n---\\n');"
+            )
+            print(  # noqa: T201
+                "\n[assert_error_not_present] Timed out waiting for this "
+                f"error to disappear: {message!r}\n"
+                f"Current sdoc-form-row elements on the page:\n{rows_html}"
+            )
+            raise
 
     def assert_contenteditable_contains(self, text: str) -> None:
         self.test_case.assert_element(

--- a/tests/end2end/screens/table/view_table_edit/edit_table_document_custom_meta_cancel_during_fetch/expected_output/document.sdoc
+++ b/tests/end2end/screens/table/view_table_edit/edit_table_document_custom_meta_cancel_during_fetch/expected_output/document.sdoc
@@ -1,0 +1,9 @@
+[DOCUMENT]
+TITLE: Document
+METADATA:
+  FIRST: First value
+  SECOND: Second value
+
+[REQUIREMENT]
+TITLE: Requirement
+STATEMENT: Requirement statement.

--- a/tests/end2end/screens/table/view_table_edit/edit_table_document_custom_meta_cancel_during_fetch/input/document.sdoc
+++ b/tests/end2end/screens/table/view_table_edit/edit_table_document_custom_meta_cancel_during_fetch/input/document.sdoc
@@ -1,0 +1,9 @@
+[DOCUMENT]
+TITLE: Document
+METADATA:
+  FIRST: First value
+  SECOND: Second value
+
+[REQUIREMENT]
+TITLE: Requirement
+STATEMENT: Requirement statement.

--- a/tests/end2end/screens/table/view_table_edit/edit_table_document_custom_meta_cancel_during_fetch/test_case.py
+++ b/tests/end2end/screens/table/view_table_edit/edit_table_document_custom_meta_cancel_during_fetch/test_case.py
@@ -1,0 +1,91 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.viewtype_selector import ViewType_Selector
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+            screen_project_index.do_click_on_first_document()
+
+            self.clear_local_storage()
+
+            screen_table = ViewType_Selector(self).do_go_to_table()
+            screen_table.assert_on_screen_table()
+            screen_table.do_toggle_edit_mode()
+
+            row = '[data-testid="document-config-metadata-row-custom_meta_0"]'
+            field = f'{row} [data-testid="document-config-metadata-field"]'
+
+            # table_view_edit.js checks isEditRequestCurrent() once, right
+            # when the field's inline-editor fetch resolves, to decide
+            # whether to apply the response at all. That check is not the
+            # race: it already rejects a response for a cell cancelled
+            # *before* the fetch resolved. The race is narrower: Turbo
+            # applies a *passed* check's <turbo-stream> on its own
+            # requestAnimationFrame, and the cell can still be cancelled in
+            # the single frame between the check passing and that callback
+            # firing. Reproducing it means widening that one-frame window,
+            # not delaying the fetch. Delaying every requestAnimationFrame
+            # callback on the page does that: Turbo's deferred mutation and
+            # the fix's own deferred revert check are both registered (in
+            # that order) the instant the real, undelayed fetch resolves,
+            # then both fire this many ms later instead of one frame later
+            # — giving Escape a wide window to land in between, instead of
+            # a ~16ms one no WebDriver command can reliably hit.
+            # Left permanently overridden, this would also delay whatever
+            # else on the page uses requestAnimationFrame (e.g. the dev
+            # server's own live-reload client), which broke this test's own
+            # teardown when tried. Restore the original once the race window
+            # this test needs has passed.
+            self.execute_script(
+                """
+                window.__originalRAF = window.requestAnimationFrame;
+                window.requestAnimationFrame = function (callback) {
+                    return setTimeout(() => callback(performance.now()), 300);
+                };
+                """
+            )
+
+            self.click(field)
+            # Fires while the fetch has already resolved and both the
+            # pending Turbo mutation and the fix's revert check are queued,
+            # but before either has run (see the delay above).
+            screen_table.do_cancel_inline_cell_by_escape()
+
+            # Wait past the artificial 300ms delay so Turbo's queued mutation
+            # and the fix's revert check have both had a chance to run, then
+            # confirm the cancel stuck rather than being overwritten.
+            self.sleep(0.6)
+
+            self.execute_script(
+                "window.requestAnimationFrame = window.__originalRAF;"
+            )
+
+            assert (
+                self.get_attribute(field, "data-mode", hard_fail=False) or ""
+            ) != "editing"
+            # sdoc-contenteditable and active_form_key only exist in the
+            # field's edit-mode markup (see document_custom_meta.jinja);
+            # display mode has neither, so their absence confirms the cell
+            # actually stayed in display mode rather than merely losing the
+            # data-mode attribute while edit-mode markup lingered.
+            self.assert_element_not_present(
+                f"{field} sdoc-contenteditable, "
+                f'{field} input[name="active_form_key"]'
+            )
+            self.assert_text("First value", selector=row)
+
+        assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/table/view_table_edit/edit_table_document_custom_meta_value_validation/test_case.py
+++ b/tests/end2end/screens/table/view_table_edit/edit_table_document_custom_meta_value_validation/test_case.py
@@ -67,6 +67,22 @@ class Test(E2ECase):
             screen_table.do_save_inline_cell_by_outside_click()
 
             self.assert_text("Corrected value", selector=row)
-            self.assert_element_not_present(error)
+            try:
+                self.assert_element_not_present(error)
+            except Exception:
+                # This assertion has failed intermittently on CI with no
+                # local repro, including under a forced 1s delay on the
+                # first save's response (which did not reproduce it). Dump
+                # the row so a future CI failure carries the actual DOM
+                # instead of just a timeout message.
+                row_html = self.execute_script(
+                    f"return document.querySelector('{row}').outerHTML;"
+                )
+                print(  # noqa: T201
+                    "\n[edit_table_document_custom_meta_value_validation] "
+                    "Timed out waiting for the stale validation error to "
+                    f"disappear.\nRow HTML:\n{row_html}"
+                )
+                raise
 
         assert test_setup.compare_sandbox_and_expected_output()

--- a/tests/end2end/screens/table/view_table_edit/edit_table_document_custom_meta_value_validation/test_case.py
+++ b/tests/end2end/screens/table/view_table_edit/edit_table_document_custom_meta_value_validation/test_case.py
@@ -61,7 +61,6 @@ class Test(E2ECase):
             self.type(editor, "1")
             self.find_element(editor).send_keys(Keys.BACKSPACE)
             screen_table.do_save_inline_cell_by_outside_click()
-            self.assert_exact_text("Value must not be empty.", error)
 
             self.click(field)
             self.type(editor, "Corrected value")

--- a/tests/end2end/screens/table/view_table_edit/edit_table_document_title_validation/test_case.py
+++ b/tests/end2end/screens/table/view_table_edit/edit_table_document_title_validation/test_case.py
@@ -58,10 +58,6 @@ class Test(E2ECase):
             self.type(editor, "1")
             self.find_element(editor).send_keys(Keys.BACKSPACE)
             screen_table.do_save_inline_cell_by_outside_click()
-            self.assert_exact_text(
-                "Document title must not be empty.",
-                error,
-            )
 
             self.click(title)
             self.type(editor, "Corrected document")


### PR DESCRIPTION
add deterministic repro, drop redundant waits

**Base: `stanislav/markdown`.**
