### PR TITLE
fix(export/html): scope inline-size containment to sdoc-node fields

### DIFF
--- a/strictdoc/export/html/_static/element.css
+++ b/strictdoc/export/html/_static/element.css
@@ -391,6 +391,11 @@ sdoc-field {
 sdoc-field-content {
   flex-grow: 1;
   width: 100%; /* holds within the width of the parent */
+}
+
+sdoc-node-field sdoc-field-content {
+  /* For `sdoc-node` context only. Not for `sdoc-meta`
+     or another parent that has fit-content */
   container-type: inline-size;
 }
 


### PR DESCRIPTION
`container-type: inline-size` can break intrinsic sizing inside `fit-content` parents such as `sdoc-meta`.