### PR TITLE
fix(table): stop metadata saves from reverting document fields

### DIFF
--- a/strictdoc/server/routers/main_router.py
+++ b/strictdoc/server/routers/main_router.py
@@ -1967,6 +1967,27 @@ def create_main_router(
                 request_form_data=request_form_data,
             )
         )
+        # The custom-metadata grid shares one <form> with hidden TITLE/UID/
+        # VERSION/CLASSIFICATION/PREFIX inputs, snapshotted whenever that
+        # form was last rendered. table__update_document_config_field saves
+        # those fields through a separate request and never refreshes this
+        # form, so a metadata-only action here (edit/add/delete/reorder a
+        # row) would otherwise resubmit that stale snapshot and silently
+        # revert whichever of those fields changed since. This endpoint
+        # owns the metadata fields only; the rest must come from the
+        # document itself, not from the request.
+        current_config_fields = DocumentConfigFormObject.create_from_document(
+            document=document
+        )
+        form_object.document_title = current_config_fields.document_title
+        form_object.document_uid = current_config_fields.document_uid
+        form_object.document_version = current_config_fields.document_version
+        form_object.document_classification = (
+            current_config_fields.document_classification
+        )
+        form_object.document_requirement_prefix = (
+            current_config_fields.document_requirement_prefix
+        )
         is_block_action = action in ("delete", "reorder")
         active_metadata_field = None
         active_metadata_index = -1

--- a/tests/end2end/screens/table/view_table_edit/edit_table_document_title_survives_custom_meta_save/expected_output/document.sdoc
+++ b/tests/end2end/screens/table/view_table_edit/edit_table_document_title_survives_custom_meta_save/expected_output/document.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: Updated document
+METADATA:
+  FIRST: Updated value
+
+[REQUIREMENT]
+TITLE: Requirement
+STATEMENT: Requirement statement.

--- a/tests/end2end/screens/table/view_table_edit/edit_table_document_title_survives_custom_meta_save/input/document.sdoc
+++ b/tests/end2end/screens/table/view_table_edit/edit_table_document_title_survives_custom_meta_save/input/document.sdoc
@@ -1,0 +1,8 @@
+[DOCUMENT]
+TITLE: Original document
+METADATA:
+  FIRST: First value
+
+[REQUIREMENT]
+TITLE: Requirement
+STATEMENT: Requirement statement.

--- a/tests/end2end/screens/table/view_table_edit/edit_table_document_title_survives_custom_meta_save/test_case.py
+++ b/tests/end2end/screens/table/view_table_edit/edit_table_document_title_survives_custom_meta_save/test_case.py
@@ -1,0 +1,66 @@
+from tests.end2end.e2e_case import E2ECase
+from tests.end2end.end2end_test_setup import End2EndTestSetup
+from tests.end2end.helpers.components.viewtype_selector import ViewType_Selector
+from tests.end2end.helpers.screens.project_index.screen_project_index import (
+    Screen_ProjectIndex,
+)
+from tests.end2end.server import SDocTestServer
+
+
+class Test(E2ECase):
+    def test(self):
+        test_setup = End2EndTestSetup(path_to_test_file=__file__)
+
+        with SDocTestServer(
+            input_path=test_setup.path_to_sandbox
+        ) as test_server:
+            self.open(test_server.get_host_and_port())
+
+            screen_project_index = Screen_ProjectIndex(self)
+            screen_project_index.assert_on_screen()
+            screen_project_index.do_click_on_first_document()
+
+            self.clear_local_storage()
+
+            screen_table = ViewType_Selector(self).do_go_to_table()
+            screen_table.assert_on_screen_table()
+            screen_table.do_toggle_edit_mode()
+
+            title = '[data-testid="document-title-field"]'
+            title_editor = '[data-testid="form-field-TITLE"]'
+
+            self.click(title)
+            self.type(title_editor, "Updated document")
+            screen_table.do_save_inline_cell_by_outside_click()
+            self.assert_text("Updated document", selector=title)
+
+            # The custom-metadata rows share one <form> with the document's
+            # TITLE/UID/VERSION/CLASSIFICATION/PREFIX fields (rendered as
+            # hidden inputs alongside the rows). Saving one metadata field
+            # submits that whole form, so the request the server receives
+            # for this metadata save also carries those hidden fields.
+            first_row = (
+                '[data-testid="document-config-metadata-row-custom_meta_0"]'
+            )
+            first_field = (
+                f'{first_row} [data-testid="document-config-metadata-field"]'
+            )
+            self.click(first_field)
+            self.wait_for_element(
+                '[data-testid="form-field-metadata-custom_meta_0"]'
+            )
+            self.type(
+                '[data-testid="form-field-metadata-custom_meta_0"]',
+                "Updated value",
+            )
+            screen_table.do_save_inline_cell_by_outside_click()
+            self.assert_text("Updated value", selector=first_row)
+
+            # The title must still read the value saved above: the hidden
+            # TITLE input carried by the metadata form's own submission was
+            # captured before that edit and must not overwrite it.
+            self.assert_text("Updated document", selector=title)
+
+            screen_table.do_toggle_edit_mode()
+
+        assert test_setup.compare_sandbox_and_expected_output()


### PR DESCRIPTION
The custom-metadata grid shares one form with hidden TITLE/UID/VERSION/ CLASSIFICATION/PREFIX inputs, captured whenever that form was last rendered. Editing the document TITLE (or the other fields) goes through a separate endpoint that never refreshes this form. Any later metadata-only action (edit/add/delete/reorder a row) resubmitted that stale snapshot, and the server applied it unconditionally, reverting whichever field had changed since, straight to disk.

table__update_document_custom_meta now reads TITLE/UID/VERSION/ CLASSIFICATION/PREFIX from the current document instead of the request; only the metadata fields it actually owns come from the submitted form.

Adds edit_table_document_title_survives_custom_meta_save: edits TITLE, saves, edits an existing metadata field, saves, then checks TITLE survives on disk. It failed before this fix (TITLE reverted) and passes now.