### PR TITLE
fix(table): fix a stale-response race that drops active cell tracking

### DIFF
--- a/strictdoc/export/html/_static/table_view_edit.js
+++ b/strictdoc/export/html/_static/table_view_edit.js
@@ -138,6 +138,12 @@
                 // fetchTurboStream() response that arrives after the cell was
                 // cancelled (or reopened) can be told apart from the current one.
                 editRequestId: 0,
+                // Bumped every time openInlineCell() (re)activates this cell,
+                // including reactivating a passive-open cell in place. Lets a
+                // save's response tell a stale activation from the current one
+                // (see performInlineCellSave): the cell reference alone can't,
+                // since reopening the same cell doesn't change it.
+                activationId: 0,
             };
             cellStates.set(cell, state);
         }
@@ -781,6 +787,12 @@
     // --- Inline-form cells (contenteditable / comments / relations) ---
 
     function openInlineCell(cell) {
+        // Bumped for any click that reaches this cell, including the no-op
+        // "already active" case right below: that's still the user re-
+        // engaging with the cell, which a save already in flight for it
+        // (dispatched before this click) needs to know about — see the
+        // activationId guard in performInlineCellSave.
+        getCellState(cell).activationId++;
         if (activeInlineCell === cell) return;
         if (activeInlineCell) {
             // [FEATURE: passive-open] Null activeInlineCell immediately so the
@@ -980,14 +992,30 @@
         // tell a real duplicate trigger from a correction typed before this
         // request's response landed.
         state.dispatchedOwnFieldsData = getCellOwnFieldsData(cell);
+        // Recorded so this save's own response can tell whether the user
+        // reopened this exact cell (passive-open reactivation) while the
+        // request was in flight — see the activeInlineCell guard below.
+        const dispatchedActivationId = state.activationId;
 
         try {
             const { response, html } = await postTurboStream(form.action, formData);
+            // A reopen click bumps activationId but, for an already
+            // passive-open cell, doesn't dispatch a new request (see
+            // openInlineCell) — it just resumes tracking the cell the user
+            // is now looking at. If that happened while this response was
+            // in flight, activeInlineCell already correctly points at the
+            // reactivated cell; clearing it here would leave the very next
+            // outside click with no active cell to save, silently dropping
+            // whatever the user typed after reopening.
+            const reactivatedSinceDispatch =
+                state.activationId !== dispatchedActivationId;
             if (response.ok) {
                 // Only clear activeInlineCell if this cell is still the active one.
                 // When called via openInlineCell, activeInlineCell was already nulled
                 // there — don't overwrite it if it has moved on to another cell.
-                if (activeInlineCell === cell) activeInlineCell = null;
+                if (activeInlineCell === cell && !reactivatedSinceDispatch) {
+                    activeInlineCell = null;
+                }
                 updateMode(cell);
                 cell.removeAttribute('data-validation-error');
                 state.originalHTML = undefined;
@@ -1000,7 +1028,9 @@
                 // [FEATURE: passive-open] Validation error — go passive-open regardless
                 // of whether save was triggered by click-outside or by a cell switch.
                 // Discard pendingNextCell: the next cell must not open while this one has an error.
-                if (activeInlineCell === cell) activeInlineCell = null;
+                if (activeInlineCell === cell && !reactivatedSinceDispatch) {
+                    activeInlineCell = null;
+                }
                 pendingNextCell = null;
                 const contentType = response.headers.get('Content-Type') || '';
                 if (contentType.includes('turbo-stream')) {
@@ -1017,7 +1047,9 @@
         } catch (err) {
             console.error('Inline cell save error:', err);
             // Network error — restore cell and discard any pending next cell.
-            if (activeInlineCell === cell) activeInlineCell = null;
+            if (activeInlineCell === cell && state.activationId === dispatchedActivationId) {
+                activeInlineCell = null;
+            }
             pendingNextCell = null;
             restoreInlineCellDOM(cell);
         }

--- a/strictdoc/export/html/_static/table_view_edit.js
+++ b/strictdoc/export/html/_static/table_view_edit.js
@@ -576,6 +576,10 @@
     }
 
     function openAutocompleteCell(cell) {
+        // See openInlineCell's identical activationId bump: this cell's
+        // save (if any is in flight) needs to know a reopen happened, even
+        // when it's this same-cell no-op below.
+        getCellState(cell).activationId++;
         if (activeAutocompleteCell === cell) return;
         if (activeAutocompleteCell) cancelAutocompleteCell();
         if (activeInlineCell) saveInlineCell(activeInlineCell);
@@ -662,13 +666,22 @@
         formData.append('field_name', cell.dataset.fieldName);
         formData.append('field_value', newValue);
 
+        // See performInlineCellSave's identical guard: if the user reopens
+        // this cell while this request is still in flight, activeAutocompleteCell
+        // already correctly points at it again by the time the response
+        // lands, and deactivating it here would leave the next outside
+        // click with nothing to save.
+        const dispatchedActivationId = state.activationId;
+
         try {
             const { response, html } = await postTurboStream(
                 '/actions/table/update_node_field',
                 formData
             );
+            const reactivatedSinceDispatch =
+                state.activationId !== dispatchedActivationId;
             if (response.ok) {
-                deactivateAutocompleteCell(cell);
+                if (!reactivatedSinceDispatch) deactivateAutocompleteCell(cell);
                 cell.removeAttribute('data-validation-error');
                 state.originalHTML = undefined;
                 renderTurboStream(html);
@@ -686,7 +699,9 @@
             }
         } catch (err) {
             console.error('Table autocomplete save error:', err);
-            deactivateAutocompleteCell(cell);
+            if (state.activationId === dispatchedActivationId) {
+                deactivateAutocompleteCell(cell);
+            }
             cell.dataset.currentValue = originalValue;
             if (state.originalHTML !== undefined) {
                 cell.innerHTML = state.originalHTML;


### PR DESCRIPTION
table_view_edit.js keeps "which cell is being edited" in a handful of
module-level variables (activeInlineCell, activeAutocompleteCell).
Every save is a fetch, and the code that applies the response was
written to trust those variables as still describing the same editing
session that started the request. They don't always: a synchronous
user action (clicking the same cell again) can happen while an earlier
request for that exact cell is still in flight, and the UI treats that
click as a no-op because the cell already looks active. When the
earlier request's response then lands, it unconditionally clears the
tracking variable, undoing the reopen the user never saw fail. The
next action (an outside click to save the correction) finds no active
cell and does nothing - no request, no error, just a stale validation
message stuck on screen with no way to clear it.

This is a general hole in the file, not one bug: any code path where a
synchronous UI action can be superseded by an async completion needs a
way to tell "this response is for the editing session that's still
current" from "this response is for a session the user already moved
past." The file already solves this once, for a different pair of
operations (a cell's cancel racing its own inline-form fetch, via an
editRequestId counter). The two fixes here apply the same idea - a
per-cell activationId, bumped on every reopen including the no-op
case - to the two remaining places nothing was tracking it: an inline
cell's own save, and an autocomplete cell's own save.

Why this only shows up in CI: the request in question is not talking
to a remote API - it's a local dev/test server subprocess that does
real work per request (write the document to disk, rebuild the
traceability index, render templates), typically finishing in low
single-digit milliseconds on an idle machine. That's fast enough that
a human, or even most automated clicks, can never land inside the race
window. A CI runner sharing CPU across parallel jobs routinely pushes
that same request past 40ms, which is enough. Reproducing this didn't
need randomness or luck - artificially delaying the response by a
fixed amount reproduces it on demand, which is also what proved the
fix: the same delayed-response setup passes cleanly afterward, across
a whole range of delays.