### PR TITLE
fix(tests/end2end): scroll into view before copy-to-clipboard hover

### DIFF
--- a/tests/end2end/helpers/components/node/requirement.py
+++ b/tests/end2end/helpers/components/node/requirement.py
@@ -275,6 +275,11 @@ class Requirement(Node):  # pylint: disable=invalid-name
         return Screen_Document(self.test_case)
 
     def do_copy_anchor_to_buffer(self) -> None:
+        # The button only appears on a real CSS :hover, so the hover target
+        # must already be on-screen: ActionChains moves the mouse to the
+        # element's current on-page position, it does not scroll for us, and
+        # a prior step in the same test may have scrolled it out of view.
+        self.test_case.sdoc_do_scroll_to_element_by_xpath(self.node_xpath)
         self.test_case.hover_and_click(
             hover_selector=f"{self.node_xpath}",
             click_selector=(
@@ -285,6 +290,9 @@ class Requirement(Node):  # pylint: disable=invalid-name
         )
 
     def do_copy_rst_anchor_to_buffer(self, anchor_uid: str) -> None:
+        # See do_copy_anchor_to_buffer: the hover target must be on-screen
+        # before hovering, not just present in the DOM.
+        self.test_case.sdoc_do_scroll_to_element_by_xpath(self.node_xpath)
         self.test_case.hover_and_click(
             hover_selector=f"{self.node_xpath}",
             click_selector=(
@@ -298,12 +306,16 @@ class Requirement(Node):  # pylint: disable=invalid-name
     def do_copy_field_content_to_buffer(
         self, field_label: str = "statement"
     ) -> None:
+        field_xpath = (
+            f"{self.node_xpath}"
+            f'//sdoc-node-field[@data-field-label="{field_label}"]'
+            "//sdoc-field"
+        )
+        # See do_copy_anchor_to_buffer: the hover target must be on-screen
+        # before hovering, not just present in the DOM.
+        self.test_case.sdoc_do_scroll_to_element_by_xpath(field_xpath)
         self.test_case.hover_and_click(
-            hover_selector=(
-                f"{self.node_xpath}"
-                f'//sdoc-node-field[@data-field-label="{field_label}"]'
-                "//sdoc-field"
-            ),
+            hover_selector=field_xpath,
             click_selector=(
                 f"{self.node_xpath}"
                 f'//sdoc-node-field[@data-field-label="{field_label}"]'
@@ -314,6 +326,9 @@ class Requirement(Node):  # pylint: disable=invalid-name
         )
 
     def do_copy_stable_link_to_buffer(self) -> None:
+        # See do_copy_anchor_to_buffer: the hover target must be on-screen
+        # before hovering, not just present in the DOM.
+        self.test_case.sdoc_do_scroll_to_element_by_xpath(self.node_xpath)
         self.test_case.hover_and_click(
             hover_selector=f"{self.node_xpath}",
             click_selector=(

--- a/tests/end2end/helpers/components/node/section.py
+++ b/tests/end2end/helpers/components/node/section.py
@@ -44,6 +44,11 @@ class Section(Node):  # pylint: disable=invalid-name
         )
 
     def do_copy_anchor_to_buffer(self) -> None:
+        # The button only appears on a real CSS :hover, so the hover target
+        # must already be on-screen: ActionChains moves the mouse to the
+        # element's current on-page position, it does not scroll for us, and
+        # a prior step in the same test may have scrolled it out of view.
+        self.test_case.sdoc_do_scroll_to_element_by_xpath(self.node_xpath)
         self.test_case.hover_and_click(
             hover_selector=f"{self.node_xpath}",
             click_selector=(


### PR DESCRIPTION
hover_and_click positions the mouse at an element's current on-page coordinates and does not scroll it into view. The copy-to-clipboard buttons only appear on a real CSS :hover, so if a hover target sits outside the viewport, the hover never lands and the button never becomes clickable, even though it is present in the DOM.

The copy-to-clipboard test hovers over a second node further down the page before returning to a field on the first node. If that first hover scrolls the page, the field is no longer guaranteed to be on-screen when the test comes back to it. Locally the document height happened to match the window height exactly, leaving no room for this to matter, so the test passed here while failing in CI.

do_copy_anchor_to_buffer, do_copy_rst_anchor_to_buffer, do_copy_field_content_to_buffer, and do_copy_stable_link_to_buffer (Section and Requirement) now scroll their hover target into view first, matching the sdoc_do_scroll_to_element_by_xpath pattern already used elsewhere in the suite.