### PR TITLE
fix: ExceptionInfo becomes unpicklable for custom exceptions, masking real errors as BrokenProcessPool crashes

### DIFF
--- a/strictdoc/helpers/exception.py
+++ b/strictdoc/helpers/exception.py
@@ -15,7 +15,18 @@ def get_exception_origin() -> Tuple[str, int, str, str]:
 
 class ExceptionInfo:
     def __init__(self, exception: Exception):
-        self.exception = exception
+        # Store the rendered message, not the exception object itself:
+        # ExceptionInfo is sent from a worker process to the parent via
+        # StrictDocChildProcessException (see parallelizer.py), and an
+        # exception object is only picklable if its class round-trips
+        # through Exception's default __reduce__ (`type(exc)(*exc.args)`).
+        # Custom StrictDoc exceptions with a keyword-only or otherwise
+        # non-trivial __init__ (e.g. StrictDocSemanticError) don't, so
+        # keeping a live reference here would make ExceptionInfo itself
+        # unpicklable and turn a normal, reportable error into an opaque
+        # BrokenProcessPool crash instead. A plain string has no such
+        # requirement and is all get_detailed_error_message() ever needed.
+        self.exception_message = str(exception)
 
         filename, lineno, func, _ = get_exception_origin()
         self.filename = filename
@@ -35,7 +46,7 @@ class ExceptionInfo:
 
     def get_detailed_error_message(self) -> str:
         return (
-            f"error: {str(self.exception)}\n"
+            f"error: {self.exception_message}\n"
             f"error source: {self.filename}:{self.lineno}, function: {self.func}()"
         )
 

--- a/tests/unit/strictdoc/helpers/test_parallelizer.py
+++ b/tests/unit/strictdoc/helpers/test_parallelizer.py
@@ -43,6 +43,23 @@ def child_process_that_reads_the_worker_context(_):
     return get_worker_context()
 
 
+class ExceptionWithKeywordOnlyInit(Exception):
+    """
+    Mirrors StrictDocSemanticError's shape: a keyword-only __init__ that
+    forwards positional args to Exception.__init__(), which is exactly what
+    breaks Exception's default __reduce__ (`type(exc)(*exc.args)`) when the
+    exception has to be pickled back from a worker process.
+    """
+
+    def __init__(self, *, title):
+        super().__init__(title)
+        self.title = title
+
+
+def child_process_that_raises_an_unpicklable_exception(_):
+    raise ExceptionWithKeywordOnlyInit(title="This exception is not picklable.")
+
+
 def test_nominal_use_case():
     parallelizer = MultiprocessingParallelizer()
 
@@ -68,8 +85,34 @@ def test_if_child_process_fails_then_parallelizer_exits_with_non_zero():
             parallelizer.run_parallel(input_items, child_process_that_fails)
 
         assert exc_info.type is StrictDocChildProcessException
-        assert exc_info.value.args[0].exception.args[0] == (
+        assert exc_info.value.args[0].exception_message == (
             "This child process always fails."
+        )
+    finally:
+        parallelizer.shutdown()
+
+
+def test_if_child_process_raises_an_exception_with_a_non_standard_init_it_still_propagates():
+    """
+    Regression test: a worker exception whose __init__ doesn't accept
+    Exception's default __reduce__ round-trip (`type(exc)(*exc.args)`) used
+    to make the wrapping StrictDocChildProcessException itself unpicklable,
+    turning a normal, reportable error into an opaque BrokenProcessPool
+    crash instead of propagating the real error message.
+    """
+    parallelizer = MultiprocessingParallelizer()
+
+    input_items = ["FAKE_INPUT"]
+
+    try:
+        with pytest.raises(Exception) as exc_info:
+            parallelizer.run_parallel(
+                input_items, child_process_that_raises_an_unpicklable_exception
+            )
+
+        assert exc_info.type is StrictDocChildProcessException
+        assert exc_info.value.args[0].exception_message == (
+            "This exception is not picklable."
         )
     finally:
         parallelizer.shutdown()


### PR DESCRIPTION
## Summary

When a worker process (under `MultiprocessingParallelizer`) raises a custom
StrictDoc exception whose `__init__` doesn't round-trip through Python's default
exception `__reduce__` (`type(exc)(*exc.args)`) - e.g. `StrictDocSemanticError`,
which is keyword-only but forwards positional args to `Exception.__init__` - the
result never makes it back to the parent process cleanly.

`processing_func_wrapper()` in `parallelizer.py` wraps the failure as
`StrictDocChildProcessException(ExceptionInfo(exception))` and returns it as the
task's result, which `ProcessPoolExecutor` then pickles to send back to the
parent. `ExceptionInfo` kept a live reference to the original exception object
(`self.exception = exception`), so pickling it requires pickling that exception
too. For an exception whose class can't be reconstructed via
`type(exc)(*exc.args)`, this raises a `TypeError` *inside the worker's result
writer*, which `concurrent.futures.process` reports as a broken worker rather
than propagating the underlying error - so instead of the real, actionable
message, the CLI crashes with:

```
concurrent.futures.process.BrokenProcessPool: A process in the process pool was
terminated abruptly while the future was running or pending.
```

### Repro

Any project where a document fails Markdown-format validation (e.g. missing the
required leading H1 heading) reproduces this today, since that raises
`StrictDocSemanticError` inside a worker during `strictdoc format`/`export`:

```
concurrent.futures.process._RemoteTraceback:
'''
Traceback (most recent call last):
  File ".../concurrent/futures/process.py", line 392, in wait_result_broken_or_wakeup
    result_item = result_reader.recv()
  File ".../multiprocessing/connection.py", line 251, in recv
    return _ForkingPickler.loads(buf.getbuffer())
TypeError: StrictDocSemanticError.__init__() takes 1 positional argument but 6 were given
'''
...
concurrent.futures.process.BrokenProcessPool: A process in the process pool was
terminated abruptly while the future was running or pending.
```

instead of the real, useful error:

```
error: could not parse file: .../SomeFile.md.
Semantic error: Markdown parsing error: the document must start with an H1 heading.
Location: .../SomeFile.md:1:1
```

## Fix

`get_detailed_error_message()` only ever needed `str(exception)`, so
`ExceptionInfo` now renders and stores that string up front
(`self.exception_message`) instead of keeping a live reference to the exception
object. This makes `ExceptionInfo` - and therefore
`StrictDocChildProcessException` - always picklable, regardless of what custom
exception type a worker raises, without having to special-case
`StrictDocSemanticError` or add pickling support to every current and future
StrictDoc exception class individually.

## Test plan

- Added `test_if_child_process_raises_an_exception_with_a_non_standard_init_it_still_propagates`
  to `tests/unit/strictdoc/helpers/test_parallelizer.py`, reproducing the bug with
  a minimal exception shaped like `StrictDocSemanticError` (keyword-only
  `__init__` forwarding positional args to `Exception.__init__`).
- Updated the existing `test_if_child_process_fails_then_parallelizer_exits_with_non_zero`
  for the renamed attribute.
- `uv run pytest tests/unit/strictdoc/helpers/test_parallelizer.py -q` - 11 passed
  (was 1 failure/crash on the new test before the fix, verified by reverting the
  fix locally).
- `uv run pytest tests/unit -k "exception or parallel" -q` - 14 passed.
- `uv run ruff check` and `uv run mypy` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)