### PR TITLE
fix(table-view-edit): close two stale-response races in inline editing

### DIFF
--- a/strictdoc/export/html/_static/table_view_edit.js
+++ b/strictdoc/export/html/_static/table_view_edit.js
@@ -1039,11 +1039,20 @@
                 // [FEATURE: passive-open] Open the cell the user clicked while this
                 // save was in flight (set by openInlineCell before starting the save).
                 openPendingCell();
+            } else if (reactivatedSinceDispatch) {
+                // The user reopened this cell (and may already be typing a
+                // correction) while this now-stale error response was still
+                // in flight. Applying it here would blow away whatever the
+                // reopened session currently holds — e.g. overwrite a
+                // corrected value with the server's stale echo of the
+                // rejected one, right before a real save silently persists
+                // that clobbered content instead of the correction.
+                pendingNextCell = null;
             } else {
                 // [FEATURE: passive-open] Validation error — go passive-open regardless
                 // of whether save was triggered by click-outside or by a cell switch.
                 // Discard pendingNextCell: the next cell must not open while this one has an error.
-                if (activeInlineCell === cell && !reactivatedSinceDispatch) {
+                if (activeInlineCell === cell) {
                     activeInlineCell = null;
                 }
                 pendingNextCell = null;

--- a/tests/end2end/helpers/screens/document/form_edit_requirement.py
+++ b/tests/end2end/helpers/screens/document/form_edit_requirement.py
@@ -25,14 +25,24 @@ class Form_EditRequirement(Form):  # pylint: disable=invalid-name
 
     def do_form_add_field_comment(self) -> MID:
         any_comment_xpath = "//*[@data-testid='requirement-form-comment-row']"
+        add_comment_xpath = "//*[@data-testid='form-action-add-comment']"
+
+        # Wait for the inline form's own content to be loaded before
+        # counting existing comment rows: do_open_inline_cell only waits
+        # for data-mode="editing", which is set before the form's fetch
+        # resolves, so this link (and any pre-existing comment rows
+        # rendered alongside it) may not exist yet. Reading comments_number
+        # too early sees 0 and, once the row that is actually the new one
+        # renders after the already-loaded content, misidentifies an
+        # existing row as the new one.
+        self.test_case.find_element(add_comment_xpath, by=By.XPATH)
+
         comments_number = len(
             self.test_case.find_elements(any_comment_xpath, by=By.XPATH)
         )
         new_comment_ordinal_number = comments_number + 1
 
-        self.test_case.click_xpath(
-            "//*[@data-testid='form-action-add-comment']"
-        )
+        self.test_case.click_xpath(add_comment_xpath)
 
         xpath = f"({any_comment_xpath})[{new_comment_ordinal_number}]"
         element = self.test_case.find_element(xpath)


### PR DESCRIPTION
Two unrelated races caused intermittent end-to-end failures.

table_view_edit.js: a rejected inline-cell save could resolve after the
user reopened the cell and typed a correction. The stale response still
rendered the server's old error markup, overwriting the correction
before it reached the server. The UI showed the corrected value, but
the saved document kept the old one. The fix skips the stale render
once the cell has been reactivated since the request was sent.

form_edit_requirement.py: do_form_add_field_comment() counted existing
comment rows before the inline form finished loading.
do_open_inline_cell() only waits for data-mode="editing", set before
the form's content request resolves. A count taken that early read
zero, so the helper picked the pre-existing comment row instead of the
new one and overwrote it. The fix waits for the "Add comment" link,
which only exists once the form has loaded, before counting rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)