### PR TITLE
Fix TOC and tree-map styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,11 +39,10 @@ __pycache__
 /*.local.toml
 /__*.sdoc
 /__*.sgra
-/docs/_draft/
-/docs/_fixture/
-/docs/_test/
 /.claude/
 /.agents/
+# **/_fixture/
+**/_draft/
 
 ### webdriver_manager: cache with downloaded Chrome Driver binaries ###
 /strictdoc/export/html2pdf/.wdm

--- a/strictdoc/export/html/_static/element.css
+++ b/strictdoc/export/html/_static/element.css
@@ -1421,6 +1421,16 @@ a.tree_item,
   padding-top: var(--base-rhythm);
   padding-bottom: var(--base-rhythm);
   padding-right: var(--base-rhythm);
+  /* to wrap a long token */
+  overflow-wrap: anywhere;
+}
+
+.toc-section-number {
+  margin-right: .5rem;
+  font-size: 0.85em;
+  font-weight: bold;
+  /* to keep on the first line when wrapping a long token */
+  float: left;
 }
 
 .toc a,

--- a/strictdoc/export/html/_static/layout.css
+++ b/strictdoc/export/html/_static/layout.css
@@ -71,14 +71,6 @@
   display: none !important;
 }
 
-/*  */
-
-.section-number {
-  margin-right: .5rem;
-  font-size: 0.85em;
-  font-weight: bold;
-}
-
 /* messages */
 
 .mars {

--- a/strictdoc/export/html/templates/screens/document/_shared/toc.jinja
+++ b/strictdoc/export/html/templates/screens/document/_shared/toc.jinja
@@ -13,7 +13,7 @@
         {%- if section.is_document_node() -%}
           {%- if not section.ng_has_requirements and view_object.is_deeptrace() -%}
             <span class="toc-title-no-link" title="Section has no requirements">
-              <span class="section-number">
+              <span class="toc-section-number">
                 {{ section.context.title_number_string }}
               </span>{{ section.title }}
             </span>
@@ -31,7 +31,7 @@
               anchor="{{ view_object.render_local_anchor(section) }}"
               data-turbo="false"
             >
-              <span class="section-number">
+              <span class="toc-section-number">
                 {{ section.context.title_number_string if section.context.title_number_string else "&nbsp;"|safe * (node_context_.get_level() * 2 - 1) }}
               </span>{{- section.title -}}
               {# TODO #fragment #}
@@ -45,7 +45,7 @@
           anchor="{{ view_object.render_local_anchor(section) }}"
           data-turbo="false"
         >
-          <span class="section-number">
+          <span class="toc-section-number">
             {{ section.context.title_number_string if section.context.title_number_string else "&nbsp;"|safe * (node_context_.get_level() * 2 - 1) }}
           </span>
           {%- if section.reserved_title is not none -%}

--- a/strictdoc/features/tree_map/assets/tree_map.css
+++ b/strictdoc/features/tree_map/assets/tree_map.css
@@ -295,10 +295,13 @@
 
 .tree-map__node[data-synthetic-group="true"]
   > .tree-map__node-surface {
+  /* can be overridden by the node's color settings: */
+  background-color: var(--color-bg-main);
+  /* texture over the background: */
   background-image: repeating-linear-gradient(
     135deg,
-    transparent,
-    transparent 6px,
+    rgb(0 0 0 / 2%),
+    rgb(0 0 0 / 2%) 6px,
     rgb(255 255 255 / 20%) 6px,
     rgb(255 255 255 / 20%) 12px
   );

--- a/tests/integration/features/html/escaping/01_escape_input_from_sdoc/test.itest
+++ b/tests/integration/features/html/escaping/01_escape_input_from_sdoc/test.itest
@@ -30,7 +30,7 @@ CHECK-ALL-NEXT: data-file_name="input.sdoc"
 CHECK-ALL-NEXT: >&lt;b&gt;&#34;escaping&#34;&amp;nbsp;&#39;document title&#39;&lt;/b&gt;</div>
 
 # Right-hand bar: Document TOC.
-CHECK-ALL: <span class="section-number">
+CHECK-ALL: <span class="toc-section-number">
 CHECK-ALL-NEXT: {{[0-9]+}}
 CHECK-ALL-NEXT: </span>&lt;b&gt;&#34;escaping&#34;&amp;nbsp;&#39;section title&#39;&lt;/b&gt;
 


### PR DESCRIPTION
- add default background color to synthetic groups in tree-map
- allow long tokens in the TOC to wrap
- move and rename .toc-section-number as a class belonging to TOC

